### PR TITLE
Turning on internal twitter handles for candidates.

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -8,7 +8,6 @@ import SupportStore from "../../stores/SupportStore";
 import {abbreviateNumber} from "../../utils/textFormat";
 import {numberWithCommas} from "../../utils/textFormat";
 
-
 export default class Candidate extends Component {
   static propTypes = {
     ballot_item_display_name: PropTypes.string.isRequired,
@@ -17,6 +16,7 @@ export default class Candidate extends Component {
     we_vote_id: PropTypes.string.isRequired,
     twitter_description: PropTypes.string,
     twitter_followers_count: PropTypes.number,
+    twitter_handle: PropTypes.string,
     office_name: PropTypes.string,
     isListItem: PropTypes.bool
   };
@@ -48,9 +48,13 @@ export default class Candidate extends Component {
       twitter_description,
       twitter_followers_count,
       office_name,
+      twitter_handle,
     } = this.props;
+
     const { supportProps, transitioning } = this.state;
-    const url = "/candidate/" + we_vote_id;
+
+    // TODO TwitterHandle
+    let candidateLink = twitter_handle ? "/" + twitter_handle : "/candidate/" + we_vote_id;
 
     return <div className="candidate-card__container">
       <div className="candidate-card">
@@ -80,7 +84,7 @@ export default class Candidate extends Component {
             }
             <h2 className="candidate-card__display-name">
               { this.props.isListItem ?
-                <Link to={url}>{ballot_item_display_name}</Link> :
+                <Link to={candidateLink}>{ballot_item_display_name}</Link> :
                 ballot_item_display_name
               }
             </h2>
@@ -100,7 +104,7 @@ export default class Candidate extends Component {
               <p className="candidate-card__description">
                   {twitter_description} 
                   { this.props.isListItem ?
-                    <Link to={url}>Read more</Link> :
+                    <Link to={candidateLink}>Read more</Link> :
                     null
                   } 
               </p> :

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -5,19 +5,22 @@ const moment = require("moment");
 
 export default class PositionItem extends Component {
   static propTypes = {
-    position_we_vote_id: PropTypes.string.isRequired,
-    last_updated: PropTypes.string,
-    speaker_type: PropTypes.string,
-    speaker_image_url_https: PropTypes.string,
     candidate_display_name: PropTypes.string.isRequired,
-    speaker_display_name: PropTypes.string.isRequired
+    last_updated: PropTypes.string,
+    position_we_vote_id: PropTypes.string.isRequired,
+    speaker_display_name: PropTypes.string.isRequired,
+    speaker_image_url_https: PropTypes.string,
+    speaker_type: PropTypes.string,
+    speaker_twitter_handle: PropTypes.string.isRequired
   };
 
   render () {
     var position = this.props;
     var dateStr = this.props.last_updated;
     var dateText = moment(dateStr).startOf("day").fromNow();
-    var speaker_we_vote_id_link = "/voterguide/" + position.speaker_we_vote_id;
+    // TODO TwitterHandle - We aren't supporting internal organization links with Twitter handles yet
+    // var speakerLink = position.speaker_twitter_handle ? "/" + position.speaker_twitter_handle : "/voterguide/" + position.speaker_we_vote_id;
+    var speakerLink = "/voterguide/" + position.speaker_we_vote_id;
 
     let image_placeholder = "";
     if (this.props.speaker_type === "O") {
@@ -66,7 +69,7 @@ export default class PositionItem extends Component {
           image_placeholder }
         <div className="position-item__content">
           <h4 className="position-item__display-name">
-            <Link to={speaker_we_vote_id_link}>
+            <Link to={speakerLink}>
               { this.props.speaker_display_name }
             </Link>
           </h4>

--- a/src/js/components/VoterGuide/Organization.jsx
+++ b/src/js/components/VoterGuide/Organization.jsx
@@ -11,6 +11,7 @@ export default class Organization extends Component {
     voter_guide_display_name: PropTypes.string,
     twitter_description: PropTypes.string,
     twitter_followers_count: PropTypes.number,
+    twitter_handle: PropTypes.string,
     children: PropTypes.array,
     is_support: PropTypes.bool,
     is_positive_rating: PropTypes.bool,
@@ -37,17 +38,19 @@ export default class Organization extends Component {
     // If the voter_guide_display_name is in the twitter_description, remove it
     let twitterDescriptionMinusName = removeTwitterNameFromDescription(voter_guide_display_name, twitterDescription);
 
-    var voter_guide_we_vote_id_link = "/voterguide/" + organization_we_vote_id;
+    // TODO TwitterHandle - We aren't supporting internal organization links with Twitter handles yet
+    // var voterGuideLink = this.props.twitter_handle ? "/" + this.props.twitter_handle : "/voterguide/" + organization_we_vote_id;
+    var voterGuideLink = "/voterguide/" + organization_we_vote_id;
 
     return <div className="organization-item">
         <div className="organization-item__avatar">
-          <Link to={voter_guide_we_vote_id_link}>
+          <Link to={voterGuideLink}>
             <Image imageUrl={voter_guide_image_url} />
           </Link>
         </div>
         <div className="organization-item__content">
           <div className="position-item__summary">
-            <Link to={voter_guide_we_vote_id_link}>
+            <Link to={voterGuideLink}>
               <h4 className="organization-item__display-name">{voter_guide_display_name}</h4>
             </Link>
             { twitterDescriptionMinusName ? <p>{twitterDescriptionMinusName}</p> :

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -14,11 +14,16 @@ export default class OrganizationPositionItem extends Component {
       vote_smart_rating,
       vote_smart_time_span,
       ballot_item_we_vote_id,
-      ballot_item_image_url_https } = this.props.position;
+      ballot_item_image_url_https,
+      ballot_item_twitter_handle } = this.props.position;
+
+    // TODO TwitterHandle
+    let candidateLink = ballot_item_twitter_handle ? "/" + ballot_item_twitter_handle : "/candidate/" + ballot_item_we_vote_id;
+    // let candidateLink = "/candidate/" + ballot_item_we_vote_id;
 
     return <li className="position-item">
           <StarAction we_vote_id={ballot_item_we_vote_id} type={kind_of_ballot_item} />
-        <Link to={"/candidate/" + ballot_item_we_vote_id }
+        <Link to={ candidateLink }
               onlyActiveOnIndex={false}>
           {/*<i className="icon-icon-add-friends-2-1 icon-light icon-medium" />*/}
           { ballot_item_image_url_https ?
@@ -30,7 +35,7 @@ export default class OrganizationPositionItem extends Component {
           }
         </Link>
         <div className="position-item__content">
-          <Link to={"/candidate/" + ballot_item_we_vote_id }
+          <Link to={ candidateLink }
                 onlyActiveOnIndex={false}>
             <span className="position-rating__candidate-name">{ballot_item_display_name}</span>
           </Link>

--- a/src/js/components/VoterGuide/VoterGuideItem.jsx
+++ b/src/js/components/VoterGuide/VoterGuideItem.jsx
@@ -30,7 +30,9 @@ export default class VoterGuideItem extends Component {
     if (this.props.twitter_followers_count) {
       twitterFollowers = twitterFollowersCount;
     }
-    var voter_guide_we_vote_id_link = "/voterguide/" + this.props.organization_we_vote_id;
+    // TODO TwitterHandle - We aren't supporting internal organization links with Twitter handles yet
+    // var voterGuideLink = this.props.twitter_handle ? "/" + this.props.twitter_handle : "/voterguide/" + this.props.organization_we_vote_id;
+    var voterGuideLink = "/voterguide/" + this.props.organization_we_vote_id;
 
     /* This was refactored into /src/js/components/VoterGuide/GuideList.jsx for "More Opinions" page.
     * Since the migration of the existing styles was not done with total fidelity, we need to leave this
@@ -38,13 +40,13 @@ export default class VoterGuideItem extends Component {
     * TODO: Complete migration of this functionality */
     return <div className="ballot-item">
       <div className="ballot-item__avatar">
-        <Link to={voter_guide_we_vote_id_link}>
+        <Link to={voterGuideLink}>
           <Image imageUrl={this.props.voter_guide_image_url} />
         </Link>
       </div>
       <div className="ballot-item__content">
         <div className="ballot-item__summary">
-          <Link to={voter_guide_we_vote_id_link}>
+          <Link to={voterGuideLink}>
             <h4 className="ballot-item__display-name">{displayName}</h4>
           </Link>
           <p className="ballot-item__short-bio">


### PR DESCRIPTION
Turning on internal twitter handles for candidates. We aren't using organizational twitter handles for internal links yet due to bug with switching between two twitter handles on NotFound.jsx page.