### PR TITLE
Adding meaning pull request and issue request messages

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,10 @@
+### Expected behavior and actual behavior
+
+
+### Steps to reproduce the problem
+
+
+### Specification like the version of the project, operating system, or hardware
+
+
+### Meaning commit message

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+### Reference to issue:  
+
+
+### Changes proposed to this pull request:  
+
+* 
+* 
+* 
+
+### Mentions: i.e @pertrai1 - please remote before adding


### PR DESCRIPTION
These templates can make for meaning messages that are found in pull
requests and in issues. I have an issue I want to add and having a good
template to go by can help those who look into the issue have the
information that is needed.