### PR TITLE
view source desktop, mobile in progress #397

### DIFF
--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
-import EditPositionAboutCandidateModal from "../../components/VoterGuide/EditPositionAboutCandidateModal";
+// import EditPositionAboutCandidateModal from "../../components/VoterGuide/EditPositionAboutCandidateModal";
 import FriendsOnlyIndicator from "../../components/Widgets/FriendsOnlyIndicator";
 import PositionRatingSnippet from "../../components/Widgets/PositionRatingSnippet";
 import PositionInformationOnlySnippet from "../../components/Widgets/PositionInformationOnlySnippet";
@@ -17,16 +17,16 @@ export default class PositionItem extends Component {
 
   constructor (props) {
     super(props);
-    this.state = { showEditPositionModal: false };
+    // this.state = { showEditPositionModal: false };
   }
 
-  closeEditPositionModal () {
-    this.setState({ showEditPositionModal: false });
-  }
-
-  openEditPositionModal () {
-    this.setState({ showEditPositionModal: true });
-  }
+  // closeEditPositionModal () {
+  //   this.setState({ showEditPositionModal: false });
+  // }
+  //
+  // openEditPositionModal () {
+  //   this.setState({ showEditPositionModal: true });
+  // }
 
   render () {
     var position = this.props.position;
@@ -65,23 +65,23 @@ export default class PositionItem extends Component {
 
     var nothing_to_display = null;
 
-    var edit_mode = false;  // TODO DALE Convert this to be dynamically set
-    const onEditPositionClick = this.state.showEditPositionModal ? this.closeEditPositionModal.bind(this) : this.openEditPositionModal.bind(this);
+    // var edit_mode = false;  // TODO DALE Convert this to be dynamically set
+    // const onEditPositionClick = this.state.showEditPositionModal ? this.closeEditPositionModal.bind(this) : this.openEditPositionModal.bind(this);
     // Only allow editing if the position we are passing in has a we_vote_id
     // TODO DALE I need to think through passing in organization below
-    const edit_position_description = edit_mode && position !== undefined ?
-      <span>
-        <span className="edit-position-action"
-              onClick={onEditPositionClick}
-              title="Edit this position">
-          { position_description }
-        </span>
-        <EditPositionAboutCandidateModal show={this.state.showEditPositionModal}
-                                         onHide={this.closeEditPositionModal.bind(this)}
-                                         position={position}
-                                         organization={this.props.organization}/>
-      </span> :
-      null;
+    // const edit_position_description = edit_mode && position !== undefined ?
+    //   <span>
+    //     <span className="edit-position-action"
+    //           onClick={onEditPositionClick}
+    //           title="Edit this position">
+    //       { position_description }
+    //     </span>
+    //     <EditPositionAboutCandidateModal show={this.state.showEditPositionModal}
+    //                                      onHide={this.closeEditPositionModal.bind(this)}
+    //                                      position={position}
+    //                                      organization={this.props.organization}/>
+    //   </span> :
+    //   null;
 
     var one_position_on_this_candidate = <li className="card-child position-item">
       {/* One Position on this Candidate */}
@@ -99,9 +99,10 @@ export default class PositionItem extends Component {
                 { position.speaker_display_name }
               </Link>
             </h4>
-            { edit_mode ?
+            {/* edit_mode ?
               edit_position_description :
-              position_description }
+              position_description */}
+              {position_description}
             <FriendsOnlyIndicator isFriendsOnly={!position.is_public_position} />
           </div>
         </div>

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -85,6 +85,7 @@ export default class PositionItem extends Component {
 
     var one_position_on_this_candidate = <li className="card-child position-item">
       {/* One Position on this Candidate */}
+      <div className="card-child__media-object-content">
         <Link to={speakerLink}>
           { position.speaker_image_url_https ?
             <ImageHandler className="img-square card-child__avatar"
@@ -92,7 +93,6 @@ export default class PositionItem extends Component {
             /> :
           image_placeholder }
         </Link>
-        <div className="card-child__media-object-content">
           <div className="card-child__content">
             <h4 className="card-child__display-name">
               <Link to={speakerLink}>

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -85,7 +85,6 @@ export default class PositionItem extends Component {
 
     var one_position_on_this_candidate = <li className="card-child position-item">
       {/* One Position on this Candidate */}
-      <div className="card-child__media-object-content">
         <Link to={speakerLink}>
           { position.speaker_image_url_https ?
             <ImageHandler className="img-square card-child__avatar"
@@ -93,6 +92,7 @@ export default class PositionItem extends Component {
             /> :
           image_placeholder }
         </Link>
+        <div className="card-child__media-object-content">
           <div className="card-child__content">
             <h4 className="card-child__display-name">
               <Link to={speakerLink}>

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -30,7 +30,7 @@ export default class OrganizationPositionItem extends Component {
 
   componentWillMount () {
     this.setState({
-      showEditPositionModal: false,
+      // showEditPositionModal: false,
       supportProps: SupportStore.get(this.props.position.ballot_item_we_vote_id),
       transitioning: false
     });
@@ -59,13 +59,13 @@ export default class OrganizationPositionItem extends Component {
     this.setState({ voter: VoterStore.getVoter() });
   }
 
-  closeEditPositionModal () {
-    this.setState({ showEditPositionModal: false });
-  }
-
-  openEditPositionModal () {
-    this.setState({ showEditPositionModal: true });
-  }
+  // closeEditPositionModal () {
+  //   this.setState({ showEditPositionModal: false });
+  // }
+  //
+  // openEditPositionModal () {
+  //   this.setState({ showEditPositionModal: true });
+  // }
 
   render (){
     var position = this.props.position;
@@ -144,7 +144,7 @@ export default class OrganizationPositionItem extends Component {
                                                              comment_text_off={comment_text_off} />;
     }
 
-    const onEditPositionClick = this.state.showEditPositionModal ? this.closeEditPositionModal.bind(this) : this.openEditPositionModal.bind(this);
+    // const onEditPositionClick = this.state.showEditPositionModal ? this.closeEditPositionModal.bind(this) : this.openEditPositionModal.bind(this);
     var contest_office_name;
     var political_party;
     if (position.kind_of_ballot_item === "CANDIDATE") {
@@ -176,7 +176,7 @@ export default class OrganizationPositionItem extends Component {
               null
             }
           {/* show explicit position, if available, otherwise show rating */}
-          { this.props.link_to_edit_modal_off ?
+          {/* this.props.link_to_edit_modal_off ?
             position_description :
             <span>
               <span className="edit-position-action"
@@ -184,11 +184,12 @@ export default class OrganizationPositionItem extends Component {
                     title="Edit this position">
                 { position_description }
               </span>
-              {/* GET WORKING WITH MEASURES <EditPositionAboutCandidateModal show={this.state.showEditPositionModal}
+              { GET WORKING WITH MEASURES <EditPositionAboutCandidateModal show={this.state.showEditPositionModal}
                                                onHide={this.closeEditPositionModal.bind(this)}
                                                position={position}
-                                               organization={organization}/>*/}
-            </span> }
+                                               organization={organization}/>}
+            </span> */}
+            { position_description }
             { signed_in_with_this_twitter_account || signed_in_with_this_facebook_account ?
               <PositionPublicToggle ballot_item_we_vote_id={position.ballot_item_we_vote_id}
                 type={position.kind_of_ballot_item}

--- a/src/js/components/VoterGuide/VoterPositionItem.jsx
+++ b/src/js/components/VoterGuide/VoterPositionItem.jsx
@@ -28,7 +28,7 @@ export default class VoterPositionItem extends Component {
 
   componentWillMount () {
     this.setState({
-      showEditPositionModal: false,
+      // showEditPositionModal: false,
       supportProps: SupportStore.get(this.props.position.ballot_item_we_vote_id),
       transitioning: false
     });
@@ -58,13 +58,13 @@ export default class VoterPositionItem extends Component {
     this.setState({ voter: VoterStore.getVoter() });
   }
 
-  closeEditPositionModal () {
-    this.setState({ showEditPositionModal: false });
-  }
-
-  openEditPositionModal () {
-    this.setState({ showEditPositionModal: true });
-  }
+  // closeEditPositionModal () {
+  //   this.setState({ showEditPositionModal: false });
+  // }
+  //
+  // openEditPositionModal () {
+  //   this.setState({ showEditPositionModal: true });
+  // }
 
   render (){
     var position = this.props.position;
@@ -114,7 +114,7 @@ export default class VoterPositionItem extends Component {
                                                              comment_text_off={comment_text_off} />;
     }
 
-    const onEditPositionClick = this.state.showEditPositionModal ? this.closeEditPositionModal.bind(this) : this.openEditPositionModal.bind(this);
+    // const onEditPositionClick = this.state.showEditPositionModal ? this.closeEditPositionModal.bind(this) : this.openEditPositionModal.bind(this);
     var contest_office_name;
     var political_party;
     if (position.kind_of_ballot_item === "CANDIDATE") {
@@ -146,7 +146,7 @@ export default class VoterPositionItem extends Component {
               null
             }
           {/* show explicit position, if available, otherwise show rating */}
-          { this.props.link_to_edit_modal_off ?
+          {/* this.props.link_to_edit_modal_off ?
             position_description :
             <span>
               <span className="edit-position-action"
@@ -154,11 +154,12 @@ export default class VoterPositionItem extends Component {
                     title="Edit this position">
                 { position_description }
               </span>
-              {/* GET WORKING WITH MEASURES <EditPositionAboutCandidateModal show={this.state.showEditPositionModal}
+              { GET WORKING WITH MEASURES <EditPositionAboutCandidateModal show={this.state.showEditPositionModal}
                                                onHide={this.closeEditPositionModal.bind(this)}
                                                position={position}
-                                               organization={organization}/>*/}
-            </span> }
+                                               organization={organization}/>}
+            </span> */}
+            {position_description}
             <PositionPublicToggle ballot_item_we_vote_id={position.ballot_item_we_vote_id}
               type={position.kind_of_ballot_item}
               supportProps={supportProps}

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import ReadMore from "../../components/Widgets/ReadMore";
-import ViewSourceModal from "../../components/Widgets/ViewSourceModal";
+// import ViewSourceModal from "../../components/Widgets/ViewSourceModal";
 
 export default class PositionInformationOnlySnippet extends Component {
   static propTypes = {
@@ -98,9 +98,9 @@ export default class PositionInformationOnlySnippet extends Component {
           </span>
         }
       </div>
-      <ViewSourceModal show={this.state.showViewSourceModal}
+      {/*<ViewSourceModal show={this.state.showViewSourceModal}
                      onHide={this.closeViewSourceModal.bind(this)}
-                     url={this.props.more_info_url} />
+                     url={this.props.more_info_url} /> */}
     </div>;
   }
 }

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import ReadMore from "../../components/Widgets/ReadMore";
+import ViewSourceModal from "../../components/Widgets/ViewSourceModal";
 
 export default class PositionInformationOnlySnippet extends Component {
   static propTypes = {
@@ -14,6 +15,23 @@ export default class PositionInformationOnlySnippet extends Component {
     comment_text_off: PropTypes.bool
   };
 
+  componentWillMount () {
+    this.setState({
+      showViewSourceModal: false,
+      transitioning: false
+    });
+  }
+
+  closeViewSourceModal () {
+    this.setState({ showViewSourceModal: false });
+  }
+
+  openViewSourceModal (event) {
+    console.log(event);
+    event.stopPropagation();
+    this.setState({ showViewSourceModal: true });
+  }
+
   render () {
     var stance_icon_src;
     var className;
@@ -23,7 +41,8 @@ export default class PositionInformationOnlySnippet extends Component {
     var { is_looking_at_self } = this.props;
     var statement_text = this.props.statement_text || "";
     var statement_text_html = <ReadMore text_to_display={statement_text} />;
-
+    // onViewSourceClick is onClick function for view source modal in mobile browser
+    // const onViewSourceClick = this.state.showViewSourceModal ? this.closeViewSourceModal.bind(this) : this.openViewSourceModal.bind(this);
 
     stance_icon_src = "/img/global/icons/mixed-rating-icon.svg";
     className = "position-rating__icon position-rating__icon--mixed";
@@ -62,11 +81,26 @@ export default class PositionInformationOnlySnippet extends Component {
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {this.props.more_info_url ?
-              <span className="explicit-position__source"> (view source)</span> :
+              <span className="explicit-position__source">
+                {/* link for desktop browser: open in new tab*/}
+                <a href={this.props.more_info_url}
+                   className="interface-element--desktop"
+                   target="_blank">
+                  (view source)
+                </a>
+                {/* link for mobile browser: open in bootstrap modal */}
+                {/*<a onClick={onViewSourceClick}
+                   className="interface-element--mobile">
+                  (view source)
+                </a> */}
+              </span> :
               null }
           </span>
         }
       </div>
+      <ViewSourceModal show={this.state.showViewSourceModal}
+                     onHide={this.closeViewSourceModal.bind(this)}
+                     url={this.props.more_info_url} />
     </div>;
   }
 }

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import ReadMore from "../../components/Widgets/ReadMore";
+import ViewSourceModal from "../../components/Widgets/ViewSourceModal";
 
 export default class PositionSupportOpposeSnippet extends Component {
   static propTypes = {
@@ -15,6 +16,23 @@ export default class PositionSupportOpposeSnippet extends Component {
     comment_text_off: PropTypes.bool
   };
 
+  componentWillMount () {
+    this.setState({
+      showViewSourceModal: false,
+      transitioning: false
+    });
+  }
+
+  closeViewSourceModal () {
+    this.setState({ showViewSourceModal: false });
+  }
+
+  openViewSourceModal (event) {
+    console.log(event);
+    event.stopPropagation();
+    this.setState({ showViewSourceModal: true });
+  }
+
   render () {
     var stance_icon_src;
     var className;
@@ -24,6 +42,8 @@ export default class PositionSupportOpposeSnippet extends Component {
     var { is_looking_at_self } = this.props;
     var statement_text = this.props.statement_text || "";
     var statement_text_html = <ReadMore text_to_display={statement_text} />;
+    // onViewSourceClick is onClick function for view source modal in mobile browser
+    // const onViewSourceClick = this.state.showViewSourceModal ? this.closeViewSourceModal.bind(this) : this.openViewSourceModal.bind(this);
 
     if (this.props.is_support){
       stance_icon_src = "/img/global/icons/thumbs-up-color-icon.svg";
@@ -72,11 +92,27 @@ export default class PositionSupportOpposeSnippet extends Component {
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {this.props.more_info_url ?
-              <span className="explicit-position__source"> (view source)</span> :
+              <span className="explicit-position__source">
+                {/* link for desktop browser: open in new tab*/}
+                <a href={this.props.more_info_url}
+                   className="interface-element--desktop"
+                   target="_blank">
+                  (view source)
+                </a>
+                {/* link for mobile browser: open in bootstrap modal */}
+                {/*
+                <a onClick={onViewSourceClick}
+                   className="interface-element--mobile">
+                  (view source)
+                </a> */}
+              </span> :
               null }
           </span>
         }
       </div>
+      <ViewSourceModal show={this.state.showViewSourceModal}
+                     onHide={this.closeViewSourceModal.bind(this)}
+                     url={this.props.more_info_url} />
     </div>;
   }
 }

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import ReadMore from "../../components/Widgets/ReadMore";
-import ViewSourceModal from "../../components/Widgets/ViewSourceModal";
+// import ViewSourceModal from "../../components/Widgets/ViewSourceModal";
 
 export default class PositionSupportOpposeSnippet extends Component {
   static propTypes = {
@@ -110,9 +110,9 @@ export default class PositionSupportOpposeSnippet extends Component {
           </span>
         }
       </div>
-      <ViewSourceModal show={this.state.showViewSourceModal}
+      {/*<ViewSourceModal show={this.state.showViewSourceModal}
                      onHide={this.closeViewSourceModal.bind(this)}
-                     url={this.props.more_info_url} />
+                     url={this.props.more_info_url} /> */}
     </div>;
   }
 }

--- a/src/js/components/Widgets/ViewSourceModal.jsx
+++ b/src/js/components/Widgets/ViewSourceModal.jsx
@@ -1,0 +1,42 @@
+import React, { Component, PropTypes } from "react";
+import { Modal } from "react-bootstrap";
+// import { $ajax } from "../../utils/service";
+import $ from "jquery";
+
+export default class ViewSourceModal extends Component {
+  static propTypes = {
+    url: PropTypes.string
+  };
+
+  componentDidMount () {
+//seems to be querying local server rather than external page.  we would like
+//this function to make GET request to external server and return the content of the page.
+    // let jquerytest = $(function () {$("#external-webpage-content").load("http://www.theleaguesf.org/#d14");});
+    // console.log("jquerytest", jquerytest);
+    this.renderExternalPage();
+  }
+
+  renderExternalPage () {
+    let url = this.props.url;
+    //not functioning as expected, we would like to see the text of the url
+    //inserted into the span with the id external-webpage-content, as a test to prepare
+    //for actual webpage content being inserted
+    $("#external-webpage-content").text(url);
+    // console.log("url:", url);
+  }
+
+render () {
+  let content = "";
+  // might be easier to store content in local variable instead of inserting via jquery method
+  return <Modal {...this.props} bsSize="large" aria-labelledby="contained-modal-title-lg">
+    <Modal.Header closeButton>
+      <Modal.Title id="contained-modal-title-lg">Source of position</Modal.Title>
+    </Modal.Header>
+    <Modal.Body>
+      <span id="external-webpage-content">{content}</span>
+    </Modal.Body>
+  </Modal>;
+  }
+
+
+}

--- a/src/sass/layout/_mediaquery.scss
+++ b/src/sass/layout/_mediaquery.scss
@@ -57,6 +57,10 @@
       display: none;
     }
   }
+
+  .interface-element--desktop {
+    display: none;
+  }
 }
 
 
@@ -64,6 +68,11 @@
   .navbar-fixed-bottom {
     display: none;
   }
+
+  .interface-element--mobile {
+    display: none;
+  }
+
   .device {
     &-menu { // device-menu
       &--large {


### PR DESCRIPTION
Included in this PR:
new classnames for elements meant only to appear in mobile browser or desktop browser respectively: .interface-element--desktop and .interface-element--mobile.  elements with these classnames will only appear in the appropriate browser, using same breakpoints/min width of header vs footer navicons.

view source link (for position statements): on desktop, opens source webpage in new tab.
on mobile, work in progress.  goal was to have source webpage display in a bootstrap modal, but we were unable to get that working properly, so modal was commented out: currently, mobile users will not see a link to view the source of a position.