### PR TITLE
Instant Search Display Fixes

### DIFF
--- a/src/js/components/Header.jsx
+++ b/src/js/components/Header.jsx
@@ -124,7 +124,7 @@ export default class Header extends Component {
           </Link>
           <span className="page-header__version"> demo</span>
         </h4>
-        <div className="page-header__address bs-pull-right u-gutter-right--window">
+        <div>
           <SearchAllBox />
         </div>
         <HeaderIcons />

--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -11,7 +11,9 @@ export default class SearchAllBox extends Component {
 
   constructor (props){
     super(props);
-    this.state = {};
+    this.state = {
+      search_results: ''
+    };
   }
 
   componentDidMount (){
@@ -54,18 +56,35 @@ export default class SearchAllBox extends Component {
     let text_from_search_field = event.target.value;
     console.log("onSearchFieldTextChange: " + text_from_search_field);
     SearchAllActions.searchAll(text_from_search_field);
+    this.setState({search_results: ''});
+  }
+
+  onSearchFocus () {
+    let searchBox = document.getElementsByClassName("page-header__search")[0];
+    let siteLogoText = document.getElementsByClassName("page-logo")[0];
+    siteLogoText.style.display = "none";
+    searchBox.className += " page-logo__hidden"
+  }
+  
+  onSearchBlur () {
+    let searchBox = document.getElementsByClassName("page-header__search")[0];
+    let siteLogoText = document.getElementsByClassName("page-logo")[0];
+    siteLogoText.style.display = "block";
+    searchBox.classList.remove("page-logo__hidden");
   }
 
   render () {
     var search_results = this.state.search_results;
 
-    return <span>
+    return <div className="page-header__search">
         <form className="bs-navbar-form" role="search">
-        <div className="bs-input-group">
+        <div className="bs-input-group site-search">
           <input type="text"
                  className="bs-form-control"
                  placeholder="Search We Vote"
                  name="master_search_field"
+                 onFocus={this.onSearchFocus.bind(this)}
+                 onBlur={this.onSearchBlur.bind(this)}
                  onChange={this.onSearchFieldTextChange.bind(this)}
                  value={this.state.text_from_search_field} />
           <div className="bs-input-group-btn">
@@ -73,28 +92,36 @@ export default class SearchAllBox extends Component {
           </div>
         </div>
         </form>
-      { search_results ?
-        search_results.map(function(one_result) {
-          var searchLink = "/";
-          if (one_result.kind_of_owner === "CANDIDATE") {
-            searchLink = (one_result.twitter_handle) ? "/" + one_result.twitter_handle : "/candidate/" + one_result.we_vote_id;
-          } else if (one_result.kind_of_owner === "OFFICE") {
-            searchLink = "/office/" + one_result.we_vote_id;
-          } else if (one_result.kind_of_owner === "ORGANIZATION") {
-            searchLink = (one_result.twitter_handle) ? "/" + one_result.twitter_handle : "/organization/" + one_result.we_vote_id;
-          } else if (one_result.kind_of_owner === "MEASURE") {
-            searchLink = "/measure/" + one_result.we_vote_id;
-          } else if (one_result.kind_of_owner === "POLITICIAN") {
-            searchLink = (one_result.twitter_handle) ? "/" + one_result.twitter_handle : "/politician/" + one_result.we_vote_id;
+        <div className="search-container">
+          { search_results ?
+            search_results.map(function(one_result) {
+            var searchLink = "/";
+            switch (one_result.kind_of_owner) {
+              case "CANDIDATE":
+                searchLink = (one_result.twitter_handle) ? "/" + one_result.twitter_handle : "/candidate/" + one_result.we_vote_id;
+                break;
+              case "OFFICE":
+                searchLink = "/office/" + one_result.we_vote_id;
+                break;
+              case "ORGANIZATION":
+                searchLink = (one_result.twitter_handle) ? "/" + one_result.twitter_handle : "/organization/" + one_result.we_vote_id;
+                break;
+              case "MEASURE":
+                searchLink = "/measure/" + one_result.we_vote_id;
+                break;
+              case "POLITICIAN":
+                searchLink = (one_result.twitter_handle) ? "/" + one_result.twitter_handle : "/politician/" + one_result.we_vote_id;
+                break;
+            }
+            return <div className="search-container__results">
+              <Link to={searchLink} className="search-container__links">
+              {one_result.result_title}
+              </Link>
+            </div>;
+            }) :
+            <span></span>
           }
-
-          return <div className="candidate-card__container">
-            <Link to={searchLink}>
-            {one_result.result_title}
-            </Link>
-          </div>;
-          }) :
-          <span></span> }
-      </span>;
+        </div>
+      </div>;
   }
 }

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -6,6 +6,7 @@ html {
 body {
   background-color: #F5F4F1;
   height: 100%;
+  letter-spacing: -0.02em;
 }
 
 #app {

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -10,4 +10,7 @@
   @include breakpoints(max nav) {
     padding-left: 10px;
   }
+  @media all and (max-width: 329px) {
+  	display: none;
+  }
 }

--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -13,10 +13,10 @@
 }
 
 .page-header {
-  
+
   background: #fff;
   @include micro-clearfix;
-  
+
   &__address {
     color: #D8D8D8;
     margin-right: 200px;
@@ -37,5 +37,113 @@
     font-weight: 200;
     overflow: hidden;
     white-space: nowrap;
+  }
+  &__search {
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    width: 70%;
+
+    @media all and (max-width: 497px) and (min-width: 330px) {
+      margin-top: -1em;
+      width: 35%;
+    }
+
+    @media all and (max-width: 659px) and (min-width: 498px) {
+      margin-top: -1em;
+      width: 59%
+    }
+
+    @media all and (max-width: 695px) and (min-width: 660px) {
+      margin-top: -1em;
+      width: 43%;
+    } 
+
+    @media all and (max-width: 805px) and (min-width: 696px) {
+      margin-top: -1em;
+      min-width: 48%;
+      max-width: 50%;
+    }
+  }
+}
+
+.page-logo {
+  
+  &__hidden {
+
+    @media all and (max-width: 499px) {
+      margin-top: -1em;
+      width: 92%;
+    }
+
+    @media all and (max-width: 657px) and (min-width: 500px) {
+      margin-top: -2em;
+      margin-left: 1em;
+      width: 97%;
+    }
+
+    @media all and (max-width: 695px) and (min-width: 658px) {
+      margin-top: -1em;
+      width: 65%;
+    } 
+
+    @media all and (max-width: 799px) and (min-width: 696px) {
+      margin-top: -1em;
+      min-width: 48%;
+      max-width: 75%;
+    }
+    
+  }
+}
+
+.site-search {
+  margin-top: -1em;
+  padding-left: 1em;
+  width: 100%;
+}
+
+.search-container {
+  background: #fff;
+  box-shadow: 5px 5px 10px rgba(0, 0, 0, .2);
+  margin-left: 27px;
+  position: absolute;
+  top: 30px;
+  min-width: 82%;
+  z-index: 1;
+
+  @media all and (max-width: 660px) {
+    margin-left: 12px;
+    min-width: 97%;
+    top: 41px;
+  }
+
+  @media all and (max-width: 695px) and (min-width: 661px) {
+    margin-left: 12px;
+    top: 41px;
+    width: 98%;
+  }
+
+  @media all and (max-width: 768px) and (min-width: 696px) {
+    top: 42px;
+    margin-left: 12px;
+  }
+
+  &__results {
+    background: #fff;
+    margin-bottom: .5em;
+    padding: .75em;
+
+    &:hover {
+      background: #d9edf7;
+    }
+  }
+
+  &__links {
+    display: block;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 }


### PR DESCRIPTION
This fix changes the position of the search results box for all
of the different media queies. It also adds the absolute position of the
dropdown results that will allow the header to stay in place and not
move down.

This does not handle the case of clicking on a link and having the
results dissapear. I am not knowledgable enough about Link to know how
to make that change at this time. It also does not take into account the
blue button being white. That is a Bootstrap icon and would need some
consideration.

Please pull from my repo this branch and test locally to see how it
works currently.