### PR TITLE
ImageHandler fix: pass in kind_of_ballot_item, remove conditional sta…

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -69,7 +69,7 @@ export default class CandidateItem extends Component {
       candidate_photo_url_html = <ImageHandler className="candidate-card__photo"
                                           imageUrl={candidate_photo_url}
                                           alt="candidate-photo"
-                                          placeholderForCandidate />;
+                                          kind_of_ballot_item="CANDIDATE" />;
     } else {
       candidate_photo_url_html = <i className="icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light utils-img-contain-glyph" />;
     }

--- a/src/js/components/ImageHandler.jsx
+++ b/src/js/components/ImageHandler.jsx
@@ -5,7 +5,7 @@ export default class ImageHandler extends Component {
     imageUrl: PropTypes.string,
     className: PropTypes.string,
     alt: PropTypes.string,
-    placeholderForCandidate: PropTypes.bool
+    kind_of_ballot_item: PropTypes.string
   };
 
   constructor (props) {
@@ -21,7 +21,7 @@ export default class ImageHandler extends Component {
     let this_class = this.props.className || "utils-img-contain";
     let alt = this.props.alt || "icon";
     let replacementClass = "";
-    if (this.props.placeholderForCandidate) {
+    if (this.props.kind_of_ballot_item === "CANDIDATE") {
       replacementClass = "icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light position-item__avatar";
     } else {
       replacementClass = "icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color position-item__avatar";

--- a/src/js/components/Twitter/TwitterAccountCard.jsx
+++ b/src/js/components/Twitter/TwitterAccountCard.jsx
@@ -29,10 +29,7 @@ export default class TwitterAccountCard extends Component {
     return <div className="card__container">
         <div className="card__main">
           <div className="card__media-object">
-            { twitter_photo_url ?
-              <ImageHandler imageUrl={twitter_photo_url} className="card__media-object-anchor" /> :
-              <i className="icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color card__media-object-anchor"></i>
-            }
+            <ImageHandler imageUrl={twitter_photo_url} className="card__media-object-anchor" />
             <div className="card__media-object-content">
               <div className="card__display-name">{displayName}</div>
               { twitterDescriptionMinusName ?

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -33,10 +33,7 @@ export default class OrganizationCard extends Component {
     let twitterDescriptionMinusName = removeTwitterNameFromDescription(displayName, twitterDescription);
 
     return <div className="card__media-object">
-          { organization_photo_url ?
-            <ImageHandler imageUrl={organization_photo_url} className="card__media-object-anchor" /> :
-            <i className="icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color card__media-object-anchor" />
-          }
+            <ImageHandler imageUrl={organization_photo_url} className="card__media-object-anchor" />
           <div className="card__media-object-content">
             <div className="card__display-name">{displayName}</div>
             { twitterDescriptionMinusName && !this.props.turn_off_description ?

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
-import EditPositionAboutCandidateModal from "../../components/VoterGuide/EditPositionAboutCandidateModal";
+// import EditPositionAboutCandidateModal from "../../components/VoterGuide/EditPositionAboutCandidateModal";
 import FriendsOnlyIndicator from "../../components/Widgets/FriendsOnlyIndicator";
 import VoterStore from "../../stores/VoterStore";
 import OfficeNameText from "../../components/Widgets/OfficeNameText";
@@ -92,7 +92,7 @@ export default class OrganizationPositionItem extends Component {
     let ballot_item_url = position.kind_of_ballot_item === "MEASURE" ? "/measure/" : "/candidate/";
     let ballotItemLink = position.ballot_item_twitter_handle ? "/" + position.ballot_item_twitter_handle : ballot_item_url + position.ballot_item_we_vote_id;
     let position_description = "";
-    let has_image = position.ballot_item_image_url_https && position.kind_of_ballot_item === "CANDIDATE";
+    let is_candidate = position.kind_of_ballot_item === "CANDIDATE";
     let ballot_item_display_name = "";
     if (position.ballot_item_display_name) {
       ballot_item_display_name = capitalizeString(position.ballot_item_display_name);
@@ -132,11 +132,12 @@ export default class OrganizationPositionItem extends Component {
         <Link to={ ballotItemLink }
               onlyActiveOnIndex={false}>
           {/*<i className="icon-icon-add-friends-2-1 icon-light icon-medium" />*/}
-          { has_image ?
+          { is_candidate ?
             <ImageHandler
               className="position-item__avatar"
               imageUrl={position.ballot_item_image_url_https}
-              alt="candidate-photo" placeholderForCandidate/> :
+              alt="candidate-photo"
+              kind_of_ballot_item={position.kind_of_ballot_item}/> :
             null
           }
         </Link>

--- a/src/js/routes/Guide/GuidePositionList.jsx
+++ b/src/js/routes/Guide/GuidePositionList.jsx
@@ -70,7 +70,7 @@ export default class GuidePositionList extends Component {
 
     const { position_list_for_one_election, position_list_for_all_except_one_election } = this.state.organization;
     var { we_vote_id } = this.state;
-    console.log("position list for one election:", position_list_for_one_election);
+    // console.log("position list for one election:", position_list_for_one_election);
     return <span>
         <div className="card__container">
           <div className="card__main">


### PR DESCRIPTION
…tments #402

This is a fix for the bug Dale encountered where some candidates were not getting image placeholders if they didn't have an image to begin with.  

Also eliminated redundant code, especially conditional statements depending on whether ballot items had images: all will now be handled by ImageHandler, which will return a placeholder icon if the ballot item doesn't have an image url OR if it is a broken/bad image url