### PR TITLE
Fixing broken image links, bootstrap-map-css warning, address not fou…

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "keymirror": "^0.1.1",
     "moment": "^2.11.2",
     "object-assign": "^4.0.1",
-    "react": "^0.14.3",
+    "react": "^0.14.8",
     "react-addons-css-transition-group": "^0.14.7",
     "react-dom": "^0.14.3",
     "superagent": "^1.5.0",

--- a/src/css/bootstrap.css
+++ b/src/css/bootstrap.css
@@ -7,7 +7,7 @@
 html {
   font-family: sans-serif;
   -webkit-text-size-adjust: 100%;
-      -ms-text-size-adjust: 100%; 
+      -ms-text-size-adjust: 100%;
 }
 body {
   margin: 0;
@@ -6757,4 +6757,4 @@ button.close {
     display: none !important;
   }
 }
-/*# sourceMappingURL=bootstrap.css.map */
+/* sourceMappingURL=bootstrap.css.map */

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -43,6 +43,10 @@ export default class Application extends Component {
     var { voter, location } = this.state;
     var ballotItemWeVoteId = ""; /* TODO Dale: Store the ballot item that is "on stage" in Ballot store? (wv02cand3) */
 
+    if (!voter || !location) {
+      return <div></div>;
+    }
+
     return <div className="app-base">
       <div className="container-fluid">
         <div className="row">

--- a/src/js/components/SearchBox.js
+++ b/src/js/components/SearchBox.js
@@ -1,4 +1,5 @@
 import React, {Component } from "react";
+import ReactDOM from "react-dom";
 import GuideActions from "../actions/GuideActions";
 import VoterStore from "../stores/VoterStore";
 
@@ -10,7 +11,7 @@ export default class SearchBox extends Component {
   }
 
   componentDidMount (){
-    React.findDOMNode(this.refs.search).focus();
+    ReactDOM.findDOMNode(this.refs.search).focus();
   }
 
   componentWillUnmount (){

--- a/src/js/components/SearchBox.js
+++ b/src/js/components/SearchBox.js
@@ -1,6 +1,6 @@
 import React, {Component } from "react";
 import GuideActions from "../actions/GuideActions";
-import BallotStore from "../stores/BallotStore";
+import VoterStore from "../stores/VoterStore";
 
 export default class SearchBox extends Component {
 
@@ -15,7 +15,7 @@ export default class SearchBox extends Component {
 
   componentWillUnmount (){
     //Clear search results when navigating away
-    let id = BallotStore.getGoogleCivicElectionId();
+    let id = VoterStore.election_id();
     GuideActions.retrieveGuidesToFollow(id);
   }
 
@@ -24,7 +24,7 @@ export default class SearchBox extends Component {
     this.setState({ query: query });
     // Search for orgs based on query regardless of whether they have opinions on your ballot (election_id is 0)
     // If you blank out the query string, return normal results for this election
-    let id = query === "" ? BallotStore.getGoogleCivicElectionId() : 0;
+    let id = query === "" ? VoterStore.election_id() : 0;
     GuideActions.retrieveGuidesToFollow(id, query);
   }
 

--- a/src/js/components/VoterGuide/Organization.jsx
+++ b/src/js/components/VoterGuide/Organization.jsx
@@ -18,6 +18,11 @@ export default class Organization extends Component {
 
   constructor (props) {
     super(props);
+    this.state = { error: false };
+  }
+
+  brokenLink (){
+    this.setState({error: true});
   }
 
   render () {
@@ -28,11 +33,15 @@ export default class Organization extends Component {
       followers,
     } = this.props;
 
+    const image = this.state.error ?
+      <i className="icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color"/> :
+      <img src={imageUrl} onError={this.brokenLink.bind(this)} alt={displayName + ".jpg"} />;
+
     const org =
       <div className="row">
         <div className="organization well well-skinny well-bg--light split-top-skinny clearfix">
           <div className="hidden-xs col-sm-2">
-            <img src={imageUrl} alt={displayName + ".jpg"} />
+            {image}
           </div>
           <div className="col-xs-6 col-sm-6 display-name">
             {displayName}

--- a/src/js/routes/Ballot/OpinionsAboutItem.jsx
+++ b/src/js/routes/Ballot/OpinionsAboutItem.jsx
@@ -1,6 +1,7 @@
 import React, {Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
 import { Link } from "react-router";
+import VoterStore from "../../stores/VoterStore";
 import BallotStore from "../../stores/BallotStore";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateStore from "../../stores/CandidateStore";
@@ -24,7 +25,7 @@ export default class OpinionsAboutItem extends Component {
     this.state = { candidate: {}, office: {}, loading: true, error: false };
     this.ballotItemWeVoteId = this.props.params.we_vote_id;
     this.kindOfBallotItem = "CANDIDATE"; /* TODO: Convert from hard coded to dynamic between CANDIDATE and MEASURE */
-    this.electionId = BallotStore.getGoogleCivicElectionId();
+    this.electionId = VoterStore.election_id();
   }
 
   componentDidMount () {

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -1,12 +1,12 @@
 let Dispatcher = require("../dispatcher/Dispatcher");
 let FluxMapStore = require("flux/lib/FluxMapStore");
 import BallotActions from "../actions/BallotActions";
+import VoterStore from "../stores/VoterStore";
 const assign = require("object-assign");
 
 class BallotStore extends FluxMapStore {
   getInitialState () {
     return {
-      _civicId: null,
       ballots: {}
     };
   }
@@ -17,16 +17,12 @@ class BallotStore extends FluxMapStore {
 
   get ballot () {
     console.log(this.getState().ballots);
-    let civicId = this.getGoogleCivicElectionId();
+    let civicId = VoterStore.election_id();
     if (!civicId){
       return undefined;
     } else {
       return this.getState().ballots[civicId];
     }
-  }
-
-  getGoogleCivicElectionId (){
-    return this.getState()._civicId;
   }
 
   reduce (state, action) {
@@ -50,7 +46,6 @@ class BallotStore extends FluxMapStore {
 
         return {
           ...state,
-          _civicId: key,
           ballot_found: action.res.ballot_found,
           ballots: assign({}, state.ballots, newBallot )
         };
@@ -62,7 +57,6 @@ class BallotStore extends FluxMapStore {
 
         return {
           ...state,
-          _civicId: key,
           ballot_found: action.res.ballot_found,
           ballots: assign({}, state.ballots, newBallot )
         };

--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -16,6 +16,10 @@ class VoterStore extends FluxMapStore {
     return this.getState().voter;
   }
 
+  election_id (){
+    return this.getState().address.google_civic_election_id;
+  }
+
   getAddress (){
     return this.getState().address.text_for_map_search;
   }
@@ -52,7 +56,8 @@ class VoterStore extends FluxMapStore {
       case "voterAddressSave":
         return {
           ...state,
-          address: { text_for_map_search: action.res.text_for_map_search}
+          address: { text_for_map_search: action.res.text_for_map_search,
+                    google_civic_election_id: action.res.google_civic_election_id }
         };
 
       case "error-voterRetrieve" || "error-voterAddressRetrieve" || "error-voterAddressSave":


### PR DESCRIPTION
…nd on page reload

-Detects errors on loading opinion images and replaces with placeholder icon if there's a load error
-Gets rid of console warning "Failed to parse SourceMap"
-Fixes issue with reloading an OpinionsAboutCandidate page, where address would not get populated first due to order of civic_id loading.
-Removes use of a deprecated React method (which gets rid of the console warning "Warning: React.findDOMNode is deprecated" in #174 