### PR TITLE
Removing src/js/config.js from github tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ sftp-config.json
 /**/migrations/*.py
 !/**/migrations/__init__.py
 config/environment_variables.json
+src/js/config.js
 web_app/build/*
 
 # Heroku Related #

--- a/docs/installing/RUNNING_FIRST_TIME.md
+++ b/docs/installing/RUNNING_FIRST_TIME.md
@@ -16,6 +16,14 @@ Please make sure you have read:
 
 * [Bringing Code to Your Machine](CLONING_CODE.md)
 
+## Local config.js file
+
+Every developer needs to maintain their own WebApp/src/js/config.js file, which can be copied from 
+WebApp/src/js/config-template.js. The default configuration should work as-is for new developers.
+
+    (WebAppEnv) $ cd /Users/<YOUR NAME HERE>/MyProjects/WebApp
+    (WebAppEnv) $ cp src/js/config-template.js src/js/config.js
+
 ## Install and start web application
 
     (WebAppEnv) $ cd /Users/<YOUR NAME HERE>/MyProjects/WebApp
@@ -29,9 +37,9 @@ You should be able to visit WebApp here:
     http://localhost:3000
 
 
-## Using We Vote API server Locally
+## Using We Vote API server Locally: OPTIONAL
 
-The default configuration connections to our live API server at: https://api.wevoteusa.org
+The default configuration connections to our live API server at: https://api.wevoteusa.org, so this step is optional.
 
 IFF you would like to install the We Vote API server locally, start by reading the instructions 
 [install WeVoteServer](https://github.com/wevote/WeVoteServer/blob/master/README_API_INSTALL.md)

--- a/src/js/config-template.js
+++ b/src/js/config-template.js
@@ -1,7 +1,7 @@
 // Note that we import these values into "web_app_config" (so we can search for it)
 module.exports = {
-    WE_VOTE_URL_PROTOCOL: "https://",  // "http://" or "https://"
-    WE_VOTE_HOSTNAME: "wevote.me",  // This should be without "https://"
+    WE_VOTE_URL_PROTOCOL: "http://",  // "http://" for local dev or "https://" for live server
+    WE_VOTE_HOSTNAME: "localhost:3000",  // This should be without "http...". This is "wevote.me" on live server.
 
     WE_VOTE_SERVER_ADMIN_ROOT_URL: "https://api.wevoteusa.org/admin/",
     WE_VOTE_SERVER_API_ROOT_URL: "https://api.wevoteusa.org/apis/v1/",

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,11 +1,12 @@
 // Note that we import these values into "web_app_config" (so we can search for it)
 module.exports = {
-    WE_VOTE_HOSTNAME: "wevote.me",  // This should be without "https://"
+    WE_VOTE_URL_PROTOCOL: "http://",  // "http://" or "https://"
+    WE_VOTE_HOSTNAME: "localhost:3000",  // This should be without "https://"
 
     WE_VOTE_SERVER_ADMIN_ROOT_URL: "https://api.wevoteusa.org/admin/",
     WE_VOTE_SERVER_API_ROOT_URL: "https://api.wevoteusa.org/apis/v1/",
     // WE_VOTE_SERVER_ADMIN_ROOT_URL: "http://localhost:8000/admin/",
-    // WE_VOTE_SERVER_API_ROOT_URL: "http://localhost:8000/apis/v1/",
+    // WE_VOTE_SERVER_API_ROOT_URL: "http://localhost:8001/apis/v1/",
 
     DEBUG_MODE: false,
 


### PR DESCRIPTION
Removing src/js/config.js from github tracking since it should be under the control of each developer. New developers can copy src/js/config-template.js. Updated installation documentation too.