### PR TITLE
Top navigation icons position to window issue

### DIFF
--- a/src/sass/layout/_mediaquery.scss
+++ b/src/sass/layout/_mediaquery.scss
@@ -83,9 +83,9 @@
         display: inline-block;
         height: 45px;
         left: auto;
-        position: fixed;
+        position: absolute;
         right: 0;
-        top: 0;
+        top: -50px;
 
         .separate-top {
           border-top: none;


### PR DESCRIPTION
See screenshot below looking at app on Mac Chrome.

![top-icons-offline](https://cloud.githubusercontent.com/assets/442374/18034799/60021222-6d14-11e6-94f6-5f45a67db159.png)
