### PR TITLE
Office Pages stuck in infinite Loading #532 Hot Fix

### DIFF
--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -34,6 +34,7 @@ export default class Office extends Component {
       this.setState({office_we_vote_id: nextProps.params.office_we_vote_id});
       OfficeActions.officeRetrieve(nextProps.params.office_we_vote_id);
     } else {
+      OfficeActions.officeRetrieve(nextProps.params.office_we_vote_id);
       this.setState({office: office, office_we_vote_id: nextProps.params.office_we_vote_id});
     }
 

--- a/src/js/stores/OfficeStore.js
+++ b/src/js/stores/OfficeStore.js
@@ -7,7 +7,8 @@ class OfficeStore extends FluxMapStore {
     // if (!this.isLoaded()){ return undefined; }
     let office_list = this.getState().offices;
     if (office_list) {
-      return office_list[office_we_vote_id];
+      // return office_list[office_we_vote_id];
+      return office_list;
     } else {
       return undefined;
     }


### PR DESCRIPTION
office_list is only a single object value (without a key or ID), which
was causing an error in getOffice resulting in an undefined variable
for _onOfficeStoreChange. Therefore returning the “office_list” itself.

Furthermore after the initial object property is loaded.
componentWillReceiveProps does not perform officeRetrieve when someone
navigates to another office page causing the new data to not be
displayed. Therefore added an additional officeRetrieve in the else
clause as well.

Likely we’ll need to dig into these later on to clean it up a bit more.
Also the Office page is still missing the ballot and candidate data.