### PR TITLE
Added support/oppose and rating data to the voter-guides-to-follow on candidate page

### DIFF
--- a/src/js/components/SubHeader.jsx
+++ b/src/js/components/SubHeader.jsx
@@ -11,19 +11,7 @@ export default class SubHeader extends Component {
   }
 
   render () {
-    var { props: { pathname, ballotItemWeVoteId } } = this;
-    /* Switch between A) a link (moreOpinionsLink) to a list of opinions about any item on the ballot, or
-     * B) a link to a list of opinions just about one ballot item. */
-    var moreOpinionsLink;
-    function getStringAfterSlash (str) {
-      return str.split("/")[2];
-    }
-    ballotItemWeVoteId = getStringAfterSlash(pathname); /* figure out ballotItemWeVoteId here until we can pass it in */
-    if (pathname === "/candidate/" + ballotItemWeVoteId) {
-      moreOpinionsLink = "/opinions/" + ballotItemWeVoteId;
-    } else {
-      moreOpinionsLink = "/opinions";
-    }
+    var moreOpinionsLink = "/opinions";
     return <section className="container-fluid ballotList-bg fluff-tight--full separate-bottom">
           <div className="row">
             <Link

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -24,13 +24,9 @@ export default class GuideList extends Component {
 
     let orgs = this.props.organizations.map( (org) => {
 
-      const organization =
-        <Organization id={org.organization_we_vote_id}
-                      key={org.organization_we_vote_id}
-                      displayName={org.voter_guide_display_name}
-                      twitterDescription={org.twitter_description}
-                      followers={org.twitter_followers_count}
-                      imageUrl={org.voter_guide_image_url} >
+    return <Organization key={org.organization_we_vote_id}
+                      {...org}
+            >
           <button className="btn btn-primary btn-sm follow"
                   onClick={this.handleFollow.bind(this, org.organization_we_vote_id)}>
             Follow
@@ -40,19 +36,13 @@ export default class GuideList extends Component {
             Ignore
           </button>
         </Organization>;
-
-      return organization;
-
     });
 
-    const guideList =
-      <div className="guidelist">
+    return <div className="guidelist">
         <ReactCSSTransitionGroup transitionName="org-ignore" transitionEnterTimeout={400} transitionLeaveTimeout={200}>
           {orgs}
         </ReactCSSTransitionGroup>
       </div>;
-
-    return guideList;
   }
 
 }

--- a/src/js/components/VoterGuide/Organization.jsx
+++ b/src/js/components/VoterGuide/Organization.jsx
@@ -5,58 +5,67 @@ import { numberWithCommas, removeTwitterNameFromDescription } from "../../utils/
 
 export default class Organization extends Component {
   static propTypes = {
-    id: PropTypes.string,
     key: PropTypes.string,
-    imageUrl: PropTypes.string,
-    displayName: PropTypes.string,
-    twitterDescription: PropTypes.string,
-    followers: PropTypes.number,
-    children: PropTypes.array
+    organization_we_vote_id: PropTypes.string,
+    voter_guide_image_url: PropTypes.string,
+    voter_guide_display_name: PropTypes.string,
+    twitter_description: PropTypes.string,
+    twitter_followers_count: PropTypes.number,
+    children: PropTypes.array,
+    is_support: PropTypes.bool,
+    is_positive_rating: PropTypes.bool,
+    is_oppose: PropTypes.bool,
+    is_negative_rating: PropTypes.bool,
+    vote_smart_rating: PropTypes.string
   };
 
   render () {
 
     const {
-      followers,
-      id,
-      imageUrl,
+      twitter_followers_count,
+      organization_we_vote_id,
+      voter_guide_image_url,
+      is_support,
+      is_positive_rating,
+      is_oppose,
+      is_negative_rating,
+      vote_smart_rating,
     } = this.props;
 
-    let displayName = this.props.displayName ? this.props.displayName : "";
-    let twitterDescription = this.props.twitterDescription ? this.props.twitterDescription : "";
-    // If the displayName is in the twitterDescription, remove it from twitterDescription
-    let twitterDescriptionMinusName = removeTwitterNameFromDescription(displayName, twitterDescription);
+    let voter_guide_display_name = this.props.voter_guide_display_name ? this.props.voter_guide_display_name : "";
+    let twitterDescription = this.props.twitter_description ? this.props.twitter_description : "";
+    // If the voter_guide_display_name is in the twitter_description, remove it
+    let twitterDescriptionMinusName = removeTwitterNameFromDescription(voter_guide_display_name, twitterDescription);
 
-    var voter_guide_we_vote_id_link = "/voterguide/" + id;
+    var voter_guide_we_vote_id_link = "/voterguide/" + organization_we_vote_id;
 
-    const org =
-      <div className="organization-item">
+    return <div className="organization-item">
         <div className="organization-item__avatar">
           <Link to={voter_guide_we_vote_id_link}>
-            <Image imageUrl={imageUrl} />
+            <Image imageUrl={voter_guide_image_url} />
           </Link>
         </div>
         <div className="organization-item__content">
           <div className="position-item__summary">
             <Link to={voter_guide_we_vote_id_link}>
-              <h4 className="organization-item__display-name">{displayName}</h4>
+              <h4 className="organization-item__display-name">{voter_guide_display_name}</h4>
             </Link>
             { twitterDescriptionMinusName ? <p>{twitterDescriptionMinusName}</p> :
               null}
-            </div>
+
+          </div>
           <div className="organization-item__additional">
             <div className="organization-item__follow-buttons">
               {this.props.children}
             </div>
-            {followers ?
+            {twitter_followers_count ?
               <span className="twitter-followers__badge">
                 <span className="fa fa-twitter twitter-followers__icon"></span>
-                {numberWithCommas(followers)}
+                {numberWithCommas(twitter_followers_count)}
               </span> :
               null}
           </div>
         </div>
       </div>;
-    return org;
   }
 }

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -49,8 +49,8 @@ export default class OrganizationPositionItem extends Component {
                 <span> {this.props.candidate_display_name}</span>
               </div>
             </div>);
-          } else if (vote_smart_rating) { */}
-          <PositionRatingSnippet rating = {vote_smart_rating} />
+          } else if (vote_smart_rating) */}
+          <PositionRatingSnippet rating = {vote_smart_rating} rating_time_span = {vote_smart_time_span} />
 
         </div>
         {/*Running for {office_display_name}
@@ -58,6 +58,6 @@ export default class OrganizationPositionItem extends Component {
           Integer ut bibendum ex. Suspendisse eleifend mi accumsan, euismod enim at, malesuada nibh.
           Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)
         <br />*/}
-      </li>;
+      </ li>;
   }
 }

--- a/src/js/components/VoterGuide/VoterGuideItem.jsx
+++ b/src/js/components/VoterGuide/VoterGuideItem.jsx
@@ -16,7 +16,7 @@ export default class VoterGuideItem extends Component {
     twitter_followers_count: PropTypes.number,
     last_updated: PropTypes.string,
     OrganizationFollowed: PropTypes.string,
-    OrganizationIgnored: PropTypes.string
+    OrganizationIgnored: PropTypes.string,
   };
 
   render () {

--- a/src/js/components/Widgets/PositionRatingSnippet.jsx
+++ b/src/js/components/Widgets/PositionRatingSnippet.jsx
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from "react";
 
 export default class PositionRatingSnippet extends Component {
   static propTypes = {
-    rating: PropTypes.number.isRequired,
+    rating: PropTypes.string.isRequired,
     rating_time_span: PropTypes.string.isRequired
   };
 


### PR DESCRIPTION
Added support/oppose and rating data to the voter-guides-to-follow shown on the candidate page. This data still needs be displayed (I did not add the html/css to display the data. Refactored how variables are passed into the Organization component. Removed the (broken) candidate-specific "More Opinions" link. Fixed a couple of other minor glitches.