### PR TITLE
fix for Copy Link problem on mobile #487

### DIFF
--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -29,7 +29,7 @@ export default class CopyLinkModal extends Component {
 
 render () {
   let urlBeingShared = this.props.urlBeingShared;
-  let browser_supports_CopyToClipboard = true; //latest iOS update supports CopyToClipboard, check for users version and let them copy if latest, perhaps with npm pckg "mobile-detect"
+  let browser_supports_CopyToClipboard = false; //latest iOS update supports CopyToClipboard, check for users version and let them copy if latest, perhaps with npm pckg "mobile-detect"
   let copy_btn_className;
   let select_all_button;
   if (browser_supports_CopyToClipboard) {

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -29,20 +29,32 @@ export default class CopyLinkModal extends Component {
 
 render () {
   let urlBeingShared = this.props.urlBeingShared;
+  let browser_supports_CopyToClipboard = true; //latest iOS update supports CopyToClipboard, check for users version and let them copy if latest, perhaps with npm pckg "mobile-detect"
+  let copy_btn_className;
+  let select_all_button;
+  if (browser_supports_CopyToClipboard) {
+    copy_btn_className = "copy-btn"; // display copy button at all times
+    select_all_button = null;
+  } else {
+    copy_btn_className = "copy-btn__hide-mobile"; // display: none; in mobile view
+    select_all_button = <button className="select-all-btn btn btn-default" onClick={()=>{this.refs.input.select();}}>Select All</button>;
+  }
+
   return <Modal {...this.props} bsSize="large" aria-labelledby="contained-modal-title-lg">
     <Modal.Header closeButton>
       <Modal.Title id="contained-modal-title-lg">Copy link to clipboard</Modal.Title>
     </Modal.Header>
     <Modal.Body>
       <div className="input-group">
-        <input value={urlBeingShared} className="form-control" style={{marginTop: "17px"}} onChange={({target: {value}}) => this.setState({value, copied: false})} />&nbsp;
+        <input ref="input" value={urlBeingShared} className="form-control" style={{marginTop: "17px"}} onChange={({target: {value}}) => this.setState({value, copied: false})} onFocus={()=>{this.refs.input.select();}} />&nbsp;
           <span className="input-group-btn">
-        <CopyToClipboard text={urlBeingShared} onCopy={() => this.setState({copied: true})}>
-          <button className="copy-btn btn btn-default">Copy</button>
-        </CopyToClipboard>
-        </span>
+            <CopyToClipboard text={urlBeingShared} onCopy={() => this.setState({copied: true})}>
+              <button className={"btn btn-default " + copy_btn_className}>Copy</button>
+            </CopyToClipboard>
+            {select_all_button}
+          </span>
       </div>
-        {this.state.copied ? <span style={{color: "red"}}>Copied.  Can now paste into an email or social media!</span> : null}
+    {this.state.copied ? <span style={{color: "red"}}>Copied.  Can now paste into an email or social media!</span> : null}
     </Modal.Body>
   </Modal>;
   }

--- a/src/sass/elements/_buttons.scss
+++ b/src/sass/elements/_buttons.scss
@@ -16,8 +16,23 @@
 	}
 }
 
+.select-all-btn{
+	height: 34px;
+	display: none;
+	@include breakpoints (max nav) {
+		display: block; // show button on small screens
+	}
+}
+
+
 .copy-btn {
 	height: 34px;
+		&__hide-mobile {
+			height: 34px;
+			@include breakpoints (max nav) {
+				display: none; // Hide button on small screens
+		}
+	}
 }
 
 


### PR DESCRIPTION
new iOS update includes support for javascript copying text to clipboard, which would resolve issue #487... if we could assume that all users would be using the latest version, and that android has a similar fix.

So instead, I have created a variable, browser_supports_CopyToClipboard.  Currently set to false, with future plan to include browser/device detection and assign to true if the browser and device support the behavior.  

When browser_supports_CopyToClipboard === false, in mobile view, the copy button will not appear.  Instead a "Select All" button will appear, with the idea that the user will have the option to copy the text once it is selected using typical iOS/android cut/copy functionality.  I have also added a select all onFocus function to the input field containing the URL, so the user can click the input field OR the button to highlight the URL.

Desktop view behavior remains the same in all cases, as does the behavior if browser_support is truthy.