### PR TITLE
Misc visual cleanup

### DIFF
--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -85,13 +85,15 @@ export default class PositionItem extends Component {
 
     var one_position_on_this_candidate = <li className="card-child position-item">
       {/* One Position on this Candidate */}
-        <Link to={speakerLink}>
-          { position.speaker_image_url_https ?
-            <ImageHandler className="img-square card-child__avatar"
-                  imageUrl={position.speaker_image_url_https}
-            /> :
-          image_placeholder }
-        </Link>
+        <div className="card-child__media-object-anchor">
+          <Link to={speakerLink}>
+            { position.speaker_image_url_https ?
+              <ImageHandler className="img-square card-child__avatar"
+                    imageUrl={position.speaker_image_url_https}
+              /> :
+            image_placeholder }
+          </Link>
+        </div>
         <div className="card-child__media-object-content">
           <div className="card-child__content">
             <h4 className="card-child__display-name">

--- a/src/js/components/VoterGuide/Organization.jsx
+++ b/src/js/components/VoterGuide/Organization.jsx
@@ -60,10 +60,10 @@ export default class Organization extends Component {
       position_description = <PositionInformationOnlySnippet {...position} is_on_ballot_item_page={is_on_ballot_item_page} />;
     }
 
-    return <div className="position-item card-child card-child--not-followed">
-      <div className="card-child__avatar">
+    return <div className="card-child card-child--not-followed">
+      <div className="card-child__media-object-anchor">
         <Link to={voterGuideLink}>
-          <ImageHandler imageUrl={voter_guide_image_url} />
+          <ImageHandler className="card-child__avatar" imageUrl={voter_guide_image_url} />
         </Link>
       </div>
       <div className="card-child__media-object-content">

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -153,18 +153,20 @@ export default class OrganizationPositionItem extends Component {
     }
     return <li className="position-item card-child">
       <StarAction we_vote_id={position.ballot_item_we_vote_id} type={position.kind_of_ballot_item} />
-        <Link to={ ballotItemLink }
-              onlyActiveOnIndex={false}>
-          {/*<i className="icon-icon-add-friends-2-1 icon-light icon-medium" />*/}
-          { is_candidate ?
+      { is_candidate ?
+        <div className="card-child__media-object-anchor">
+          <Link to={ ballotItemLink }
+                onlyActiveOnIndex={false}>
             <ImageHandler
               className="card-child__avatar"
               imageUrl={position.ballot_item_image_url_https}
               alt="candidate-photo"
-              kind_of_ballot_item={position.kind_of_ballot_item}/> :
-            null
-          }
-        </Link>
+              kind_of_ballot_item={position.kind_of_ballot_item}/>
+          </Link>
+        </div> :
+        null
+      }
+      <div className="card-child__media-object-content">
         <div className="card-child__content">
           <Link to={ ballotItemLink }
                 onlyActiveOnIndex={false}>
@@ -198,6 +200,7 @@ export default class OrganizationPositionItem extends Component {
                 <FriendsOnlyIndicator isFriendsOnly={!is_public_position}/>
               }
         </div>
-      </ li>;
+      </div>
+    </li>;
   }
 }

--- a/src/js/components/VoterGuide/VoterPositionItem.jsx
+++ b/src/js/components/VoterGuide/VoterPositionItem.jsx
@@ -123,6 +123,7 @@ export default class VoterPositionItem extends Component {
     }
     return <li className="position-item card-child">
       <StarAction we_vote_id={position.ballot_item_we_vote_id} type={position.kind_of_ballot_item} />
+      <div className="card-child__media-object-anchor">
         <Link to={ ballotItemLink }
               onlyActiveOnIndex={false}>
           {/*<i className="icon-icon-add-friends-2-1 icon-light icon-medium" />*/}
@@ -135,6 +136,8 @@ export default class VoterPositionItem extends Component {
             null
           }
         </Link>
+      </div>
+      <div className="card-child__media-object-content">
         <div className="card-child__content">
           <Link to={ ballotItemLink }
                 onlyActiveOnIndex={false}>
