### PR TITLE
uglification

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -9,6 +9,7 @@ const source = require("vinyl-source-stream");
 const buffer = require("vinyl-buffer");
 const del = require("del");
 const server = require("./server");
+const closureCompiler = require("gulp-closure-compiler");
 
 const PRODUCTION = process.env.NODE_ENV === "production";
 
@@ -33,9 +34,9 @@ gulp.task("browserify", function () {
     .bundle()
     .on("error", err)
     .pipe(source("bundle.js"))
-    .pipe(gulp.dest("./build/js"))
     .pipe(buffer())
-    .pipe(uglify()) :
+    .pipe(uglify({ preserveComments: false, mangle: false }))
+    .pipe(gulp.dest("./build/js")) :
 
   // development build... no minification
   browserify(ops)

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -1,30 +1,50 @@
 // dependencies
 const gulp = require("gulp");
 const sass = require("gulp-sass");
+const uglify = require("gulp-uglify");
 const browserSync = require("browser-sync").create();
 const browserify = require("browserify");
 const babelify = require("babelify");
 const source = require("vinyl-source-stream");
+const buffer = require("vinyl-buffer");
 const del = require("del");
 const server = require("./server");
 
 const PRODUCTION = process.env.NODE_ENV === "production";
 
 gulp.task("browserify", function () {
-  return browserify({
+  const ops = {
+    debug: !PRODUCTION,
     entries: "js/index.js",
     extensions: [".js", ".jsx"],
     basedir: "./src",
     transform: [babelify]
-  })
-  .bundle()
-  .on("error", function (err) {
-    console.error(err.toString());
+  };
+
+  function err (e){
+    console.error(e.toString());
     this.emit("end");
-  })
-  .pipe(source("bundle.js"))
-  .pipe(gulp.dest("./build/js"))
-  .pipe(browserSync.stream());
+  }
+
+  return PRODUCTION ?
+
+  // production build with minification
+  browserify(ops)
+    .bundle()
+    .on("error", err)
+    .pipe(source("bundle.js"))
+    .pipe(gulp.dest("./build/js"))
+    .pipe(buffer())
+    .pipe(uglify()) :
+
+  // development build... no minification
+  browserify(ops)
+    .bundle()
+    .on("error", err)
+    .pipe(source("bundle.js"))
+    .pipe(gulp.dest("./build/js"))
+    .pipe(browserSync.stream());
+
 });
 
 gulp.task("server", PRODUCTION ? () => server(PRODUCTION) : function () {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:doc": "doctoc --github --title \"## Contents\" ./"
   },
   "dependencies": {
+    "gulp-uglify": "^1.5.3",
     "keymirror": "^0.1.1",
     "moment": "^2.11.2",
     "object-assign": "^4.0.1",
@@ -30,7 +31,8 @@
     "react-addons-css-transition-group": "^0.14.7",
     "react-dom": "^0.14.3",
     "superagent": "^1.5.0",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "vinyl-buffer": "^1.0.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "build:doc": "doctoc --github --title \"## Contents\" ./"
   },
   "dependencies": {
+    "closure-compiler": "^0.2.12",
+    "gulp-closure-compiler": "^0.4.0",
     "gulp-uglify": "^1.5.3",
     "keymirror": "^0.1.1",
     "moment": "^2.11.2",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
     "build:doc": "doctoc --github --title \"## Contents\" ./"
   },
   "dependencies": {
-    "closure-compiler": "^0.2.12",
-    "gulp-closure-compiler": "^0.4.0",
     "gulp-uglify": "^1.5.3",
     "keymirror": "^0.1.1",
     "moment": "^2.11.2",


### PR DESCRIPTION
 adding uglification process to production build, reducing the bundle.js size output by ~%75, ~5.5mb -> ~1.3mb

please make sure npm packages are updated on live server and dev environments before running any npm commands again. To do this, run the command: `npm install` and npm will automatically fetch all packages that haven't been downloaded yet.

please test before pushing to production.

issue #226 