### PR TITLE
added sizeClassName to ImageHandler, removed underline for placeholde…

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -67,18 +67,19 @@ export default class CandidateItem extends Component {
     let candidate_photo_url_html;
     if (candidate_photo_url) {
       candidate_photo_url_html = <ImageHandler className="card-main__avatar"
+                                          sizeClassName="icon-office-child "
                                           imageUrl={candidate_photo_url}
                                           alt="candidate-photo"
                                           kind_of_ballot_item="CANDIDATE" />;
     } else {
-      candidate_photo_url_html = <i className="icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light utils-img-contain-glyph" />;
+      candidate_photo_url_html = <i className="card-main__avatar icon-office-child icon-main icon-icon-person-placeholder-6-1" />;
     }
 
     return <div className="card-main candidate-card">
       <div className="card-main__media-object">
         <div className="card-main__media-object-anchor">
           {this.props.link_to_ballot_item_page ?
-            <Link to={candidateLink}>{candidate_photo_url_html}</Link> :
+            <Link to={candidateLink} className="no-underline">{candidate_photo_url_html}</Link> :
             candidate_photo_url_html
           }
 

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -86,9 +86,10 @@ export default class PositionItem extends Component {
     var one_position_on_this_candidate = <li className="card-child position-item">
       {/* One Position on this Candidate */}
         <div className="card-child__media-object-anchor">
-          <Link to={speakerLink}>
+          <Link to={speakerLink} className="no-underline">
             { position.speaker_image_url_https ?
               <ImageHandler className="img-square card-child__avatar"
+                    sizeClassName="icon-lg "
                     imageUrl={position.speaker_image_url_https}
               /> :
             image_placeholder }

--- a/src/js/components/Friends/FriendDisplayForList.jsx
+++ b/src/js/components/Friends/FriendDisplayForList.jsx
@@ -34,12 +34,12 @@ export default class FriendDisplayForList extends Component {
     return <div className="position-item card-child card-child--not-followed">
       <div className="card-child__avatar">
         <Link to={voterGuideLink}>
-          <ImageHandler imageUrl={voter_photo_url} />
+          <ImageHandler sizeClassName="icon-lg " imageUrl={voter_photo_url} />
         </Link>
       </div>
       <div className="card-child__media-object-content">
         <div className="card-child__content">
-          <Link to={voterGuideLink}>
+          <Link to={voterGuideLink} className="no-underline">
             <h4 className="card-child__display-name">{voter_display_name}</h4>
           </Link>
           { twitterDescriptionMinusName ? <p>{twitterDescriptionMinusName}</p> :

--- a/src/js/components/Friends/FriendInvitationDisplayForList.jsx
+++ b/src/js/components/Friends/FriendInvitationDisplayForList.jsx
@@ -44,8 +44,8 @@ export default class FriendInvitationDisplayForList extends Component {
 
     return <div className="position-item card-child card-child--not-followed">
       <div className="card-child__avatar">
-        <Link to={voterGuideLink}>
-          <ImageHandler imageUrl={voter_photo_url} kind_of_ballot_item="CANDIDATE" />
+        <Link to={voterGuideLink} className="no-underline">
+          <ImageHandler sizeClassName="icon-lg " imageUrl={voter_photo_url} kind_of_ballot_item="CANDIDATE" />
         </Link>
       </div>
       <div className="card-child__media-object-content">

--- a/src/js/components/ImageHandler.jsx
+++ b/src/js/components/ImageHandler.jsx
@@ -5,7 +5,8 @@ export default class ImageHandler extends Component {
     imageUrl: PropTypes.string,
     className: PropTypes.string,
     alt: PropTypes.string,
-    kind_of_ballot_item: PropTypes.string
+    kind_of_ballot_item: PropTypes.string,
+    sizeClassName: PropTypes.string
   };
 
   constructor (props) {
@@ -21,16 +22,17 @@ export default class ImageHandler extends Component {
     let this_class = this.props.className || "utils-img-contain";
     let alt = this.props.alt || "icon";
     let replacementClass = "";
+    let sizeClassName = this.props.sizeClassName || "";
     if (this.props.kind_of_ballot_item === "CANDIDATE") {
-      replacementClass = "icon-lg icon-main icon-icon-person-placeholder-6-1 icon-light card-child__avatar";
+      replacementClass = "icon-main icon-icon-person-placeholder-6-1 card-child__avatar";
     } else {
-      replacementClass = "icon-org-lg icon-icon-org-placeholder-6-2 icon-org-resting-color card-child__avatar";
+      replacementClass = "icon-main icon-icon-org-placeholder-6-2 card-child__avatar";
     }
 
 
     const image = this.state.error ?
-      <i className={replacementClass} /> :
-      <img className={this_class} src={this.props.imageUrl} alt={alt}
+      <i className={sizeClassName + replacementClass} /> :
+      <img className={sizeClassName + this_class} src={this.props.imageUrl} alt={alt}
            onError={this.brokenLink.bind(this)} />;
 
     return image;

--- a/src/js/components/Twitter/TwitterAccountCard.jsx
+++ b/src/js/components/Twitter/TwitterAccountCard.jsx
@@ -30,7 +30,7 @@ export default class TwitterAccountCard extends Component {
         <div className="card-main">
           <div className="card-main__media-object">
             <div className="card-main__media-object-anchor">
-              <ImageHandler imageUrl={twitter_photo_url} className="card-main__avatar" />
+              <ImageHandler imageUrl={twitter_photo_url} className="card-main__avatar" sizeClassName="icon-lg "/>
             </div>
             <div className="card-main__media-object-content">
               <div className="card-main__display-name">{displayName}</div>

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -34,7 +34,7 @@ export default class OrganizationCard extends Component {
 
     return <div className="card-main__media-object">
       <div className="card-main__media-object-anchor">
-        <ImageHandler imageUrl={organization_photo_url} className="card-main__avatar" />
+        <ImageHandler imageUrl={organization_photo_url} className="card-main__avatar" sizeClassName="icon-lg "/>
       </div>
       <div className="card-main__media-object-content">
         <div className="card-main__display-name">{displayName}</div>

--- a/src/js/components/VoterGuide/OrganizationDisplayForList.jsx
+++ b/src/js/components/VoterGuide/OrganizationDisplayForList.jsx
@@ -63,8 +63,8 @@ export default class OrganizationDisplayForList extends Component {
 
     return <div className="card-child card-child--not-followed">
       <div className="card-child__media-object-anchor">
-        <Link to={voterGuideLink}>
-          <ImageHandler className="card-child__avatar" imageUrl={voter_guide_image_url} />
+        <Link to={voterGuideLink} className="no-underline">
+          <ImageHandler className="card-child__avatar" sizeClassName="icon-lg " imageUrl={voter_guide_image_url} />
         </Link>
       </div>
       <div className="card-child__media-object-content">

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -156,9 +156,11 @@ export default class OrganizationPositionItem extends Component {
       { is_candidate ?
         <div className="card-child__media-object-anchor">
           <Link to={ ballotItemLink }
+                className="no-underline"
                 onlyActiveOnIndex={false}>
             <ImageHandler
               className="card-child__avatar"
+              sizeClassName="icon-lg "
               imageUrl={position.ballot_item_image_url_https}
               alt="candidate-photo"
               kind_of_ballot_item={position.kind_of_ballot_item}/>

--- a/src/js/components/VoterGuide/VoterGuideItem.jsx
+++ b/src/js/components/VoterGuide/VoterGuideItem.jsx
@@ -41,8 +41,8 @@ export default class VoterGuideItem extends Component {
 
     return <div className="card-child">
       <div className="card-child__media-object-avatar">
-        <Link to={voterGuideLink}>
-          <ImageHandler className="card-child__avatar"imageUrl={this.props.voter_guide_image_url} />
+        <Link to={voterGuideLink} className="no-underline">
+          <ImageHandler className="card-child__avatar" sizeClassName="icon-lg " imageUrl={this.props.voter_guide_image_url} />
         </Link>
       </div>
       <div className="card-child__media-object-content">

--- a/src/js/components/VoterGuide/VoterPositionItem.jsx
+++ b/src/js/components/VoterGuide/VoterPositionItem.jsx
@@ -125,11 +125,13 @@ export default class VoterPositionItem extends Component {
       <StarAction we_vote_id={position.ballot_item_we_vote_id} type={position.kind_of_ballot_item} />
       <div className="card-child__media-object-anchor">
         <Link to={ ballotItemLink }
+              className="no-underline"
               onlyActiveOnIndex={false}>
           {/*<i className="icon-icon-add-friends-2-1 icon-light icon-medium" />*/}
           { is_candidate ?
             <ImageHandler
               className="card-child__avatar"
+              sizeClassName="icon-lg "
               imageUrl={position.ballot_item_image_url_https}
               alt="candidate-photo"
               kind_of_ballot_item={position.kind_of_ballot_item}/> :

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -11,25 +11,25 @@ export default class CopyLinkModal extends Component {
     super(props);
     this.state = {
       value: "",
-      copied: false
+      was_copied: false
     };
   }
 
   componentWillMount () {
     this.setState({
-      copied: false
+      was_copied: false
     });
   }
 
   componentWillReceiveProps () {
     this.setState({
-      copied: false
+      was_copied: false
     });
   }
 
-  copied () {
+  updateWasCopied () {
     this.setState({
-      copied: true
+      was_copied: true
     });
   }
 
@@ -60,13 +60,13 @@ render () {
                style={{marginTop: "17px"}}
                onFocus={()=>{document.getElementById("url-to-copy").setSelectionRange(0, 999);}} />&nbsp;
           <span className="input-group-btn">
-            <CopyToClipboard text={urlBeingShared} onCopy={this.copied.bind(this)}>
+            <CopyToClipboard text={urlBeingShared} onCopy={this.updateWasCopied.bind(this)}>
               <button className={"btn btn-default " + copy_btn_className}>Copy</button>
             </CopyToClipboard>
             {select_all_button}
           </span>
       </div>
-    {this.state.copied ? <span style={{color: "red"}}>Copied.  Can now paste into an email or social media!</span> : null}
+    {this.state.was_copied ? <span style={{color: "red"}}>Copied.  Can now paste into an email or social media!</span> : null}
     </Modal.Body>
   </Modal>;
   }

--- a/src/sass/base/_fonts.scss
+++ b/src/sass/base/_fonts.scss
@@ -42,6 +42,10 @@
     -moz-osx-font-smoothing: grayscale;
 }
 
+.no-underline {
+    text-decoration: none !important;
+}
+
 .icon-icon-vote-3-4:before {
     content: "a";
 }
@@ -73,6 +77,10 @@
 
 .icon-xl {
   font-size: 10em;
+}
+
+.icon-office-child {
+  font-size: 80px;
 }
 
 .icon-lg {


### PR DESCRIPTION
…r icons, renamed vars in CopyLinkModal

This PR tackles 4 things. 
1) placeholder icons weren't always appearing at the correct size (especially on Office page when filling in for a candidate) so added prop sizeClassName, a string to be passed in, added to the class name to customize the size of the icon.

(NOTE: we were already passing in the desired className as a prop, so I could have just included size in that existing className, but figured this way could be easier to troubleshoot/customize.  happy to consolidate these two className props if people would prefer it, or that seems cleaner/DRYer/etc)

2) placeholder icons were showing blue underline on hover, so added classname "no-underline" to all anchors surrounding icons to prevent this behavior.

3) renamed fn "copied" in CopyLinkModal to "updateWasCopied", and state.copied to state.was_copied to make names more declarative/easy to understand

4) removed some deprecated class names from ImageHandler