### PR TITLE
Header icons stay in place in desktop mode

### DIFF
--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
+import HeaderIcons from "./Navigation/HeaderIcons";
 
 export default class Header extends Component {
   static propTypes = {
@@ -61,11 +62,12 @@ export default class Header extends Component {
               </Link>
               <span className="header-version"> demo</span>
             </h4>
-            <aside className="header-address pull-right gutter-right--window gutter-top--small">
+            <div className="header-address pull-right gutter-right--window gutter-top--small">
               <Link to="/settings/location" className="font-lightest">
                 {location}
               </Link>
-            </aside>
+            </div>
+            <HeaderIcons />
           </section>
       {/* The components/MoreMenu code has to be reproduced here for mobile */}
         <div className={(visible ? "visible" : "hidden") + " device-menu--mobile container-fluid well well-90"}>

--- a/src/js/components/Navigation/HeaderIcons.jsx
+++ b/src/js/components/Navigation/HeaderIcons.jsx
@@ -87,7 +87,7 @@ export default class Navigator extends Component {
     const navigator =
       <div className="navigator row">
         <div className="container-fluid">
-          <div className="navbar navbar-default navbar-fixed-bottom">
+          <div className="device-headericons--large">
             <div className="container-fluid fluff-loose--top separate-top">
               <div className="row">
                 {ballot(pathname === "/ballot")}

--- a/src/sass/layout/_mediaquery.scss
+++ b/src/sass/layout/_mediaquery.scss
@@ -48,8 +48,19 @@
     }
 }
 
+@media all and (max-width: 661px) {
+    .device {
+        &-headericons--large {
+            display: none;
+        }
+    }
+}
+
 
 @media all and (min-width : 660px) {
+    .navbar-fixed-bottom {
+        display: none;
+    }
     .device {
         &-menu {
             &--large {
@@ -58,13 +69,14 @@
                 width: 220px;
             }
         }
-        &-footer {
+        &-headericons {
             &--large {
                 background: transparent;
                 border-color: #fff;
                 display: inline-block;
                 height: 45px;
                 left: auto;
+                position: fixed;
                 right: 0;
                 top: 0;
 


### PR DESCRIPTION
When the viewport is in desktop mode, the icons on the
top will stay in place with the header and subheader. When
the viewport is not desktop, they go away and the icons show
at the bottom footer.

NOTE: Still needs cleanup when UI is put in place