### PR TITLE
Improvements to ReadMore

### DIFF
--- a/src/js/components/VoterGuide/OrganizationDisplayForList.jsx
+++ b/src/js/components/VoterGuide/OrganizationDisplayForList.jsx
@@ -42,7 +42,6 @@ export default class OrganizationDisplayForList extends Component {
       voter_guide_image_url,
     } = this.props;
     let num_of_lines = 2;
-    let max_num_of_char = 160;
     let voter_guide_display_name = this.props.voter_guide_display_name ? this.props.voter_guide_display_name : "";
     let twitterDescription = this.props.twitter_description ? this.props.twitter_description : "";
     // If the voter_guide_display_name is in the twitter_description, remove it
@@ -73,7 +72,7 @@ export default class OrganizationDisplayForList extends Component {
           <Link to={voterGuideLink}>
             <h4 className="card-child__display-name">{voter_guide_display_name}</h4>
           </Link>
-          { twitterDescriptionMinusName ? <ReadMore text_to_display={twitterDescriptionMinusName} max_num_of_char={max_num_of_char} num_of_lines={num_of_lines} /> :
+          { twitterDescriptionMinusName ? <ReadMore text_to_display={twitterDescriptionMinusName} num_of_lines={num_of_lines} /> :
             null}
           { position_description }
         </div>

--- a/src/js/components/VoterGuide/OrganizationDisplayForList.jsx
+++ b/src/js/components/VoterGuide/OrganizationDisplayForList.jsx
@@ -5,6 +5,7 @@ import { numberWithCommas, removeTwitterNameFromDescription } from "../../utils/
 import PositionRatingSnippet from "../../components/Widgets/PositionRatingSnippet";
 import PositionInformationOnlySnippet from "../../components/Widgets/PositionInformationOnlySnippet";
 import PositionSupportOpposeSnippet from "../../components/Widgets/PositionSupportOpposeSnippet";
+import ReadMore from "../../components/Widgets/ReadMore";
 
 // OrganizationDisplayForList is used by GuideList for viewing voter guides you can follow on the Candidate
 // and Opinions (you can follow) Components
@@ -40,7 +41,8 @@ export default class OrganizationDisplayForList extends Component {
       organization_we_vote_id,
       voter_guide_image_url,
     } = this.props;
-
+    let num_of_lines = 2;
+    let max_num_of_char = 160;
     let voter_guide_display_name = this.props.voter_guide_display_name ? this.props.voter_guide_display_name : "";
     let twitterDescription = this.props.twitter_description ? this.props.twitter_description : "";
     // If the voter_guide_display_name is in the twitter_description, remove it
@@ -71,20 +73,20 @@ export default class OrganizationDisplayForList extends Component {
           <Link to={voterGuideLink}>
             <h4 className="card-child__display-name">{voter_guide_display_name}</h4>
           </Link>
-          { twitterDescriptionMinusName ? <p>{twitterDescriptionMinusName}</p> :
+          { twitterDescriptionMinusName ? <ReadMore text_to_display={twitterDescriptionMinusName} max_num_of_char={max_num_of_char} num_of_lines={num_of_lines} /> :
             null}
           { position_description }
         </div>
         <div className="card-child__additional">
           <div className="card-child__follow-buttons">
             {this.props.children}
-          </div>
           {twitter_followers_count ?
             <span className="twitter-followers__badge">
               <span className="fa fa-twitter twitter-followers__icon"></span>
               {numberWithCommas(twitter_followers_count)}
             </span> :
             null}
+          </div>
         </div>
       </div>
     </div>;

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -88,11 +88,12 @@ export default class PositionInformationOnlySnippet extends Component {
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {more_info_url ?
-              <div className="explicit-position__source">
+              <div className="view-source">
                 {/* default: open in new tab*/}
                 <a href={more_info_url}
-                   target="_blank">
-                  (view source <i className="fa fa-external-link-square" aria-hidden="true"></i>)
+                   target="_blank"
+                   className="explicit-position__source">
+                  view source <i className="fa fa-external-link-square" aria-hidden="true"></i>
                 </a>
                 {/* link for mobile browser: open in bootstrap modal */}
                 {/*<a onClick={onViewSourceClick}>

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -100,11 +100,12 @@ export default class PositionSupportOpposeSnippet extends Component {
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
             {more_info_url ?
-              <div className="explicit-position__source">
+              <div className="view-source">
                 {/* default: open in new tab*/}
                 <a href={more_info_url}
-                   target="_blank">
-                  (view source <i className="fa fa-external-link-square" aria-hidden="true"></i>)
+                   target="_blank"
+                   className="explicit-position__source">
+                  view source <i className="fa fa-external-link-square" aria-hidden="true"></i>
                 </a>
                 {/* link for mobile browser: open in bootstrap modal */}
                 {/*

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -83,17 +83,17 @@ export default class ReadMore extends Component {
         if (not_enough_text_to_truncate) {
           return <span>{expanded_text_to_display}</span>;
         }
-          if (this.state.readMore) {
-            return <span>
-              <TextTruncate
-                    line={num_of_lines}
-                    truncateText="..."
-                    text={text_to_display}
-                    textTruncateChild={<a href="#" onClick={this.toggleLines}>{link_text}</a>}
-                />
-            </span>;
-          } else {
-            return <span>{expanded_text_to_display}&nbsp;&nbsp;<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
-          }
+        if (this.state.readMore) {
+          return <span>
+            <TextTruncate
+                  line={num_of_lines}
+                  truncateText="..."
+                  text={text_to_display}
+                  textTruncateChild={<a href="#" onClick={this.toggleLines}>{link_text}</a>}
+              />
+          </span>;
+        } else {
+          return <span>{expanded_text_to_display}&nbsp;&nbsp;<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
         }
+    } //end render
   }

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -6,8 +6,7 @@ export default class ReadMore extends Component {
     text_to_display: PropTypes.node.isRequired,
     link_text: PropTypes.node,
     collapse_text: PropTypes.node,
-    num_of_lines: PropTypes.number,
-    max_num_of_char: PropTypes.number
+    num_of_lines: PropTypes.number
   };
 
     constructor (...args) {
@@ -27,8 +26,8 @@ export default class ReadMore extends Component {
     }
 
     render () {
-        let { text_to_display, link_text, num_of_lines, collapse_text, max_num_of_char } = this.props;
-        //default props
+        let { text_to_display, link_text, num_of_lines, collapse_text } = this.props;
+        // default prop valuess
         if (num_of_lines === undefined) {
           num_of_lines = 3;
         }
@@ -38,9 +37,9 @@ export default class ReadMore extends Component {
         if (collapse_text === undefined) {
           collapse_text = "Show Less  ";
         }
-        if (max_num_of_char === undefined) {
-          max_num_of_char = 100;
-        }
+        // if (max_num_of_char === undefined) {
+        //   max_num_of_char = 100;
+        // }
 
         // remove extra ascii carriage returns or other control text
         text_to_display = text_to_display.replace(/[\x0D-\x1F]/g, "");
@@ -51,6 +50,7 @@ export default class ReadMore extends Component {
         let not_enough_text_to_truncate = false;
         let all_lines_short = true;
         let max_num_of_lines = num_of_lines;
+        // max num of lines shouldn't be greater than the total num of line breaks hard coded
         if (max_num_of_lines > expanded_text_array.length) {
           max_num_of_lines = expanded_text_array.length;
         }
@@ -82,7 +82,7 @@ export default class ReadMore extends Component {
 
         if (not_enough_text_to_truncate) {
           return <span>{expanded_text_to_display}</span>;
-        } else {
+        }
           if (this.state.readMore) {
             return <span>
               <TextTruncate
@@ -97,4 +97,3 @@ export default class ReadMore extends Component {
           }
         }
   }
-}

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -27,6 +27,7 @@ export default class ReadMore extends Component {
 
     render () {
         let { text_to_display, link_text, num_of_lines, collapse_text } = this.props;
+        //default props
         if (num_of_lines === undefined) {
           num_of_lines = 3;
         }
@@ -36,39 +37,49 @@ export default class ReadMore extends Component {
         if (collapse_text === undefined) {
           collapse_text = " ...Show Less  ";
         }
+
+        // remove extra ascii carriage returns or other control text
+        text_to_display = text_to_display.replace(/[\x0D-\x1F]/g, "");
+        // convert text into array, splitting on line breaks
         let expanded_text_array = text_to_display.replace(/(?:\r\n|\r|\n){2,}/g, "\r\n\r\n").split(/(?:\r\n|\r|\n)/g);
 
         // There are cases where we would like to show line breaks when there is a little bit of text
         let not_enough_text_to_truncate = false;
-        if (text_to_display.length <= 81) {
+        if (expanded_text_array.length <= num_of_lines && text_to_display.length <= 100) {
           not_enough_text_to_truncate = true;
         }
-
+        // wrap text in array in seperate spans with html line breaks
         let expanded_text_to_display = expanded_text_array.map(function (item, key){
            if (key === 0) {
             return <span key={key}>
               {item}
               </span>;
-          } else {
-          return <span key={key}>
-            <br/>
+          } else if (key >= expanded_text_array.length - 2 && item === "") {
+            return <span key={key}>
               {item}
-            </span>; }
+              </span>;
+          } else {
+            return <span key={key}>
+              <br/>
+              {item}
+              </span>; }
         });
 
         if (not_enough_text_to_truncate) {
           return <span>{expanded_text_to_display}</span>;
-        } else if (this.state.readMore) {
-          return <span>
-            <TextTruncate
-                  line={num_of_lines}
-                  truncateText="..."
-                  text={text_to_display}
-                  textTruncateChild={<a href="#" onClick={this.toggleLines}>{link_text}</a>}
-              />
-          </span>;
         } else {
-          return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
+          if (this.state.readMore) {
+            return <span>
+              <TextTruncate
+                    line={num_of_lines}
+                    truncateText="..."
+                    text={text_to_display}
+                    textTruncateChild={<a href="#" onClick={this.toggleLines}>{link_text}</a>}
+                />
+            </span>;
+          } else {
+            return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
+          }
         }
-    }
+  }
 }

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -6,7 +6,8 @@ export default class ReadMore extends Component {
     text_to_display: PropTypes.node.isRequired,
     link_text: PropTypes.node,
     collapse_text: PropTypes.node,
-    num_of_lines: PropTypes.number
+    num_of_lines: PropTypes.number,
+    max_num_of_char: PropTypes.number
   };
 
     constructor (...args) {
@@ -26,7 +27,7 @@ export default class ReadMore extends Component {
     }
 
     render () {
-        let { text_to_display, link_text, num_of_lines, collapse_text } = this.props;
+        let { text_to_display, link_text, num_of_lines, collapse_text, max_num_of_char } = this.props;
         //default props
         if (num_of_lines === undefined) {
           num_of_lines = 3;
@@ -35,7 +36,10 @@ export default class ReadMore extends Component {
           link_text = "More";
         }
         if (collapse_text === undefined) {
-          collapse_text = " ...Show Less  ";
+          collapse_text = "Show Less  ";
+        }
+        if (max_num_of_char === undefined) {
+          max_num_of_char = 100;
         }
 
         // remove extra ascii carriage returns or other control text
@@ -45,7 +49,18 @@ export default class ReadMore extends Component {
 
         // There are cases where we would like to show line breaks when there is a little bit of text
         let not_enough_text_to_truncate = false;
-        if (expanded_text_array.length <= num_of_lines && text_to_display.length <= 100) {
+        let all_lines_short = true;
+        let max_num_of_lines = num_of_lines;
+        if (max_num_of_lines > expanded_text_array.length) {
+          max_num_of_lines = expanded_text_array.length;
+        }
+        for ( var i = 0; i < max_num_of_lines; i++) {
+          if (expanded_text_array[i].length > 38) {
+            all_lines_short = false;
+            break;
+          }
+        }
+        if (expanded_text_array.length <= num_of_lines && all_lines_short) {
           not_enough_text_to_truncate = true;
         }
         // wrap text in array in seperate spans with html line breaks
@@ -78,7 +93,7 @@ export default class ReadMore extends Component {
                 />
             </span>;
           } else {
-            return <span>{expanded_text_to_display}<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
+            return <span>{expanded_text_to_display}&nbsp;&nbsp;<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
           }
         }
   }

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -137,7 +137,7 @@
 
   .card-child {
     position: relative;
-    padding: 15px;
+    padding: 15px 15px 7px 15px;
     margin-top: -1px;
     background-color: $pale-gray;
     border-top: 1px solid $lighter-gray;
@@ -189,10 +189,16 @@
       .btn {
         margin: 0 5px 0 0;
       }
+      .twitter-followers__badge {
+        margin: 5px 0;
+      }
       @include breakpoints(medium) {
         flex-direction: column;
         .btn {
           margin: 0 0 5px;
+        }
+        .twitter-followers__badge {
+          margin: 0;
         }
       }
     }

--- a/src/sass/elements/_twitter-followers.scss
+++ b/src/sass/elements/_twitter-followers.scss
@@ -4,7 +4,6 @@
   color: $mid-gray;
   display: inline-block;
   line-height: 2rem;
-  padding: 5px 0;
   white-space: nowrap;
 }
 

--- a/src/sass/layout/_mediaquery.scss
+++ b/src/sass/layout/_mediaquery.scss
@@ -1,5 +1,9 @@
 // TODO: Jeff - Refactor all styles here and remove this partial
 
+.view-source {
+  display: none;
+}
+
 .device {
   &-menu {
     &--large {
@@ -63,6 +67,10 @@
 @include breakpoints(nav) {
   .navbar-fixed-bottom {
     display: none;
+  }
+
+  .view-source {
+    display: block;
   }
 
   .device {


### PR DESCRIPTION
Improvements include:
Organizational Descriptions, displayed in list view, now are truncated by ReadMore, with two lines visible (#491).

added regex to remove ascii control text that was interfering with handling of line breaks

ReadMore will now not truncate text if it has fewer than the maximum number of lines AND each line is shorter than 38 characters

removed parens around View Source, gave it a className so it won't display in mobile and will have mid-gray color

also changed margins slightly for twitter follow buttons/twitter followers badge so that organization cards take up less vertical real estate
