### PR TITLE
workaround for firefox ImageHandler problem #509

### DIFF
--- a/src/js/components/ImageHandler.jsx
+++ b/src/js/components/ImageHandler.jsx
@@ -29,8 +29,7 @@ export default class ImageHandler extends Component {
       replacementClass = "icon-main icon-icon-org-placeholder-6-2 card-child__avatar";
     }
 
-
-    const image = this.state.error ?
+    const image = this.state.error || this.props.imageUrl === "" ?
       <i className={sizeClassName + replacementClass} /> :
       <img className={sizeClassName + this_class} src={this.props.imageUrl} alt={alt}
            onError={this.brokenLink.bind(this)} />;

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -37,9 +37,6 @@ export default class ReadMore extends Component {
         if (collapse_text === undefined) {
           collapse_text = "Show Less  ";
         }
-        // if (max_num_of_char === undefined) {
-        //   max_num_of_char = 100;
-        // }
 
         // remove extra ascii carriage returns or other control text
         text_to_display = text_to_display.replace(/[\x0D-\x1F]/g, "");


### PR DESCRIPTION
it seems that firefox does not recognize a missing image source as an error, and instead replaces the image with a string (i believe the last five characters there are "photo", though I'd need to spend more time to decipher the whole string).  Rather than digging TOO deeply on how to get firefox to see this as an error, I simply added an extra statement to the conditional in ImageHandler's assignment of the constant "image", so that if there is no source for the image, we use a replacement icon.

also removed commented out, deprecated prop default assignment from ReadMore.