### PR TITLE
Refresh header on address change

### DIFF
--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -20,11 +20,18 @@ export default class Header extends Component {
   }
 
   componentDidMount () {
+    this._onChange();
+    this.listener = VoterStore.addChangeListener(this._onChange.bind(this));
+  }
+
+  componentWillUnmount (){
+    this.listener.remove();
+  }
+
+  _onChange (){
     VoterStore.getLocation( (err, location) => {
       if (err) console.error(err);
-
       this.setState({ location });
-
     });
   }
 

--- a/src/js/routes/Settings/Location.jsx
+++ b/src/js/routes/Settings/Location.jsx
@@ -1,7 +1,5 @@
 import React, { Component } from "react";
-import { Button, ButtonToolbar } from "react-bootstrap";
-import BallotActions from "../../actions/BallotActions";
-import HeaderBackNavigation from "../../components/Navigation/HeaderBackNavigation";
+import { ButtonToolbar } from "react-bootstrap";
 import VoterStore from "../../stores/VoterStore";
 
 export default class Location extends Component {
@@ -26,16 +24,10 @@ export default class Location extends Component {
     e.preventDefault();
     var { location } = this.state;
     console.log("Saving location", location);
-    VoterStore.saveLocation( location, (res) => {
-      if (res){
-        this.props.history.push('/ballot');
-      } else {
-        BallotActions.init(); // reinitialize ballot in case old ballot items from old addresses are stored.
-        this.props.history.push('/ballot/empty');
-      }
-    }, (err) =>{
-      console.log(err);
-    });
+    VoterStore.saveLocation( location,
+        (res) => { this.props.history.push("/ballot"); },
+        (err) =>{ console.log(err);}
+      );
   }
 
   render () {

--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -170,14 +170,9 @@ const VoterStore = createStore({
       endpoint: "voterAddressSave",
       success: (res) => {
         var { text_for_map_search: savedLocation } = res;
-        cookies.setItem('location', savedLocation);
-
-        if (res.success){ // Successfully saved address and found Google Civic Election ID
-          callback(true, savedLocation);
-        } else if (res.status.indexOf("GOOGLE_CIVIC_API_ERROR") != -1){ // Saved Address but couldn't find election ID
-          console.log("No election for the address");
-          callback(false, savedLocation);
-        }
+        _setLocation(savedLocation);
+        that.emitChange();
+        callback(savedLocation);
       },
       error: (err) => callback(err, null)
     });


### PR DESCRIPTION
The address in the header now updates when you change the address.
This also removes the logic to check for GOOGLE_CIVIC_API_ERROR on voterAddressSave, since the API is no longer returning this.

@pertrai1 