### PR TITLE
Issue #505 WIP - On focus, select all text in Search box

### DIFF
--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -106,6 +106,7 @@ export default class SearchAllBox extends Component {
         <form onSubmit={this.onSearchFormSubmit.bind(this)} className="" role="search">
         <div className="input-group site-search">
           <input type="text"
+                 id="SearchAllBox-input"
                  className="form-control site-search__input-field"
                  placeholder="Search We Vote…"
                  name="master_search_field"

--- a/src/js/utils/search-functions.js
+++ b/src/js/utils/search-functions.js
@@ -4,9 +4,14 @@ export function enterSearch () {
   // const searchButton = document.getElementsByClassName("site-search__button")[0];
   // searchButton.classList.remove("btn-default");
   // searchButton.classList.add("btn-primary");
-  // Clear out the contents of the search box
+
+  // Clear out the contents of the search box. Then select the text in searchInput. We're searching the DOM and then
+  // using setSelectionRange because the normal way I'd do things in React (e.target.select(), instead of the
+  // relatively-slow DOM search) apparently doesn't work in some iPhone mobile browsers. I haven't verified that
+  // (Nico 9/28/16)
   const searchInput = document.getElementById("SearchAllBox-input");
   searchInput.setSelectionRange(0, 999);
+
   // Hide the hamburger navigation and site name
   const siteLogoText = document.getElementsByClassName("page-logo")[0];
   siteLogoText.style.display = "none";

--- a/src/js/utils/search-functions.js
+++ b/src/js/utils/search-functions.js
@@ -5,8 +5,8 @@ export function enterSearch () {
   // searchButton.classList.remove("btn-default");
   // searchButton.classList.add("btn-primary");
   // Clear out the contents of the search box
-  const searchInput = document.getElementsByTagName("input")[0];
-  searchInput.value = "";
+  const searchInput = document.getElementById("SearchAllBox-input");
+  searchInput.setSelectionRange(0, 999);
   // Hide the hamburger navigation and site name
   const siteLogoText = document.getElementsByClassName("page-logo")[0];
   siteLogoText.style.display = "none";


### PR DESCRIPTION
This commit updates the behavior when focusing (e.g., clicking into) the Search box. Before, focusing the Search box cleared all the text. Now, all the text is selected, so the user can easily delete it, but can also leave it and type more.