### PR TITLE
added images to search results #506

### DIFF
--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -88,7 +88,7 @@ export default class PositionItem extends Component {
         <div className="card-child__media-object-anchor">
           <Link to={speakerLink} className="no-underline">
             { position.speaker_image_url_https ?
-              <ImageHandler className="img-square card-child__avatar"
+              <ImageHandler className="card-child__avatar"
                     sizeClassName="icon-lg "
                     imageUrl={position.speaker_image_url_https}
               /> :

--- a/src/js/components/ImageHandler.jsx
+++ b/src/js/components/ImageHandler.jsx
@@ -25,6 +25,8 @@ export default class ImageHandler extends Component {
     let sizeClassName = this.props.sizeClassName || "";
     if (this.props.kind_of_ballot_item === "CANDIDATE") {
       replacementClass = "icon-main icon-icon-person-placeholder-6-1";
+    } else if (this.props.kind_of_ballot_item === "MEASURE" || this.props.kind_of_ballot_item === "OFFICE"){
+      return <i className="search-image__filler" />;
     } else {
       replacementClass = "icon-main icon-icon-org-placeholder-6-2";
     }

--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -4,6 +4,7 @@ import SearchAllActions from "../actions/SearchAllActions";
 import SearchAllStore from "../stores/SearchAllStore";
 import { enterSearch, exitSearch, makeSearchLink } from "../utils/search-functions";
 import { capitalizeString } from "../utils/textFormat";
+import ImageHandler from "../components/ImageHandler";
 
 export default class SearchAllBox extends Component {
   static propTypes = {
@@ -103,7 +104,6 @@ export default class SearchAllBox extends Component {
 
   render () {
     var search_results = this.state.search_results;
-
     return <div className="page-header__search">
         <form onSubmit={this.onSearchFormSubmit.bind(this)} className="" role="search">
         <div className="input-group site-search">
@@ -128,6 +128,10 @@ export default class SearchAllBox extends Component {
               let capitalized_title = capitalizeString(one_result.result_title);
               return <Link key={one_result.we_vote_id} to={makeSearchLink(one_result.twitter_handle, one_result.we_vote_id, one_result.kind_of_owner)} className="search-container__links">
                   <div className="search-container__results">
+                  <span><ImageHandler imageUrl={one_result.result_image}
+                                kind_of_ballot_item={one_result.kind_of_owner}
+                                sizeClassName="search-image "
+                                className={one_result.kind_of_owner} /></span>
                     {capitalized_title}
                   </div>
                 </Link>;

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -34,7 +34,7 @@ export default class OrganizationCard extends Component {
 
     return <div className="card-main__media-object">
       <div className="card-main__media-object-anchor">
-        <ImageHandler imageUrl={organization_photo_url} className="card-main__avatar" sizeClassName="icon-lg "/>
+        <ImageHandler imageUrl={organization_photo_url} className="card-main__org-avatar" sizeClassName="icon-lg "/>
       </div>
       <div className="card-main__media-object-content">
         <div className="card-main__display-name">{displayName}</div>

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -159,7 +159,7 @@ export default class OrganizationPositionItem extends Component {
                 className="no-underline"
                 onlyActiveOnIndex={false}>
             <ImageHandler
-              className="card-child__avatar"
+              className="card-child__avatar-round"
               sizeClassName="icon-lg "
               imageUrl={position.ballot_item_image_url_https}
               alt="candidate-photo"

--- a/src/js/components/VoterGuide/VoterPositionItem.jsx
+++ b/src/js/components/VoterGuide/VoterPositionItem.jsx
@@ -130,7 +130,7 @@ export default class VoterPositionItem extends Component {
           {/*<i className="icon-icon-add-friends-2-1 icon-light icon-medium" />*/}
           { is_candidate ?
             <ImageHandler
-              className="card-child__avatar"
+              className="card-child__avatar-round"
               sizeClassName="icon-lg "
               imageUrl={position.ballot_item_image_url_https}
               alt="candidate-photo"

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -52,6 +52,14 @@
         border-radius: 10em;
       }
     }
+
+    &__org-avatar {
+      max-width: 50px;
+      @include breakpoints(mid-small) {
+        max-width: 80px;
+      }
+    }
+
     .icon-lg { // temp - for placeholder icons
       font-size: 50px;
       @include breakpoints(mid-small) {
@@ -169,10 +177,10 @@
     }
 
     &__avatar { // placed on the actual image
-      border-radius: 2px;
       max-width: 50px;
-      &.img-square {
-        width: 50px;
+      &-round {
+        border-radius: 25px;
+        max-width: 50px;
       }
     }
     .icon-lg { // temp - for placeholder icons

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -122,11 +122,15 @@
 }
 
 .search-image {
-  width: 30px;
-  font-size: 30px;
-  margin: 0 12px 0 0;
-  &__filler {
-    padding: 0 21px;
+  display: none;
+  @include breakpoints(mid-small) {
+    display: inline;
+    width: 30px;
+    font-size: 30px;
+    margin: 0 12px 0 0;
+    &__filler {
+      padding: 0 21px;
+    }
   }
 }
   .CANDIDATE {

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -120,3 +120,15 @@
     }
   }
 }
+
+.search-image {
+  width: 30px;
+  font-size: 30px;
+  margin: 0 12px 0 0;
+  &__filler {
+    padding: 0 21px;
+  }
+}
+  .CANDIDATE {
+    border-radius: 15px;
+  }

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -122,15 +122,15 @@
 }
 
 .search-image {
-  display: none;
-  @include breakpoints(mid-small) {
-    display: inline;
-    width: 30px;
-    font-size: 30px;
-    margin: 0 12px 0 0;
-    &__filler {
-      padding: 0 21px;
-    }
+  display: inline;
+  width: 30px;
+  font-size: 30px;
+  margin: 0 12px 0 0;
+  &__filler {
+    padding: 0 21px;
+  }
+  @include breakpoints(max nav) {
+    display: none;
   }
 }
   .CANDIDATE {

--- a/src/sass/elements/_buttons.scss
+++ b/src/sass/elements/_buttons.scss
@@ -18,20 +18,19 @@
 
 .select-all-btn{
 	height: 34px;
+	margin: -1px 0 0 0;
 	display: none;
 	@include breakpoints (max nav) {
-		display: block; // show button on small screens
+		display: inline; // show button on small screens
 	}
 }
 
 
-.copy-btn {
-	height: 34px;
-		&__hide-mobile {
-			height: 34px;
-			@include breakpoints (max nav) {
-				display: none; // Hide button on small screens
-		}
+.copy-btn__hide-mobile {
+		margin: -1px 0 0 0;
+		height: 34px;
+		@include breakpoints (max nav) {
+			display: none; // Hide button on small screens
 	}
 }
 


### PR DESCRIPTION
in this PR:
1) added images to search results
2) standardized org and candidate images: candidate images now always appear as circles, while orgs appear as squares.  (NOTE: placeholder icon for orgs is round, breaking this convention)
3) added support in ImageHandler to return space filler for Measures and Offices
4) refactored, removed a few deprecated classes