### PR TITLE
fix visibility toggle (friends-public) positioning (fixes #445)

### DIFF
--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -3,8 +3,8 @@
 }
 
 .candidate-card-position-public-toggle {
-  position: absolute;
-  right: 15px;
+  flex-grow: 10; // arbitrary value large enough to fill space
+  text-align: right;
 
 }
 


### PR DESCRIPTION
There is some additional spacing cleanup we can do in the ItemActionBar, but I kept this scoped to the specific issue specified.

Related suggestions for improvement:
- hide Share button on small screens until a position is taken
- use icons for public/friends toggle instead of text