### PR TITLE
[Issue #481] Add instructions for creating ssh keys for Windows

### DIFF
--- a/docs/installing/CLONING_CODE.md
+++ b/docs/installing/CLONING_CODE.md
@@ -11,26 +11,27 @@ Make sure you have created a place to put all of the code from Github:
 
 1. Install and configure git on your local machine.
 
-2. Create a fork of wevote/WebApp.git. You can do this from https://github.com/wevote/WebApp with the "Fork" button 
+1. Create a fork of wevote/WebApp.git. You can do this from https://github.com/wevote/WebApp with the "Fork" button  
 (upper right of screen)
 
-3. Change into the `/Users/<YOUR NAME HERE>/MyProjects/` folder and clone your fork:
-
+1. Change into the `/Users/<YOUR NAME HERE>/MyProjects/` folder and clone your fork:  
 `git clone https://github.com/<YOUR USERNAME HERE>/WebApp.git`  
 
-4. Change into your local WebApp repository folder, and set up a remote for upstream:  
+1. Change into your local WebApp repository folder, and set up a remote for upstream:  
 `$ git remote add upstream git@github.com:wevote/WebApp.git`  
 
-5.Create ssh keys: `ssh-keygen -t rsa -C "youremail@somedomain.com"`  
+1. Create SSH keys (or follow [these instructions](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#platform-windows) for Windows):
 
-6.`ssh-add ~/.ssh/id_rsa` OR `ssh-add ~/.ssh/github_rsa`
+    1. Create ssh keys: `ssh-keygen -t rsa -C "youremail@somedomain.com"`  
 
-7.`pbcopy < ~/.ssh/id_rsa.pub` OR `pbcopy < ~/.ssh/github_rsa.pub`
+    1. `ssh-add ~/.ssh/id_rsa` OR `ssh-add ~/.ssh/github_rsa`
 
-The command "pbcopy" copies the contents of the "~/.ssh/id_rsa.pub" key file so you can paste it.
+    1. `pbcopy < ~/.ssh/id_rsa.pub` OR `pbcopy < ~/.ssh/github_rsa.pub`  
 
-8.Go your profile in Github. In the left navigation, choose "SSH and GPG keys". 
-Click the "New SSH key" button to the right of "SSH keys". 
+        1. The command "pbcopy" copies the contents of the "~/.ssh/id_rsa.pub" key file so you can paste it.
+
+1. Go your profile in Github. In the left navigation, choose "SSH and GPG keys".  
+Click the "New SSH key" button to the right of "SSH keys".  
 Paste the contents of the "~/.ssh/id_rsa.pub" key file into the "Key" text area, and give it any Title you would like.  
 
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Closes #481 

### Changes included this pull request?

Our docs didn't have good instructions for windows users. This commit adds some instructions; it also cleans up the formatting of the bulleted list some.

Closes issue #481.