### PR TITLE
added onBlur to make search results and share dropdown disappear #415

### DIFF
--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -96,6 +96,7 @@ export default class SearchAllBox extends Component {
                  name="master_search_field"
                  autoComplete="off"
                  onFocus={this.onSearchFocus.bind(this)}
+                 onBlur={this.onSearchBlur.bind(this)}
                  onChange={this.onSearchFieldTextChange.bind(this)}
                  value={this.state.text_from_search_field} />
           <div className="input-group-btn">

--- a/src/js/components/Widgets/ShareButtonDropdown.jsx
+++ b/src/js/components/Widgets/ShareButtonDropdown.jsx
@@ -58,7 +58,7 @@ export default class ShareButtonDropdown extends Component {
     const {shareIcon, shareText, urlBeingShared} = this.props;
     const onClick = this.state.open ? this.closeDropdown.bind(this) : this.openDropdown.bind(this);
     const onCopyLinkClick = this.state.showCopyLinkModal ? this.closeCopyLinkModal.bind(this) : this.openCopyLinkModal.bind(this);
-    return <div className="btn-group open">
+    return <div onBlur={this.closeDropdown.bind(this)} className="btn-group open">
       <button onClick={onClick} className="dropdown item-actionbar__btn item-actionbar__btn--position-selected btn btn-default">
         {shareIcon} {shareText} <span className="caret"></span>
       </button>
@@ -66,14 +66,13 @@ export default class ShareButtonDropdown extends Component {
         <ul className="dropdown-menu">
           <li>
             <a onBlur={this.closeDropdown.bind(this)}
-               onClick={onCopyLinkClick}>
+              onClick={onCopyLinkClick}>
                 Copy link
             </a>
           </li>
           <li>
-            <a
-               onBlur={this.closeDropdown.bind(this)}
-               onClick={this.shareFacebookComment.bind(this)}>
+            <a onBlur={this.closeDropdown.bind(this)}
+              onClick={this.shareFacebookComment.bind(this)}>
                 Share on Facebook
             </a>
           </li>


### PR DESCRIPTION
added existing closing functions to onBlur listener, now if users click somewhere else on the screen, search results and/or share dropdown will close.