### PR TITLE
added expanded_text_to_display to ReadMore to preserve line breaks #428

### DIFF
--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -36,18 +36,15 @@ export default class ReadMore extends Component {
         if (collapse_text === undefined) {
           collapse_text = " ...Less";
         }
-        let expanded_text_array = text_to_display.split(/(?:\r\n|\r|\n)+/g);
+        let expanded_text_array = text_to_display.replace(/(?:\r\n|\r|\n){2,}/g, "\r\n\r\n").split(/(?:\r\n|\r|\n)/g);
 
         let expanded_text_to_display = expanded_text_array.map(function (item, key){
-          if (item.trim() === "") {
-            return null;
-          } else if (key === 0) {
+           if (key === 0) {
             return <span key={key}>
               {item}
               </span>;
           } else {
           return <span key={key}>
-            <br/>
             <br/>
               {item}
             </span>; }

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -38,6 +38,12 @@ export default class ReadMore extends Component {
         if (collapse_text === undefined) {
           collapse_text = " ...Less";
         }
+        let expanded_text_to_display = text_to_display.split(/(?:\r\n|\r|\n)/g).map(function (item, key){
+          return <span key={key}>
+              {item}
+              <br/>
+            </span>;
+        });
 
         if (this.state.readMore) {
           return <span>
@@ -49,7 +55,7 @@ export default class ReadMore extends Component {
               />
           </span>;
         } else {
-          return <span>{text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
+          return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
         }
     }
 }

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -15,13 +15,11 @@ export default class ReadMore extends Component {
       this.state = {
         readMore: true
       };
-
       this.toggleLines = this.toggleLines.bind(this);
     }
 
     toggleLines (event) {
         event.preventDefault();
-
         this.setState({
             readMore: !this.state.readMore
         });
@@ -38,11 +36,21 @@ export default class ReadMore extends Component {
         if (collapse_text === undefined) {
           collapse_text = " ...Less";
         }
-        let expanded_text_to_display = text_to_display.split(/(?:\r\n|\r|\n)/g).map(function (item, key){
-          return <span key={key}>
+        let expanded_text_array = text_to_display.split(/(?:\r\n|\r|\n)+/g);
+
+        let expanded_text_to_display = expanded_text_array.map(function (item, key){
+          if (item.trim() === "") {
+            return null;
+          } else if (key === 0) {
+            return <span key={key}>
               {item}
-              <br/>
-            </span>;
+              </span>;
+          } else {
+          return <span key={key}>
+            <br/>
+            <br/>
+              {item}
+            </span>; }
         });
 
         if (this.state.readMore) {
@@ -55,7 +63,7 @@ export default class ReadMore extends Component {
               />
           </span>;
         } else {
-          return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
+          return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}><br/>{collapse_text}</a></span>;
         }
     }
 }


### PR DESCRIPTION
react-text-truncate was not preserving line breaks in position statements, so used map function to split text on line breaks and put each section of text between line breaks into its own <span>.  As this would break truncate, stored expanded text in its own variable.  Truncated version will not preserve line breaks, but we wouldn't want it to as this would quickly overwhelm the limited number of lines visible (default: 3). Instead, if this.state.readMore is true, we display expanded text, otherwise we display truncated text.