@@ -165,6 +168,7 @@ export default class VoterPositionItem extends Component {
               supportProps={supportProps}
               className="organization-position-item-toggle"/>
         </div>
-      </ li>;
+      </div>
+    </li>;
   }
 }

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -80,18 +80,18 @@ export default class ItemActionBar extends Component {
           is_oppose || is_support ?
           <PositionDropdown removePositionFunction={remove_position_function} positionIcon={position_icon} positionText={position_text}/> :
           // Voter hasn't supported or opposed, show both options
-          <div>
+          <div className="btn-group item-actionbar__btn-set">
             <button className="item-actionbar__btn item-actionbar__btn--support btn btn-default" onClick={this.supportItem.bind(this)}>
               <span className="btn__icon">
                 <Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={icon_color} />
               </span>
-              <span className="interface-element--desktop">Support</span>
+              <span className="item-actionbar__position-btn-label">Support</span>
             </button>
             <button className="item-actionbar__btn item-actionbar__btn--oppose btn btn-default" onClick={this.opposeItem.bind(this)}>
               <span className="btn__icon">
                 <Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={icon_color} />
               </span>
-              <span className="interface-element--desktop">Oppose</span>
+              <span className="item-actionbar__position-btn-label">Oppose</span>
             </button>
           </div>
         }

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -168,7 +168,7 @@ export default class ItemPositionStatementActionBar extends Component {
         // Show the comment, but in read-only mode
         <div className={short_version ? "position-statement--truncated" : "position-statement"}>
           { speaker_image_url_https ?
-            <img className="card-child__avatar"
+            <img className="position-statement__avatar"
                   src={speaker_image_url_https}
                   width="34px"
             /> :

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -113,9 +113,9 @@ export default class ItemPositionStatementActionBar extends Component {
         statement_placeholder_text = "Why you oppose…";
       }
     } else if (this.props.ballot_item_display_name) {
-      statement_placeholder_text = "Share your thoughts about " + this.props.ballot_item_display_name + "…";
+      statement_placeholder_text = "Your thoughts about " + this.props.ballot_item_display_name + "…";
     } else {
-      statement_placeholder_text = "Share your thoughts…";
+      statement_placeholder_text = "Your thoughts…";
     }
 
     // Currently this "Post" text is the same given we display the visibility setting, but we may want to change this
@@ -161,7 +161,7 @@ export default class ItemPositionStatementActionBar extends Component {
                 placeholder={statement_placeholder_text}
                 value={statement_text_to_be_saved}
                 />
-              <button className="btn btn-default btn-sm utils-nowrap" type="submit">{post_button_text}</button>
+              <button className="btn btn-default btn-sm" type="submit">{post_button_text}</button>
             </span>
           </div>
         </form> :
@@ -173,30 +173,23 @@ export default class ItemPositionStatementActionBar extends Component {
                   width="34px"
             /> :
           image_placeholder }
-          <span className="position-statement__description">
-          {/*<span className="position-statement__description edit-position-action"
-                onClick={onSavePositionStatementClick}
-                title="Edit this position"> */}
+          <div className="position-statement__description">
             { speaker_display_name ?
               <span className="position-statement__speaker-name">{speaker_display_name} <br /></span> :
               null }
             <ReadMore text_to_display={statement_text_to_be_saved} />
-            </span>
 
-          { short_version ?
-            <span className="position-statement__edit-position-pseudo"
+
+            { short_version ?
+              <span className="position-statement__edit-position-pseudo"
+                    onClick={onSavePositionStatementClick}
+                    title="Edit this position"/> :
+              null
+            }
+            <div className="position-statement__edit-position-link"
                   onClick={onSavePositionStatementClick}
-                  title="Edit this position"/> :
-            null
-          }
-          { short_version ?
-            <span className="position-statement__edit-position-link"
-                  onClick={onSavePositionStatementClick}
-                  title="Edit this position">&nbsp;Edit</span> :
-            <span className="position-statement__edit-position-link-long"
-                  onClick={onSavePositionStatementClick}
-                  title="Edit this position">&nbsp;&nbsp;Edit</span>
-          }
+                  title="Edit this position">Edit</div>
+          </div>
         </div>
       }
     </div>;

--- a/src/js/components/Widgets/PositionDropdown.jsx
+++ b/src/js/components/Widgets/PositionDropdown.jsx
@@ -33,7 +33,7 @@ export default class PositionDropdown extends Component {
     const {removePositionFunction, positionIcon, positionText} = this.props;
     const onClick = this.state.open ? this.closeDropdown.bind(this) : this.openDropdown.bind(this);
 
-    return <div className="btn-group open">
+    return <div className="btn-group open item-actionbar__btn-set">
       <button onBlur={this.onButtonBlur.bind(this)} onClick={onClick} className="dropdown item-actionbar__btn item-actionbar__btn--position-selected btn btn-default">
         {positionIcon} {positionText} <span className="caret"></span>
       </button>

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -88,19 +88,17 @@ export default class PositionInformationOnlySnippet extends Component {
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {more_info_url ?
-              <span className="explicit-position__source">
-                {/* link for desktop browser: open in new tab*/}
+              <div className="explicit-position__source">
+                {/* default: open in new tab*/}
                 <a href={more_info_url}
-                   className="interface-element--desktop"
                    target="_blank">
-                  (view source)
+                  (view source <i className="fa fa-external-link-square" aria-hidden="true"></i>)
                 </a>
                 {/* link for mobile browser: open in bootstrap modal */}
-                {/*<a onClick={onViewSourceClick}
-                   className="interface-element--mobile">
+                {/*<a onClick={onViewSourceClick}>
                   (view source)
                 </a> */}
-              </span> :
+              </div> :
               null }
           </span>
         }

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -100,20 +100,18 @@ export default class PositionSupportOpposeSnippet extends Component {
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {more_info_url ?
-              <span className="explicit-position__source">
-                {/* link for desktop browser: open in new tab*/}
+              <div className="explicit-position__source">
+                {/* default: open in new tab*/}
                 <a href={more_info_url}
-                   className="interface-element--desktop"
                    target="_blank">
-                  (view source)
+                  (view source <i className="fa fa-external-link-square" aria-hidden="true"></i>)
                 </a>
                 {/* link for mobile browser: open in bootstrap modal */}
                 {/*
-                <a onClick={onViewSourceClick}
-                   className="interface-element--mobile">
+                <a onClick={onViewSourceClick}>
                   (view source)
                 </a> */}
-              </span> :
+              </div> :
               null }
           </span>
         }

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -34,7 +34,7 @@ export default class ReadMore extends Component {
           link_text = "More";
         }
         if (collapse_text === undefined) {
-          collapse_text = " ...Less";
+          collapse_text = " ...Show Less  ";
         }
         let expanded_text_array = text_to_display.replace(/(?:\r\n|\r|\n){2,}/g, "\r\n\r\n").split(/(?:\r\n|\r|\n)/g);
 
@@ -60,7 +60,7 @@ export default class ReadMore extends Component {
               />
           </span>;
         } else {
-          return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}><br/>{collapse_text}</a></span>;
+          return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
         }
     }
 }

