### PR TITLE
fixed measure naming collision, created and commented out MeasureCons…

### DIFF
--- a/src/js/actions/MeasureActions.js
+++ b/src/js/actions/MeasureActions.js
@@ -1,17 +1,21 @@
-import MeasureConstants from "../constants/MeasureConstants";
-const AppDispatcher = require("../dispatcher/AppDispatcher");
-
+// import MeasureConstants from "../constants/MeasureConstants";
+// const AppDispatcher = require("../dispatcher/AppDispatcher");
+//
+// Zach: "without addItemById, neither of the above variables are used, so commented out."
 
 const MeasureActions = {
   /**
    * @param {String} id we_vote_id of ballot item
    * @param {Object} item ballot item as javascript object
    */
-  addItemById: function (id, item) {
-    AppDispatcher.dispatch({
-      actionType: MeasureConstants.MEASURE_ADDED, id, item
-    });
-  }
+  //  Zach: "not sure what addItemById, or MeasureConstants is
+  //  intended to do.  No similar method or constants for candidates"
+
+  // addItemById: function (id, item) {
+  //   AppDispatcher.dispatch({
+  //     actionType: MeasureConstants.MEASURE_ADDED, id, item
+  //   });
+  // }
 };
 
 export default MeasureActions;

--- a/src/js/actions/MeasureActions.js
+++ b/src/js/actions/MeasureActions.js
@@ -1,21 +1,8 @@
-// import MeasureConstants from "../constants/MeasureConstants";
-// const AppDispatcher = require("../dispatcher/AppDispatcher");
-//
-// Zach: "without addItemById, neither of the above variables are used, so commented out."
+import Dispatcher from "../dispatcher/Dispatcher";
 
