### PR TITLE
#116 - Reduce vertical display of voter guide boxes

### DIFF
--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -30,11 +30,19 @@ export default class GuideList extends Component {
                       displayName={org.voter_guide_display_name}
                       followers={org.twitter_followers_count}
                       imageUrl={org.voter_guide_image_url} >
-          <button className="btn btn-primary follow"
+          <button className="btn btn-primary btn-sm follow hidden-xs"
                   onClick={this.handleFollow.bind(this, org.organization_we_vote_id)}>
             Follow
           </button>
-          <button className="btn btn-default ignore"
+          <button className="btn btn-primary btn-xs follow visible-xs-block utils-margin_bottom5"
+                  onClick={this.handleFollow.bind(this, org.organization_we_vote_id)}>
+            Follow
+          </button>
+          <button className="btn btn-default btn-sm hidden-xs"
+                  onClick={this.handleIgnore.bind(this, org.organization_we_vote_id)}>
+            Ignore
+          </button>
+          <button className="btn btn-default btn-xs visible-xs-block"
                   onClick={this.handleIgnore.bind(this, org.organization_we_vote_id)}>
             Ignore
           </button>

--- a/src/js/components/VoterGuide/Organization.jsx
+++ b/src/js/components/VoterGuide/Organization.jsx
@@ -38,21 +38,23 @@ export default class Organization extends Component {
     var voter_guide_we_vote_id_link = "/voterguide/" + id;
 
     const image = this.state.error ?
-      <i className="icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color"/> :
-      <img src={imageUrl} onError={this.brokenLink.bind(this)} alt={displayName + ".jpg"} />;
+      <i className="icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color utils-img-contain-glyph" /> :
+      <img className="utils-img-contain" src={imageUrl} onError={this.brokenLink.bind(this)} alt={displayName + ".jpg"} />;
 
     const org =
       <div className="row">
         <div className="organization well well-skinny well-bg--light split-top-skinny clearfix">
-          <Link to={voter_guide_we_vote_id_link}>
-            <div className="hidden-xs col-sm-2">
+          <div className="col-xs-2">
+            <Link to={voter_guide_we_vote_id_link}>
               {image}
-            </div>
-            <div className="col-xs-6 col-sm-6 display-name">
+            </Link>
+          </div>
+          <div className="col-xs-8 col-sm-6 display-name">
+            <Link to={voter_guide_we_vote_id_link}>
               {displayName}
-            </div>
-          </Link>
-          <div className="col-xs-6 col-sm-4 utils-paddingright0"
+            </Link>
+          </div>
+          <div className="col-xs-2 col-sm-4 utils-paddingright0"
                 style={ {textAlign: "right"} }>
               {this.props.children}
           </div>

--- a/src/sass/components/_organization.scss
+++ b/src/sass/components/_organization.scss
@@ -1,4 +1,6 @@
 .organization {
+  margin-bottom: 5px;
+  padding: 10px;
   position: relative;
 
   img {

--- a/src/sass/utils/_app.scss
+++ b/src/sass/utils/_app.scss
@@ -9,6 +9,19 @@
         padding-right: 0 !important;
       }
     }
+    &-margin {
+      &_bottom5 {
+        margin-bottom: 5px;
+      }
+    }
+    &-img {
+      &-contain {
+        max-width: 100%;
+        &-glyph {
+          font-size: 3em !important;
+        }
+      }
+    }
 }
 
 .transparent, .transparent:hover {


### PR DESCRIPTION
The mobile view had issues with the content overlapping, so the following was done:

*Make it so that the logo would get smaller when in mobile view
*Redo the columns so they are inline
*Have the buttons stack and show smaller in mobile view