### PR TITLE
improved format and structure of OpinionsFollowed

### DIFF
--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -26,7 +26,7 @@ import Measure from "./routes/Ballot/Measure";
 import NotFound from "./routes/NotFound";
 import Office from "./routes/Ballot/Office";
 import Opinions from "./routes/Opinions";
-import OpinionsFollowed from "./routes/More/OpinionsFollowed";
+import OpinionsFollowed from "./routes/OpinionsFollowed";
 import Privacy from "./routes/More/Privacy";
 import Requests from "./routes/Requests";
 import Settings from "./routes/Settings/Settings";
@@ -59,6 +59,7 @@ const routes = () =>
 
     {/* Ballot Off-shoot Pages */}
     <Route path="/opinions" component={Opinions} />
+    <Route path="/opinions_followed" component={OpinionsFollowed} />
     <Route path="/friends" >
       <IndexRoute component={Friends} />
       <Route path="add" component={Connect} />
@@ -70,7 +71,6 @@ const routes = () =>
     <Route path="/more/email_ballot" component={EmailBallot} />
     <Route path="/more/about" component={About} />
     <Route path="/more/connect" component={Connect} />
-    <Route path="/more/opinions/followed" component={OpinionsFollowed} />
     <Route path="/more/privacy" component={Privacy} />
 
     {/* Voter Guide Pages */}

