### PR TITLE
implemented ReadMore text truncator for position statements #465

### DIFF
--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import ReadMore from "../../components/Widgets/ReadMore";
 
 export default class PositionInformationOnlySnippet extends Component {
   static propTypes = {
@@ -20,6 +21,9 @@ export default class PositionInformationOnlySnippet extends Component {
     var positionLabel;
     var hasThisToSay;
     var { is_looking_at_self } = this.props;
+    var statement_text = this.props.statement_text || "";
+    var statement_text_html = <ReadMore text_to_display={statement_text} />;
+
 
     stance_icon_src = "/img/global/icons/mixed-rating-icon.svg";
     className = "position-rating__icon position-rating__icon--mixed";
@@ -37,7 +41,7 @@ export default class PositionInformationOnlySnippet extends Component {
 
     return <div className="explicit-position">
       {stance_display_off ? null : <img src={stance_icon_src} width="20" height="20" className={className} alt={alt} />}
-      <p className="explicit-position__text">
+      <div className="explicit-position__text">
         { stance_display_off ?
           null :
           <span>
@@ -55,14 +59,14 @@ export default class PositionInformationOnlySnippet extends Component {
         }
         { comment_text_off ? null :
           <span>
-            <span> {this.props.statement_text}</span>
+            <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {this.props.more_info_url ?
               <span className="explicit-position__source"> (view source)</span> :
               null }
           </span>
         }
-      </p>
+      </div>
     </div>;
   }
 }

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import ReadMore from "../../components/Widgets/ReadMore";
 
 export default class PositionSupportOpposeSnippet extends Component {
   static propTypes = {
@@ -21,6 +22,9 @@ export default class PositionSupportOpposeSnippet extends Component {
     var positionLabel;
     var isSupportedBy;
     var { is_looking_at_self } = this.props;
+    var statement_text = this.props.statement_text || "";
+    var statement_text_html = <ReadMore text_to_display={statement_text} />;
+
     if (this.props.is_support){
       stance_icon_src = "/img/global/icons/thumbs-up-color-icon.svg";
       className = "explicit-position__icon";
@@ -47,7 +51,7 @@ export default class PositionSupportOpposeSnippet extends Component {
     }
     return <div className="explicit-position">
       { stance_display_off ? null : <img src={stance_icon_src} width="20" height="20" className={className} alt={alt} /> }
-      <p className="explicit-position__text">
+      <div className="explicit-position__text">
         { stance_display_off ?
           null :
           <span>
@@ -65,14 +69,14 @@ export default class PositionSupportOpposeSnippet extends Component {
         }
         { comment_text_off ? null :
           <span>
-            <span> {this.props.statement_text}</span>
+            <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {this.props.more_info_url ?
               <span className="explicit-position__source"> (view source)</span> :
               null }
           </span>
         }
-      </p>
+      </div>
     </div>;
   }
 }

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -5,6 +5,7 @@ export default class ReadMore extends Component {
   static propTypes = {
     text_to_display: PropTypes.node.isRequired,
     link_text: PropTypes.node,
+    collapse_text: PropTypes.node,
     num_of_lines: PropTypes.number
   };
 
@@ -26,12 +27,15 @@ export default class ReadMore extends Component {
     }
 
     render () {
-        let { text_to_display, link_text, num_of_lines } = this.props;
+        let { text_to_display, link_text, num_of_lines, collapse_text } = this.props;
         if (num_of_lines === undefined) {
           num_of_lines = 3;
         }
         if (link_text === undefined) {
           link_text = "More";
+        }
+        if (collapse_text === undefined) {
+          collapse_text = "...Less";
         }
 
         if (this.state.readMore){
@@ -42,7 +46,7 @@ export default class ReadMore extends Component {
                 textTruncateChild={<a href="#" onClick={this.toggleLines}>{link_text}</a>}
             /></span>
           ;} else {
-            return <span>{text_to_display}<a href="#" onClick={this.toggleLines}> ...Less</a></span>;
+            return <span>{text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
           }
     }
 }

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -1,0 +1,48 @@
+import React, { Component, PropTypes } from "react";
+import TextTruncate from "react-text-truncate";
+
+export default class ReadMore extends Component {
+  static propTypes = {
+    text_to_display: PropTypes.node.isRequired,
+    link_text: PropTypes.node,
+    num_of_lines: PropTypes.number
+  };
+
+    constructor (...args) {
+        super(...args);
+
+        this.state = {readMore: true};
+
+        this.toggleLines = this.toggleLines.bind(this);
+
+    }
+
+    toggleLines (event) {
+        event.preventDefault();
+
+        this.setState({
+            readMore: !this.state.readMore
+        });
+    }
+
+    render () {
+        let { text_to_display, link_text, num_of_lines } = this.props;
+        if (num_of_lines === undefined) {
+          num_of_lines = 3;
+        }
+        if (link_text === undefined) {
+          link_text = "More";
+        }
+
+        if (this.state.readMore){
+        return <span><TextTruncate
+                line={num_of_lines}
+                truncateText="..."
+                text={text_to_display}
+                textTruncateChild={<a href="#" onClick={this.toggleLines}>{link_text}</a>}
+            /></span>
+          ;} else {
+            return <span>{text_to_display}<a href="#" onClick={this.toggleLines}> ...Less</a></span>;
+          }
+    }
+}


### PR DESCRIPTION
Created ReadMore.jsx in components/Widgets.  uses react-text-truncate to truncate text, could easily be imported wherever needed.  

Pass in as props: 
text_to_display (required), 
link_text (the text for the link to expand the truncated text, defaults to "More"),
collapse_text (text for link to collapse back to truncated text, defaults to  "...Less"), and 
num_of_lines (the number of vertical lines of text which will appear in the truncated version, defaults to 3)

included in both Position Statements (Oppose/Support and Information Only)