### PR TITLE
instant toggle changes #564 #565

### DIFF
--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -48,11 +48,11 @@ export default class FollowToggle extends Component {
 
     var that = this;
     const followFunc = function () {
-      is_following = !is_following;
+      is_following = true;
       GuideActions.organizationFollow.bind(that, we_vote_id);
     };
     const stopFollowingFunc = function () {
-      is_following = !is_following;
+      is_following = false;
       GuideActions.organizationStopFollowing.bind(that, we_vote_id);
     };
     const floatRight = { float: "right"};

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -46,8 +46,15 @@ export default class FollowToggle extends Component {
     // You should not be able to follow yourself
     if (is_looking_at_self) { return <div></div>; }
 
-    const followFunc = GuideActions.organizationFollow.bind(this, we_vote_id);
-    const stopFollowingFunc = GuideActions.organizationStopFollowing.bind(this, we_vote_id);
+    var that = this;
+    const followFunc = function () {
+      is_following = !is_following;
+      GuideActions.organizationFollow.bind(that, we_vote_id);
+    };
+    const stopFollowingFunc = function () {
+      is_following = !is_following;
+      GuideActions.organizationStopFollowing.bind(that, we_vote_id);
+    };
     const floatRight = { float: "right"};
 
     return <span style={floatRight}>

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -36,12 +36,12 @@ export default class PositionPublicToggle extends Component {
     var that = this;
     if (is_public_position) {
       onChange = function () {
-        is_public_position = !is_public_position;
+        is_public_position = false;
         that.showItemToFriendsOnly();
       };
     } else {
       onChange = function () {
-        is_public_position = !is_public_position;
+        is_public_position = true;
         that.showItemToPublic();
       };
     }

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -12,27 +12,12 @@ export default class PositionPublicToggle extends Component {
     supportProps: PropTypes.object
   };
 
-  constructor (props) {
-    super(props);
-    this.state = {
-      transitioning: false
-    };
-  }
-
-  componentWillReceiveProps () {
-    this.setState({transitioning: false});
-  }
-
   showItemToFriendsOnly () {
-    if (this.state.transitioning){ return; }
     SupportActions.voterPositionVisibilitySave(this.props.ballot_item_we_vote_id, this.props.type, "FRIENDS_ONLY");
-    this.setState({transitioning: true});
   }
 
   showItemToPublic () {
-    if (this.state.transitioning){ return; }
     SupportActions.voterPositionVisibilitySave(this.props.ballot_item_we_vote_id, this.props.type, "SHOW_PUBLIC");
-    this.setState({transitioning: true});
   }
 
   render () {
@@ -48,12 +33,18 @@ export default class PositionPublicToggle extends Component {
     const tooltip = <Tooltip id="visibility-tooltip">{is_public_position ? visibilityPublic : visibilityFriendsOnly}</Tooltip>;
 
     var onChange;
+    var that = this;
     if (is_public_position) {
-      onChange = this.showItemToFriendsOnly.bind(this);
+      onChange = function () {
+        is_public_position = !is_public_position;
+        that.showItemToFriendsOnly();
+      };
     } else {
-      onChange = this.showItemToPublic.bind(this);
+      onChange = function () {
+        is_public_position = !is_public_position;
+        that.showItemToPublic();
+      };
     }
-
 
     const positionPublicToggle =
     <div className={this.props.className}>


### PR DESCRIPTION
in PositionPublicToggle and FollowToggle, we now invert the variable used to determine the appearance of the toggle before making our API call.  this way, the button will change appearance as soon as the user clicks it.  this variable is still reassigned once the response comes from the server, so it will still accurately reflect the state once the cycle is complete, but will respond instantly to click so users don't get frustrated and start mashing the button multiple times.

also eliminated the "transitioning" state from PositionPublicToggle as this was preventing the toggle from rendering until the transition was complete.