### PR TITLE
Add orgs details

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,8 @@ You should be able to visit WebApp here:
 ## After Installation: Working with WebApp Day-to-Day
 
 [Read about working with WebApp on a daily basis](README_WORKING_WITH_WEB_APP.md)
+
+## SemVer
+
+We follow [SemVer](http://semver.org/) for our releases. Please read if you plan
+to tag for any releases.

--- a/src/js/actions/BallotActions.js
+++ b/src/js/actions/BallotActions.js
@@ -21,20 +21,6 @@ module.exports = {
     });
   },
 
-  voterSupportingSave: function (we_vote_id) {  // VOTER_SUPPORTING_SAVE
-    AppDispatcher.dispatch({
-      actionType: BallotConstants.VOTER_SUPPORTING_SAVE,
-      we_vote_id
-    });
-  },
-
-  voterSupportingSave: function (we_vote_id) {  // VOTER_SUPPORTING_SAVE
-    AppDispatcher.dispatch({
-      actionType: BallotConstants.VOTER_SUPPORTING_SAVE,
-      we_vote_id
-    });
-  },
-
   voterStopSupportingSave: function (we_vote_id) {  // VOTER_STOP_SUPPORTING_SAVE
     AppDispatcher.dispatch({
       actionType: BallotConstants.VOTER_STOP_SUPPORTING_SAVE,

--- a/src/js/actions/BallotActions.js
+++ b/src/js/actions/BallotActions.js
@@ -6,10 +6,11 @@ var BallotConstants = require('../constants/BallotConstants');
 //  When action calls one of these functions, we are telling the code in the AppDispatcher block to run
 module.exports = {
 
-  downloadOrganizations: function( we_vote_id) {
+  positionsRetrieved: function( we_vote_id, payload) {
     AppDispatcher.dispatch({
-      actionType: BallotConstants.DOWNLOAD_ORGANIZATIONS,
-      we_vote_id
+      actionType: BallotConstants.POSITIONS_RETRIEVED,
+      payload: payload,
+      we_vote_id: we_vote_id
     });
   },
 

--- a/src/js/actions/BallotActions.js
+++ b/src/js/actions/BallotActions.js
@@ -5,6 +5,28 @@ var BallotConstants = require('../constants/BallotConstants');
 // In the stores, there are AppDispatcher blocks that listen for these actionType constants (ex/ VOTER_SUPPORTING_SAVE)
 //  When action calls one of these functions, we are telling the code in the AppDispatcher block to run
 module.exports = {
+
+  downloadOrganizations: function( we_vote_id) {
+    AppDispatcher.dispatch({
+      actionType: BallotConstants.DOWNLOAD_ORGANIZATIONS,
+      we_vote_id
+    });
+  },
+
+  voterSupportingSave: function (we_vote_id) {  // VOTER_SUPPORTING_SAVE
+    AppDispatcher.dispatch({
+      actionType: BallotConstants.VOTER_SUPPORTING_SAVE,
+      we_vote_id
+    });
+  },
+
+  voterSupportingSave: function (we_vote_id) {  // VOTER_SUPPORTING_SAVE
+    AppDispatcher.dispatch({
+      actionType: BallotConstants.VOTER_SUPPORTING_SAVE,
+      we_vote_id
+    });
+  },
+
   voterSupportingSave: function (we_vote_id) {  // VOTER_SUPPORTING_SAVE
     AppDispatcher.dispatch({
       actionType: BallotConstants.VOTER_SUPPORTING_SAVE,

--- a/src/js/actions/PositionActions.js
+++ b/src/js/actions/PositionActions.js
@@ -1,6 +1,6 @@
 'use strict';
 var AppDispatcher = require('../dispatcher/AppDispatcher');
-var PositionConstants = require('../constants/BallotConstants');
+var PositionConstants = require('../constants/PositionConstants');
 
 // In the stores, there are AppDispatcher blocks that listen for these actionType constants (ex/ VOTER_SUPPORTING_SAVE)
 //  When action calls one of these functions, we are telling the code in the AppDispatcher block to run

--- a/src/js/actions/PositionActions.js
+++ b/src/js/actions/PositionActions.js
@@ -1,0 +1,17 @@
+'use strict';
+var AppDispatcher = require('../dispatcher/AppDispatcher');
+var PositionConstants = require('../constants/BallotConstants');
+
+// In the stores, there are AppDispatcher blocks that listen for these actionType constants (ex/ VOTER_SUPPORTING_SAVE)
+//  When action calls one of these functions, we are telling the code in the AppDispatcher block to run
+module.exports = {
+
+  positionRetrieved: function( we_vote_id, payload) {
+    AppDispatcher.dispatch({
+      actionType: PositionConstants.POSITION_RETRIEVED,
+      payload: payload,
+      we_vote_id: we_vote_id
+    });
+  },
+
+};

--- a/src/js/components/Ballot/OrganizationItem.jsx
+++ b/src/js/components/Ballot/OrganizationItem.jsx
@@ -1,0 +1,60 @@
+import React, { Component, PropTypes } from 'react';
+import { Link } from 'react-router';
+import BallotActions from '../../actions/BallotActions';
+import BallotStore from '../../stores/BallotStore';
+
+export default class OrganizationItem extends Component {
+  static propTypes = {
+    position_we_vote_id: PropTypes.string.isRequired,
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = { organization: this.props};
+  }
+
+  componentDidMount () {
+    BallotStore.addChangeListener(this._onChange.bind(this));
+  }
+
+  componentWillUnmount () {
+    BallotStore.removeChangeListener(this._onChange.bind(this));
+  }
+
+  _onChange () {
+    // this.setState({ organization: BallotStore.getOrganization(this.props.candidate_we_vote_id, this.props.item.position_we_vote_id) });
+  }
+
+  render() {
+    var organization = this.state.organization;
+    var supportText = organization.is_oppose ? "Opposes" : "Supports";
+    return (
+        <div>
+        <li className="list-group-item">
+                <div className="row">
+                  <div className="pull-left col-xs-2 col-md-4">
+                      <Link to="ballot_candidate_one_org_position" params={{id: 2, org_id: 27}}>
+                        <i className={"icon-icon-org-placeholder-6-2 icon-light"}></i>
+                      </Link>
+                  </div>
+                  <div className="pull-right col-xs-10  col-md-8">
+                      <h4 className="">
+                          <Link className="" to="ballot_candidate_one_org_position"
+                          params={{id: organization.speaker_id, org_id: organization.speaker_we_vote_id}}>
+                            { organization.speaker_label }
+                          </Link>
+                      </h4>
+                      <p className="">{supportText} <span className="small">Yesterday at 7:18 PM</span></p>
+                  </div>
+                </div>
+                <div className="row">
+                    Integer ut bibendum ex. Suspendisse eleifend mi accumsan, euismod enim at, malesuada nibh.
+                    Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)
+                </div>
+                <br />
+                23 Likes<br />
+            </li>
+        </div>
+    );
+  }
+}

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -10,12 +10,10 @@ export default class PositionItem extends Component {
 
   constructor (props) {
     super(props);
-    this.state = { position: {} };
+    this.state = { position: {}, organization: {} };
   }
 
   componentDidMount () {
-    console.log("Position Item Component Mounted with wevoteid:")
-    console.log(this.props.position_we_vote_id);
     PositionStore.retrievePositionByWeVoteId(this.props.position_we_vote_id);
     PositionStore.addChangeListener(this._onChange.bind(this));
   }
@@ -26,12 +24,11 @@ export default class PositionItem extends Component {
 
   _onChange () {
     this.setState({ position: PositionStore.getLocalPositionByWeVoteId(this.props.position_we_vote_id) });
-    console.log("This Position Item:")
+    console.log("Position:")
     console.log(this.state.position);
   }
 
   render() {
-    // console.log(this.state.position);
     var position = this.state.position;
     var supportText = position.is_oppose ? "Opposes" : "Supports";
     return (
@@ -47,7 +44,7 @@ export default class PositionItem extends Component {
                       <h4 className="">
                           <Link className="" to="ballot_candidate_one_org_position"
                           params={{id: position.speaker_id, org_id: position.speaker_we_vote_id}}>
-                            { position.speaker_label }
+                            { this.props.speaker_label }
                           </Link>
                       </h4>
                       <p className="">{supportText} <span className="small">Yesterday at 7:18 PM</span></p>

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -1,33 +1,39 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
-import BallotActions from '../../actions/BallotActions';
-import BallotStore from '../../stores/BallotStore';
+import PositionActions from '../../actions/PositionActions';
+import PositionStore from '../../stores/PositionStore';
 
-export default class OrganizationItem extends Component {
+export default class PositionItem extends Component {
   static propTypes = {
     position_we_vote_id: PropTypes.string.isRequired,
   };
 
   constructor (props) {
     super(props);
-    this.state = { organization: this.props};
+    this.state = { position: {} };
   }
 
   componentDidMount () {
-    BallotStore.addChangeListener(this._onChange.bind(this));
+    console.log("Position Item Component Mounted with wevoteid:")
+    console.log(this.props.position_we_vote_id);
+    PositionStore.retrievePositionByWeVoteId(this.props.position_we_vote_id);
+    PositionStore.addChangeListener(this._onChange.bind(this));
   }
 
   componentWillUnmount () {
-    BallotStore.removeChangeListener(this._onChange.bind(this));
+    PositionStore.removeChangeListener(this._onChange.bind(this));
   }
 
   _onChange () {
-    // this.setState({ organization: BallotStore.getOrganization(this.props.candidate_we_vote_id, this.props.item.position_we_vote_id) });
+    this.setState({ position: PositionStore.getLocalPositionByWeVoteId(this.props.position_we_vote_id) });
+    console.log("This Position Item:")
+    console.log(this.state.position);
   }
 
   render() {
-    var organization = this.state.organization;
-    var supportText = organization.is_oppose ? "Opposes" : "Supports";
+    // console.log(this.state.position);
+    var position = this.state.position;
+    var supportText = position.is_oppose ? "Opposes" : "Supports";
     return (
         <div>
         <li className="list-group-item">
@@ -40,16 +46,15 @@ export default class OrganizationItem extends Component {
                   <div className="pull-right col-xs-10  col-md-8">
                       <h4 className="">
                           <Link className="" to="ballot_candidate_one_org_position"
-                          params={{id: organization.speaker_id, org_id: organization.speaker_we_vote_id}}>
-                            { organization.speaker_label }
+                          params={{id: position.speaker_id, org_id: position.speaker_we_vote_id}}>
+                            { position.speaker_label }
                           </Link>
                       </h4>
                       <p className="">{supportText} <span className="small">Yesterday at 7:18 PM</span></p>
                   </div>
                 </div>
                 <div className="row">
-                    Integer ut bibendum ex. Suspendisse eleifend mi accumsan, euismod enim at, malesuada nibh.
-                    Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)
+                    {position.statement_text}
                 </div>
                 <br />
                 23 Likes<br />

--- a/src/js/components/Ballot/PositionList.jsx
+++ b/src/js/components/Ballot/PositionList.jsx
@@ -23,13 +23,14 @@ export default class PositionList extends Component {
 
   _onChange(){
     this.setState({ position_list: BallotStore.getCandidateByWeVoteId(this.props.we_vote_id).position_list });
+    console.log(this.state.position_list);
   }
 
   render() {
     return (
       <ul className="list-group">
         { this.state.position_list.map( item =>
-            <PositionItem key={item.position_we_vote_id} position_we_vote_id={item.position_we_vote_id} /> )
+            <PositionItem key={item.position_we_vote_id} position_we_vote_id={item.position_we_vote_id} speaker_label={item.speaker_label}/> )
         }
       </ul>
     );

--- a/src/js/components/Ballot/PositionList.jsx
+++ b/src/js/components/Ballot/PositionList.jsx
@@ -1,0 +1,37 @@
+import React, { Component, PropTypes } from 'react';
+import BallotStore from '../../stores/BallotStore';
+import PositionItem from './PositionItem';
+
+export default class PositionList extends Component {
+  static propTypes = {
+    we_vote_id: PropTypes.string.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = { position_list: [] };
+  }
+    // no candidate exists... go to ballot
+  componentDidMount(){
+    BallotStore.fetchCandidatePositionsByWeVoteId(this.props.we_vote_id)
+    BallotStore.addChangeListener(this._onChange.bind(this));
+  }
+
+  componentWillUnmount(){
+    BallotStore.removeChangeListener(this._onChange.bind(this));
+  }
+
+  _onChange(){
+    this.setState({ position_list: BallotStore.getCandidateByWeVoteId(this.props.we_vote_id).position_list });
+  }
+
+  render() {
+    return (
+      <ul className="list-group">
+        { this.state.position_list.map( item =>
+            <PositionItem key={item.position_we_vote_id} position_we_vote_id={item.position_we_vote_id} /> )
+        }
+      </ul>
+    );
+  }
+}

--- a/src/js/components/StarAction.jsx
+++ b/src/js/components/StarAction.jsx
@@ -40,6 +40,7 @@ export default class StarAction extends Component {
   }
 
   _onChange () {
+    console.log("StarActiononChange");
     this.setState({
       is_starred: BallotStore.getStarState(this.props.we_vote_id)
     });

--- a/src/js/constants/BallotConstants.js
+++ b/src/js/constants/BallotConstants.js
@@ -6,6 +6,5 @@ module.exports = require('keymirror')({
   VOTER_STOP_OPPOSING_SAVE: null,
   VOTER_STAR_ON_SAVE: null,
   VOTER_STAR_OFF_SAVE: null,
-  VOTER_STAR_OFF_SAVE: null,
-  DOWNLOAD_ORGANIZATIONS: null
+  POSITIONS_RETRIEVED: null
 });

--- a/src/js/constants/BallotConstants.js
+++ b/src/js/constants/BallotConstants.js
@@ -5,5 +5,7 @@ module.exports = require('keymirror')({
   VOTER_OPPOSING_SAVE: null,
   VOTER_STOP_OPPOSING_SAVE: null,
   VOTER_STAR_ON_SAVE: null,
-  VOTER_STAR_OFF_SAVE: null
+  VOTER_STAR_OFF_SAVE: null,
+  VOTER_STAR_OFF_SAVE: null,
+  DOWNLOAD_ORGANIZATIONS: null
 });

--- a/src/js/constants/PositionConstants.js
+++ b/src/js/constants/PositionConstants.js
@@ -1,0 +1,3 @@
+module.exports = require('keymirror')({
+  POSITION_RETRIEVED: null
+});

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 
 import BallotStore from '../../stores/BallotStore';
 import BallotItem from '../../components/Ballot/BallotItem';
+import BallotActions from '../../actions/BallotActions';
 
 export default class Ballot extends Component {
   static propTypes = {

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -19,6 +19,15 @@ export default class Candidate extends Component {
     this.state = { candidate: {} };
   }
 
+  componentWillMount(){
+    // Redirects to root if candidate isn't fetched yet; TODO: just fetch params to enable sending links to candidate page.
+    var candidate = BallotStore.getCandidateByWeVoteId(this.props.params.we_vote_id);
+    if (Object.keys(candidate).length === 0)
+      {
+        this.props.history.replace('/ballot');
+      }
+  }
+
   componentDidMount(){
     this.setState({ candidate: BallotStore.getCandidateByWeVoteId(this.props.params.we_vote_id) });
   }

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -97,7 +97,7 @@ export default class Candidate extends Component {
             </div>
           </div>
           <div className="col-xs-8">
-            <div>Running for US House - District 12</div>
+            <div>{ candidate.office_display_name }</div>
             <ItemActionBar2 we_vote_id={candidate.we_vote_id}
                            is_support={candidate.is_support} is_oppose={candidate.is_oppose}
                            supportCount={candidate.supportCount} opposeCount={candidate.opposeCount} />

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -2,10 +2,9 @@ import React, { Component, PropTypes } from 'react';
 import { Button, ButtonToolbar, DropdownButton, Input, MenuItem, Navbar } from "react-bootstrap";
 import { Link } from 'react-router';
 
-import BallotActions from '../../actions/BallotActions';
 import BallotStore from '../../stores/BallotStore';
 import CandidateDetail from '../../components/Ballot/CandidateDetail';
-import OrganizationItem from '../../components/Ballot/OrganizationItem';
+import PositionList from '../../components/Ballot/PositionList';
 import ItemActionbar from '../../components/ItemActionbar';
 import ItemActionBar2 from '../../components/ItemActionBar2';
 import StarAction from '../../components/StarAction';
@@ -17,38 +16,25 @@ export default class Candidate extends Component {
 
   constructor(props) {
     super(props);
-    this.state = { candidate: BallotStore.getCandidateByWeVoteId(this.props.params.we_vote_id) };
+    this.state = { candidate: {} };
   }
-    // no candidate exists... go to ballot
+
   componentDidMount(){
-    if (Object.keys(this.state.candidate).length === 0){
-      this.props.history.replace('/ballot');
-    }
-    console.log('Candidate Component Mounted!')
-    BallotActions.downloadOrganizations(this.props.params.we_vote_id);
-    BallotStore.addChangeListener(this._onChange.bind(this));
-  }
-
-  componentWillUnmount(){
-    BallotStore.removeChangeListener(this._onChange.bind(this));
-  }
-
-  _onChange(){
-    console.log('onChange!');
-    var we_vote_id = this.props.params.we_vote_id;
-    this.setState({ candidate: BallotStore.getCandidateByWeVoteId(we_vote_id) });
+    this.setState({ candidate: BallotStore.getCandidateByWeVoteId(this.props.params.we_vote_id) });
   }
 
   render() {
-    var candidate = BallotStore.getCandidateByWeVoteId(`${this.props.params.we_vote_id}`);
-    if (!candidate){return (<div></div>);}
-    // var candidate = this.state.candidate;
-    console.log("Candidate Object:");
-    console.log(candidate);
-    var position_list = candidate ? candidate.position_list : undefined;
+    // if (Object.keys(this.state.candidate).length === 0){
+    //   this.props.history.replace('/ballot');
+    // };
+    var candidate = this.state.candidate;
+    var we_vote_id = this.props.params.we_vote_id;
+    if (!candidate.we_vote_id){
+      return ( <div></div> );
+    };
 
-    if (Object.keys(candidate).length === 0){
-      this.props.history.replace('/ballot');}
+    // if (Object.keys(candidate).length === 0){
+    //   this.props.history.replace('/ballot');}
 
     var support_item;
     if (this.props.support_on) {
@@ -134,14 +120,7 @@ export default class Candidate extends Component {
             </li>
         </ul>
 
-        <ul className="list-group">
-          { (position_list) ? position_list.map( item =>
-                <OrganizationItem key={item.id}
-                                  candidate_we_vote_id={candidate.we_vote_id}
-                                  {...item} />
-            ) : (<div></div>)
-          }
-        </ul>
+        <PositionList we_vote_id={we_vote_id} />
       </div>
 
     </div>

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -5,26 +5,50 @@ import { Link } from 'react-router';
 import BallotActions from '../../actions/BallotActions';
 import BallotStore from '../../stores/BallotStore';
 import CandidateDetail from '../../components/Ballot/CandidateDetail';
+import OrganizationItem from '../../components/Ballot/OrganizationItem';
 import ItemActionbar from '../../components/ItemActionbar';
 import ItemActionBar2 from '../../components/ItemActionBar2';
 import StarAction from '../../components/StarAction';
 
 export default class Candidate extends Component {
   static propTypes = {
-    //history: PropTypes.func.isRequired,
-    params: PropTypes.object.isRequired,
+    params: PropTypes.object.isRequired
   };
 
   constructor(props) {
     super(props);
+    this.state = { candidate: BallotStore.getCandidateByWeVoteId(this.props.params.we_vote_id) };
+  }
+    // no candidate exists... go to ballot
+  componentDidMount(){
+    if (Object.keys(this.state.candidate).length === 0){
+      this.props.history.replace('/ballot');
+    }
+    console.log('Candidate Component Mounted!')
+    BallotActions.downloadOrganizations(this.props.params.we_vote_id);
+    BallotStore.addChangeListener(this._onChange.bind(this));
+  }
+
+  componentWillUnmount(){
+    BallotStore.removeChangeListener(this._onChange.bind(this));
+  }
+
+  _onChange(){
+    console.log('onChange!');
+    var we_vote_id = this.props.params.we_vote_id;
+    this.setState({ candidate: BallotStore.getCandidateByWeVoteId(we_vote_id) });
   }
 
   render() {
     var candidate = BallotStore.getCandidateByWeVoteId(`${this.props.params.we_vote_id}`);
+    if (!candidate){return (<div></div>);}
+    // var candidate = this.state.candidate;
+    console.log("Candidate Object:");
+    console.log(candidate);
+    var position_list = candidate ? candidate.position_list : undefined;
 
-    // no candidate exists... go to ballot
-    if (Object.keys(candidate).length === 0)
-      this.props.history.replace('/ballot');
+    if (Object.keys(candidate).length === 0){
+      this.props.history.replace('/ballot');}
 
     var support_item;
     if (this.props.support_on) {
@@ -41,113 +65,87 @@ export default class Candidate extends Component {
     }
 
     return (
-      <div className='candidate-detail-route'>
-        {/*
-        <header className="row">
-          <div className="col-xs-6 col-md-6 text-center">
-            <Link to='/ballot'>
-              &lt; Back to My Ballot
+    <div className='candidate-detail-route'>
+      {/*
+      <header className="row">
+        <div className="col-xs-6 col-md-6 text-center">
+          <Link to='/ballot'>
+            &lt; Back to My Ballot
+          </Link>
+        </div>
+        <div className="col-xs-6 col-md-6 text-center">
+          <i className="icon-icon-more-opinions-2-2 icon-light icon-medium">
+          </i>
+          <Link
+            to="/ballot/opinions"
+            className="font-darkest fluff-left-narrow">
+              More Opinions
+          </Link>
+        </div>
+      </header>
+      */}
+
+      <StarAction
+        we_vote_id={candidate.we_vote_id}
+        is_starred={candidate.is_starred} />
+      <div className="row" style={{ paddingBottom: '10px' }}>
+        <div
+          className="col-xs-4"
+          style={candidate.candidate_photo_url ? {} : {height:'95px'}}>
+
+          {
+            candidate.candidate_photo_url ?
+              <img
+                className="img-circle"
+                style={{display:'block', paddingTop: '10px', width:'100px'}}
+                src={candidate.candidate_photo_url}
+                alt="candidate-photo"/> :
+            <i className="icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light"/>
+          }
+        </div>
+        <div className="col-xs-8">
+          <h4 className="bufferNone">
+            <Link className="linkLight"
+                  to={"/candidate/" + candidate.we_vote_id }
+                  onlyActiveOnIndex={false}>
+                    { candidate.ballot_item_display_name }
             </Link>
-          </div>
-          <div className="col-xs-6 col-md-6 text-center">
-            <i className="icon-icon-more-opinions-2-2 icon-light icon-medium">
-            </i>
-            <Link
-              to="/ballot/opinions"
-              className="font-darkest fluff-left-narrow">
-                More Opinions
-            </Link>
-          </div>
-        </header>
-        */}
-
-        <StarAction
-          we_vote_id={candidate.we_vote_id}
-          is_starred={candidate.is_starred} />
-        <div className="row" style={{ paddingBottom: '10px' }}>
-          <div
-            className="col-xs-4"
-            style={candidate.candidate_photo_url ? {} : {height:'95px'}}>
-
-            {
-              candidate.candidate_photo_url ?
-
-                <img
-                  className="img-circle"
-                  style={{display:'block', paddingTop: '10px', width:'100px'}}
-                  src={candidate.candidate_photo_url}
-                  alt="candidate-photo"/> :
-
-              <i className="icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light"/>
-
-            }
-          </div>
-          <div className="col-xs-8">
-            <h4 className="bufferNone">
-              <Link className="linkLight"
-                    to={"/candidate/" + candidate.we_vote_id }
-                    onlyActiveOnIndex={false}>
-                      { candidate.ballot_item_display_name }
-              </Link>
-            </h4>
-            <div>
-                {/* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur posuere vulputate massa ut efficitur.
-                Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)<br />
-                Courtesy of Ballotpedia.org */}
-            </div>
-          </div>
-          <div className="col-xs-8">
-            <div>{ candidate.office_display_name }</div>
-            <ItemActionBar2 we_vote_id={candidate.we_vote_id}
-                           is_support={candidate.is_support} is_oppose={candidate.is_oppose}
-                           supportCount={candidate.supportCount} opposeCount={candidate.opposeCount} />
+          </h4>
+          <div>
+              {/* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur posuere vulputate massa ut efficitur.
+              Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)<br />
+              Courtesy of Ballotpedia.org */}
           </div>
         </div>
-        <div className="container-fluid well well-90">
-          <ul className="list-group">
-              <li className="list-group-item">
-                  <div>
-                      <input type="text" name="address" className="form-control" defaultValue="What do you think?" />
-                      <Link to="ballot_candidate" params={{id: 2}}><Button bsSize="small">Post Privately</Button></Link>
-                  </div>
-              </li>
-          </ul>
-          <ul className="list-group">
-            <li className="list-group-item">
-                <div className="row">
-                  <div className="pull-left col-xs-2 col-md-4">
-                      <Link to="ballot_candidate_one_org_position" params={{id: 2, org_id: 27}}>
-                        <i className={"icon-icon-org-placeholder-6-2 icon-light"}></i>
-                      </Link>
-                  </div>
-                  <div className="pull-right col-xs-10  col-md-8">
-                      <h4 className="">
-                          <Link className="" to="ballot_candidate_one_org_position" params={{id: 2, org_id: 27}}>
-                              Organization Name<br />{/* TODO icon-org-placeholder */}
-                          </Link>
-                      </h4>
-                      <p className="">supports <span className="small">Yesterday at 7:18 PM</span></p>
-                  </div>
-                </div>
-                <div className="row">
-                    Integer ut bibendum ex. Suspendisse eleifend mi accumsan, euismod enim at, malesuada nibh.
-                    Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)
-                </div>
-                <br />
-                23 Likes<br />
-            </li>
-            <li className="list-group-item">
-                <span className="glyphicon glyphicon-small glyphicon-tower"></span>&nbsp;Another Organization<br />{/* TODO icon-org-placeholder */}
-                <span>opposes</span> <span>Yesterday at 2:34 PM</span><br />
-                Integer ut bibendum ex. Suspendisse eleifend mi accumsan, euismod enim at, malesuada nibh.
-                Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)<br />
-                5 Likes<br />
-            </li>
-          </ul>
+        <div className="col-xs-8">
+          <div>{ candidate.office_display_name }</div>
+          <ItemActionBar2 we_vote_id={candidate.we_vote_id}
+                         is_support={candidate.is_support} is_oppose={candidate.is_oppose}
+                         supportCount={candidate.supportCount} opposeCount={candidate.opposeCount} />
         </div>
-
       </div>
-    );
+      <div className="container-fluid well well-90">
+        <ul className="list-group">
+            <li className="list-group-item">
+                <div>
+                    <input type="text" name="address" className="form-control" defaultValue="What do you think?" />
+                    <Link to="ballot_candidate" params={{id: 2}}><Button bsSize="small">Post Privately</Button></Link>
+                </div>
+            </li>
+        </ul>
+
+        <ul className="list-group">
+          { (position_list) ? position_list.map( item =>
+                <OrganizationItem key={item.id}
+                                  candidate_we_vote_id={candidate.we_vote_id}
+                                  {...item} />
+            ) : (<div></div>)
+          }
+        </ul>
+      </div>
+
+    </div>
+  );
 
   }
 }

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -225,6 +225,7 @@ const BallotStore = createStore({
                   BallotAPIWorker
                     .candidatesRetrieve ( we_vote_id )
                       .then( (response) => {
+                      var office_display_name = _ballot_store[response.office_we_vote_id]['ballot_item_display_name'];
                       var cand_list = _ballot_store [
                         response.office_we_vote_id
                       ] . candidate_list = [];
@@ -235,6 +236,7 @@ const BallotStore = createStore({
                             var { we_vote_id: candidate_we_vote_id } = candidate;
                             cand_list . push (candidate_we_vote_id);
                             _ballot_store [ candidate_we_vote_id ] = shallowClone( candidate );
+                            _ballot_store [ candidate_we_vote_id ].office_display_name = office_display_name;
 
                             promiseQueue
                               .push (

--- a/src/js/stores/PositionStore.js
+++ b/src/js/stores/PositionStore.js
@@ -60,7 +60,7 @@ getLocalPositionByWeVoteId: function(we_vote_id){
 });
 
 function setLocalPosition(we_vote_id, position) {
-  _ballot_store[we_vote_id] = position;
+  _position_store[we_vote_id] = position;
   return true;
 }
 
@@ -69,13 +69,12 @@ AppDispatcher.register( action => {
     switch (action.actionType) {
 
     case PositionConstants.POSITION_RETRIEVED:
-    console.log("Action Payload:");
-    console.log(action.payload);
       setLocalPosition(action.we_vote_id, action.payload )
       && PositionStore.emitChange();
     break;
 
   }
+
 });
 
 export default PositionStore;

--- a/src/js/stores/PositionStore.js
+++ b/src/js/stores/PositionStore.js
@@ -1,0 +1,81 @@
+import service from '../utils/service';
+import { createStore } from '../utils/createStore';
+import { shallowClone } from '../utils/object-utils';
+
+const AppDispatcher = require('../dispatcher/AppDispatcher');
+const PositionConstants = require('../constants/PositionConstants');
+const PositionActions = require('../actions/PositionActions');
+
+var _position_store = {}; // All positions that have been fetched (by we_vote_ids)
+
+function printErr (err) {
+  console.error(err);
+}
+
+const POSITION_CHANGE_EVENT = 'POSITION_CHANGE_EVENT';
+
+const PositionAPIWorker = {
+
+  positionRetrieve: function (we_vote_id, success) {
+    return service.get({
+      endpoint: 'positionRetrieve',
+      query: {
+         position_we_vote_id: we_vote_id,
+      },
+      success
+    });
+  }
+
+};
+
+const PositionStore = createStore({
+
+  emitChange: function () {
+    this.emit(POSITION_CHANGE_EVENT);
+  },
+
+  addChangeListener: function(callback) {
+    // console.log("Change listener added");
+    this.on(POSITION_CHANGE_EVENT, callback);
+  },
+
+  removeChangeListener: function(callback) {
+    // console.log("Change listener removed!");
+   this.removeListener(POSITION_CHANGE_EVENT, callback);
+ },
+
+retrievePositionByWeVoteId: function(we_vote_id){
+  PositionAPIWorker.positionRetrieve(we_vote_id,
+    function(res){
+      PositionActions.positionRetrieved(we_vote_id, res);
+      console.log("Response");
+      console.log(res);
+    });
+},
+
+getLocalPositionByWeVoteId: function(we_vote_id){
+  return shallowClone(_position_store[we_vote_id]);
+}
+
+});
+
+function setLocalPosition(we_vote_id, position) {
+  _ballot_store[we_vote_id] = position;
+  return true;
+}
+
+AppDispatcher.register( action => {
+  var { we_vote_id } = action;
+    switch (action.actionType) {
+
+    case PositionConstants.POSITION_RETRIEVED:
+    console.log("Action Payload:");
+    console.log(action.payload);
+      setLocalPosition(action.we_vote_id, action.payload )
+      && PositionStore.emitChange();
+    break;
+
+  }
+});
+
+export default PositionStore;


### PR DESCRIPTION
Connecting data from the API to the candidate detail page. Retrieves the positions list using positionListForBallotItem API. Gets details about each position using positionRetrieve API.

Organization name - displays the 'speaker_label' field under the positionListForBallotItem API, although this often returns "Organization Name TEMP"

Blurb  - displays the 'statement_text' from positionRetrieve API. The API sometimes returns a nice descriptive blurb about the position "Hilary supported organization X for yadda yadda" but sometimes it just returns blank string "".

Opposes/Supports at <Time>- now displays the is_oppose field of positionRetrieve API.

Num Likes - still a static 23.