### PR TITLE
3 bug fixes, added ReadMore to ItemPositionStatementActionBar

### DIFF
--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -85,13 +85,13 @@ export default class ItemActionBar extends Component {
               <span className="btn__icon">
                 <Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={icon_color} />
               </span>
-              <span>Support</span>
+              <span className="interface-element--desktop">Support</span>
             </button>
             <button className="item-actionbar__btn item-actionbar__btn--oppose btn btn-default" onClick={this.opposeItem.bind(this)}>
               <span className="btn__icon">
                 <Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={icon_color} />
               </span>
-              <span>Oppose</span>
+              <span className="interface-element--desktop">Oppose</span>
             </button>
           </div>
         }

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -63,8 +63,12 @@ export default class ItemActionBar extends Component {
     const icon_size = 18;
     var icon_color = "#999";
     var selected_color = "#0D546F";
-
-    const url_being_shared = web_app_config.WE_VOTE_URL_PROTOCOL + web_app_config.WE_VOTE_HOSTNAME + "/candidate/" + this.props.ballot_item_we_vote_id;
+    var url_being_shared;
+    if (this.props.type === "CANDIDATE") {
+      url_being_shared = web_app_config.WE_VOTE_URL_PROTOCOL + web_app_config.WE_VOTE_HOSTNAME + "/candidate/" + this.props.ballot_item_we_vote_id;
+    } else {
+      url_being_shared = web_app_config.WE_VOTE_URL_PROTOCOL + web_app_config.WE_VOTE_HOSTNAME + "/measure/" + this.props.ballot_item_we_vote_id;
+    }
     const remove_position_function = is_support ? this.stopSupportingItem.bind(this) : this.stopOpposingItem.bind(this);
     const position_text = is_support ? "I Support" : "I Oppose";
     const position_icon = is_support ?

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import ReadMore from "../../components/Widgets/ReadMore";
 import Textarea from "react-textarea-autosize";
 import SupportActions from "../../actions/SupportActions";
 import SupportStore from "../../stores/SupportStore";
@@ -172,14 +173,15 @@ export default class ItemPositionStatementActionBar extends Component {
                   width="34px"
             /> :
           image_placeholder }
-          <span className="position-statement__description edit-position-action"
+          <span className="position-statement__description">
+          {/*<span className="position-statement__description edit-position-action"
                 onClick={onSavePositionStatementClick}
-                title="Edit this position">
+                title="Edit this position"> */}
             { speaker_display_name ?
               <span className="position-statement__speaker-name">{speaker_display_name} <br /></span> :
               null }
-            {statement_text_to_be_saved}
-          </span>
+            <ReadMore text_to_display={statement_text_to_be_saved} />
+            </span>
 
           { short_version ?
             <span className="position-statement__edit-position-pseudo"

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -58,7 +58,7 @@ export default class PositionInformationOnlySnippet extends Component {
       comment_text_off = this.props.comment_text_off ? true : false;
     }
     if (more_info_url) {
-      if (more_info_url.toLowerCase.startsWith("http")) {
+      if (more_info_url.toLowerCase().startsWith("http")) {
         more_info_url = more_info_url;
       } else {
         more_info_url = "http://" + more_info_url;

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -38,7 +38,7 @@ export default class PositionInformationOnlySnippet extends Component {
     var alt;
     var positionLabel;
     var hasThisToSay;
-    var { is_looking_at_self } = this.props;
+    var { is_looking_at_self, more_info_url } = this.props;
     var statement_text = this.props.statement_text || "";
     var statement_text_html = <ReadMore text_to_display={statement_text} />;
     // onViewSourceClick is onClick function for view source modal in mobile browser
@@ -56,6 +56,13 @@ export default class PositionInformationOnlySnippet extends Component {
     let comment_text_off = false;
     if (this.props.comment_text_off !== undefined) {
       comment_text_off = this.props.comment_text_off ? true : false;
+    }
+    if (more_info_url) {
+      if (more_info_url.includes("http://")) {
+        more_info_url = more_info_url;
+      } else {
+        more_info_url = "http://" + more_info_url;
+      }
     }
 
     return <div className="explicit-position">
@@ -80,10 +87,10 @@ export default class PositionInformationOnlySnippet extends Component {
           <span>
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
-            {this.props.more_info_url ?
+            {more_info_url ?
               <span className="explicit-position__source">
                 {/* link for desktop browser: open in new tab*/}
-                <a href={this.props.more_info_url}
+                <a href={more_info_url}
                    className="interface-element--desktop"
                    target="_blank">
                   (view source)

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -58,7 +58,7 @@ export default class PositionInformationOnlySnippet extends Component {
       comment_text_off = this.props.comment_text_off ? true : false;
     }
     if (more_info_url) {
-      if (more_info_url.includes("http://")) {
+      if (more_info_url.toLowerCase.startsWith("http")) {
         more_info_url = more_info_url;
       } else {
         more_info_url = "http://" + more_info_url;

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -70,7 +70,7 @@ export default class PositionSupportOpposeSnippet extends Component {
       comment_text_off = this.props.comment_text_off ? true : false;
     }
     if (more_info_url) {
-      if (more_info_url.includes("http://")) {
+      if (more_info_url.toLowerCase.startsWith("http")) {
         more_info_url = more_info_url;
       } else {
         more_info_url = "http://" + more_info_url;

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -70,7 +70,7 @@ export default class PositionSupportOpposeSnippet extends Component {
       comment_text_off = this.props.comment_text_off ? true : false;
     }
     if (more_info_url) {
-      if (more_info_url.toLowerCase.startsWith("http")) {
+      if (more_info_url.toLowerCase().startsWith("http")) {
         more_info_url = more_info_url;
       } else {
         more_info_url = "http://" + more_info_url;

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -39,7 +39,7 @@ export default class PositionSupportOpposeSnippet extends Component {
     var alt;
     var positionLabel;
     var isSupportedBy;
-    var { is_looking_at_self } = this.props;
+    var { is_looking_at_self, more_info_url } = this.props;
     var statement_text = this.props.statement_text || "";
     var statement_text_html = <ReadMore text_to_display={statement_text} />;
     // onViewSourceClick is onClick function for view source modal in mobile browser
@@ -69,6 +69,14 @@ export default class PositionSupportOpposeSnippet extends Component {
     if (this.props.comment_text_off !== undefined) {
       comment_text_off = this.props.comment_text_off ? true : false;
     }
+    if (more_info_url) {
+      if (more_info_url.includes("http://")) {
+        more_info_url = more_info_url;
+      } else {
+        more_info_url = "http://" + more_info_url;
+      }
+    }
+
     return <div className="explicit-position">
       { stance_display_off ? null : <img src={stance_icon_src} width="20" height="20" className={className} alt={alt} /> }
       <div className="explicit-position__text">
@@ -91,10 +99,10 @@ export default class PositionSupportOpposeSnippet extends Component {
           <span>
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
-            {this.props.more_info_url ?
+            {more_info_url ?
               <span className="explicit-position__source">
                 {/* link for desktop browser: open in new tab*/}
-                <a href={this.props.more_info_url}
+                <a href={more_info_url}
                    className="interface-element--desktop"
                    target="_blank">
                   (view source)

--- a/src/js/routes/Guide/GuidePositionList.jsx
+++ b/src/js/routes/Guide/GuidePositionList.jsx
@@ -101,7 +101,7 @@ export default class GuidePositionList extends Component {
                 return <OrganizationPositionItem key={item.position_we_vote_id}
                                                  position={item}
                                                  organization={this.state.organization}
-                                                 popover_off />;
+                                                  />;
               }) :
               <div>{LoadingWheel}</div>
             }
@@ -117,7 +117,7 @@ export default class GuidePositionList extends Component {
                   return <OrganizationPositionItem key={item.position_we_vote_id}
                                                    position={item}
                                                    organization={this.state.organization}
-                                                   popover_off />;
+                                                    />;
                 }) }
               </span> :
               <div>{LoadingWheel}</div>


### PR DESCRIPTION
BUG 1: The share link works for candidate links, but not for measure links.
FIX: "/candidate/" was hardcoded into the urlBeingShared, added conditional based on "type" of ballot item

BUG 2: Vote Smart popover not working in some places.
FIX: prop "popover_off" was being passed through, a holdover from EditPositionAboutCandidateModal. stopped passing it, but left the prop in case we ever want to turn off the popovers.

BUG 3: if the “view source” link is “www.cnn.com” it tacks it onto the end of the local url, so it goes here: http://localhost:3000/measure/www.cnn.com
FIX: added js if/else to see if url includes "http://", if not, put it on the front of the url.

Also, per Dale's request, user's own position statement, when viewed from the ItemPositionStatementActionBar, no longer allows user to edit by clicking anywhere, or shows entire statement.  Statement is now truncated by ReadMore if longer than 3 vertical lines, and user must click "Edit" if they want to edit.