### PR TITLE
Added BallotItemsRetrieve to AddressSave, resolves Issue #553

### DIFF
--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -144,6 +144,7 @@ class VoterStore extends FluxMapStore {
       };
 
       case "voterAddressSave":
+      BallotActions.voterBallotItemsRetrieve();
         return {
           ...state,
           address: { text_for_map_search: action.res.text_for_map_search,


### PR DESCRIPTION
Added a voterBallotItemsRetrieve invocation to the case for voterAddressSave in the VoterStore; we weren't retrieving all the ballot items when users saved their address, necessitating a browser refresh to trigger this action and populate the user's ballot.