### PR TITLE
Use multiple apis

### DIFF
--- a/src/js/actions/SupportActions.js
+++ b/src/js/actions/SupportActions.js
@@ -1,17 +1,22 @@
 import Dispatcher from "../dispatcher/Dispatcher";
 
 module.exports = {
-  retrieve: function (we_vote_id, type) {
-    Dispatcher.loadEndpoint("voterPositionRetrieve", {ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type } );
-    Dispatcher.loadEndpoint("positionSupportCountForBallotItem", {ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type});
-    Dispatcher.loadEndpoint("positionOpposeCountForBallotItem", {ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type});
+
+  retrieveAll: function (){
+    Dispatcher.loadEndpoint("voterAllPositionsRetrieve");
+  },
+
+  retrieveAllCounts: function (election_id){
+    Dispatcher.loadEndpoint("positionsCountForAllBallotItems", {google_civic_election_id: election_id});
   },
 
   voterOpposingSave: function (we_vote_id, type) {
+    console.log("opposing save action");
     Dispatcher.loadEndpoint("voterOpposingSave", {ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type});
   },
 
   voterStopOpposingSave: function (we_vote_id, type) {
+        console.log("stop opposing save action");
     Dispatcher.loadEndpoint("voterStopOpposingSave", {ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type});
   },
 

--- a/src/js/components/ItemSupportOppose.jsx
+++ b/src/js/components/ItemSupportOppose.jsx
@@ -15,11 +15,7 @@ export default class ItemSupportOppose extends Component {
 
   componentDidMount () {
     this.listener = SupportStore.addListener(this._onChange.bind(this));
-    if (!SupportStore.isRetrieved(this.props.we_vote_id)){
-      SupportActions.retrieve(this.props.we_vote_id, this.props.type);
-    } else {
-      this.setState({ supportProps: SupportStore.get(this.props.we_vote_id) });
-    }
+    this.setState({ supportProps: SupportStore.get(this.props.we_vote_id) });
   }
 
   componentWillUnmount () {

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from "react";
 import BallotStore from "../../stores/BallotStore";
+import SupportStore from "../../stores/SupportStore";
+import SupportActions from "../../actions/SupportActions";
 import LoadingWheel from "../../components/LoadingWheel";
 import BallotItem from "../../components/Ballot/BallotItem";
 
@@ -13,20 +15,24 @@ export default class Ballot extends Component {
 
   componentDidMount () {
     if (BallotStore.ballot_found === false){ // No ballot found
-      this.props.history.push("settings/location")
+      this.props.history.push("settings/location");
     }
+      SupportActions.retrieveAll();
+      SupportActions.retrieveAllCounts();
+      this.supportToken = SupportStore.addListener(this._onChange.bind(this));
       this.token = BallotStore.addListener(this._onChange.bind(this));
   }
 
   componentWillUnmount (){
     this.token.remove();
+    this.supportToken.remove();
   }
 
   _onChange (){
     if (BallotStore.ballot_found && BallotStore.ballot.length === 0){ // Ballot is found but ballot is empty
       this.props.history.push("ballot/empty");
-    } else if (BallotStore.ballot){
-      this.setState({ ballot: BallotStore.ballot });
+    } else if (BallotStore.ballot && SupportStore.supportList){
+      this.setState({ballot: BallotStore.ballot});
     }
   }
 

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -2,6 +2,7 @@ let Dispatcher = require("../dispatcher/Dispatcher");
 let FluxMapStore = require("flux/lib/FluxMapStore");
 import BallotActions from "../actions/BallotActions";
 import VoterStore from "../stores/VoterStore";
+import SupportStore from "../stores/SupportStore";
 const assign = require("object-assign");
 
 class BallotStore extends FluxMapStore {
@@ -15,8 +16,28 @@ class BallotStore extends FluxMapStore {
     return this.getState().ballot_found;
   }
 
+  get ballot_supported () {
+    let ballot = this.ballot;
+    if (!ballot) { return undefined; }
+
+    return ballot.filter( ballot_item => {
+      let { kind_of_ballot_item, we_vote_id, candidate_list } = ballot_item;
+      if (kind_of_ballot_item === "OFFICE"){ //Offices
+        ballot_item.candidate_list = this.filtered_candidate_list(candidate_list);
+        return ballot_item.candidate_list.length > 0 ? ballot_item : false;
+      } else { //MEASURES
+        return SupportStore.supportList[we_vote_id];
+      }
+    });
+  }
+
+  filtered_candidate_list (list){
+    return list.filter(candidate =>{
+      return SupportStore.supportList[candidate.we_vote_id] ? true : false;
+    });
+  }
+
   get ballot () {
-    console.log(this.getState().ballots);
     let civicId = VoterStore.election_id();
     if (!civicId){
       return undefined;


### PR DESCRIPTION
This gets rid of calling separate API Endpoints for voter_supports, voter_opposes, support_counts, oppose_counts for each item on the ballot (now uses the multiple api endpoint for each).
Refactors the supportStore to handle the new server responses and make it easy to filter a ballot based on support/oppose status.
Adds a filtered_ballot method to ballot_store (almost ready to link up to the 'Items I support').

Note that starStatuses are still retrieved individually for each item.