-const MeasureActions = {
-  /**
-   * @param {String} id we_vote_id of ballot item
-   * @param {Object} item ballot item as javascript object
-   */
-  //  Zach: "not sure what addItemById, or MeasureConstants is
-  //  intended to do.  No similar method or constants for candidates"
-
-  // addItemById: function (id, item) {
-  //   AppDispatcher.dispatch({
-  //     actionType: MeasureConstants.MEASURE_ADDED, id, item
-  //   });
-  // }
+module.exports = {
+  retrieve: function (we_vote_id) {
+    Dispatcher.loadEndpoint("measureRetrieve", { measure_we_vote_id: we_vote_id} );
+    Dispatcher.loadEndpoint("positionListForBallotItem", { ballot_item_we_vote_id: we_vote_id, kind_of_ballot_item: "MEASURE"} );
+  }
 };
-
-export default MeasureActions;

--- a/src/js/components/Ballot/BallotItem.jsx
+++ b/src/js/components/Ballot/BallotItem.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import CandidateList from "../../components/Ballot/CandidateList";
-import Measure from "../../components/Ballot/Measure";
+import MeasureItem from "../../components/Ballot/MeasureItem";
 import StarAction from "../../components/Widgets/StarAction";
 
 const TYPES = require("keymirror")({
@@ -23,7 +23,7 @@ export default class BallotItem extends Component {
   render () {
     return <div className="ballot-section" id={this.props.we_vote_id}>
         { this.isMeasure() ?
-          <Measure {...this.props}
+          <MeasureItem {...this.props}
                    link_to_ballot_item_page /> :
           <span>
             <h2 className="ballot-section__display-name">

--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -12,9 +12,11 @@ export default class MeasureItem extends Component {
     key: PropTypes.string,
     we_vote_id: PropTypes.string.isRequired,
     measure_subtitle: PropTypes.string,
+    measure_text: PropTypes.string,
     kind_of_ballot_item: PropTypes.string.isRequired,
     ballot_item_display_name: PropTypes.string.isRequired,
-    link_to_ballot_item_page: PropTypes.bool
+    link_to_ballot_item_page: PropTypes.bool,
+    measure_url: PropTypes.string
   };
   constructor (props) {
     super(props);
@@ -40,6 +42,9 @@ export default class MeasureItem extends Component {
     var we_vote_id = this.props.we_vote_id;
     var measure_subtitle = capitalizeString(this.props.measure_subtitle);
     var ballot_item_display_name = capitalizeString(this.props.ballot_item_display_name);
+    var measure_text = this.props.measure_text;
+    var measure_url = this.props.measure_url;
+    var measure_url_display_name = "View Measure Webpage";
     var measureLink = "/measure/" + we_vote_id;
     return <div className="measure-card__container">
       <div className="measure-card">
@@ -65,6 +70,12 @@ export default class MeasureItem extends Component {
             <StarAction we_vote_id={we_vote_id} type="MEASURE"/>
 
             <div>{measure_subtitle}</div>
+              { this.props.measure_text ?
+                <div className="measure_text">{measure_text}</div> :
+                null }
+              { this.props.measure_url ?
+                <Link to={measure_url} target="_blank">{measure_url_display_name}</Link> :
+                null }
             <div className="bs-row" style={{ paddingBottom: "2rem" }}>
               <div className="col-xs-12">
               </div>

--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -7,7 +7,7 @@ import StarAction from "../../components/Widgets/StarAction";
 import SupportStore from "../../stores/SupportStore";
 import { capitalizeString } from "../../utils/textFormat";
 
-export default class Measure extends Component {
+export default class MeasureItem extends Component {
   static propTypes = {
     key: PropTypes.string,
     we_vote_id: PropTypes.string.isRequired,

--- a/src/js/constants/MeasureConstants.js
+++ b/src/js/constants/MeasureConstants.js
@@ -1,7 +1,0 @@
-import keyMirror from "keymirror";
-
-const MeasureConstants = {
-
-};
-
-module.exports = keyMirror(MeasureConstants);

--- a/src/js/constants/MeasureConstants.js
+++ b/src/js/constants/MeasureConstants.js
@@ -1,0 +1,7 @@
+import keyMirror from "keymirror";
+
+const MeasureConstants = {
+
+};
+
+module.exports = keyMirror(MeasureConstants);

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -24,11 +24,11 @@ export default class Ballot extends Component {
     }
       SupportActions.retrieveAll();
       SupportActions.retrieveAllCounts();
-      this.supportToken = SupportStore.addListener(this._onChange.bind(this));
+      this.supportStoreListener = SupportStore.addListener(this._onChange.bind(this));
     }
 
   componentWillUnmount (){
-    this.supportToken.remove();
+    this.supportStoreListener.remove();
   }
 
   componentWillReceiveProps (nextProps){

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -22,8 +22,8 @@ export default class Candidate extends Component {
   }
 
   componentDidMount (){
-    this.candidateToken = CandidateStore.addListener(this._onChange.bind(this));
-    this.officeToken = OfficeStore.addListener(this._onChange.bind(this));
+    this.candidateStoreListener = CandidateStore.addListener(this._onChange.bind(this));
+    this.officeStoreListener = OfficeStore.addListener(this._onChange.bind(this));
     var { candidate_we_vote_id } = this.state;
 
     CandidateActions.retrieve(candidate_we_vote_id);
@@ -52,8 +52,8 @@ export default class Candidate extends Component {
   }
 
   componentWillUnmount () {
-    this.candidateToken.remove();
-    this.officeToken.remove();
+    this.candidateStoreListener.remove();
+    this.officeStoreListener.remove();
     this.listener.remove();
   }
 

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -42,10 +42,6 @@ export default class Measure extends Component {
     var measure = MeasureStore.get(this.we_vote_id) || {};
     this.setState({ measure: measure, guideList: GuideStore.toFollowListForCand() });
 
-    // if (candidate.contest_office_we_vote_id){
-    //   this.setState({ office: OfficeStore.get(candidate.contest_office_we_vote_id) || {} });
-    // }
-
   }
 
   render () {

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -23,7 +23,7 @@ export default class Measure extends Component {
   }
 
   componentDidMount (){
-    this.measureToken = MeasureStore.addListener(this._onChange.bind(this));
+    this.measureStoreListener = MeasureStore.addListener(this._onChange.bind(this));
 
     MeasureActions.retrieve(this.we_vote_id);
 
@@ -34,7 +34,7 @@ export default class Measure extends Component {
   }
 
   componentWillUnmount () {
-    this.measureToken.remove();
+    this.measureStoreListener.remove();
     this.listener.remove();
   }
 

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -1,17 +1,16 @@
 import React, { Component, PropTypes } from "react";
-import CandidateActions from "../../actions/CandidateActions";
-import CandidateItem from "../../components/Ballot/CandidateItem";
-import CandidateStore from "../../stores/CandidateStore";
+
 import GuideList from "../../components/VoterGuide/GuideList";
 import GuideStore from "../../stores/GuideStore";
 import GuideActions from "../../actions/GuideActions";
-import OfficeStore from "../../stores/OfficeStore";
+import MeasureItem from "../../components/Ballot/MeasureItem";
+import MeasureActions from "../../actions/MeasureActions";
+import MeasureStore from "../../stores/MeasureStore";
 import PositionList from "../../components/Ballot/PositionList";
-import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
 import VoterStore from "../../stores/VoterStore";
 import { exitSearch } from "../../utils/search-functions";
 
-// TODO DALE Convert to work for a Measure
+
 export default class Measure extends Component {
   static propTypes = {
     params: PropTypes.object.isRequired
@@ -20,46 +19,43 @@ export default class Measure extends Component {
   constructor (props) {
     super(props);
     this.we_vote_id = this.props.params.we_vote_id;
-    this.state = {candidate: {}, office: {} };
+    this.state = {measure: {} };
   }
 
   componentDidMount (){
-    this.candidateToken = CandidateStore.addListener(this._onChange.bind(this));
-    this.officeToken = OfficeStore.addListener(this._onChange.bind(this));
+    this.measureToken = MeasureStore.addListener(this._onChange.bind(this));
 
-    CandidateActions.retrieve(this.we_vote_id);
+    MeasureActions.retrieve(this.we_vote_id);
 
     this.listener = GuideStore.addListener(this._onChange.bind(this));
-    GuideActions.retrieveGuidesToFollowByBallotItem(this.we_vote_id, "CANDIDATE");
+    GuideActions.retrieveGuidesToFollowByBallotItem(this.we_vote_id, "MEASURE");
 
     exitSearch("");
   }
 
   componentWillUnmount () {
-    this.candidateToken.remove();
-    this.officeToken.remove();
+    this.measureToken.remove();
     this.listener.remove();
   }
 
   _onChange (){
-    var candidate = CandidateStore.get(this.we_vote_id) || {};
-    this.setState({ candidate: candidate, guideList: GuideStore.toFollowListForCand() });
+    var measure = MeasureStore.get(this.we_vote_id) || {};
+    this.setState({ measure: measure, guideList: GuideStore.toFollowListForCand() });
 
-    if (candidate.contest_office_we_vote_id){
-      this.setState({ office: OfficeStore.get(candidate.contest_office_we_vote_id) || {} });
-    }
+    // if (candidate.contest_office_we_vote_id){
+    //   this.setState({ office: OfficeStore.get(candidate.contest_office_we_vote_id) || {} });
+    // }
 
   }
 
   render () {
     const electionId = VoterStore.election_id();
-    const NO_VOTER_GUIDES_TEXT = "We could not find any more voter guides to follow about this candidate or measure.";
-    var { candidate, office, guideList } = this.state;
+    const NO_VOTER_GUIDES_TEXT = "We could not find any more voter guides to follow about this measure.";
+    var { measure, guideList } = this.state;
 
-    if (!candidate.ballot_item_display_name){
+    if (!measure.ballot_item_display_name){
       return <div className="bs-container-fluid bs-well u-gutter-top--small fluff-full1">
               <h3>No Measure Found</h3>
-        NOTE: The We Vote team is still building support for Measures.
                 <div className="small">We were not able to find that measure.
                   Please search again.</div>
                 <br />
@@ -67,28 +63,24 @@ export default class Measure extends Component {
     }
 
     return <span>
-        <section className="candidate-card__container">
-          <CandidateItem {...candidate} office_name={office.ballot_item_display_name}/>
-          <div className="candidate-card__additional">
-            { candidate.position_list ?
+        <section className="measure-card__container">
+          <MeasureItem {...measure} />
+          <div className="measure-card__additional">
+            { measure.position_list ?
               <div>
                 <PositionList
-                position_list={candidate.position_list}
-                candidate_display_name={candidate.ballot_item_display_name} />
+                position_list={measure.position_list}
+                candidate_display_name={measure.ballot_item_display_name} />
               </div> :
               null
             }
             {guideList.length === 0 ?
-              <p className="candidate-card__no-additional">{NO_VOTER_GUIDES_TEXT}</p> :
-              <div><h3 className="candidate-card__additional-heading">{"More opinions about " + candidate.ballot_item_display_name}</h3>
+              <p className="measure-card__no-additional">{NO_VOTER_GUIDES_TEXT}</p> :
+              <div><h3 className="measure-card__additional-heading">{"More opinions about " + measure.ballot_item_display_name}</h3>
               <GuideList id={electionId} ballotItemWeVoteId={this.we_vote_id} organizations={guideList}/></div>
             }
           </div>
         </section>
-        <br />
-        <ThisIsMeAction twitter_handle_being_viewed={candidate.twitter_handle}
-                      name_being_viewed={candidate.ballot_item_display_name}
-                      kind_of_owner="POLITICIAN" />
         <br />
       </span>;
 

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -24,8 +24,8 @@ export default class Office extends Component {
   }
 
   componentDidMount (){
-    this.candidateToken = CandidateStore.addListener(this._onChange.bind(this));
-    this.officeToken = OfficeStore.addListener(this._onChange.bind(this));
+    this.candidateStoreListener = CandidateStore.addListener(this._onChange.bind(this));
+    this.officeStoreListener = OfficeStore.addListener(this._onChange.bind(this));
 
     CandidateActions.retrieve(this.we_vote_id);
 
@@ -36,8 +36,8 @@ export default class Office extends Component {
   }
 
   componentWillUnmount () {
-    this.candidateToken.remove();
-    this.officeToken.remove();
+    this.candidateStoreListener.remove();
+    this.officeStoreListener.remove();
     this.listener.remove();
   }
 

--- a/src/js/stores/MeasureStore.js
+++ b/src/js/stores/MeasureStore.js
@@ -1,33 +1,42 @@
-// import MeasureConstants from "../constants/MeasureConstants";
-// Zach: "not sure what the purpose of MeasureConstants is, no similar constants for candidates"
-import { createStore } from "../utils/createStore";
-// import { shallowClone } from "../utils/object-utils";
-const AppDispatcher = require("../dispatcher/AppDispatcher");
+var Dispatcher = require("../dispatcher/Dispatcher");
+var FluxMapStore = require("flux/lib/FluxMapStore");
+const assign = require("object-assign");
 
-// Zach: "not sure of purpose of addItemById.  appears here and in MeasureActions,
-//      but no similar method associated with candidates"
 
-// const _measures = {};
+class MeasureStore extends FluxMapStore {
 
-// function addItemById (id, item) {
-//   _measures[id] = shallowClone(item);
-// }
+  reduce (state, action) {
 
-const MeasureStore = createStore({});
+    // Exit if we don't have a successful response (since we expect certain variables in a successful response below)
+    if (!action.res || !action.res.success)
+      return state;
 
-MeasureStore.dispatchToken = AppDispatcher.register( (action) => {
-  switch (action.actionType) {
+    var key;
+    var merged_properties;
 
-    // case MeasureConstants.OFFICE_ADDED:
-    //   addItemById(action.id, action.item);
-    //   MeasureStore.emitChange();
-    //   break;
-    // Zach: "see note above: not sure of purpose of MeasureConstants.  also,
-    // not sure why 'OFFICE_ADDED' would be relevant since measures aren't offices"
+    switch (action.type) {
 
-    default:
-      break;
+      case "measureRetrieve":
+        key = action.res.we_vote_id;
+        merged_properties = assign({}, state.get(key), action.res );
+        return state.set(key, merged_properties );
+
+      case "positionListForBallotItem":
+        key = action.res.ballot_item_we_vote_id;
+        var position_list = action.res.position_list;
+        merged_properties = assign({}, state.get(key), {position_list: position_list} );
+        return state.set(key, merged_properties );
+
+      case "error-measureRetrieve" || "error-positionListForBallotItem":
+        console.log(action);
+        return state;
+
+      default:
+        return state;
+    }
+
   }
-});
 
-export default MeasureStore;
+}
+
+module.exports = new MeasureStore(Dispatcher);

--- a/src/js/stores/MeasureStore.js
+++ b/src/js/stores/MeasureStore.js
@@ -1,24 +1,29 @@
-import MeasureConstants from "../constants/MeasureConstants";
+// import MeasureConstants from "../constants/MeasureConstants";
+// Zach: "not sure what the purpose of MeasureConstants is, no similar constants for candidates"
 import { createStore } from "../utils/createStore";
-import { shallowClone } from "../utils/object-utils";
+// import { shallowClone } from "../utils/object-utils";
 const AppDispatcher = require("../dispatcher/AppDispatcher");
 
+// Zach: "not sure of purpose of addItemById.  appears here and in MeasureActions,
+//      but no similar method associated with candidates"
 
-const _measures = {};
+// const _measures = {};
 
-function addItemById (id, item) {
-  _measures[id] = shallowClone(item);
-}
+// function addItemById (id, item) {
+//   _measures[id] = shallowClone(item);
+// }
 
 const MeasureStore = createStore({});
 
 MeasureStore.dispatchToken = AppDispatcher.register( (action) => {
   switch (action.actionType) {
 
-    case MeasureConstants.OFFICE_ADDED:
-      addItemById(action.id, action.item);
-      MeasureStore.emitChange();
-      break;
+    // case MeasureConstants.OFFICE_ADDED:
+    //   addItemById(action.id, action.item);
+    //   MeasureStore.emitChange();
+    //   break;
+    // Zach: "see note above: not sure of purpose of MeasureConstants.  also,
+    // not sure why 'OFFICE_ADDED' would be relevant since measures aren't offices"
 
     default:
       break;

--- a/src/sass/components/_measure.scss
+++ b/src/sass/components/_measure.scss
@@ -19,7 +19,7 @@
     display: flex;
     flex-direction: column;
     @media (min-width: 480px) {
-      width: 80px;
+      width: 15px;
     }
   }
   &__photo {


### PR DESCRIPTION
…tants.  Created the constants file, because it was called for and didn't exist, but since neither Dale nor I could quickly determine what these constants were for, I simply commented all references to them out.  The naming collision is the main fix of this pull request (components/ballot/measure is now components/ballot/measureitem to disambiguate from routes, tracked down and replaced all mentions of former name)