--- a/src/js/components/Widgets/ShareButtonDropdown.jsx
+++ b/src/js/components/Widgets/ShareButtonDropdown.jsx
@@ -63,25 +63,27 @@ export default class ShareButtonDropdown extends Component {
     const onClick = this.state.open ? this.closeDropdown.bind(this) : this.openDropdown.bind(this);
     const onCopyLinkClick = this.state.showCopyLinkModal ? this.closeCopyLinkModal.bind(this) : this.openCopyLinkModal.bind(this);
     // const onButtonBlur = ;
-    return <div className="btn-group open">
-      <button onBlur={this.onButtonBlur.bind(this)} onClick={onClick} className="dropdown item-actionbar__btn item-actionbar__btn--position-selected btn btn-default">
-        {shareIcon} {shareText} <span className="caret"></span>
-      </button>
-      {this.state.open ?
-        <ul className="dropdown-menu">
-          <li>
-            <a onClick={onCopyLinkClick}>
-                Copy link
-            </a>
-          </li>
-          <li>
-            <a onClick={this.shareFacebookComment.bind(this)}>
-                Share on Facebook
-            </a>
-          </li>
-        </ul> :
-        null
-      }
+    return <div>
+      <div className="btn-group open item-actionbar__btn-set">
+        <button onBlur={this.onButtonBlur.bind(this)} onClick={onClick} className="dropdown item-actionbar__btn btn btn-default">
+          {shareIcon} {shareText} <span className="caret"></span>
+        </button>
+        {this.state.open ?
+          <ul className="dropdown-menu">
+            <li>
+              <a onClick={onCopyLinkClick}>
+                  Copy link
+              </a>
+            </li>
+            <li>
+              <a onClick={this.shareFacebookComment.bind(this)}>
+                  Share on Facebook
+              </a>
+            </li>
+          </ul> :
+          null
+        }
+        </div>
       <CopyLinkModal show={this.state.showCopyLinkModal}
                      onHide={this.closeCopyLinkModal.bind(this)}
                      urlBeingShared={urlBeingShared} />

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -133,7 +133,7 @@
   // Card 'Child'
   // previously 'position-item' - candidates or orgs/users and their positions under a card-main
 
-  @include media-object('.card-child', '.card-child__avatar', '.card-child__media-object-content');
+  @include media-object('.card-child', '.card-child__media-object-anchor', '.card-child__media-object-content');
 
   .card-child {
     position: relative;

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -14,12 +14,20 @@
   margin: 1em 0;
   padding-top: 10px;
 
+  &__btn-set {
+    margin-right: 8px;
+  }
+
   &__btn {
     // currently uses Bootstrap .btn styling
-    margin-right: 8px;
-
     &--position-selected {
       color: $selected-color;
+    }
+  }
+
+  &__position-btn-label {
+    @include breakpoints (max mid-small) {
+      display: none; // Hide Support/Oppose button labels on small screens
     }
   }
 

--- a/src/sass/components/_itemPositionStatementActionBar.scss
+++ b/src/sass/components/_itemPositionStatementActionBar.scss
@@ -4,7 +4,6 @@
 .position-statement {
   display: flex;
   flex: 1 1 100%;
-  margin-top: 5px;
   width: 100%;
 
   &__avatar {
@@ -15,11 +14,11 @@
     width: 34px;
     display: inline-block;
     flex-shrink: 0;
-    margin-top: -2px;
   }
 
   &__input-group {
     display: flex;
+    align-items: flex-start;
   }
 
   &__input {
@@ -29,7 +28,7 @@
   &__container {
     background-color: $pale-gray;
     margin-top: 0px;
-    padding-top: 4px;
+    padding-top: 10px;
     padding-right: 15px;
     padding-bottom: 10px;
     padding-left: 15px;
@@ -102,15 +101,16 @@
 }
 
 .position-statement__edit-position-link {
-  @include hide-text;
-  position: absolute;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 5;
-}
-
-.position-statement__edit-position-link-long {
   color: $link-color;
+  cursor: pointer;
+
+  &--area { // Is this still needed anywhere?
+    @include hide-text;
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 5;
+  }
 }

--- a/src/sass/layout/_mediaquery.scss
+++ b/src/sass/layout/_mediaquery.scss
@@ -57,19 +57,11 @@
       display: none;
     }
   }
-
-  .interface-element--desktop {
-    display: none;
-  }
 }
 
 
 @include breakpoints(nav) {
   .navbar-fixed-bottom {
-    display: none;
-  }
-
-  .interface-element--mobile {
     display: none;
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
- cleans up leftover layout updates for .card-child media-object layouts (may address #474)

### Changes included this pull request?
- fixes some visual bugs in ItemActionBar
- small adjustments for links following position statements (view source, show more/less, edit)
- removes `interface-element--desktop` and `interface-element--mobile`
    - added a more appropriate breakpoint for the Support/Oppose button labels
    - made the `view source` link visible for all screen sizes along with an icon to indicate it's an external link. Once there is a more mobile-friendly option, fine to show in a different context.
- renames `position-statement__edit-position-link-long` to `position-statement__edit-position-link` and renames previous `position-statement__edit-position-link` to `position-statement__edit-position-link--area` which better describes that it stretches the link over the whole area. That said, it's not clear that it's still needed, but I left the css in case.
