### PR TITLE
Added edit mode for Friends page #567, improvements to CopyLinkModal #487

### DIFF
--- a/src/js/components/Friends/FriendDisplayForList.jsx
+++ b/src/js/components/Friends/FriendDisplayForList.jsx
@@ -14,7 +14,8 @@ export default class FriendDisplayForList extends Component {
     voter_display_name: PropTypes.string,
     voter_twitter_handle: PropTypes.string,
     voter_twitter_description: PropTypes.string,
-    voter_twitter_followers_count: PropTypes.number
+    voter_twitter_followers_count: PropTypes.number,
+    editMode: PropTypes.bool
   };
 
   render () {
@@ -55,7 +56,7 @@ export default class FriendDisplayForList extends Component {
         </div>
         <div className="card-child__additional">
           <div className="card-child__follow-buttons">
-            <FriendToggle other_voter_we_vote_id={voter_we_vote_id}/>
+            { this.props.editMode ? <FriendToggle other_voter_we_vote_id={voter_we_vote_id}/> : null }
           </div>
           {voter_twitter_followers_count ?
             <span className="twitter-followers__badge">

--- a/src/js/components/Friends/FriendList.jsx
+++ b/src/js/components/Friends/FriendList.jsx
@@ -1,13 +1,11 @@
 import React, { Component, PropTypes } from "react";
 import FriendDisplayForList from "./FriendDisplayForList";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
-import FriendToggle from "./FriendToggle";
 
 export default class FriendList extends Component {
 
   static propTypes = {
     friendList: PropTypes.array,
-    instantRefreshOn: PropTypes.bool,
     editMode: PropTypes.bool
   };
 
@@ -36,13 +34,8 @@ export default class FriendList extends Component {
     }
 
     const friend_list_for_display = this.state.friend_list.map( (friend) => {
-      if (this.props.editMode) {
-        return <FriendDisplayForList key={friend.voter_we_vote_id} {...friend} >
-          <FriendToggle other_voter_we_vote_id={friend.voter_we_vote_id} />
-        </FriendDisplayForList>;
-      } else {
-      return <FriendDisplayForList key={friend.voter_we_vote_id} {...friend} />;
-      }
+      return <FriendDisplayForList editMode={this.props.editMode}
+                                   key={friend.voter_we_vote_id} {...friend} />;
     });
 
     return <div className="guidelist card-child__list-group">

--- a/src/js/components/Friends/FriendList.jsx
+++ b/src/js/components/Friends/FriendList.jsx
@@ -1,11 +1,14 @@
 import React, { Component, PropTypes } from "react";
 import FriendDisplayForList from "./FriendDisplayForList";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
+import FriendToggle from "./FriendToggle";
 
 export default class FriendList extends Component {
 
   static propTypes = {
-    friendList: PropTypes.array
+    friendList: PropTypes.array,
+    instantRefreshOn: PropTypes.bool,
+    editMode: PropTypes.bool
   };
 
   constructor (props) {
@@ -33,7 +36,13 @@ export default class FriendList extends Component {
     }
 
     const friend_list_for_display = this.state.friend_list.map( (friend) => {
+      if (this.props.editMode) {
+        return <FriendDisplayForList key={friend.voter_we_vote_id} {...friend} >
+          <FriendToggle other_voter_we_vote_id={friend.voter_we_vote_id} />
+        </FriendDisplayForList>;
+      } else {
       return <FriendDisplayForList key={friend.voter_we_vote_id} {...friend} />;
+      }
     });
 
     return <div className="guidelist card-child__list-group">

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -37,14 +37,10 @@ render () {
   let urlBeingShared = this.props.urlBeingShared;
   let browser_supports_CopyToClipboard = false; //latest iOS update supports CopyToClipboard, check for users version and let them copy if latest, perhaps with npm pckg "mobile-detect"
   let copy_btn_className;
-  let select_all_button;
   if (browser_supports_CopyToClipboard) {
     copy_btn_className = "copy-btn"; // display copy button at all times
-    select_all_button = null;
   } else {
-    copy_btn_className = "copy-btn__hide-mobile"; // display: none; in mobile view
-    select_all_button = <button className="select-all-btn btn btn-default"
-                                onClick={()=>{document.getElementById("url-to-copy").setSelectionRange(0, 999);}}>Select All</button>;
+    copy_btn_className = "copy-btn hide-mobile"; // display: none; in mobile view
   }
 
 
@@ -53,18 +49,15 @@ render () {
       <Modal.Title id="contained-modal-title-lg">Copy link to clipboard</Modal.Title>
     </Modal.Header>
     <Modal.Body>
-      <div className="input-group">
-        <input id="url-to-copy"
-               readOnly="true"
-               value={urlBeingShared}
-               className="form-control"
-               style={{marginTop: "17px"}}
-               onFocus={()=>{document.getElementById("url-to-copy").setSelectionRange(0, 999);}} />&nbsp;
+      <div className="input-group url-to-copy">
+        <textarea readOnly="true"
+                  value={urlBeingShared}
+                  className="form-control url-to-copy"
+                  style={{height: "52px"}} />
           <span className="input-group-btn">
             <CopyToClipboard text={urlBeingShared} onCopy={this.updateWasCopied.bind(this)}>
               <button className={"btn btn-default " + copy_btn_className}>Copy</button>
             </CopyToClipboard>
-            {select_all_button}
           </span>
       </div>
     {this.state.was_copied ? <span style={{color: "red"}}>

--- a/src/js/components/Widgets/ShareButtonDropdown.jsx
+++ b/src/js/components/Widgets/ShareButtonDropdown.jsx
@@ -1,5 +1,10 @@
 import React, { Component, PropTypes } from "react";
 import CopyLinkModal from "../../components/Widgets/CopyLinkModal";
+// import CopyLinkModal from "../../components/Widgets/CopyLinkManual";
+// import CopyLinkModal from "../../components/Widgets/CopyLinkModalManual";
+//zachmonteith: comment out either line 2 or line 3, depending on whether
+// 1) a dynamic select all/copy button with a select all onFocus input field
+// is desired, or 2) always manual copy button with textarea field.
 
 export default class ShareButtonDropdown extends Component {
   static propTypes = {

--- a/src/js/components/Widgets/ShareButtonDropdown.jsx
+++ b/src/js/components/Widgets/ShareButtonDropdown.jsx
@@ -1,10 +1,5 @@
 import React, { Component, PropTypes } from "react";
 import CopyLinkModal from "../../components/Widgets/CopyLinkModal";
-// import CopyLinkModal from "../../components/Widgets/CopyLinkManual";
-// import CopyLinkModal from "../../components/Widgets/CopyLinkModalManual";
-//zachmonteith: comment out either line 2 or line 3, depending on whether
-// 1) a dynamic select all/copy button with a select all onFocus input field
-// is desired, or 2) always manual copy button with textarea field.
 
 export default class ShareButtonDropdown extends Component {
   static propTypes = {

--- a/src/js/routes/Friends.jsx
+++ b/src/js/routes/Friends.jsx
@@ -41,6 +41,10 @@ export default class Friends extends Component {
     return current_route;
   }
 
+  toggleEditMode (){
+    this.setState({editMode: !this.state.editMode});
+  }
+
   getFollowingType (){
     switch (this.getCurrentRoute()) {
       case "/friends":
@@ -56,12 +60,18 @@ export default class Friends extends Component {
       <Helmet title="Your Friends - We Vote" />
       <h1 className="h1">Build Your Network</h1>
       <FollowingFilter following_type={this.getFollowingType()} />
+      <a className="fa-pull-right"
+         onClick={this.toggleEditMode.bind(this)}>
+        {this.state.editMode ? "Done Editing" : "Edit"}
+      </a>
       <div>
         <p>
           These friends see what you support, oppose, and which opinions you follow.
         </p>
         <div className="card">
-          <FriendList friendList={current_friend_list} />
+          <FriendList friendList={current_friend_list}
+                      editMode={this.state.editMode}
+                      />
         </div>
       </div>
       <Link to="/requests">

--- a/src/sass/elements/_buttons.scss
+++ b/src/sass/elements/_buttons.scss
@@ -16,21 +16,17 @@
 	}
 }
 
-.select-all-btn{
-	height: 34px;
-	margin: -1px 0 0 0;
-	display: none;
-	@include breakpoints (max nav) {
-		display: inline; // show button on small screens
-	}
+.url-to-copy {
+	width: 100% !important;
 }
 
+.copy-btn{
+	height: 52px;
+}
 
-.copy-btn__hide-mobile {
-		margin: -1px 0 0 0;
-		height: 34px;
-		@include breakpoints (max nav) {
-			display: none; // Hide button on small screens
+.hide-mobile {
+	@include breakpoints (max nav) {
+		display: none; // Hide button on small screens
 	}
 }
 


### PR DESCRIPTION
In this PR:
1) added editMode state to Friends page, which gets passed as a prop to the FriendDisplayForList, through the FriendList.  Toggling edit mode will toggle whether the Friend/Unfriend toggle buttons appear next to each friend in a user's list, similar to the edit mode pattern established for organizations a user is following.

2) removed Select All button from CopyLinkModal: it was only being used on mobile browsers, and not all mobile browsers supported it.  Also changed the field containing the URL from a read-only input to a read-only textarea, so that users can more easily see the entire URL string and highlight/select it themselves, to account for cases where the select all script wasn't working properly (most mobile browsers).  Modified appearance of Copy button to match new text area.

left structure in place for future device testing: CopyLinkModal contains a variable named browser_supports_CopyToClipboard, if truthy, copy button will always appear regardless of window size. Default behavior for now will be to only display copy button on max nav browser windows, as it seems to work properly in all desktop browsers.