### PR TITLE
OfficeNameText now functional #411, OfficeStore only used in Office routes

### DIFF
--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -27,7 +27,7 @@ import Measure from "./routes/Ballot/Measure";
 import Office from "./routes/Ballot/Office";
 
 /* Ballot Off-shoot Pages */
-import GuidePositionList from "./routes/Guide/PositionList"; // A list of all positions from one guide
+import GuidePositionList from "./routes/Guide/GuidePositionList"; // A list of all positions from one guide
 import Opinions from "./routes/Opinions"; // More opinions about anything on the ballot
 
 /* More */
@@ -84,7 +84,7 @@ const routes = () =>
 
     <Route path="ballot" component={BallotIndex}>
       <IndexRoute component={Ballot}/>
-      <Route path="/office/:we_vote_id" component={Office} />
+      <Route path="/office/:office_we_vote_id" component={Office} />
       <Route path="/candidate/:candidate_we_vote_id" component={Candidate} />
       <Route path="/measure/:measure_we_vote_id" component={Measure} />
     </Route>

--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -5,6 +5,7 @@ import StarAction from "../../components/Widgets/StarAction";
 import ItemActionBar from "../../components/Widgets/ItemActionBar";
 import ItemPositionStatementActionBar from "../../components/Widgets/ItemPositionStatementActionBar";
 import ItemSupportOpposeCounts from "../../components/Widgets/ItemSupportOpposeCounts";
+import OfficeNameText from "../../components/Widgets/OfficeNameText";
 import SupportStore from "../../stores/SupportStore";
 import {abbreviateNumber} from "../../utils/textFormat";
 import {numberWithCommas} from "../../utils/textFormat";
@@ -117,15 +118,10 @@ export default class CandidateItem extends Component {
             } onClick={this.props.link_to_ballot_item_page ?
               goToCandidateLink : null }
           >
