### PR TITLE
created CopyLinkModal for ShareButtonDropdown #435

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,10 @@
     "react-addons-css-transition-group": "^0.14.7",
     "react-bootstrap-toggle": "^1.2.19",
     "react-burger-menu": "^1.10.4",
+    "react-copy-to-clipboard": "^4.2.3",
     "react-dom": "^0.14.3",
     "react-textarea-autosize": "^4.0.4",
+    "react-text-truncate": "^0.8.2",
     "superagent": "^1.5.0",
     "underscore": "^1.8.3",
     "vinyl-buffer": "^1.0.0"
@@ -90,7 +92,6 @@
     "react-select": "^0.9.1",
     "react-svg-icons": "^0.2.0",
     "react-tap-event-plugin": "^0.2.1",
-    "react-text-truncate": "^0.8.2",
     "tape": "^4.4.0",
     "vinyl-source-stream": "^1.1.0",
     "yargs": "^3.31.0"

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -1,0 +1,49 @@
+import React, { Component, PropTypes } from "react";
+import { Modal } from "react-bootstrap";
+import CopyToClipboard from "react-copy-to-clipboard";
+
+export default class CopyLinkModal extends Component {
+  static propTypes = {
+    urlBeingShared: PropTypes.string
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      value: "",
+      copied: false
+    };
+  }
+
+  componentWillMount () {
+    this.setState({
+      copied: false
+    });
+  }
+
+  componentWillReceiveProps () {
+    this.setState({
+      copied: false
+    });
+  }
+
+render () {
+  let urlBeingShared = this.props.urlBeingShared;
+  return <Modal {...this.props} bsSize="large" aria-labelledby="contained-modal-title-lg">
+    <Modal.Header closeButton>
+      <Modal.Title id="contained-modal-title-lg">Copy link to clipboard</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <div className="input-group">
+        <input value={urlBeingShared} className="form-control" style={{marginTop: "17px"}} onChange={({target: {value}}) => this.setState({value, copied: false})} />&nbsp;
+          <span className="input-group-btn">
+        <CopyToClipboard text={urlBeingShared} onCopy={() => this.setState({copied: true})}>
+          <button className="copy-btn btn btn-default">Copy</button>
+        </CopyToClipboard>
+        </span>
+      </div>
+        {this.state.copied ? <span style={{color: "red"}}>Copied.  Can now paste into an email or social media!</span> : null}
+    </Modal.Body>
+  </Modal>;
+  }
+}

--- a/src/js/components/Widgets/ShareButtonDropdown.jsx
+++ b/src/js/components/Widgets/ShareButtonDropdown.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import CopyLinkModal from "../../components/Widgets/CopyLinkModal";
 
 export default class ShareButtonDropdown extends Component {
   static propTypes = {
@@ -10,7 +11,14 @@ export default class ShareButtonDropdown extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {open: false };
+    this.state = { open: false };
+  }
+
+  componentWillMount () {
+    this.setState({
+      showCopyLinkModal: false,
+      transitioning: false
+    });
   }
 
   closeDropdown () {
@@ -33,16 +41,23 @@ export default class ShareButtonDropdown extends Component {
     this.closeDropdown();
  }
 
- copyToClipboard (event) {
+
+ closeCopyLinkModal () {
+   this.setState({ showCopyLinkModal: false });
+ }
+
+ openCopyLinkModal (event) {
    console.log(event);
    event.stopPropagation();
+   this.setState({ showCopyLinkModal: true });
    this.closeDropdown();
  }
 
-  render () {
-    const {shareIcon, shareText} = this.props;
-    const onClick = this.state.open ? this.closeDropdown.bind(this) : this.openDropdown.bind(this);
 
+  render () {
+    const {shareIcon, shareText, urlBeingShared} = this.props;
+    const onClick = this.state.open ? this.closeDropdown.bind(this) : this.openDropdown.bind(this);
+    const onCopyLinkClick = this.state.showCopyLinkModal ? this.closeCopyLinkModal.bind(this) : this.openCopyLinkModal.bind(this);
     return <div className="btn-group open">
       <button onClick={onClick} className="dropdown item-actionbar__btn item-actionbar__btn--position-selected btn btn-default">
         {shareIcon} {shareText} <span className="caret"></span>
@@ -51,7 +66,7 @@ export default class ShareButtonDropdown extends Component {
         <ul className="dropdown-menu">
           <li>
             <a onBlur={this.closeDropdown.bind(this)}
-               onClick={this.copyToClipboard.bind(this)}>
+               onClick={onCopyLinkClick}>
                 Copy link
             </a>
           </li>
@@ -65,6 +80,9 @@ export default class ShareButtonDropdown extends Component {
         </ul> :
         null
       }
+      <CopyLinkModal show={this.state.showCopyLinkModal}
+                     onHide={this.closeCopyLinkModal.bind(this)}
+                     urlBeingShared={urlBeingShared} />
     </div>;
   }
 }

--- a/src/sass/elements/_buttons.scss
+++ b/src/sass/elements/_buttons.scss
@@ -16,6 +16,10 @@
 	}
 }
 
+.copy-btn {
+	height: 34px;
+}
+
 
 // TODO: Jeff - move styles to <Button> component (doesn't currently exist)
 .btn__icon {


### PR DESCRIPTION
Tested on desktop and mobile browser: selecting "Copy Link" from share dropdown now activates a modal with an input field containing the ballot item url and a button to copy that url directly to the user's clipboard using package react-copy-to-clipboard.  
On click, red text appears telling user they have successfully copied the url, and suggesting what they might do next.