### PR TITLE
added Helmet for title and description #526, created Credits page

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-burger-menu": "^1.10.4",
     "react-copy-to-clipboard": "^4.2.3",
     "react-dom": "^0.14.3",
+    "react-helmet": "^3.1.0",
     "react-textarea-autosize": "^4.0.4",
     "react-text-truncate": "^0.8.2",
     "superagent": "^1.5.0",

--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -7,7 +7,6 @@ import Application from "./Application";
 
 /****************************** ROUTE-COMPONENTS ******************************/
 import About from "./routes/More/About";
-import Credits from "./routes/More/Credits";
 import Activity from "./routes/Activity";
 import Ballot from "./routes/Ballot/Ballot";
 import BallotIndex from "./routes/Ballot/BallotIndex";
@@ -15,6 +14,7 @@ import Bookmarks from "./components/Bookmarks/Bookmarks";
 import Candidate from "./routes/Ballot/Candidate";
 import ClaimYourPage from "./routes/Settings/ClaimYourPage";
 import Connect from "./routes/Connect";
+import Credits from "./routes/More/Credits";
 import EmailBallot from "./routes/More/EmailBallot";
 import EmptyBallot from "./routes/Ballot/EmptyBallot";
 import Friends from "./routes/Friends";

--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -7,6 +7,7 @@ import Application from "./Application";
 
 /****************************** ROUTE-COMPONENTS ******************************/
 import About from "./routes/More/About";
+import Credits from "./routes/More/Credits";
 import Activity from "./routes/Activity";
 import Ballot from "./routes/Ballot/Ballot";
 import BallotIndex from "./routes/Ballot/BallotIndex";
@@ -71,6 +72,7 @@ const routes = () =>
     {/* More Menu Pages */}
     <Route path="/more/sign_in" component={SignIn} />
     <Route path="/more/email_ballot" component={EmailBallot} />
+    <Route path="/more/credits" component={Credits} />
     <Route path="/more/about" component={About} />
     <Route path="/more/connect" component={Connect} />
     <Route path="/more/privacy" component={Privacy} />