-            { party ?
-              <span><span className="candidate-card__political-party">
-                {party}
-              </span><span> candidate for </span></span> :
-              "Candidate for "
-            }
-            <span className="candidate-card__office">
-              { office_name }
-            </span>
+          { office_name ?
+          <OfficeNameText political_party={party} office_name={office_name} /> :
+            null
+          }
           </p>
           { twitter_description ?
             <div className={ this.props.link_to_ballot_item_page ? "candidate-card__description-container--truncated" : "candidate-card__description-container"}>

--- a/src/js/components/ImageHandler.jsx
+++ b/src/js/components/ImageHandler.jsx
@@ -22,7 +22,7 @@ export default class ImageHandler extends Component {
     let alt = this.props.alt || "icon";
     let replacementClass = "";
     if (this.props.placeholderForCandidate) {
-      replacementClass = "icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light position-item__avatar replacement-icon";
+      replacementClass = "icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light position-item__avatar";
     } else {
       replacementClass = "icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color position-item__avatar";
     }

--- a/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
+++ b/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
@@ -5,7 +5,6 @@ import FollowToggle from "../../components/Widgets/FollowToggle";
 import ItemActionBar from "../../components/Widgets/ItemActionBar";
 import ItemPositionStatementActionBar from "../../components/Widgets/ItemPositionStatementActionBar";
 import LoadingWheel from "../../components/LoadingWheel";
-import OfficeStore from "../../stores/OfficeStore";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";
 import OrganizationPositionItem from "../../components/VoterGuide/OrganizationPositionItem";
 import OrganizationStore from "../../stores/OrganizationStore";
@@ -22,7 +21,7 @@ export default class EditPositionAboutCandidateModal extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {candidate: {}, office: {}};
+    this.state = {candidate: {}};
   }
 
   componentDidMount () {
@@ -32,7 +31,6 @@ export default class EditPositionAboutCandidateModal extends Component {
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
 
     this.candidateStoreListener = CandidateStore.addListener(this._onCandidateStoreChange.bind(this));
-    this.officeStoreListener = OfficeStore.addListener(this._onCandidateStoreChange.bind(this));
     this.supportStoreListener = SupportStore.addListener(this._onSupportStoreChange.bind(this));
 
     // let { ballot_item_we_vote_id } = this.props.position;
@@ -45,7 +43,7 @@ export default class EditPositionAboutCandidateModal extends Component {
     // }
 
     // this.props.position.ballot_item_we_vote_id is the candidate
-    var ballot_item_we_vote_id = this.props.position.ballot_item_we_vote_id;
+    let ballot_item_we_vote_id = this.props.position.ballot_item_we_vote_id;
     let supportProps = SupportStore.get(ballot_item_we_vote_id);
 
     this.setState({supportProps: supportProps});
@@ -60,7 +58,6 @@ export default class EditPositionAboutCandidateModal extends Component {
 
   componentWillUnmount () {
     this.candidateStoreListener.remove();
-    this.officeStoreListener.remove();
     this.organizationStoreListener.remove();
     this.voterStoreListener.remove();
     this.supportStoreListener.remove();
@@ -86,9 +83,6 @@ export default class EditPositionAboutCandidateModal extends Component {
     //   candidate: candidate,
     // });
     //
-    // if (candidate.contest_office_we_vote_id) {
-    //   this.setState({office: OfficeStore.get(candidate.contest_office_we_vote_id) || {}});
-    // }
   }
 
   _onSupportStoreChange () {

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -4,6 +4,7 @@ import ImageHandler from "../../components/ImageHandler";
 import EditPositionAboutCandidateModal from "../../components/VoterGuide/EditPositionAboutCandidateModal";
 import FriendsOnlyIndicator from "../../components/Widgets/FriendsOnlyIndicator";
 import VoterStore from "../../stores/VoterStore";
+import OfficeNameText from "../../components/Widgets/OfficeNameText";
 import PositionInformationOnlySnippet from "../../components/Widgets/PositionInformationOnlySnippet";
 import PositionRatingSnippet from "../../components/Widgets/PositionRatingSnippet";
 import PositionPublicToggle from "../../components/Widgets/PositionPublicToggle";
@@ -25,13 +26,15 @@ export default class OrganizationPositionItem extends Component {
 
   constructor (props) {
     super(props);
-    this.state = { showEditPositionModal: false };
+    this.state = {
+      showEditPositionModal: false };
   }
 
   componentDidMount () {
     this.supportStoreListener = SupportStore.addListener(this._onSupportStoreChange.bind(this));
     this._onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
+
   }
 
   componentWillUnmount () {
@@ -41,6 +44,7 @@ export default class OrganizationPositionItem extends Component {
 
   _onSupportStoreChange () {
     let position = this.props.position;
+    // console.log("position:", position);
     this.setState({
       supportProps: SupportStore.get(position.ballot_item_we_vote_id),
       transitioning: false
@@ -60,8 +64,9 @@ export default class OrganizationPositionItem extends Component {
   }
 
   render (){
-    let position = this.props.position;
+    var position = this.props.position;
     let organization = this.props.organization;
+
     let { stance_display_off, comment_text_off, popover_off, placement } = this.props;
     const { supportProps } = this.state;
 
@@ -115,7 +120,13 @@ export default class OrganizationPositionItem extends Component {
     }
 
     const onEditPositionClick = this.state.showEditPositionModal ? this.closeEditPositionModal.bind(this) : this.openEditPositionModal.bind(this);
-
+    // console.log("this.props.position:", this.props.position);
+    var office_name;
+    var political_party;
+    if (position.kind_of_ballot_item === "CANDIDATE") {
+      office_name = position.office_name;
+      political_party = position.political_party;
+    }
     return <li className="position-item">
       <StarAction we_vote_id={position.ballot_item_we_vote_id} type={position.kind_of_ballot_item} />
         <Link to={ ballotItemLink }
@@ -134,6 +145,11 @@ export default class OrganizationPositionItem extends Component {
                 onlyActiveOnIndex={false}>
             <span className="position-rating__candidate-name">{ballot_item_display_name}</span>
           </Link>
+          <br />
+            { position.kind_of_ballot_item === "CANDIDATE" && office_name !== undefined ?
+            <OfficeNameText political_party={political_party} office_name={office_name} /> :
+              null
+            }
           {/* show explicit position, if available, otherwise show rating */}
           { this.props.link_to_edit_modal_off ?
             position_description :
@@ -156,11 +172,6 @@ export default class OrganizationPositionItem extends Component {
                 <FriendsOnlyIndicator isFriendsOnly={!is_public_position}/>
               }
         </div>
-        {/*Running for {office_display_name}
-        <br />
-          Integer ut bibendum ex. Suspendisse eleifend mi accumsan, euismod enim at, malesuada nibh.
-          Duis a eros fringilla, dictum leo vitae, vulputate mi. Nunc vitae neque nec erat fermentum... (more)
-        <br />*/}
       </ li>;
   }
 }

--- a/src/js/components/Widgets/OfficeNameText.jsx
+++ b/src/js/components/Widgets/OfficeNameText.jsx
@@ -1,0 +1,37 @@
+import React, { Component, PropTypes } from "react";
+
+export default class OfficeNameText extends Component {
+  static propTypes = {
+    political_party: PropTypes.string,
+    office_name: PropTypes.string
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      transitioning: false
+    };
+  }
+
+  componentWillReceiveProps () {
+    this.setState({transitioning: false});
+  }
+
+
+  render () {
+    let nameText = "";
+    let { office_name, political_party } = this.props;
+    if (political_party === undefined) {
+      nameText = <span className="no-political-party">
+      Candidate for <span className="candidate-card__office">
+      { office_name } </span> </span>;
+    } else {
+      nameText = <span> <span className="candidate-card__political-party">
+      {political_party} </span> candidate for <span className="candidate-card__office">
+        { office_name }
+      </span></span>;
+    }
+    return nameText;
+
+  }
+}

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -6,7 +6,6 @@ import GuideList from "../../components/VoterGuide/GuideList";
 import GuideStore from "../../stores/GuideStore";
 import GuideActions from "../../actions/GuideActions";
 import LoadingWheel from "../../components/LoadingWheel";
-import OfficeStore from "../../stores/OfficeStore";
 import PositionList from "../../components/Ballot/PositionList";
 import SupportActions from "../../actions/SupportActions";
 import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
@@ -22,7 +21,6 @@ export default class Candidate extends Component {
     super(props);
     this.state = {
       candidate: {},
-      office: {},
       candidate_we_vote_id: this.props.params.candidate_we_vote_id,
       guideToFollowList: GuideStore.toFollowListForBallotItem()
 
@@ -30,10 +28,10 @@ export default class Candidate extends Component {
   }
 
   componentDidMount (){
-    this.candidateStoreListener = CandidateStore.addListener(this._onCandidateChange.bind(this));
-    this.officeStoreListener = OfficeStore.addListener(this._onCandidateChange.bind(this));
+    this.candidateStoreListener = CandidateStore.addListener(this._onCandidateStoreChange.bind(this));
     var { candidate_we_vote_id } = this.state;
     CandidateActions.retrieve(candidate_we_vote_id);
+
 
     // Get the latest guides to follow for this candidate
     this.guideStoreListener = GuideStore.addListener(this._onGuideStoreChange.bind(this));
@@ -64,18 +62,13 @@ export default class Candidate extends Component {
 
   componentWillUnmount () {
     this.candidateStoreListener.remove();
-    this.officeStoreListener.remove();
     this.guideStoreListener.remove();
   }
 
-  _onCandidateChange (){
+  _onCandidateStoreChange (){
     var { candidate_we_vote_id } = this.state;
     var candidate = CandidateStore.get(candidate_we_vote_id) || {};
     this.setState({ candidate: candidate });
-
-    if (candidate.contest_office_we_vote_id){
-      this.setState({ office: OfficeStore.get(candidate.contest_office_we_vote_id) || {} });
-    }
   }
 
   _onGuideStoreChange (){
@@ -87,7 +80,7 @@ export default class Candidate extends Component {
   render () {
     const electionId = VoterStore.election_id();
     const NO_VOTER_GUIDES_TEXT = "We could not find any more voter guides to follow about this candidate or measure.";
-    var { candidate, office, guideToFollowList, candidate_we_vote_id } = this.state;
+    var { candidate, guideToFollowList, candidate_we_vote_id } = this.state;
 
     if (!candidate.ballot_item_display_name){
       // TODO DALE If the candidate we_vote_id is not valid, we need to update this with a notice
@@ -99,7 +92,7 @@ export default class Candidate extends Component {
 
     return <span>
         <section className="candidate-card__container">
-          <CandidateItem {...candidate} office_name={office.ballot_item_display_name}/>
+          <CandidateItem {...candidate} office_name={candidate.office_name} />
           <div className="candidate-card__additional">
             { candidate.position_list ?
               <div>

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -1,11 +1,11 @@
 import React, { Component, PropTypes } from "react";
-import CandidateActions from "../../actions/CandidateActions";
+// import CandidateActions from "../../actions/CandidateActions";
 import CandidateItem from "../../components/Ballot/CandidateItem";
 import CandidateStore from "../../stores/CandidateStore";
 import GuideList from "../../components/VoterGuide/GuideList";
 import GuideStore from "../../stores/GuideStore";
-import GuideActions from "../../actions/GuideActions";
-import OfficeStore from "../../stores/OfficeStore";
+// import OfficeActions from "../../actions/OfficeActions";
+// import OfficeStore from "../../stores/OfficeStore";
 import PositionList from "../../components/Ballot/PositionList";
 import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
 import VoterStore from "../../stores/VoterStore";
@@ -19,35 +19,32 @@ export default class Office extends Component {
 
   constructor (props) {
     super(props);
-    this.we_vote_id = this.props.params.we_vote_id;
+    this.office_we_vote_id = this.props.params.office_we_vote_id;
     this.state = {candidate: {}, office: {} };
   }
 
   componentDidMount (){
     this.candidateStoreListener = CandidateStore.addListener(this._onChange.bind(this));
-    this.officeStoreListener = OfficeStore.addListener(this._onChange.bind(this));
+    // this.officeStoreListener = OfficeStore.addListener(this._onChange.bind(this));
 
-    CandidateActions.retrieve(this.we_vote_id);
-
-    this.guideStoreListener = GuideStore.addListener(this._onChange.bind(this));
-    GuideActions.retrieveGuidesToFollowByBallotItem(this.we_vote_id, "CANDIDATE");
+    // OfficeActions.retrieve(this.office_we_vote_id);
 
     exitSearch("");
   }
 
   componentWillUnmount () {
     this.candidateStoreListener.remove();
-    this.officeStoreListener.remove();
-    this.guideStoreListener.remove();
+    // this.officeStoreListener.remove();
+
   }
 
   _onChange (){
     var candidate = CandidateStore.get(this.we_vote_id) || {};
     this.setState({ candidate: candidate, guideToFollowList: GuideStore.toFollowListForBallotItem() });
 
-    if (candidate.contest_office_we_vote_id){
-      this.setState({ office: OfficeStore.get(candidate.contest_office_we_vote_id) || {} });
-    }
+    // if (candidate.contest_office_we_vote_id){
+    //   this.setState({ office: OfficeStore.getOffice(candidate.contest_office_we_vote_id) || {} });
+    // }
 
   }
 
@@ -80,7 +77,7 @@ export default class Office extends Component {
             {guideToFollowList.length === 0 ?
               <p className="candidate-card__no-additional">{NO_VOTER_GUIDES_TEXT}</p> :
               <div><h3 className="candidate-card__additional-heading">{"More opinions about " + candidate.ballot_item_display_name}</h3>
-              <GuideList id={electionId} ballotItemWeVoteId={this.we_vote_id} organizationsToFollow={guideToFollowList}/></div>
+              <GuideList id={electionId} ballotItemWeVoteId={this.office_we_vote_id} organizationsToFollow={guideToFollowList}/></div>
             }
           </div>
         </section>

--- a/src/js/routes/Guide/GuidePositionList.jsx
+++ b/src/js/routes/Guide/GuidePositionList.jsx
@@ -70,6 +70,7 @@ export default class GuidePositionList extends Component {
 
     const { position_list_for_one_election, position_list_for_all_except_one_election } = this.state.organization;
     var { we_vote_id } = this.state;
+    console.log("position list for one election:", position_list_for_one_election);
     return <span>
         <div className="card__container">
           <div className="card__main">
@@ -82,6 +83,7 @@ export default class GuidePositionList extends Component {
                 return <OrganizationPositionItem key={item.position_we_vote_id}
                                                  position={item}
                                                  organization={this.state.organization}
+
                                                  popover_off />;
               }) :
               <div>{LoadingWheel}</div>

--- a/src/js/routes/Guide/VerifyThisIsMe.jsx
+++ b/src/js/routes/Guide/VerifyThisIsMe.jsx
@@ -5,7 +5,6 @@ import CandidateItem from "../../components/Ballot/CandidateItem";
 import CandidateStore from "../../stores/CandidateStore";
 import FollowToggle from "../../components/Widgets/FollowToggle";
 import LoadingWheel from "../../components/LoadingWheel";
-import OfficeStore from "../../stores/OfficeStore";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";
 import OrganizationStore from "../../stores/OrganizationStore";
 import TwitterAccountCard from "../../components/Twitter/TwitterAccountCard";
@@ -21,7 +20,7 @@ export default class VerifyThisIsMe extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {candidate: {}, office: {} };
+    this.state = {candidate: {} };
   }
 
   componentDidMount () {
@@ -35,14 +34,12 @@ export default class VerifyThisIsMe extends Component {
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
 
     this.candidateStoreListener = CandidateStore.addListener(this._onCandidateStoreChange.bind(this));
-    this.officeStoreListener = OfficeStore.addListener(this._onCandidateStoreChange.bind(this));
 
     this.twitterStoreListener = TwitterStore.addListener(this._onTwitterStoreChange.bind(this));
   }
 
   componentWillUnmount (){
     this.candidateStoreListener.remove();
-    this.officeStoreListener.remove();
     this.organizationStoreListener.remove();
     this.voterStoreListener.remove();
     this.twitterStoreListener.remove();
@@ -67,10 +64,6 @@ export default class VerifyThisIsMe extends Component {
     this.setState({
       candidate: candidate,
     });
-
-    if (candidate.contest_office_we_vote_id){
-      this.setState({ office: OfficeStore.get(candidate.contest_office_we_vote_id) || {} });
-    }
   }
 
   _onTwitterStoreChange () {
@@ -95,7 +88,7 @@ export default class VerifyThisIsMe extends Component {
 
   render () {
     // Manage the control over this organization voter guide
-    var {candidate, office, organization, voter} = this.state;
+    var {candidate, organization, voter} = this.state;
     var signed_in_twitter = voter === undefined ? false : voter.signed_in_twitter;
     var signed_in_with_this_twitter_account = false;
     if (signed_in_twitter) {
@@ -117,7 +110,7 @@ export default class VerifyThisIsMe extends Component {
       this.props.params.we_vote_id = this.state.owner_we_vote_id;
       return <span>
         <section className="candidate-card__container">
-          <CandidateItem {...candidate} office_name={office.ballot_item_display_name}/>
+          <CandidateItem {...candidate} />
         </section>
         <div>
           <br />

--- a/src/js/routes/NotFound.jsx
+++ b/src/js/routes/NotFound.jsx
@@ -3,7 +3,7 @@ import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import Candidate from "./Ballot/Candidate";
 import LoadingWheel from "../components/LoadingWheel";
-import GuidePositionList from "./Guide/PositionList";
+import GuidePositionList from "./Guide/GuidePositionList";
 import OrganizationActions from "../actions/OrganizationActions";
 import PositionListForFriends from "./Guide/PositionListForFriends";
 import TwitterActions from "../actions/TwitterActions";

--- a/src/js/stores/OfficeStore.js
+++ b/src/js/stores/OfficeStore.js
@@ -1,7 +1,13 @@
 var Dispatcher = require("../dispatcher/Dispatcher");
 var FluxMapStore = require("flux/lib/FluxMapStore");
+const assign = require("object-assign");
 
 class OfficeStore extends FluxMapStore {
+  getOffice (office_we_vote_id) {
+      // if (!this.isLoaded()){ return undefined; }
+      console.log("in getOffice, office_we_vote_id and office:", office_we_vote_id, this.getState().office[office_we_vote_id]);
+      return this.getState().office[office_we_vote_id];
+    }
 
   reduce (state, action) {
 
@@ -9,12 +15,35 @@ class OfficeStore extends FluxMapStore {
     if (!action.res || !action.res.success)
       return state;
 
+      var key;
+
     switch (action.type) {
 
       case "officeRetrieve":
-        var key = action.res.we_vote_id;
+        key = action.res.we_vote_id;
+        console.log("officeRetrieve action.res", action.res);
         var office = action.res || {};
-        return state.set(key, office);
+        console.log("in OfficeStore, officeRetrieve office:", office);
+        return {
+          ...state,
+          office: assign({}, state.office, office )
+        };
+
+
+      case "voterBallotItemsRetrieve":
+        key = action.res.google_civic_election_id;
+        var offices = {};
+        action.res.ballot_item_list.forEach(one_ballot_item =>{
+          if (one_ballot_item.kind_of_ballot_item === "OFFICE") {
+            offices[one_ballot_item.we_vote_id] = one_ballot_item;
+          }
+        });
+        console.log("In OfficeStore, voterBallotItemsRetrieve offices:", offices);
+
+        return {
+          ...state,
+          offices: assign({}, state.offices, offices )
+        };
 
       case "error-officeRetrieve":
         console.log(action);


### PR DESCRIPTION
changes in this pull request:
1) renamed a few files and variables to avoid name duplication/collisions (most obvious of these is GuidePositionList) and be more descriptive
2) removed deprecated classnames from ImageHandler 
3) created OfficeNameText component to display party name and office name for candidates #411 
4) removed OfficeStore from places where it was only being called to populate office_name, which **TODO: will be passed in with "position" and "candidate" objects**
5) preliminary changes to OfficeStore in preparation for Office routes fix