### PR TITLE
The onSearchBlur code was breaking the ability to click on a selection in the Instant search drop-down.

### DIFF
--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from "react";
 import { Link } from "react-router";
 import SearchAllActions from "../actions/SearchAllActions";
 import SearchAllStore from "../stores/SearchAllStore";
+import { enterSearch } from "../utils/search-functions";
 
 export default class SearchAllBox extends Component {
   static propTypes = {
@@ -60,23 +61,11 @@ export default class SearchAllBox extends Component {
 
   // both of the two methods below need to have constants refactored
   onSearchFocus () {
-    const searchBox = document.getElementsByClassName("page-header__search")[0];
-    const siteLogoText = document.getElementsByClassName("page-logo")[0];
-    const searchResultsBox = document.getElementsByClassName("search-container")[0];
-    siteLogoText.style.display = "none";
-    searchResultsBox.style.display = "block";
-    searchBox.className += " page-logo__hidden"
+    enterSearch();
   }
 
   onSearchBlur () {
-    const searchBox = document.getElementsByClassName("page-header__search")[0];
-    const siteLogoText = document.getElementsByClassName("page-logo")[0];
-    const searchResultsBox = document.getElementsByClassName("search-container")[0];
-    const searchInput = document.getElementsByTagName('input')[0];
-    searchInput.value = "";
-    siteLogoText.style.display = "block";
-    searchResultsBox.style.display = "none";
-    searchBox.classList.remove("page-logo__hidden");
+    // We have code (exitSearch) that closes the search box once you arrive at a destination
   }
 
   render () {
@@ -94,7 +83,7 @@ export default class SearchAllBox extends Component {
                  onChange={this.onSearchFieldTextChange.bind(this)}
                  value={this.state.text_from_search_field} />
           <div className="bs-input-group-btn">
-            <button className="bs-btn bs-btn-primary" type="submit"><i className="bs-glyphicon bs-glyphicon-search"></i></button>
+            <button className="page-header__search-button bs-btn bs-btn-default" type="submit"><i className="bs-glyphicon bs-glyphicon-search"></i></button>
           </div>
         </div>
         </form>
@@ -119,11 +108,11 @@ export default class SearchAllBox extends Component {
                 searchLink = (one_result.twitter_handle) ? "/" + one_result.twitter_handle : "/politician/" + one_result.we_vote_id;
                 break;
             }
-            return <div className="search-container__results">
-              <Link to={searchLink} className="search-container__links">
-              {one_result.result_title}
-              </Link>
-            </div>;
+            return <Link to={searchLink} className="search-container__links">
+                <div className="search-container__results">
+                  {one_result.result_title}
+                </div>
+              </Link>;
             }) :
             <span></span>
           }

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -9,6 +9,7 @@ import OfficeStore from "../../stores/OfficeStore";
 import PositionList from "../../components/Ballot/PositionList";
 import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
 import VoterStore from "../../stores/VoterStore";
+import { exitSearch } from "../../utils/search-functions";
 
 export default class Candidate extends Component {
   static propTypes = {
@@ -29,6 +30,11 @@ export default class Candidate extends Component {
 
     this.listener = GuideStore.addListener(this._onChange.bind(this));
     GuideActions.retrieveGuidesToFollowByBallotItem(this.we_vote_id, "CANDIDATE");
+
+    // Display the candidate's name in the search box
+    var { candidate } = this.state;
+    var searchBoxText = candidate.ballot_item_display_name || "";  // TODO DALE Not working right now
+    exitSearch(searchBoxText);
   }
 
   componentWillUnmount () {

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -9,6 +9,7 @@ import OfficeStore from "../../stores/OfficeStore";
 import PositionList from "../../components/Ballot/PositionList";
 import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
 import VoterStore from "../../stores/VoterStore";
+import { exitSearch } from "../../utils/search-functions";
 
 // TODO DALE Convert to work for a Measure
 export default class Measure extends Component {
@@ -30,6 +31,8 @@ export default class Measure extends Component {
 
     this.listener = GuideStore.addListener(this._onChange.bind(this));
     GuideActions.retrieveGuidesToFollowByBallotItem(this.we_vote_id, "CANDIDATE");
+
+    exitSearch("");
   }
 
   componentWillUnmount () {

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -9,6 +9,7 @@ import OfficeStore from "../../stores/OfficeStore";
 import PositionList from "../../components/Ballot/PositionList";
 import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
 import VoterStore from "../../stores/VoterStore";
+import { exitSearch } from "../../utils/search-functions";
 
 // TODO DALE Convert to work for an Office
 export default class Office extends Component {
@@ -30,6 +31,8 @@ export default class Office extends Component {
 
     this.listener = GuideStore.addListener(this._onChange.bind(this));
     GuideActions.retrieveGuidesToFollowByBallotItem(this.we_vote_id, "CANDIDATE");
+
+    exitSearch("");
   }
 
   componentWillUnmount () {

--- a/src/js/routes/Guide/PositionList.jsx
+++ b/src/js/routes/Guide/PositionList.jsx
@@ -6,6 +6,7 @@ import OrganizationStore from "../../stores/OrganizationStore";
 import OrganizationPositionItem from "../../components/VoterGuide/OrganizationPositionItem";
 import LoadingWheel from "../../components/LoadingWheel";
 import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
+import { exitSearch } from "../../utils/search-functions";
 
 /* VISUAL DESIGN HERE: https://projects.invisionapp.com/share/2R41VR3XW#/screens/94226088 */
 
@@ -27,6 +28,12 @@ export default class GuidePositionList extends Component {
     OrganizationActions.retrievePositions(we_vote_id, true);
     // Positions for this organization, NOT including for this voter / election
     OrganizationActions.retrievePositions(we_vote_id, false, true);
+
+    // Display the organization's name in the search box
+    // var { organization } = this.state;
+    // var searchBoxText = organization.organization_name || "";  // TODO DALE Not working right now
+    // exitSearch(searchBoxText);
+    exitSearch("");
   }
 
   componentWillUnmount (){

--- a/src/js/utils/search-functions.js
+++ b/src/js/utils/search-functions.js
@@ -1,0 +1,39 @@
+// Prepare the searchAllBox for action
+export function enterSearch () {
+  // Change color of search button
+  const searchButton = document.getElementsByClassName("page-header__search-button")[0];
+  searchButton.classList.remove("bs-btn-default");
+  searchButton.classList.add("bs-btn-primary");
+  // Clear out the contents of the search box
+  const searchInput = document.getElementsByTagName('input')[0];
+  searchInput.value = "";
+  // Hide the hamburger navigation and site name
+  const siteLogoText = document.getElementsByClassName("page-logo")[0];
+  siteLogoText.style.display = "none";
+  const searchBox = document.getElementsByClassName("page-header__search")[0];
+  searchBox.className += " page-logo__hidden";
+  // Show the search box drop-down
+  const searchResultsBox = document.getElementsByClassName("search-container")[0];
+  searchResultsBox.style.display = "block";
+}
+
+
+// Clean up the searchAllBox after arriving at your destination
+export function exitSearch (textForSearchBox) {
+  // Change color of search button
+  const searchButton = document.getElementsByClassName("page-header__search-button")[0];
+  searchButton.classList.remove("bs-btn-primary");
+  searchButton.classList.add("bs-btn-default");
+
+  // Add the name of the item you are looking at to the search box
+  const searchInput = document.getElementsByTagName('input')[0];
+  searchInput.value = textForSearchBox;
+  // Show the hamburger navigation and site name
+  const siteLogoText = document.getElementsByClassName("page-logo")[0];
+  siteLogoText.style.display = "block";
+  const searchBox = document.getElementsByClassName("page-header__search")[0];
+  searchBox.classList.remove("page-logo__hidden");
+  // Hide the search box drop-down
+  const searchResultsBox = document.getElementsByClassName("search-container")[0];
+  searchResultsBox.style.display = "none";
+}


### PR DESCRIPTION
The onSearchBlur code was breaking the ability to click on a selection in the Instant search drop-down. Moved the code that shows and hides Instant search results into utils/search-functions, and we are now calling the "exitSearch" code once we arrive at Candidate or PositionList routes.

@pertrai1, any attempt I have made to hide the "search-container" drop-down with the "onBlur" action in SearchAllBox.js has led to the Link not taking the view to the candidate or measure page. We need to figure out another way to hide the "search-container" drop-down when you click outside of that drop-down area.