### PR TITLE
added text for VoteSmart popover, changed color of position-rating__s…

### DIFF
--- a/src/js/components/Widgets/PositionRatingSnippet.jsx
+++ b/src/js/components/Widgets/PositionRatingSnippet.jsx
@@ -14,7 +14,7 @@ export default class PositionRatingSnippet extends Component {
     var src;
     var className;
     var alt;
-    //var Popover = <RatingPopover id="testID" placement="top" />;
+
     if (rating >= 65){
       src = "/img/global/icons/up-arrow-color-icon.svg";
       className = "position-rating__icon position-rating__icon--positive";
@@ -28,9 +28,20 @@ export default class PositionRatingSnippet extends Component {
       className = "position-rating__icon position-rating__icon--mixed";
       alt = "Mixed Rating";
     }
-    const popoverClickRootClose = <Popover id="popover-trigger-click-root-close" title="VoteSmart Ratings">
-      Ratings are given by the organization, and collected by the nonprofit Vote Smart. <img src="/img/global/icons/down-arrow-color-icon.svg" width="20" height="20" /> 0% is a low score, and <img src="/img/global/icons/up-arrow-color-icon.svg" width="20" height="20" />100% is a high score.
-      Ratings can be invaluable in showing where an incumbent has stood on a series of votes in the past one or two years, especially when ratings by groups on all sides of an issue are compared. Some groups select votes that tend to favor members of one political party over another, rather than choosing votes based solely on issues concerns. Please visit the group's website or call 1-888-VOTESMART for more specific information.
+    const popoverClickRootClose = <Popover id="popover-trigger-click-root-close"
+                                           title="Ratings from Vote Smart">
+      Ratings are given by the organization, and collected by the
+      nonprofit Vote Smart. <span style={{whiteSpace: "nowrap"}}><img
+           src="/img/global/icons/down-arrow-color-icon.svg"
+           width="20" height="20" /> 0%</span> is a low score, and
+           <span style={{whiteSpace: "nowrap"}}><img
+           src="/img/global/icons/up-arrow-color-icon.svg"
+           width="20" height="20" /> 100%</span> is a high score.
+      Ratings can be invaluable in showing where an incumbent has stood
+      on a series of votes. Some groups select votes that tend to favor
+      members of one political party over another, rather than choosing
+      votes based solely on issues. Please call 1-888-VOTESMART for
+      more specific information.
       </Popover>;
 
 
@@ -40,8 +51,11 @@ export default class PositionRatingSnippet extends Component {
           <span className="position-rating__percentage" data-percentage={rating}>{rating}% </span> rating
           { rating_time_span ? <span className="position-rating__timestamp"> in {rating_time_span}</span> :
             null }
+            {/* zachmonteith:OverlayTrigger placement should be "auto" with bootstrap 4 */}
           { rating ?
-            <OverlayTrigger trigger="click" rootClose placement="bottom" overlay={popoverClickRootClose}>
+            <OverlayTrigger trigger="click" rootClose
+                            placement="top"
+                            overlay={popoverClickRootClose}>
               <span className="position-rating__source">&nbsp;(source: VoteSmart.org)</span>
             </OverlayTrigger> :
             null

--- a/src/js/components/Widgets/PositionRatingSnippet.jsx
+++ b/src/js/components/Widgets/PositionRatingSnippet.jsx
@@ -29,8 +29,7 @@ export default class PositionRatingSnippet extends Component {
       alt = "Mixed Rating";
     }
     const popoverClickRootClose = <Popover id="popover-trigger-click-root-close" title="VoteSmart Ratings">
-      Ratings are given by the organization, and collected by the nonprofit Vote Smart.
-      (down arrow icon) 0% is a low score, and (up arrow icon) 100% is a high score.
+      Ratings are given by the organization, and collected by the nonprofit Vote Smart. <img src="/img/global/icons/down-arrow-color-icon.svg" width="20" height="20" /> 0% is a low score, and <img src="/img/global/icons/up-arrow-color-icon.svg" width="20" height="20" />100% is a high score.
       Ratings can be invaluable in showing where an incumbent has stood on a series of votes in the past one or two years, especially when ratings by groups on all sides of an issue are compared. Some groups select votes that tend to favor members of one political party over another, rather than choosing votes based solely on issues concerns. Please visit the group's website or call 1-888-VOTESMART for more specific information.
       </Popover>;
 

--- a/src/js/components/Widgets/PositionRatingSnippet.jsx
+++ b/src/js/components/Widgets/PositionRatingSnippet.jsx
@@ -28,8 +28,10 @@ export default class PositionRatingSnippet extends Component {
       className = "position-rating__icon position-rating__icon--mixed";
       alt = "Mixed Rating";
     }
-    const popoverClickRootClose = <Popover id="popover-trigger-click-root-close" title="Popover bottom">
-        <strong>Holy guacamole!</strong> Check this info.
+    const popoverClickRootClose = <Popover id="popover-trigger-click-root-close" title="VoteSmart Ratings">
+      Ratings are given by the organization, and collected by the nonprofit Vote Smart.
+      (down arrow icon) 0% is a low score, and (up arrow icon) 100% is a high score.
+      Ratings can be invaluable in showing where an incumbent has stood on a series of votes in the past one or two years, especially when ratings by groups on all sides of an issue are compared. Some groups select votes that tend to favor members of one political party over another, rather than choosing votes based solely on issues concerns. Please visit the group's website or call 1-888-VOTESMART for more specific information.
       </Popover>;
 
 

--- a/src/sass/components/_position.scss
+++ b/src/sass/components/_position.scss
@@ -62,7 +62,7 @@
   }
 
   &__source {
-    color: #549bb6;
+    color: $popover-link-color;
   }
 
   &__candidate-name {

--- a/src/sass/components/_position.scss
+++ b/src/sass/components/_position.scss
@@ -62,7 +62,7 @@
   }
 
   &__source {
-    color: $mid-gray;
+    color: #549bb6;
   }
 
   &__candidate-name {

--- a/src/sass/utils/_variables.scss
+++ b/src/sass/utils/_variables.scss
@@ -56,6 +56,10 @@ $brand-color: #E50050 !default;
 /// @type Color
 $link-color: #337ab7 !default; // mirrors Bootstrap default - TODO: set custom value globally
 
+
+/// Popover Link Color
+/// @type Color
+$popover-link-color: #549bb6 !default;
 /// Copy text color
 /// @type Color
 $text-color: $darker-gray !default;


### PR DESCRIPTION
…ource text

this was a simple change, as Dale/Jeff already got the popover working, but with sample text.  changed text to approved VoteSmart Rating explanation, modified css color so users will more easily recognize they can click to read popover (light grayish blue, so not typical hyperlink color but similar enough to encourage a click)

This is intended to resolve issue #324