--- a/src/js/components/Navigation/FollowingFilter.jsx
+++ b/src/js/components/Navigation/FollowingFilter.jsx
@@ -26,7 +26,7 @@ export default class FollowingFilter extends Component {
       <Link to="/opinions" className={ following_type === "WHO_YOU_CAN_FOLLOW" ? "active btn btn-default" : "btn btn-default"}>
         To Follow
       </Link>
-      <Link to="/more/opinions/followed" className={ following_type === "WHO_YOU_FOLLOW" ? "active btn btn-default" : "btn btn-default"}>
+      <Link to="/opinions_followed" className={ following_type === "WHO_YOU_FOLLOW" ? "active btn btn-default" : "btn btn-default"}>
         Following
       </Link>
       <Link to="/friends" className={ following_type === "YOUR_FRIENDS" ? "active btn btn-default" : "btn btn-default"}>

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -48,6 +48,7 @@ export default class GuideList extends Component {
     }
 
     const orgs = this.state.organizations_to_follow.map( (org) => {
+
       return <OrganizationDisplayForList key={org.organization_we_vote_id} {...org}>
             <FollowToggle we_vote_id={org.organization_we_vote_id} />
             <button className="btn btn-default btn-sm"

--- a/src/js/components/VoterGuide/OpinionsFollowedList.jsx
+++ b/src/js/components/VoterGuide/OpinionsFollowedList.jsx
@@ -1,0 +1,71 @@
+import React, { Component, PropTypes } from "react";
+import FollowToggle from "../Widgets/FollowToggle";
+import GuideActions from "../../actions/GuideActions";
+import OrganizationDisplayForList from "./OrganizationDisplayForList";
+import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+
+export default class OpinionsFollowedList extends Component {
+
+  static propTypes = {
+    ballotItemWeVoteId: PropTypes.string,
+    organizationsFollowed: PropTypes.array,
+    instantRefreshOn: PropTypes.bool,
+    editMode: PropTypes.bool
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      organizations_followed: this.props.organizationsFollowed,
+      ballot_item_we_vote_id: ""
+    };
+  }
+
+  componentDidMount () {
+    this.setState({
+      organizations_followed: this.props.organizationsFollowed,
+      ballot_item_we_vote_id: this.props.ballotItemWeVoteId
+    });
+  }
+
+  componentWillReceiveProps (nextProps){
+    //if (nextProps.instantRefreshOn ) {
+      // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked
+      this.setState({
+        organizations_followed: nextProps.organizationsFollowed,
+        ballot_item_we_vote_id: nextProps.ballotItemWeVoteId
+      });
+    //}
+  }
+
+  handleIgnore (id) {
+    GuideActions.organizationFollowIgnore(id);
+    this.setState({ organizations_followed: this.state.organizations_followed.filter( (org) => { return org.organization_we_vote_id !== id;})});
+  }
+
+  render () {
+    if (this.state.organizations_followed === undefined) {
+      return null;
+    }
+    // zachmonteith: extra span tags inside of OrganizationDisplayForList are to ensure that {org} gets passed in
+    // as an array rather than an object, so that our propTypes validations in OrganizationDisplayForList work.
+    // there is probably a more elegant way to do this, but left it this way for now as it works.
+    const orgs = this.state.organizations_followed.map( (org) => {
+      if (this.props.editMode) {
+        return <OrganizationDisplayForList key={org.organization_we_vote_id} {...org}>
+              <FollowToggle we_vote_id={org.organization_we_vote_id} /><span></span>
+            </OrganizationDisplayForList>;
+      } else {
+        return <OrganizationDisplayForList key={org.organization_we_vote_id} {...org}>
+              <span></span><span></span></OrganizationDisplayForList>;
+      }
+    });
+
+    return <div className="guidelist card-child__list-group">
+        <ReactCSSTransitionGroup transitionName="org-ignore" transitionEnterTimeout={4000} transitionLeaveTimeout={2000}>
+          {orgs}
+        </ReactCSSTransitionGroup>
+      </div>;
+  }
+
+}

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -55,6 +55,7 @@ render () {
     <Modal.Body>
       <div className="input-group">
         <input id="url-to-copy"
+               readOnly="true"
                value={urlBeingShared}
                className="form-control"
                style={{marginTop: "17px"}}

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -90,8 +90,9 @@ export default class PositionInformationOnlySnippet extends Component {
               <div className="view-source">
                 {/* default: open in new tab*/}
                 <a href={more_info_url}
-                   target="_blank">
-                  (view source <i className="fa fa-external-link" aria-hidden="true"></i>)
+                   target="_blank"
+                   className="gray-mid">
+                  view source <i className="fa fa-external-link" aria-hidden="true"></i>
                 </a>
                 {/* link for mobile browser: open in bootstrap modal */}
                 {/*<a onClick={onViewSourceClick}>

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -103,8 +103,9 @@ export default class PositionSupportOpposeSnippet extends Component {
               <div className="view-source">
                 {/* default: open in new tab*/}
                 <a href={more_info_url}
-                   target="_blank">
-                  (view source <i className="fa fa-external-link" aria-hidden="true"></i>)
+                   target="_blank"
+                   className="gray-mid">
+                  view source <i className="fa fa-external-link" aria-hidden="true"></i>
                 </a>
                 {/* link for mobile browser: open in bootstrap modal */}
                 {/*

--- a/src/js/routes/Connect.jsx
+++ b/src/js/routes/Connect.jsx
@@ -61,7 +61,7 @@ export default class Connect extends Component {
 				</span>
 				<p>Find voter guides you can follow. These voter guides have been created by nonprofits, public figures, your friends, and more.<br />
 				<br /></p>
-        <Link to="/more/opinions/followed">See who you are following</Link>
+        <Link to="/opinions_followed">See who you are following</Link>
       </div>
 
 		</div>;

--- a/src/js/routes/Opinions.jsx
+++ b/src/js/routes/Opinions.jsx
@@ -48,7 +48,7 @@ export default class Opinions extends Component {
     switch (this.getCurrentRoute()) {
       case "/opinions":
         return "WHO_YOU_CAN_FOLLOW";
-      case "/more/opinions/followed":
+      case "/opinions_followed":
       default :
         return "WHO_YOU_FOLLOW";
     }

--- a/src/js/routes/OpinionsFollowed.jsx
+++ b/src/js/routes/OpinionsFollowed.jsx
@@ -1,8 +1,8 @@
 import React, {Component, PropTypes } from "react";
-import FollowingFilter from "../../components/Navigation/FollowingFilter";
-import GuideStore from "../../stores/GuideStore";
-import GuideActions from "../../actions/GuideActions";
-import VoterGuideItem from "../../components/VoterGuide/VoterGuideItem";
+import FollowingFilter from "../components/Navigation/FollowingFilter";
+import GuideStore from "../stores/GuideStore";
+import GuideActions from "../actions/GuideActions";
+import OpinionsFollowedList from "../components/VoterGuide/OpinionsFollowedList";
 
 /* VISUAL DESIGN HERE: https://invis.io/8F53FDX9G */
 
@@ -14,7 +14,8 @@ export default class OpinionsFollowed extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {voter_guide_followed_list: GuideStore.followedList()};
+    this.state = {voter_guide_followed_list: GuideStore.followedList(),
+                  editMode: false};
   }
 
   componentDidMount () {
@@ -35,15 +36,19 @@ export default class OpinionsFollowed extends Component {
   }
 
   getCurrentRoute (){
-    var current_route = "/more/opinions/followed";
+    var current_route = "/opinions_followed";
     return current_route;
+  }
+
+  toggleEditMode (){
+    this.setState({editMode: !this.state.editMode});
   }
 
   getFollowingType (){
     switch (this.getCurrentRoute()) {
       case "/opinions":
         return "WHO_YOU_CAN_FOLLOW";
-      case "/more/opinions/followed":
+      case "/opinions_followed":
       default :
         return "WHO_YOU_FOLLOW";
     }
@@ -51,8 +56,9 @@ export default class OpinionsFollowed extends Component {
 
   render () {
     return <div className="opinions-followed__container">
-      <h1 className="h1">Your Network</h1>
+      <h1 className="h1">Build Your Network</h1>
       <FollowingFilter following_type={this.getFollowingType()} />
+      <a className="fa-pull-right" onClick={this.toggleEditMode.bind(this)}>{this.state.editMode ? "Done Editing" : "Edit"}</a>
         <p>
           Organizations, public figures and other voters you currently follow. <em>We will never sell your email</em>.
         </p>
@@ -60,9 +66,10 @@ export default class OpinionsFollowed extends Component {
         <div className="card-child__list-group">
           {
             this.state.voter_guide_followed_list && this.state.voter_guide_followed_list.length ?
-            this.state.voter_guide_followed_list.map( item =>
-              <VoterGuideItem key={item.we_vote_id} {...item} />
-            ) : null
+            <OpinionsFollowedList organizationsFollowed={this.state.voter_guide_followed_list}
+                                  editMode={this.state.editMode}
+                                  instantRefreshOn /> :
+              null
           }
         </div>
       </div>


### PR DESCRIPTION
In this PR:
1) changed view source links to reflect an earlier PR: mid-gray color, no parens.

2) moved route OpinionsFollowed to the root level

3) switched OpinionsFollowed from using deprecated VoterGuideItem to have structure more similar to Opinions: similar to GuideList, created component OpinionsFollowedList.

4) added "editMode" state to OpinionsFollowed, so users can toggle whether or not they are following particular orgs from this list.

5) made CopyLinkModal input field read-only to prevent a console warning

NEXT STEPS
- [ ] add a route (and a link to it on OpinionsFollowed) for orgs/users you are ignoring #396 
- [ ] more elegant solution to the array vs object prop type issue (see comment on line 50 of OpinionsFollowedList)
- [ ] related to last item, formatting of OpinionsFollowedList: button children spacing still appears even when edit mode is true and buttons are turned off (see screen shots below)
![screen shot 2016-10-01 at 12 51 19 pm](https://cloud.githubusercontent.com/assets/17035647/19016704/f76e5440-87d6-11e6-88f9-97a5c5fcf080.png)
![screen shot 2016-10-01 at 12 51 29 pm](https://cloud.githubusercontent.com/assets/17035647/19016705/f989f18a-87d6-11e6-81e9-c350bd99e860.png)


