### PR TITLE
fix android footer keyboard issue

### DIFF
--- a/src/sass/layout/_mediaquery.scss
+++ b/src/sass/layout/_mediaquery.scss
@@ -106,6 +106,8 @@
     width: 100%;
   }
   .container-main {
+    margin-bottom: -72px;
+    min-height: 100%;
     padding-bottom: 72px;
   }
   .display-name {


### PR DESCRIPTION
This fix is for the footer pushing up
over the container area and not allowing for enough root for a user to
interact with the input search box. This has been tested on Android
Samsung Note

Fix for #176