### PR TITLE
Add support ballot

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "react-mixin": "^1.5.0",
     "react-pikaday": "^0.2.0",
     "react-pure-render": "^1.0.2",
-    "react-router": "^1.0.0",
+    "react-router": "^2.0.0",
     "react-router-bootstrap": "^0.16.0",
     "react-select": "^0.9.1",
     "react-tap-event-plugin": "^0.2.1",

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -102,11 +102,11 @@ export default class Header extends Component {
               </Link>
             </li>
             <li className="list-group-item">
-              <Link onClick={this.hide.bind(this)} to="/ballot">
-                <div>
+            <Link onClick={this.hide.bind(this)} to={{ pathname: "/ballot", query: { filterSupport: true } }}>
+              <div>
                 What I Support
-                </div>
-              </Link>
+              </div>
+            </Link>
             </li>
             <li className="list-group-item">
               <Link onClick={this.hide.bind(this)} to="/ballot">

--- a/src/js/components/MoreMenu.jsx
+++ b/src/js/components/MoreMenu.jsx
@@ -30,7 +30,7 @@ export default class MoreMenu extends Component {
       <ul className="list-group">
         <li className="list-group-item"><Link to="/ballot"><div>My Voter Guide</div></Link></li>
         <li className="list-group-item"><Link to="/more/opinions/followed"><div>Opinions I'm Following</div></Link></li>
-        <li className="list-group-item"><Link to="/ballot"><div>What I Support</div></Link></li>
+        <li className="list-group-item"><Link to={{ pathname: "/ballot", query: { filterSupport: true } }}><div>What I Support</div></Link></li>
         <li className="list-group-item"><Link to="/ballot"><div>What I've Starred</div></Link></li>
         <li className="list-group-item"><Link to="/settings/location"><div>My Address</div></Link></li>
         {this.props.signed_in_personal ?

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,17 +1,13 @@
 import React from "react";
-import Router from "react-router";
-import ReactDOM from "react-dom";
-import { createHistory } from "history";
+import { render } from "react-dom";
+import { browserHistory, Router} from "react-router";
 import routes from "./Root";
 
 // polyfill
 if (!Object.assign) Object.assign = React.__spread;
 
-// wrapping for privacy
-(function () {
-    ReactDOM.render(
-      <Router history={createHistory()}>
-        { routes() }
-      </Router>, document.getElementById("app")
-    );
-}());
+render((
+  <Router history={browserHistory}>
+    { routes() }
+  </Router>
+), document.getElementById("app"));

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, PropTypes } from "react";
 import BallotStore from "../../stores/BallotStore";
 import SupportStore from "../../stores/SupportStore";
 import SupportActions from "../../actions/SupportActions";
@@ -6,11 +6,14 @@ import LoadingWheel from "../../components/LoadingWheel";
 import BallotItem from "../../components/Ballot/BallotItem";
 
 export default class Ballot extends Component {
-  constructor (props) {
+  static propTypes = {
+      history: PropTypes.object,
+      location: PropTypes.object
+  };
+
+  constructor (props){
     super(props);
-    this.state = {
-      ballot: BallotStore.ballot
-    };
+    this.state = {loading: true};
   }
 
   componentDidMount () {
@@ -20,35 +23,33 @@ export default class Ballot extends Component {
       SupportActions.retrieveAll();
       SupportActions.retrieveAllCounts();
       this.supportToken = SupportStore.addListener(this._onChange.bind(this));
-      this.token = BallotStore.addListener(this._onChange.bind(this));
-  }
+    }
 
   componentWillUnmount (){
-    this.token.remove();
     this.supportToken.remove();
   }
 
   _onChange (){
     if (BallotStore.ballot_found && BallotStore.ballot.length === 0){ // Ballot is found but ballot is empty
       this.props.history.push("ballot/empty");
-    } else if (BallotStore.ballot && SupportStore.supportList){
-      this.setState({ballot: BallotStore.ballot});
     }
+    this.setState({loading: false});
   }
 
   render () {
+    let query = this.props.location.query;
+    let ballot = query && query.filterSupport ? BallotStore.ballot_supported : BallotStore.ballot;
 
-    const ballot =
+    return (
       <div className="ballot">
-        { this.state.ballot ?
-          this.state.ballot.map( (item) =>
+        { ballot ?
+          ballot.map( (item) =>
           <BallotItem key={item.we_vote_id} {...item} />
         ) :
         LoadingWheel
         }
-      </div>;
-
-    return ballot;
+      </div>
+    );
   }
 
 }

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -16,27 +16,6 @@ class BallotStore extends FluxMapStore {
     return this.getState().ballot_found;
   }
 
-  get ballot_supported () {
-    let ballot = this.ballot;
-    if (!ballot) { return undefined; }
-
-    return ballot.filter( ballot_item => {
-      let { kind_of_ballot_item, we_vote_id, candidate_list } = ballot_item;
-      if (kind_of_ballot_item === "OFFICE"){ //Offices
-        ballot_item.candidate_list = this.filtered_candidate_list(candidate_list);
-        return ballot_item.candidate_list.length > 0 ? ballot_item : false;
-      } else { //MEASURES
-        return SupportStore.supportList[we_vote_id];
-      }
-    });
-  }
-
-  filtered_candidate_list (list){
-    return list.filter(candidate =>{
-      return SupportStore.supportList[candidate.we_vote_id] ? true : false;
-    });
-  }
-
   get ballot () {
     let civicId = VoterStore.election_id();
     if (!civicId){
@@ -44,6 +23,35 @@ class BallotStore extends FluxMapStore {
     } else {
       return this.getState().ballots[civicId];
     }
+  }
+
+  get ballot_supported () {
+    let ballot = this.ballot;
+    if (!ballot) { return undefined; }
+
+    return this.ballot_filtered_unsupported_candidates().filter( ballot_item => {
+      if (ballot_item.kind_of_ballot_item === "OFFICE"){ //Offices
+        return ballot_item.candidate_list.length > 0;
+      } else { //MEASURES
+        return SupportStore.supportList[ballot_item.we_vote_id];
+      }
+    });
+  }
+
+//Filters the ballot items which are type OFFICE
+  ballot_filtered_unsupported_candidates (){
+    return this.ballot.map( item =>{
+      let is_office = item.kind_of_ballot_item === "OFFICE";
+      return is_office ? this.filtered_ballot_item(item) : item;
+    });
+  }
+
+//Filters out the unsupported candidates from a ballot_item where type is OFFICE
+  filtered_ballot_item (ballot_item){
+    let filtered_list = ballot_item.candidate_list.filter(candidate => {
+      return SupportStore.supportList[candidate.we_vote_id] ? true : false;
+    });
+    return assign({}, ballot_item, {candidate_list: filtered_list });
   }
 
   reduce (state, action) {


### PR DESCRIPTION
-Add a filtered_ballot method to BallotStore which calculates a different version of ballot based on SupportStore values.

-upgrade the react router from 1.0 to current version (2.0, which supports query strings), hence we can let the Ballot route take a query search parameter. Note that it's backwards compatible, but we are using some methods that are out of date by 2.0 standards, hence we'll get a couple console warnings until we can update use of deprecated router methods.

-Links up the Ballot component to the new method.