### PR TITLE
Turn Facebook login back on, remove unnecessary ballot caveat box

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -52,7 +52,7 @@ export default class Application extends Component {
       <Headroom>
         <div className="container-fluid">
           <div className="row">
-            <Header location={location}/>
+            <Header location={location} voter={voter}/>
           </div>
         </div>
         <div className="container-fluid">

--- a/src/js/actions/FacebookActionCreators.js
+++ b/src/js/actions/FacebookActionCreators.js
@@ -1,11 +1,20 @@
 const web_app_config = require("../config");
 import FacebookDispatcher from "../dispatcher/FacebookDispatcher";
+import VoterActions from "../actions/VoterActions";
 import FacebookConstants from "../constants/FacebookConstants";
+const cookies = require("../utils/cookies");
 
 const FacebookActionCreators = {
+
+  appLogout: function (){
+    cookies.removeItem("voter_device_id");
+    VoterActions.signOut();
+    VoterActions.retrieveVoter();
+  },
+
     initFacebook: function () {
         window.fbAsyncInit = function () {
-            FB.init({
+            window.FB.init({
               appId: web_app_config.FACEBOOK_APP_ID,
               xfbml: true,
               version: "v2.5"
@@ -60,6 +69,7 @@ const FacebookActionCreators = {
             });
         });
     },
+
     // Dale considering the need for this here
     //connectWithFacebook: () => {
     //    // Add connection between We Vote and Facebook

--- a/src/js/actions/VoterActions.js
+++ b/src/js/actions/VoterActions.js
@@ -2,6 +2,10 @@ import Dispatcher from "../dispatcher/Dispatcher";
 
 module.exports = {
 
+  signOut: function (){
+    Dispatcher.loadEndpoint("voterSignOut", {sign_out_all_devices: true});
+  },
+
   retrieveVoter: function () {
     Dispatcher.loadEndpoint("voterRetrieve");
   },

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -118,11 +118,11 @@ export default class Header extends Component {
           <h4 className="text-left"></h4>
           <ul className="list-group">
             <li className="list-group-item">
-              <div onClick={this.hide.bind(this)} to="/more/about">
+              <Link onClick={this.hide.bind(this)} to="/more/about">
                 <div>
                 About <strong>We Vote</strong>
                 </div>
-              </div>
+              </Link>
             </li>
             { signed_in_personal ?
               <li className="list-group-item">

--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -1,14 +1,12 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
 import HeaderIcons from "./Navigation/HeaderIcons";
+import FacebookActionCreators from "../actions/FacebookActionCreators";
 
 export default class Header extends Component {
   static propTypes = {
-    email: PropTypes.string,
     location: PropTypes.string,
-    first_name: PropTypes.string,
-    voter_photo_url: PropTypes.string,
-    signed_in_personal: PropTypes.bool
+    voter: PropTypes.object
   };
 
   constructor (props) {
@@ -49,7 +47,8 @@ export default class Header extends Component {
   render () {
     var { visible } = this.state;
     let location = this.props.location;
-    var { signed_in_personal: signedIn } = this.props;
+    var { signed_in_personal } = this.props.voter;
+    const logOut = FacebookActionCreators.appLogout;
 
     const header =
       <header className="header row">
@@ -70,23 +69,7 @@ export default class Header extends Component {
             <HeaderIcons />
           </section>
       {/* The components/MoreMenu code has to be reproduced here for mobile */}
-        <div className={(visible ? "visible" : "hidden") + " device-menu--mobile container-fluid well well-90"}>
-          {/* Please keep these styles up-to-date since we need to turn this on soon
-          { signedIn ? <span></span> :
-            <span>
-              <ul className="list-group">
-                <li className="list-group-item">
-                  <Link onClick={this.hide.bind(this)} to="/more/sign_in">
-                    <div>
-                    Sign In
-                    </div>
-                  </Link>
-                </li>
-              </ul>
-              <h4 className="text-left"></h4>
-            </span>
-          }
-          */}
+        <div className={(visible ? "visible" : "hidden") + " device-menu--mobile container-fluid well well-90"}>}
           <ul className="list-group">
             <li className="list-group-item">
               <Link onClick={this.hide.bind(this)} to="/ballot">
@@ -123,33 +106,31 @@ export default class Header extends Component {
                 </div>
               </Link>
             </li>
-            { signedIn ?
                 <li className="list-group-item">
                   <Link onClick={this.hide.bind(this)} to="/more/sign_in">
                     <div>
-                    Account Settings
+                    {signed_in_personal ? "Account Settings" : "Sign In"}
                     </div>
                   </Link>
                 </li> :
                 <span></span>
-            }
           </ul>
           <h4 className="text-left"></h4>
           <ul className="list-group">
             <li className="list-group-item">
-              <Link onClick={this.hide.bind(this)} to="/more/about">
+              <div onClick={this.hide.bind(this)} to="/more/about">
                 <div>
                 About <strong>We Vote</strong>
                 </div>
-              </Link>
+              </div>
             </li>
-            { signedIn ?
+            { signed_in_personal ?
               <li className="list-group-item">
-                <Link onClick={this.hide.bind(this)} to="/signout">
-                  <div>
+                <div onClick={logOut}>
+                  <a>
                   Sign Out
-                  </div>
-                </Link>
+                  </a>
+                </div>
               </li> : <span></span> }
           </ul>
         </div>

--- a/src/js/components/MoreMenu.jsx
+++ b/src/js/components/MoreMenu.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes, Component } from "react";
 import { Link } from "react-router";
+import FacebookActionCreators from "../actions/FacebookActionCreators";
 
 export default class MoreMenu extends Component {
   static propTypes = {
@@ -19,6 +20,7 @@ export default class MoreMenu extends Component {
   }
 
   render () {
+    const logOut = FacebookActionCreators.appLogout;
 
   return <div>
     <div className="device-menu--large container-fluid well well-90">
@@ -40,14 +42,15 @@ export default class MoreMenu extends Component {
         {this.menuLink("/ballot?type=filterRemaining", "Choices Remaining")}
         {this.menuLink("/settings/location", "My Address")}
         {this.props.signed_in_personal ?
-          <li className="list-group-item"><Link to="/more/sign_in"><div>Account Settings</div></Link></li> : <span></span>
+          this.menuLink("/more/sign_in", "Account Settings") :
+          this.menuLink("/more/sign_in", "Sign In")
         }
       </ul>
       <h4 className="text-left"></h4>
       <ul className="list-group">
       {this.menuLink("/more/about", "About We Vote")}
         {this.props.signed_in_personal ?
-          <li className="list-group-item"><Link to="/signout">Sign Out</Link></li> :
+          <li onClick={logOut} className="list-group-item"><a>Sign Out</a></li> :
           <span></span>
         }
       </ul>

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -137,10 +137,13 @@ export default class Ballot extends Component {
 
     return <div className="ballot">
       <h4 className="text-center">{this.getTitle()}</h4>
+      {ballot_caveat !== "" ?
         <div className="alert alert-info alert-dismissible" role="alert">
           <button type="button" className="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
           {ballot_caveat}
-        </div>
+        </div> :
+        <div></div>
+      }
         {emptyBallot}
         {ballotItems}
       </div>;

--- a/src/js/routes/More/SignIn.jsx
+++ b/src/js/routes/More/SignIn.jsx
@@ -1,63 +1,37 @@
-import React, { Component, PropTypes } from "react";
-// import { Link } from "react-router";
+import React, { Component } from "react";
 import FacebookActionCreators from "../../actions/FacebookActionCreators";
 import FacebookStore from "../../stores/FacebookStore";
-import FacebookDisconnect from "../../components/Facebook/FacebookDisconnect";
 import FacebookSignIn from "../../components/Facebook/FacebookSignIn";
 import Main from "../../components/Facebook/Main";
+import LoadingWheel from "../../components/LoadingWheel";
 import VoterStore from "../../stores/VoterStore";
 
 export default class SignIn extends Component {
-  static propTypes = {
-    children: PropTypes.object
-  };
 
   constructor (props) {
-	super(props);
-
-    this.state = {
-        voter: {
-        }
-    };
+    super(props);
+    this.state = {};
   }
 
   componentDidMount () {
-    this.setState(this.getFacebookState());
-    //console.log("SignIn, About to initialize VoterStore");
-    VoterStore.getLocation( (err) => {
-      if (err) console.error("FacebookStore.js, Error initializing voter object", err);
-
-      VoterStore.getVoterObject( (_err, voter) => {
-        if (_err) console.error("FacebookStore.js, Error initializing voter object", err);
-
-        this.setState({voter});
-        // console.log("SignIn: ", voter, "voter is your object")
-      });
-    });
-
+    this._onVoterStoreChange();
     FacebookActionCreators.initFacebook();
     this.changeListener = this._onFacebookChange.bind(this);
     FacebookStore.addChangeListener(this.changeListener);
-    this.voterListener = this._onVoterStoreChange.bind(this);
-    // console.log("SignIn componentDidMount VoterStore.addChangeListener");
-    VoterStore.addChangeListener(this.voterListener);
+    this.listener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
   }
 
   componentWillUnmount () {
+    this.listener.remove();
     FacebookStore.removeChangeListener(this.changeListener);
-
-    // console.log("SignIn componentWillUnmount VoterStore.removeChangeListener");
-    VoterStore.removeChangeListener(this.voterListener);
   }
 
   _onVoterStoreChange () {
-    this.setState({
-      voter: VoterStore.getCachedVoterObject()
-    });
+    this.setState({ voter: VoterStore.voter() });
   }
 
   _onFacebookChange () {
-    this.setState(this.getFacebookState());
+    this.setState({ fb_state: this.getFacebookState() });
   }
 
   getFacebookState () {
@@ -70,18 +44,21 @@ export default class SignIn extends Component {
     };
   }
 
-  static getProps () {
-	return {};
-  }
-
   render () {
-    var { voter } = this.state;
+    console.log(this.state);
+    var { voter} = this.state;
+    if (!voter){
+      return LoadingWheel;
+    }
 
     return <div className="">
       <div className="container-fluid well gutter-top--small fluff-full1">
         <h3 className="text-center">{voter.signed_in_personal ? <span>My Account</span> : <span>Sign In</span>}</h3>
         <div className="text-center">
-          {voter.signed_in_facebook ? <span></span> : <FacebookSignIn />}
+          {voter.signed_in_facebook ?
+            <span><a className="btn btn-social btn-lg btn-facebook" onClick={FacebookActionCreators.appLogout}>
+            <i className="fa fa-facebook"></i>Sign Out</a></span> : <FacebookSignIn />
+          }
           {/*
           <div>
             <Link to="add_friends_confirmed" className="btn btn-social btn-lg btn-twitter">
@@ -97,9 +74,12 @@ export default class SignIn extends Component {
         </div>
         <br />
         <br />
+        {/*
         <div className="text-center">
           {voter.signed_in_facebook ? <FacebookDisconnect /> : null}
         </div>
+        */}
+
         {/* FOR DEBUGGING */}
         <div className="text-center">
           signed_in_personal: {voter.signed_in_personal ? <span>True</span> : null}<br />

--- a/src/js/stores/FacebookStore.js
+++ b/src/js/stores/FacebookStore.js
@@ -2,6 +2,7 @@ import { $ajax } from "../utils/service";
 import FacebookConstants from "../constants/FacebookConstants";
 import FacebookDispatcher from "../dispatcher/FacebookDispatcher";
 import VoterStore from "../stores/VoterStore";
+import VoterActions from "../actions/VoterActions";
 import {EventEmitter} from "events";
 import service from "../utils/service";
 
@@ -144,18 +145,7 @@ class FacebookStore extends EventEmitter {
             // console.log("Call to FacebookAPIWorker.facebookSignIn has completed");
             this.emit(FACEBOOK_CHANGE_EVENT);
             // Once we have connected to Facebook, grab a fresh version of the voter
-            VoterStore.getLocation( (err) => {
-              if (err) handleVoterError(err);
-              VoterStore.retrieveFreshVoterObject( (_err, voter_object) => {
-                if (_err) {
-                  handleVoterError(_err);
-                } else {
-                  // console.log("facebookStore.connectWithFacebook, voter: ", voter_object);
-                  // Finally, update all components listening for changes in Voter Store
-                  VoterStore.emitChange();
-                }
-              });
-            });
+            VoterActions.retrieveVoter();
           }
         );
       }
@@ -195,13 +185,6 @@ class FacebookStore extends EventEmitter {
     removeChangeListener (callback) {
         this.removeListener(FACEBOOK_CHANGE_EVENT, callback);
     }
-}
-
-function sleep (milliseconds) {
-  var start = new Date().getTime();
-  for (var i = 0; i < 1e7; i++) {
-    if (new Date().getTime() - start > milliseconds) break;
-  }
 }
 
 function handleVoterError (err) {


### PR DESCRIPTION
This doesn't remove the FB.login() error (which was a bug already present) but other than that it makes Facebook login working (as before), and adds an app signout function which deletes the cookies and calls the new voterSignOut endpoint.
@DaleMcGrew 