### PR TITLE
full height of the app container

### DIFF
--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -1,3 +1,8 @@
+body, html {
+  height: 100%;
+  min-height: 100%;
+}
+
 html {
     box-sizing: border-box;
 }


### PR DESCRIPTION
In desktop mode the app would not have the left and right border extend the full height of the view. Needed to add a 100% on the body and html to allow for the borders to extend the full height.