### PR TITLE
Fix modal styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "pre-commit": "^1.1.2",
     "react-addons-linked-state-mixin": "^0.14.3",
     "react-addons-test-utils": "~0.14.0",
-    "react-bootstrap": "^0.28.1",
+    "react-bootstrap": "^0.28.5",
     "react-headroom": "^1.7.3",
     "react-hot-loader": "^1.3.0",
     "react-intl": "^1.2.0",

--- a/src/img/global/svg-icons/bookmark-icon.svg
+++ b/src/img/global/svg-icons/bookmark-icon.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path strokeWidth="2px" d="M17 3H7c-1.1 0-1.99.9-1.99 2L5 21l7-3 7 3V5c0-1.1-.9-2-2-2z"/>
+    <path d="M0 0h24v24H0z" fill="none" stroke="none" />
+</svg>

--- a/src/js/actions/SearchAllActions.js
+++ b/src/js/actions/SearchAllActions.js
@@ -2,21 +2,21 @@ import Dispatcher from "../dispatcher/Dispatcher";
 
 module.exports = {
   searchAll: function (text_from_search_field) {
-    Dispatcher.loadEndpoint("searchAll", 
-      { 
+    Dispatcher.loadEndpoint("searchAll",
+      {
         text_from_search_field: text_from_search_field
       });
   },
-  
+
   retrieveRecentSearches: function () {
-    // Dispatcher.loadEndpoint("retrieveRecentSearches", 
-    //   { 
+    // Dispatcher.loadEndpoint("retrieveRecentSearches",
+    //   {
     //   });
   },
-  
+
   retrieveRelatedSearches: function () {
-    // Dispatcher.loadEndpoint("retrieveRelatedSearches", 
-    //   { 
+    // Dispatcher.loadEndpoint("retrieveRelatedSearches",
+    //   {
     //   });
   },
 

--- a/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
+++ b/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
@@ -102,18 +102,15 @@ export default class EditPositionAboutCandidateModal extends Component {
     //   is_for_friends_only
     // } = this.props;
 
-    return <Modal {...this.props} bsSize="large" aria-labelledby="contained-modal-title-lg">
-        <Modal.Header closeButton>
-          <Modal.Title id="contained-modal-title-lg">{this.props.ballot_item_display_name}</Modal.Title>
+    return <Modal {...this.props} bsClass="bs-modal" bsSize="large" aria-labelledby="contained-modal-title-lg">
+        <Modal.Header bsClass="bs-modal" closeButton>
+          <Modal.Title bsClass="bs-modal" id="contained-modal-title-lg">{this.props.ballot_item_display_name}</Modal.Title>
         </Modal.Header>
-        <Modal.Body>
+        <Modal.Body bsClass="bs-modal" >
           <p>Cras mattis consectetur purus sit amet fermentum. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros.</p>
           <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor.</p>
           <p>Aenean lacinia bibendum nulla sed consectetur. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Donec sed odio dui. Donec ullamcorper nulla non metus auctor fringilla.</p>
         </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={this.props.onHide}>Close</Button>
-        </Modal.Footer>
       </Modal>;
     // // Manage the control over this organization voter guide
     // var {candidate, office, organization, voter} = this.state;

--- a/src/sass/utils/_bootstrap-overrides.scss
+++ b/src/sass/utils/_bootstrap-overrides.scss
@@ -3,3 +3,51 @@
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
 }
+
+
+// Customizations to accommodate React Bootstrap's modal component
+// Accounts for .close, .fade, and .in
+// These customizations were added for React Bootstrap v0.25.5
+// – future versions might allow better workarounds
+.bs-modal {
+  .close { // this Bootstrap class can't be prefixed so it's redefined it in a scoped context
+    float: right;
+    font-size: 21px;
+    font-weight: bold;
+    line-height: 1;
+    color: #000;
+    text-shadow: 0 1px 0 #fff;
+    opacity: .2;
+  }
+  button.close {
+    appearance: none;
+    padding: 0;
+    cursor: pointer;
+    background: transparent;
+    border: 0;
+  }
+
+  &.fade .bs-modal-dialog {
+    transform: translate(0, -25%);
+    transition: transform .3s ease-out
+  }
+  &.in .bs-modal-dialog {
+    transform: translate(0, 0);
+  }
+  &.fade {
+    opacity: 0;
+    transition: opacity .15s linear;
+    &.in {
+      opacity: 1;
+    }
+  }
+  &-backdrop { // .bs-modal-backdrop
+    &.fade {
+      opacity: 0;
+      transition: opacity .15s linear;
+      &.in {
+        opacity: $modal-backdrop-opacity;
+      }
+    }
+  }
+}

--- a/src/sass/utils/_variables.scss
+++ b/src/sass/utils/_variables.scss
@@ -90,3 +90,6 @@ $breakpoints: (
 /// @example scss - When using a CDN
 ///   $base-url: 'http://cdn.example.com/assets/';
 $base-url: '/assets/' !default;
+
+
+$modal-backdrop-opacity: .5;


### PR DESCRIPTION
I found a way to use this component without rolling back the prefixing. If it creates unresolvable issues in the future, we can still roll back the prefixing, but I would obviously prefer not to, if possible.

@DaleMcGrew I couldn't tell how the modal trigger was being bound, but the trigger content/text should be given a pointer cursor.

resolves #352