--- a/src/js/components/Navigation/MoreMenu.jsx
+++ b/src/js/components/Navigation/MoreMenu.jsx
@@ -92,6 +92,7 @@ export default class MoreMenu extends Component {
         <h4 className="text-left"></h4>
         <ul className="list-group">
         {this.menuLink("/more/about", "About We Vote")}
+        {this.menuLink("/more/credits", "Credits")}
           <li className="list-group-item">
             <a href="https://goo.gl/forms/B6P0iE44R21t36L42" target="_blank"><div>
               <span className="header-menu-text-left">What would make We Vote better? <i className="fa fa-external-link"></i></span>

--- a/src/js/routes/Activity.jsx
+++ b/src/js/routes/Activity.jsx
@@ -1,4 +1,5 @@
 import React, { PropTypes, Component } from "react";
+import Helmet from "react-helmet";
 
 export default class Activity extends Component {
   static propTypes = {
@@ -15,6 +16,7 @@ export default class Activity extends Component {
 
   render () {
     return <div>
+      <Helmet title="Activity Feed - We Vote" />
       <div className="container-fluid well u-gutter__top--small fluff-full1">
         <h3 className="text-center">Activity Feed</h3>
         <h4 className="text-center">Coming Soon</h4>

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -5,6 +5,7 @@ import BallotItem from "../../components/Ballot/BallotItem";
 import BallotItemCompressed from "../../components/Ballot/BallotItemCompressed";
 import BallotStore from "../../stores/BallotStore";
 import BallotFilter from "../../components/Navigation/BallotFilter";
+import Helmet from "react-helmet";
 import LoadingWheel from "../../components/LoadingWheel";
 import SupportActions from "../../actions/SupportActions";
 import SupportStore from "../../stores/SupportStore";
@@ -168,6 +169,7 @@ export default class Ballot extends Component {
 
     return <div className="ballot">
       <div className="ballot__heading">
+        <Helmet title="Ballot - We Vote" />
         <OverlayTrigger placement="top" overlay={electionTooltip} >
           <h1 className="h1 ballot__election-name">{election_name}</h1>
         </OverlayTrigger>

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -2,9 +2,11 @@ import React, { Component, PropTypes } from "react";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateItem from "../../components/Ballot/CandidateItem";
 import CandidateStore from "../../stores/CandidateStore";
+import { capitalizeString } from "../../utils/textFormat";
 import GuideList from "../../components/VoterGuide/GuideList";
 import GuideStore from "../../stores/GuideStore";
 import GuideActions from "../../actions/GuideActions";
+import Helmet from "react-helmet";
 import LoadingWheel from "../../components/LoadingWheel";
 import PositionList from "../../components/Ballot/PositionList";
 import SupportActions from "../../actions/SupportActions";
@@ -92,8 +94,14 @@ export default class Candidate extends Component {
                 <br />
             </div>;
     }
+    let candidate_name = capitalizeString(candidate.ballot_item_display_name);
+    let title_text = candidate_name + " - We Vote";
+    let description_text = "Information about " + candidate_name + ", candidate for " + candidate.contest_office_name;
 
     return <span>
+      <Helmet title={title_text}
+              meta={[{"name": "description", "content": description_text}]}
+              />
         <section className="card">
           <CandidateItem {...candidate} contest_office_name={candidate.contest_office_name} />
           <div className="card__additional">

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from "react";
 import GuideList from "../../components/VoterGuide/GuideList";
 import GuideStore from "../../stores/GuideStore";
 import GuideActions from "../../actions/GuideActions";
+import Helmet from "react-helmet";
 import LoadingWheel from "../../components/LoadingWheel";
 import MeasureItem from "../../components/Ballot/MeasureItem";
 import MeasureActions from "../../actions/MeasureActions";
@@ -9,6 +10,7 @@ import MeasureStore from "../../stores/MeasureStore";
 import PositionList from "../../components/Ballot/PositionList";
 import SupportActions from "../../actions/SupportActions";
 import VoterStore from "../../stores/VoterStore";
+import { capitalizeString } from "../../utils/textFormat";
 import { exitSearch } from "../../utils/search-functions";
 
 
@@ -82,8 +84,14 @@ export default class Measure extends Component {
                 <br />
             </div>;
     }
+    let measure_name = capitalizeString(measure.ballot_item_display_name);
+    let title_text = measure_name + " - We Vote";
+    let description_text = "Information about " + measure_name;
 
     return <section className="card">
+      <Helmet title={title_text}
+              meta={[{"name": "description", "content": description_text}]}
+              />
           <MeasureItem {...measure} />
           <div className="card__additional">
             { measure.position_list ?

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -1,5 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import CandidateList from "../../components/Ballot/CandidateList";
+import { capitalizeString } from "../../utils/textFormat";
+import Helmet from "react-helmet";
 import LoadingWheel from "../../components/LoadingWheel";
 import OfficeActions from "../../actions/OfficeActions";
 import OfficeItem from "../../components/Ballot/OfficeItem";
@@ -62,8 +64,14 @@ export default class Office extends Component {
           <br />
         </div>;
     }
+    let office_name = capitalizeString(office.ballot_item_display_name);
+    let title_text = office_name + " - We Vote";
+    let description_text = "Choose who you support for " + office_name + "in the November Election";
 
     return <div>
+      <Helmet title={title_text}
+              meta={[{"name": "description", "content": description_text}]}
+              />
       <OfficeItem we_vote_id={office.we_vote_id}
                   kind_of_ballot_item="OFFICE"
                   ballot_item_display_name={office.ballot_item_display_name} />

--- a/src/js/routes/Connect.jsx
+++ b/src/js/routes/Connect.jsx
@@ -5,6 +5,7 @@ import AddFriendsByEmail from "../components/Friends/AddFriendsByEmail";
 import AddFriendsByFacebook from "../components/Friends/AddFriendsByFacebook";
 import AddFriendsByTwitter from "../components/Friends/AddFriendsByTwitter";
 import AddFriendsFilter from "../components/Navigation/AddFriendsFilter";
+import Helmet from "react-helmet";
 
 /* VISUAL DESIGN HERE: https://invis.io/E45246B2C */
 
@@ -46,6 +47,7 @@ export default class Connect extends Component {
     }
 
 		return <div>
+			<Helmet title={add_friends_header} />
 			<div className="container-fluid well u-gutter__top--small fluff-full1">
         <h4 className="text-left">{add_friends_header}</h4>
         <div className="ballot__filter"><AddFriendsFilter add_friends_type={this.state.add_friends_type}

--- a/src/js/routes/Friends.jsx
+++ b/src/js/routes/Friends.jsx
@@ -5,6 +5,7 @@ import FollowingFilter from "../components/Navigation/FollowingFilter";
 import FriendList from "../components/Friends/FriendList";
 import FriendActions from "../actions/FriendActions";
 import FriendStore from "../stores/FriendStore";
+import Helmet from "react-helmet";
 
 export default class Friends extends Component {
   static propTypes = {
@@ -52,6 +53,7 @@ export default class Friends extends Component {
     const { current_friend_list } = this.state;
 
     return <div className="opinion-view">
+      <Helmet title="Your Friends - We Vote" />
       <h1 className="h1">Build Your Network</h1>
       <FollowingFilter following_type={this.getFollowingType()} />
       <div>

--- a/src/js/routes/Guide/GuidePositionList.jsx
+++ b/src/js/routes/Guide/GuidePositionList.jsx
@@ -1,7 +1,9 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
 import { Button } from "react-bootstrap";
+import { capitalizeString } from "../../utils/textFormat";
 import FollowToggle from "../../components/Widgets/FollowToggle";
+import Helmet from "react-helmet";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";
 import OrganizationStore from "../../stores/OrganizationStore";
@@ -89,7 +91,14 @@ export default class GuidePositionList extends Component {
         </div>;
     }
     var { organization_we_vote_id } = this.state;
+    let organization_name = capitalizeString(this.state.organization.organization_name);
+    let title_text = organization_name + " - We Vote";
+    let description_text = "See endorsements and opinions from " + organization_name + " for the November election";
+
     return <span>
+      <Helmet title={title_text}
+              meta={[{"name": "description", "content": description_text}]}
+              />
         <div className="card">
           <div className="card-main">
             <FollowToggle we_vote_id={organization_we_vote_id} />

--- a/src/js/routes/Guide/GuidePositionListForVoter.jsx
+++ b/src/js/routes/Guide/GuidePositionListForVoter.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import Helmet from "react-helmet";
 import LoadingWheel from "../../components/LoadingWheel";
 import VoterPositionItem from "../../components/VoterGuide/VoterPositionItem";
 
@@ -24,6 +25,7 @@ export default class GuidePositionListForVoter extends Component {
 
     const { position_list_for_one_election, position_list_for_all_except_one_election } = this.state.voter;
     return <span>
+      <Helmet title="Your Voter Guide - We Vote" />
         <div className="card">
           <ul className="list-group">
             { position_list_for_one_election ?

--- a/src/js/routes/Guide/VerifyThisIsMe.jsx
+++ b/src/js/routes/Guide/VerifyThisIsMe.jsx
@@ -4,6 +4,7 @@ import { browserHistory, Link } from "react-router";
 import CandidateItem from "../../components/Ballot/CandidateItem";
 import CandidateStore from "../../stores/CandidateStore";
 import FollowToggle from "../../components/Widgets/FollowToggle";
+import Helmet from "react-helmet";
 import LoadingWheel from "../../components/LoadingWheel";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";
 import OrganizationStore from "../../stores/OrganizationStore";
@@ -109,6 +110,7 @@ export default class VerifyThisIsMe extends Component {
       console.log("this.state.kind_of_owner === CANDIDATE");
       this.props.params.we_vote_id = this.state.owner_we_vote_id;
       return <span>
+        <Helmet title="Claim This Page - We Vote" />
         <section className="card">
           <CandidateItem {...candidate} />
         </section>
@@ -136,6 +138,7 @@ export default class VerifyThisIsMe extends Component {
       }
 
       return <span>
+        <Helmet title="Claim This Page - We Vote" />
           <div className="card">
             <div className="card-main">
               <FollowToggle we_vote_id={this.props.params.we_vote_id} />
@@ -158,6 +161,7 @@ export default class VerifyThisIsMe extends Component {
     } else if (this.state.kind_of_owner === "TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE"){
       console.log("this.state.kind_of_owner === TWITTER_HANDLE_NOT_FOUND_IN_WE_VOTE");
       return <div>
+        <Helmet title="Claim This Page - We Vote" />
         <TwitterAccountCard {...this.state}/>
         <div>
           <br />
@@ -174,6 +178,7 @@ export default class VerifyThisIsMe extends Component {
       </div>;
     } else {
       return <div className="container-fluid well u-gutter__top--small fluff-full1">
+        <Helmet title="Could Not Confirm - We Vote" />
               <h3 className="h3">Could Not Confirm</h3>
                 <div className="small">We were not able to find an account for this
                   Twitter Handle{ this.props.params.twitter_handle ?

--- a/src/js/routes/Intro/Intro.jsx
+++ b/src/js/routes/Intro/Intro.jsx
@@ -1,6 +1,6 @@
 "use strict";
 import React, { Component, PropTypes } from "react";
-
+import Helmet from "react-helmet";
 const request = require("superagent");
 const web_app_config = require("../../config");
 import AddressBox from "../../components/AddressBox";
@@ -60,6 +60,7 @@ export default class Intro extends Component {
     } = this.state;
 
     return <div>
+      <Helmet title="Welcome to We Vote" />
       { this.props.children ||
         <div className="container-fluid well u-gutter__top--small fluff-full1">
           <h2 className="text-center">We Vote</h2>

--- a/src/js/routes/More/About.jsx
+++ b/src/js/routes/More/About.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import Helmet from "react-helmet";
 
 export default class About extends Component {
   constructor (props) {
@@ -11,6 +12,7 @@ export default class About extends Component {
 
   render () {
     return <div>
+      <Helmet title="About Us - We Vote" />
         <div className="container-fluid card">
           <h1 className="h1">About We Vote</h1>
           <p>
@@ -19,92 +21,6 @@ export default class About extends Component {
             This is a demonstration version and has not been launched to the general public yet.
           </p>
 
-          <h2 className="h2">Acknowledgements</h2>
-
-          <h3 className="h4">We are grateful for these organizations that are critical to our work.</h3>
-          <ul>
-              <li><strong>Ballotpedia</strong> - Data</li>
-              <li><strong>Center for Technology and Civic Life</strong> - Data</li>
-              <li><strong>Change.org</strong> - Data</li>
-              <li><strong>CivicMakers</strong> - Event Collaborations</li>
-              <li><strong>Code for San Francisco &amp; Code for America</strong> - Our Home for Volunteer Work</li>
-              <li><strong>DLA Piper</strong> - Legal</li>
-              <li><strong>Facebook</strong> - Authentication &amp; Data</li>
-              <li><strong>Google Civic</strong> - Data</li>
-              <li><strong>League of Women Voters</strong> - Data</li>
-              <li><strong>MapLight</strong> - Data</li>
-              <li><strong>Microsoft</strong> - For supporting Code for San Francisco</li>
-              <li><strong>Sunlight Foundation</strong> - Data</li>
-              <li><strong>TurboVote, Democracy Works</strong> - Data</li>
-              <li><strong>Twitter</strong> - Authentication &amp; Data</li>
-              <li><strong>Vote Smart</strong> - Data</li>
-              <li><strong>Voting Information Project, Pew Charitable Trusts</strong> - Data</li>
-              <li><strong>We Vote Education</strong> - Data</li>
-              <li><strong>Wikipedia</strong> - Data</li>
-          </ul>
-
-          <h3 className="h4">Thank you to our Board of Directors.</h3>
-          <p> <em>We Vote USA: coming soon</em><br />
-            We Vote Education: Jenifer Fernandez Ancona, Debra Cleaver, Dale McGrew, Anat Shenker-Osorio,
-            William Winters (coming soon: Tiana Epps-Johnson and Lawrence Grodeska)<br />
-          </p>
-          <h3 className="h4">Special thanks to our team of volunteers.</h3>
-          <p>You are the best! <br />
-            (This is a list of volunteers who have contributed 10 or more hours, in rough order of hours contributed.)<br />
-          </p>
-          <ul>
-            <li>Dale McGrew - Oakland, CA</li>
-            <li>Jenifer Fernandez Ancona - Oakland, CA</li>
-            <li>Rob Simpson - Warrenton, VA</li>
-            <li>Jeff French - Oakland, CA</li>
-            <li>Zach Monteith - San Francisco, CA</li>
-            <li>Lisa Cho - San Francisco, CA</li>
-            <li>Nicolas Fiorini - Arlington, VA</li>
-            <li>Colette Phair - Oakland, CA</li>
-            <li>Jennifer Holmes - Pacifica, CA</li>
-            <li>Joe Evans - Santa Cruz, CA</li>
-            <li>Adam Barry - San Francisco, CA</li>
-            <li>Mary O'Connor - Sebastopol, CA</li>
-            <li>Harsha Dronamraju - San Francisco, CA</li>
-            <li>Nitin Garg - San Francisco, CA</li>
-            <li>Niko Barry - Berkeley, CA</li>
-            <li>Marissa Luna - Lansing, MI</li>
-            <li>Aaron Borden - San Francisco, CA</li>
-            <li>Judy Johnson - Oakland, CA</li>
-            <li>Udi Davidovich - Walnut Creek, CA</li>
-            <li>Mikel Duffy - San Francisco, CA</li>
-            <li>Robin Braverman - Walnut Creek, CA</li>
-            <li>Mike McConnell - San Francisco, CA</li>
-            <li>Dan Ancona - Oakland, CA</li>
-            <li>Zak Zaidman - Ojai, CA</li>
-            <li>Debra Cleaver - San Francisco, CA</li>
-            <li>William Winters - Oakland, CA</li>
-            <li>Andrea Moed - San Francisco, CA</li>
-            <li>Anat Shenker-Osorio - Oakland, CA</li>
-            <li>Kad Smith - Berkeley, CA</li>
-            <li>Courtney Gonzales - Benicia, CA</li>
-            <li>Jenna Haywood - Berkeley, CA</li>
-            <li>Tom Furlong - Menlo Park, CA</li>
-            <li>Jayadev Akkiraju - Santa Clara, CA</li>
-            <li>Raphael Merx - San Francisco, CA</li>
-            <li>Susan Clark - Oakland, CA</li>
-            <li>Kim Anderson - San Francisco, CA</li>
-            <li>Jesse Aldridge - San Francisco, CA</li>
-            <li>Josh Levinger - Oakland, CA</li>
-            <li>Leslie Castellanos - San Francisco, CA</li>
-            <li>Miguel Elasmar - Sarasota, FL</li>
-            <li>Nicole Shanahan - Palo Alto, CA</li>
-            <li>Steve Whetstone - San Francisco, CA</li>
-            <li>Brian Bordley - Berkeley, CA</li>
-            <li>Marcus Busby - San Francisco, CA</li>
-            <li>lulu - New York, NY</li>
-            <li>Chris Griffith - Santa Cruz, CA</li>
-            <li>Nathan Stankowski - San Rafael, CA</li>
-            <li>Sean McMahon - Redwood City, CA</li>
-            <li>Scott Wasserman - Philadelphia, PA</li>
-            <li>Adrienne Yang - Oakland, CA</li>
-            <li>Mark Rosenthal - Oakland, CA</li>
-          </ul>
         </div>
       </div>;
   }

--- a/src/js/routes/More/Credits.jsx
+++ b/src/js/routes/More/Credits.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import Helmet from "react-helmet";
 
-export default class About extends Component {
+export default class Credits extends Component {
   constructor (props) {
     super(props);
   }

--- a/src/js/routes/More/Credits.jsx
+++ b/src/js/routes/More/Credits.jsx
@@ -1,0 +1,106 @@
+import React, { Component } from "react";
+import Helmet from "react-helmet";
+
+export default class About extends Component {
+  constructor (props) {
+    super(props);
+  }
+
+  static getProps () {
+    return {};
+  }
+
+  render () {
+    return <div>
+      <Helmet title="Credits - We Vote" />
+        <div className="container-fluid card">
+          <h1 className="h1">Credits</h1>
+
+          <h3 className="h4">We are grateful for these organizations that are critical to our work.</h3>
+          <ul>
+              <li><strong>Ballotpedia</strong> - Data</li>
+              <li><strong>Center for Technology and Civic Life</strong> - Data</li>
+              <li><strong>Change.org</strong> - Data</li>
+              <li><strong>CivicMakers</strong> - Event Collaborations</li>
+              <li><strong>Code for San Francisco &amp; Code for America</strong> - Our Home for Volunteer Work</li>
+              <li><strong>DLA Piper</strong> - Legal</li>
+              <li><strong>Facebook</strong> - Authentication &amp; Data</li>
+              <li><strong>Google Civic</strong> - Data</li>
+              <li><strong>League of Women Voters</strong> - Data</li>
+              <li><strong>MapLight</strong> - Data</li>
+              <li><strong>Microsoft</strong> - For supporting Code for San Francisco</li>
+              <li><strong>Sunlight Foundation</strong> - Data</li>
+              <li><strong>TurboVote, Democracy Works</strong> - Data</li>
+              <li><strong>Twitter</strong> - Authentication &amp; Data</li>
+              <li><strong>Vote Smart</strong> - Data</li>
+              <li><strong>Voting Information Project, Pew Charitable Trusts</strong> - Data</li>
+              <li><strong>We Vote Education</strong> - Data</li>
+              <li><strong>Wikipedia</strong> - Data</li>
+          </ul>
+
+          <h3 className="h4">Thank you to our Board of Directors.</h3>
+          <p> <em>We Vote USA: coming soon</em><br />
+            We Vote Education: Jenifer Fernandez Ancona, Debra Cleaver, Dale McGrew, Anat Shenker-Osorio,
+            William Winters (coming soon: Tiana Epps-Johnson and Lawrence Grodeska)<br />
+          </p>
+          <h3 className="h4">Special thanks to our team of volunteers.</h3>
+          <p>You are the best! <br />
+            (This is a list of volunteers who have contributed 10 or more hours, in rough order of hours contributed.)<br />
+          </p>
+          <ul>
+            <li>Dale McGrew - Oakland, CA</li>
+            <li>Jenifer Fernandez Ancona - Oakland, CA</li>
+            <li>Rob Simpson - Warrenton, VA</li>
+            <li>Jeff French - Oakland, CA</li>
+            <li>Zach Monteith - San Francisco, CA</li>
+            <li>Lisa Cho - San Francisco, CA</li>
+            <li>Nicolas Fiorini - Arlington, VA</li>
+            <li>Colette Phair - Oakland, CA</li>
+            <li>Jennifer Holmes - Pacifica, CA</li>
+            <li>Joe Evans - Santa Cruz, CA</li>
+            <li>Adam Barry - San Francisco, CA</li>
+            <li>Mary O'Connor - Sebastopol, CA</li>
+            <li>Harsha Dronamraju - San Francisco, CA</li>
+            <li>Nitin Garg - San Francisco, CA</li>
+            <li>Niko Barry - Berkeley, CA</li>
+            <li>Marissa Luna - Lansing, MI</li>
+            <li>Aaron Borden - San Francisco, CA</li>
+            <li>Judy Johnson - Oakland, CA</li>
+            <li>Udi Davidovich - Walnut Creek, CA</li>
+            <li>Mikel Duffy - San Francisco, CA</li>
+            <li>Robin Braverman - Walnut Creek, CA</li>
+            <li>Mike McConnell - San Francisco, CA</li>
+            <li>Dan Ancona - Oakland, CA</li>
+            <li>Zak Zaidman - Ojai, CA</li>
+            <li>Debra Cleaver - San Francisco, CA</li>
+            <li>William Winters - Oakland, CA</li>
+            <li>Andrea Moed - San Francisco, CA</li>
+            <li>Anat Shenker-Osorio - Oakland, CA</li>
+            <li>Kad Smith - Berkeley, CA</li>
+            <li>Courtney Gonzales - Benicia, CA</li>
+            <li>Jenna Haywood - Berkeley, CA</li>
+            <li>Tom Furlong - Menlo Park, CA</li>
+            <li>Jayadev Akkiraju - Santa Clara, CA</li>
+            <li>Raphael Merx - San Francisco, CA</li>
+            <li>Susan Clark - Oakland, CA</li>
+            <li>Kim Anderson - San Francisco, CA</li>
+            <li>Jesse Aldridge - San Francisco, CA</li>
+            <li>Josh Levinger - Oakland, CA</li>
+            <li>Leslie Castellanos - San Francisco, CA</li>
+            <li>Miguel Elasmar - Sarasota, FL</li>
+            <li>Nicole Shanahan - Palo Alto, CA</li>
+            <li>Steve Whetstone - San Francisco, CA</li>
+            <li>Brian Bordley - Berkeley, CA</li>
+            <li>Marcus Busby - San Francisco, CA</li>
+            <li>lulu - New York, NY</li>
+            <li>Chris Griffith - Santa Cruz, CA</li>
+            <li>Nathan Stankowski - San Rafael, CA</li>
+            <li>Sean McMahon - Redwood City, CA</li>
+            <li>Scott Wasserman - Philadelphia, PA</li>
+            <li>Adrienne Yang - Oakland, CA</li>
+            <li>Mark Rosenthal - Oakland, CA</li>
+          </ul>
+        </div>
+      </div>;
+  }
+}

--- a/src/js/routes/More/EmailBallot.jsx
+++ b/src/js/routes/More/EmailBallot.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import { Button, Input } from "react-bootstrap";
 import { Link } from "react-router";
+import Helmet from "react-helmet";
 import Main from "../../components/Facebook/Main";
 
 /* VISUAL DESIGN HERE: https://projects.invisionapp.com/share/2R41VR3XW#/screens/89479656 */
@@ -18,6 +19,7 @@ export default class EmailBallot extends Component {
 
 		const emailBallot =
 			<div>
+				<Helmet title="Email Your Ballot - We Vote" />
 				<div className="container-fluid well">
 					<h2 className="text-center">Print, Save or Email Ballot</h2>
 					<div>

--- a/src/js/routes/More/SignIn.jsx
+++ b/src/js/routes/More/SignIn.jsx
@@ -2,6 +2,7 @@ import React, { Component } from "react";
 import FacebookActions from "../../actions/FacebookActions";
 import FacebookStore from "../../stores/FacebookStore";
 import FacebookSignIn from "../../components/Facebook/FacebookSignIn";
+import Helmet from "react-helmet"
 import Main from "../../components/Facebook/Main";
 import LoadingWheel from "../../components/LoadingWheel";
 import TwitterSignIn from "../../components/Twitter/TwitterSignIn";
@@ -66,6 +67,7 @@ export default class SignIn extends Component {
     }
 
     return <div className="">
+      <Helmet title="Sign In - We Vote" />
       <div className="container-fluid well u-gutter__top--small fluff-full1">
         <h3 className="text-center">{voter.signed_in_personal ? <span>My Account</span> : <span>Sign In</span>}</h3>
         <div className="text-center">

--- a/src/js/routes/NotFound.jsx
+++ b/src/js/routes/NotFound.jsx
@@ -2,6 +2,7 @@ import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import Candidate from "./Ballot/Candidate";
+import Helmet from "react-helmet";
 import LoadingWheel from "../components/LoadingWheel";
 import GuidePositionList from "./Guide/GuidePositionList";
 import OrganizationActions from "../actions/OrganizationActions";
@@ -112,6 +113,7 @@ export default class NotFound extends Component {
       return <UnknownTwitterAccount {...this.state} />;
     } else {
       return <div className="container-fluid well u-gutter__top--small fluff-full1">
+              <Helmet title="Not Found - We Vote" />
               <h3 className="h3">Claim Your Page</h3>
                 <div className="medium">
                   We were not able to find an account for this

--- a/src/js/routes/Opinions.jsx
+++ b/src/js/routes/Opinions.jsx
@@ -1,6 +1,7 @@
 import { Button } from "react-bootstrap";
 import FollowingFilter from "../components/Navigation/FollowingFilter";
 import GuideStore from "../stores/GuideStore";
+import Helmet from "react-helmet";
 import SearchGuidesToFollowBox from "../components/SearchGuidesToFollowBox";
 import VoterStore from "../stores/VoterStore";
 import GuideList from "../components/VoterGuide/GuideList";
@@ -88,6 +89,7 @@ export default class Opinions extends Component {
       }
 
     return <div className="opinion-view">
+      <Helmet title="Build Your Network - We Vote" />
         <h1 className="h1">Build Your Network</h1>
         <FollowingFilter following_type={this.getFollowingType()} />
           {guides}

--- a/src/js/routes/OpinionsFollowed.jsx
+++ b/src/js/routes/OpinionsFollowed.jsx
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes } from "react";
 import FollowingFilter from "../components/Navigation/FollowingFilter";
+import Helmet from "react-helmet";
 import GuideStore from "../stores/GuideStore";
 import GuideActions from "../actions/GuideActions";
 import OpinionsFollowedList from "../components/VoterGuide/OpinionsFollowedList";
@@ -56,6 +57,7 @@ export default class OpinionsFollowed extends Component {
 
   render () {
     return <div className="opinions-followed__container">
+      <Helmet title="Organizations You Follow - We Vote" />
       <h1 className="h1">Build Your Network</h1>
       <FollowingFilter following_type={this.getFollowingType()} />
       <a className="fa-pull-right" onClick={this.toggleEditMode.bind(this)}>{this.state.editMode ? "Done Editing" : "Edit"}</a>

--- a/src/js/routes/Requests.jsx
+++ b/src/js/routes/Requests.jsx
@@ -4,6 +4,7 @@ import { Link } from "react-router";
 import FriendInvitationList from "../components/Friends/FriendInvitationList";
 import FriendActions from "../actions/FriendActions";
 import FriendStore from "../stores/FriendStore";
+import Helmet from "react-helmet";
 
 export default class RequestsPage extends Component {
   constructor (props) {
@@ -34,6 +35,7 @@ export default class RequestsPage extends Component {
 
   render () {
     return <section className="card">
+      <Helmet title="Friend Requests - We Vote" />
       <div className="card-main">
         <h3 className="h3">Friend Requests</h3>
         { this.state.friend_invitations_sent_to_me.length ?

--- a/src/js/routes/Settings/ClaimYourPage.jsx
+++ b/src/js/routes/Settings/ClaimYourPage.jsx
@@ -1,9 +1,11 @@
 import React, { Component } from "react";
+import Helmet from "react-helmet";
 import TwitterHandleBox from "../../components/Twitter/TwitterHandleBox";
 
 export default class ClaimYourPage extends Component {
   render () {
     return <div>
+      <Helmet title="Claim Your Page - We Vote" />
       <div className="container-fluid well u-gutter__top--small fluff-full1">
         <h3 className="text-center">
           Claim Your Page

--- a/src/js/routes/Settings/Location.jsx
+++ b/src/js/routes/Settings/Location.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import AddressBox from "../../components/AddressBox";
+import Helmet from "react-helmet";
 
 export default class Location extends Component {
       // <div className="container-fluid well u-gutter__top--small fluff-full1">
@@ -21,6 +22,7 @@ export default class Location extends Component {
 
   render () {
     return <div>
+      <Helmet title="Enter Your Address - We Vote" />
       <h3 className="h3">
         Enter address where you are registered to vote
       </h3>


### PR DESCRIPTION
1) Added nfl's react-helmet component to most unique route pages, to give each its own title; tried to account for all titles we would need, and give descriptive, attractive titles.  

2) Added descriptions to Candidate, Office, Measure and GuidePositionList as well.  These are placeholder descriptions until Colette composes final ones, but easy to update, and gives a sense of the pattern, so can easily be applied to other appearances of Helmet where we want a page description.

3) created Credits route, took most of content from About and moved to Credits