### PR TITLE
Replace multiple API calls with single starAllStatusRetrieve

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -4,6 +4,7 @@ import MoreMenu from "./components/MoreMenu";
 import Header from "./components/Header";
 import SubHeader from "./components/SubHeader";
 import VoterStore from "./stores/VoterStore";
+import StarActions from "./actions/StarActions";
 import VoterActions from "./actions/VoterActions";
 
 export default class Application extends Component {
@@ -24,6 +25,7 @@ export default class Application extends Component {
   componentDidMount () {
     let voter_device_id = VoterStore.voterDeviceId();
     VoterActions.retrieveVoter(voter_device_id);
+    StarActions.retrieveAll();
     this.token = VoterStore.addListener(this._onChange.bind(this));
   }
 

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -6,6 +6,7 @@ import SubHeader from "./components/SubHeader";
 import VoterStore from "./stores/VoterStore";
 import StarActions from "./actions/StarActions";
 import VoterActions from "./actions/VoterActions";
+import LoadingWheel from "./components/LoadingWheel";
 
 export default class Application extends Component {
   static propTypes = {
@@ -16,10 +17,7 @@ export default class Application extends Component {
 
   constructor (props) {
     super(props);
-
-    this.state = {
-      voter: { }
-    };
+    this.state = {};
   }
 
   componentDidMount () {
@@ -45,8 +43,8 @@ export default class Application extends Component {
     var { voter, location } = this.state;
     var ballotItemWeVoteId = ""; /* TODO Dale: Store the ballot item that is "on stage" in Ballot store? (wv02cand3) */
 
-    if (!voter || !location) {
-      return <div></div>;
+    if (voter === undefined || location === undefined ) {
+      return LoadingWheel;
     }
 
     return <div className="app-base">

--- a/src/js/actions/StarActions.js
+++ b/src/js/actions/StarActions.js
@@ -1,8 +1,9 @@
 import Dispatcher from "../dispatcher/Dispatcher";
 
 module.exports = {
-  retrieve: function (we_vote_id, type) {
-    Dispatcher.loadEndpoint("voterStarStatusRetrieve", { ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type });
+
+  retrieveAll: function (){
+    Dispatcher.loadEndpoint("voterAllStarsStatusRetrieve");
   },
 
   voterStarOnSave: function (we_vote_id, type) {

--- a/src/js/actions/SupportActions.js
+++ b/src/js/actions/SupportActions.js
@@ -11,12 +11,10 @@ module.exports = {
   },
 
   voterOpposingSave: function (we_vote_id, type) {
-    console.log("opposing save action");
     Dispatcher.loadEndpoint("voterOpposingSave", {ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type});
   },
 
   voterStopOpposingSave: function (we_vote_id, type) {
-        console.log("stop opposing save action");
     Dispatcher.loadEndpoint("voterStopOpposingSave", {ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: type});
   },
 

--- a/src/js/components/StarAction.jsx
+++ b/src/js/components/StarAction.jsx
@@ -21,20 +21,11 @@ export default class StarAction extends Component {
 
   componentDidMount (){
     this.token = StarStore.addListener(this._onChange.bind(this));
-    var is_starred = StarStore.get(this.props.we_vote_id);
-    if (is_starred === undefined){
-      StarActions.retrieve(this.props.we_vote_id, this.props.type);
-    } else {
-      this.setState({is_starred: is_starred});
-    }
+    this._onChange();
   }
 
   _onChange (){
-    var is_starred = StarStore.get(this.props.we_vote_id);
-
-    if (is_starred !== undefined){
-      this.setState({ is_starred: is_starred });
-    }
+    this.setState({ is_starred: StarStore.get(this.props.we_vote_id) || false});
   }
 
   starClick () {
@@ -49,7 +40,7 @@ export default class StarAction extends Component {
 
 	render () {
     if (this.state.is_starred === undefined){
-      return <span></span>;
+      return <span className="star-action"></span>;
     }
     return <span className="star-action"
               onClick={this.starClick.bind(this)}

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -27,7 +27,7 @@ class BallotStore extends FluxMapStore {
 
   get ballot_remaining_choices (){
     let ballot = this.ballot;
-    if (!ballot) { return undefined; }
+    if (!ballot || !SupportStore.supportList ) { return undefined; }
 
     return ballot.filter( ballot_item => {
       let {kind_of_ballot_item, we_vote_id, candidate_list } = ballot_item;
@@ -43,7 +43,7 @@ class BallotStore extends FluxMapStore {
 
   get ballot_supported () {
     let ballot = this.ballot;
-    if (!ballot) { return undefined; }
+    if (!ballot || !SupportStore.supportList ) { return undefined; }
 
     return this.ballot_filtered_unsupported_candidates().filter( ballot_item => {
       if (ballot_item.kind_of_ballot_item === "OFFICE"){ //Offices

--- a/src/js/stores/StarStore.js
+++ b/src/js/stores/StarStore.js
@@ -14,8 +14,12 @@ class StarStore extends FluxMapStore {
 
     switch (action.type) {
 
-      case "voterStarStatusRetrieve":
-        return state.set(key, action.res.is_starred);
+      case "voterAllStarsStatusRetrieve":
+        let newState = {};
+        action.res.star_list.forEach(el =>{
+          newState[el.ballot_item_we_vote_id] = el.star_on;
+        });
+        return state.merge(newState);
 
       case "voterStarOnSave":
         return state.set(key, true);


### PR DESCRIPTION
Get rid of all the single voterStarStatusRetrieve API calls and replace with a call to the new endpoint that retrieves them all at once.