### PR TITLE
Show search results even if they don't have a twitter handle.

### DIFF
--- a/src/js/stores/SearchAllStore.js
+++ b/src/js/stores/SearchAllStore.js
@@ -35,8 +35,11 @@ class SearchAllStore extends FluxMapStore {
         let twitter_handle;
         let alreadyContains;
         action.res.search_results.forEach(one_search_result =>{
+          alreadyContains = false;
           twitter_handle = one_search_result.twitter_handle || "";
-          alreadyContains = alreadyFoundTwitterHandles.indexOf(twitter_handle.toLowerCase()) > -1;
+          if (twitter_handle && twitter_handle !== "") {
+            alreadyContains = alreadyFoundTwitterHandles.indexOf(twitter_handle.toLowerCase()) > -1;
+          }
           if (!alreadyContains) {
             searchResults.push(one_search_result);
             alreadyFoundTwitterHandles.push(twitter_handle.toLowerCase());


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixed search results not showing up when there is an empty twitter handle.

### Changes included this pull request?

