### PR TITLE
Fix for #342 z-index overlay

### DIFF
--- a/src/sass/layout/_header.scss
+++ b/src/sass/layout/_header.scss
@@ -44,7 +44,6 @@
     padding: 0;
     position: relative;
     width: 70%;
-    z-index: 0;
 
     @media all and (max-width: 329px) {
       margin-top: -1em;

--- a/src/sass/vendor/_react-burger-menu.scss
+++ b/src/sass/vendor/_react-burger-menu.scss
@@ -47,6 +47,7 @@
     margin-top: -15px;
     margin-left: -15px;
     tranform: translateY(100%);
+    z-index: 3 !important;
   }
 
   // Morph shape necessary with bubble or elastic
@@ -76,7 +77,7 @@
 }
 
 // HACKY override for .headpin repositioning
-.bm-overlay, .bm-menu-wrap {  
+.bm-overlay, .bm-menu-wrap {
   .headroom--unpinned & {
     transform: translateY(99px);
   }


### PR DESCRIPTION
The Add Friends and Who I Can Follow were stacked on top of the search container without having the correct z-index for the elements. There also was an issue where the search box would be stacked on top of the hamburger menu when it was open. This has been resolved.