### PR TITLE
fix for #227, bookmark can now be tabbed to

### DIFF
--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -30,7 +30,10 @@ export default class MeasureItem extends Component {
 
   componentDidMount () {
     this.supportStoreListener = SupportStore.addListener(this._onChange.bind(this));
-    this.setState({ supportProps: SupportStore.get(this.props.we_vote_id) });
+    var supportProps = SupportStore.get(this.props.we_vote_id);
+    if (supportProps !== undefined) {
+      this.setState({ supportProps: supportProps, transitioning: false });
+    }
   }
 
   componentWillUnmount () {

--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -30,10 +30,7 @@ export default class MeasureItem extends Component {
 
   componentDidMount () {
     this.supportStoreListener = SupportStore.addListener(this._onChange.bind(this));
-    var supportProps = SupportStore.get(this.props.we_vote_id);
-    if (supportProps !== undefined) {
-      this.setState({ supportProps: supportProps, transitioning: false });
-    }
+    this.setState({ supportProps: SupportStore.get(this.props.we_vote_id) });
   }
 
   componentWillUnmount () {

--- a/src/js/components/Facebook/FacebookSignIn.jsx
+++ b/src/js/components/Facebook/FacebookSignIn.jsx
@@ -10,8 +10,17 @@ class FacebookSignIn extends React.Component {
     FacebookActions.login();
   }
 
+  onKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      this.didClickFacebookSignInButton();
+    }
+  }
+
   render () {
-    return <a className="btn btn-social btn-lg btn-facebook" onClick={this.didClickFacebookSignInButton}>
+    return <a tabIndex="0" onKeyDown={this.onKeyDown.bind(this)}
+              className="btn btn-social btn-lg btn-facebook"
+              onClick={this.didClickFacebookSignInButton}>
       <i className="fa fa-facebook"></i>Sign in with Facebook
     </a>;
   }

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -113,6 +113,14 @@ export default class AddFriendsByEmail extends Component {
     return true;
   }
 
+  onKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    let scope = this;
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      scope.AddFriendsByEmailStepsManager(event).bind(scope);
+    }
+  }
+
   AddFriendsByEmailStepsManager (event) {
     // This function is called when the form is submitted
     console.log("AddFriendsByEmailStepsManager");
@@ -211,6 +219,8 @@ export default class AddFriendsByEmail extends Component {
             <ButtonToolbar bsClass="btn-toolbar">
               <span style={floatRight}>
                 <Button
+                  tabIndex="0"
+                  onKeyDown={this.onKeyDown.bind(this)}
                   onClick={this.AddFriendsByEmailStepsManager.bind(this)}
                   bsStyle="primary"
                   disabled={!this.state.email_addresses}
@@ -241,6 +251,8 @@ export default class AddFriendsByEmail extends Component {
             <ButtonToolbar bsClass="btn-toolbar">
               <span style={floatRight}>
                 <Button
+                  tabIndex="0"
+                  onKeyDown={this.onKeyDown.bind(this)}
                   onClick={this.AddFriendsByEmailStepsManager.bind(this)}
                   bsStyle="primary"
                   disabled={!this.state.sender_email_address}

--- a/src/js/components/Friends/AddFriendsByFacebook.jsx
+++ b/src/js/components/Friends/AddFriendsByFacebook.jsx
@@ -79,6 +79,14 @@ export default class AddFriendsByFacebook extends Component {
     return voter !== undefined ? voter.has_valid_email : false;
   }
 
+  onKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    let scope = this;
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      scope.AddFriendsByFacebookStepsManager(event).bind(scope);
+    }
+  }
+
   AddFriendsByFacebookStepsManager (event) {
     // This function is called when the form is submitted
     console.log("AddFriendsByFacebookStepsManager");
@@ -138,6 +146,8 @@ export default class AddFriendsByFacebook extends Component {
             <ButtonToolbar bsClass="btn-toolbar">
               <span style={floatRight}>
                 <Button
+                  tabIndex="0"
+                  onKeyDown={this.onKeyDown.bind(this)}
                   onClick={this.AddFriendsByFacebookStepsManager.bind(this)}
                   bsStyle="primary"
                   disabled={!this.state.email_addresses}

--- a/src/js/components/Friends/AddFriendsByTwitter.jsx
+++ b/src/js/components/Friends/AddFriendsByTwitter.jsx
@@ -79,6 +79,14 @@ export default class AddFriendsByTwitter extends Component {
     return voter !== undefined ? voter.has_valid_email : false;
   }
 
+  onKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    let scope = this;
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      scope.AddFriendsByTwitterStepsManager(event).bind(scope);
+    }
+  }
+
   AddFriendsByTwitterStepsManager (event) {
     // This function is called when the form is submitted
     console.log("AddFriendsByTwitterStepsManager");
@@ -151,6 +159,8 @@ export default class AddFriendsByTwitter extends Component {
             <ButtonToolbar bsClass="btn-toolbar">
               <span style={floatRight}>
                 <Button
+                  tabIndex="0"
+                  onKeyDown={this.onKeyDown.bind(this)}
                   onClick={this.AddFriendsByTwitterStepsManager.bind(this)}
                   bsStyle="primary"
                   disabled={!this.state.twitter_handles}

--- a/src/js/components/Navigation/AddFriendsFilter.jsx
+++ b/src/js/components/Navigation/AddFriendsFilter.jsx
@@ -9,23 +9,34 @@ export default class AddFriendsFilter extends Component {
 
   render () {
     const {add_friends_type, changeAddFriendsTypeFunction} = this.props;
-
+    var onKeyDown = function (event) {
+      let enterAndSpaceKeyCodes = [13, 32];
+      if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+        changeAddFriendsTypeFunction(event);
+      }
+    };
     return <div className="btn-group t-mb3">
-      <span id="ADD_FRIENDS_BY_EMAIL"
+      <span tabIndex="0"
+            onKeyDown={onKeyDown}
+            id="ADD_FRIENDS_BY_EMAIL"
             className={ add_friends_type === "ADD_FRIENDS_BY_EMAIL" ? "active btn btn-default" : "btn btn-default"}
             onClick={changeAddFriendsTypeFunction}>
         By Email
       </span>
 
-      <span onClick={changeAddFriendsTypeFunction}
-         id="ADD_FRIENDS_BY_TWITTER"
-         className={ add_friends_type === "ADD_FRIENDS_BY_TWITTER" ? "active btn btn-default" : "btn btn-default"}>
+      <span tabIndex="0"
+            onKeyDown={onKeyDown}
+            onClick={changeAddFriendsTypeFunction}
+            id="ADD_FRIENDS_BY_TWITTER"
+            className={ add_friends_type === "ADD_FRIENDS_BY_TWITTER" ? "active btn btn-default" : "btn btn-default"}>
         Twitter
       </span>
 
-      <span onClick={changeAddFriendsTypeFunction}
-         id="ADD_FRIENDS_BY_FACEBOOK"
-         className={ add_friends_type === "ADD_FRIENDS_BY_FACEBOOK" ? "active btn btn-default" : "btn btn-default"}>
+      <span tabIndex="0"
+            onKeyDown={onKeyDown}
+            onClick={changeAddFriendsTypeFunction}
+            id="ADD_FRIENDS_BY_FACEBOOK"
+            className={ add_friends_type === "ADD_FRIENDS_BY_FACEBOOK" ? "active btn btn-default" : "btn btn-default"}>
         Facebook
       </span>
     </div>;

--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -21,6 +21,13 @@ export default class TwitterSignIn extends Component {
     this.twitterSignInStart(return_url);
   }
 
+  onKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      this.didClickTwitterSignInButton();
+    }
+  }
+
   twitterSignInStart () {
     let return_url = web_app_config.WE_VOTE_URL_PROTOCOL + web_app_config.WE_VOTE_HOSTNAME + "/twitter_sign_in";
     $ajax({
@@ -48,7 +55,9 @@ export default class TwitterSignIn extends Component {
 
   render () {
 
-    return <a className="btn btn-social btn-lg btn-twitter" onClick={this.twitterSignInStart} >
+    return <a tabIndex="0" onKeyDown={this.onKeyDown.bind(this)}
+              className="btn btn-social btn-lg btn-twitter"
+              onClick={this.twitterSignInStart} >
       <i className="fa fa-twitter" />Sign in with Twitter
     </a>;
   }

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -164,6 +164,13 @@ export default class ItemPositionStatementActionBar extends Component {
     var no_statement_text = statement_text_to_be_saved !== null && statement_text_to_be_saved.length ? false : true;
     var edit_mode = this.state.showEditPositionStatementInput || no_statement_text;
     const onSavePositionStatementClick = this.state.showEditPositionStatementInput ? this.closeEditPositionStatementInput.bind(this) : this.openEditPositionStatementInput.bind(this);
+    var onKeyDown = function (e) {
+      let enterAndSpaceKeyCodes = [13, 32];
+      if (enterAndSpaceKeyCodes.includes(e.keyCode)) {
+        onSavePositionStatementClick();
+      }
+    };
+
     return <div className="position-statement__container">
 
       <div className="position-statement__overview u-flex items-center mb2">
@@ -212,14 +219,16 @@ export default class ItemPositionStatementActionBar extends Component {
 
 
             { short_version ?
-              <span className="position-statement__edit-position-pseudo"
+              <span tabIndex="0" onKeyDown={onKeyDown}
+                    className="position-statement__edit-position-pseudo"
                     onClick={onSavePositionStatementClick}
                     title="Edit this position"/> :
               null
             }
-            <div className="position-statement__edit-position-link"
-                  onClick={onSavePositionStatementClick}
-                  title="Edit this position">Edit</div>
+            <div tabIndex="0" onKeyDown={onKeyDown}
+                 className="position-statement__edit-position-link"
+                 onClick={onSavePositionStatementClick}
+                 title="Edit this position">Edit</div>
           </div>
         </div>
       }

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -45,12 +45,22 @@ export default class PositionPublicToggle extends Component {
         that.showItemToPublic();
       };
     }
+// this onKeyDown function is for accessibility: the parent div of the toggle
+// has a tab index so that users can use tab key to select the toggle, and then
+// press either space or enter (key codes 32 and 13, respectively) to toggle
+    var onKeyDown = function (e) {
+      let enterAndSpaceKeyCodes = [13, 32];
+      if (enterAndSpaceKeyCodes.includes(e.keyCode)) {
+        onChange();
+      }
+    };
 
     const positionPublicToggle =
     <div className={this.props.className}>
       <div style={{display: "inline-block"}}>
         <OverlayTrigger className="trigger" placement="top" overlay={tooltip}>
-          <div><ReactBootstrapToggle on={publicIcon} off={friendsIcon}
+          <div tabIndex="0" onKeyDown={onKeyDown}> {/*tabIndex and onKeyDown are for accessibility*/}
+            <ReactBootstrapToggle on={publicIcon} off={friendsIcon}
                                     active={is_public_position}
                                     onstyle="success" size="mini"
                                     width="40px"

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -28,8 +28,8 @@ export default class PositionPublicToggle extends Component {
     var { is_public_position } = this.props.supportProps;
     let visibilityPublic = "Public";
     let visibilityFriendsOnly = "Your friends";
-    const publicIcon = <Icon name="public-icon" color="#fff" width={18} height={18} />;
-    const friendsIcon = <Icon name="group-icon" color="#555" width={18} height={18} />;
+    const publicIcon = <Icon alt="Visible to Public" name="public-icon" color="#fff" width={18} height={18} />;
+    const friendsIcon = <Icon alt="Visible to Friends Only" name="group-icon" color="#555" width={18} height={18} />;
     const tooltip = <Tooltip id="visibility-tooltip">{is_public_position ? visibilityPublic : visibilityFriendsOnly}</Tooltip>;
 
     var onChange;

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -24,6 +24,15 @@ export default class ReadMore extends Component {
             readMore: !this.state.readMore
         });
     }
+    // this onKeyDown function is for accessibility: both toggle links
+    // have a tab index so that users can use tab key to select the link, and then
+    // press either space or enter (key codes 32 and 13, respectively) to toggle
+    onKeyDown (event) {
+      let enterAndSpaceKeyCodes = [13, 32];
+      if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+        this.toggleLines(event);
+      }
+    }
 
     render () {
         let { text_to_display, link_text, num_of_lines, collapse_text } = this.props;
@@ -86,11 +95,24 @@ export default class ReadMore extends Component {
                   line={num_of_lines}
                   truncateText="..."
                   text={text_to_display}
-                  textTruncateChild={<a href="#" onClick={this.toggleLines}>{link_text}</a>}
+                  textTruncateChild={<a tabIndex="0"
+                                        href="#"
+                                        onClick={this.toggleLines}
+                                        onKeyDown={this.onKeyDown.bind(this)}>
+                                      {link_text}
+                                     </a>
+                                    }
               />
           </span>;
         } else {
-          return <span>{expanded_text_to_display}&nbsp;&nbsp;<a href="#" onClick={this.toggleLines}>{collapse_text}</a></span>;
+          return <span tabIndex="0"> {expanded_text_to_display}&nbsp;&nbsp;
+            <a tabIndex="0"
+               href="#"
+               onClick={this.toggleLines}
+               onKeyDown={this.onKeyDown.bind(this)}>
+              {collapse_text}
+            </a>
+          </span>;
         }
     } //end render
   }

--- a/src/js/components/Widgets/StarAction.jsx
+++ b/src/js/components/Widgets/StarAction.jsx
@@ -39,7 +39,8 @@ export default class StarAction extends Component {
   }
 
   starKeyDown (e) {
-    if (e.keyCode === 13) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    if (enterAndSpaceKeyCodes.includes(e.keyCode)) {
       this.starClick().bind(this);
     }
   }

--- a/src/js/components/Widgets/StarAction.jsx
+++ b/src/js/components/Widgets/StarAction.jsx
@@ -55,8 +55,8 @@ export default class StarAction extends Component {
                  onKeyDown={this.starKeyDown.bind(this)}
                  title="Bookmark for later">
               {this.state.is_starred ?
-                <Icon name="bookmark-icon" width={24} height={24} fill="#999" stroke="none" /> :
-                <Icon name="bookmark-icon" width={24} height={24} fill="none" stroke="#ccc" strokeWidth={2} />
+                <Icon alt="Is Bookmarked" name="bookmark-icon" width={24} height={24} fill="#999" stroke="none" /> :
+                <Icon alt="Bookmark for later" name="bookmark-icon" width={24} height={24} fill="none" stroke="#ccc" strokeWidth={2} />
               }
             </span>;
 	}

--- a/src/js/components/Widgets/StarAction.jsx
+++ b/src/js/components/Widgets/StarAction.jsx
@@ -38,13 +38,21 @@ export default class StarAction extends Component {
       StarActions.voterStarOnSave(we_vote_id, this.props.type);
   }
 
+  starKeyDown (e) {
+    if (e.keyCode === 13) {
+      this.starClick().bind(this);
+    }
+  }
+
 	render () {
     if (this.state.is_starred === undefined){
       return <span className="star-action"></span>;
     }
-    return <span className="star-action ml1"
-              onClick={this.starClick.bind(this)}
-              title="Bookmark for later">
+    return <span tabIndex="0"
+                 className="star-action ml1"
+                 onClick={this.starClick.bind(this)}
+                 onKeyDown={this.starKeyDown.bind(this)}
+                 title="Bookmark for later">
               {this.state.is_starred ?
                 <Icon name="bookmark-icon" width={24} height={24} fill="#999" stroke="none" /> :
                 <Icon name="bookmark-icon" width={24} height={24} fill="none" stroke="#ccc" strokeWidth={2} />

--- a/src/js/routes/Connect.jsx
+++ b/src/js/routes/Connect.jsx
@@ -60,6 +60,14 @@ export default class Connect extends Component {
     this.setState({editMode: !this.state.editMode});
   }
 
+	onKeyDownEditMode (event) {
+		let enterAndSpaceKeyCodes = [13, 32];
+		let scope = this;
+		if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+			scope.setState({editMode: !this.state.editMode});
+		}
+	}
+
   getFollowingType (){
     switch (this.getCurrentRoute()) {
       case "/more/connect":
@@ -96,7 +104,9 @@ export default class Connect extends Component {
 
 			<div className="container-fluid well u-gutter__top--small fluff-full1">
         <a className="fa-pull-right"
-           onClick={this.toggleEditMode.bind(this)}>
+						tabIndex="0"
+						onKeyDown={this.onKeyDownEditMode.bind(this)}
+						onClick={this.toggleEditMode.bind(this)}>
           {this.state.editMode ? "Done Editing" : "Edit"}
         </a>
         <div>

--- a/src/js/routes/More/SignIn.jsx
+++ b/src/js/routes/More/SignIn.jsx
@@ -43,6 +43,20 @@ export default class SignIn extends Component {
     });
   }
 
+  facebookLogOutOnKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      FacebookActions.appLogout();
+    }
+  }
+
+  twitterLogOutOnKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      TwitterActions.appLogout();
+    }
+  }
+
   // getFacebookAuthResponse () {
   //   return {
   //     accessToken: FacebookStore.accessToken,
@@ -89,15 +103,17 @@ export default class SignIn extends Component {
           <h1 className="h3">{voter.is_signed_in ? <span>Your Account</span> : <span>Sign In</span>}</h1>
           <div>
             {voter.signed_in_facebook ?
-              <span><a className="btn btn-social btn-lg btn-facebook" onClick={FacebookActions.appLogout}>
+              <span tabIndex="0" onKeyDown={this.facebookLogOutOnKeyDown.bind(this)}>
+                <a className="btn btn-social btn-lg btn-facebook" onClick={FacebookActions.appLogout}>
               <i className="fa fa-facebook" />Sign Out</a></span> : facebook_sign_in_option
             }
             <br />
             <br />
             {/* appLogout signs out the voter, regardless of how they are signed in */}
             {voter.signed_in_twitter ?
-              <span><a className="btn btn-social btn-lg btn-twitter" onClick={TwitterActions.appLogout}>
-              <i className="fa fa-twitter" />Sign Out</a></span> : twitter_sign_in_option
+              <span tabIndex="0" onKeyDown={this.twitterLogOutOnKeyDown.bind(this)}>
+                <a className="btn btn-social btn-lg btn-twitter" onClick={TwitterActions.appLogout}>
+                  <i className="fa fa-twitter" />Sign Out</a></span> : twitter_sign_in_option
             }
             {/*
             <div>

--- a/src/js/routes/OpinionsFollowed.jsx
+++ b/src/js/routes/OpinionsFollowed.jsx
@@ -45,6 +45,14 @@ export default class OpinionsFollowed extends Component {
     this.setState({editMode: !this.state.editMode});
   }
 
+  onKeyDownEditMode (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    let scope = this;
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      scope.setState({editMode: !this.state.editMode});
+    }
+  }
+
   getFollowingType (){
     switch (this.getCurrentRoute()) {
       case "/opinions":
@@ -60,7 +68,10 @@ export default class OpinionsFollowed extends Component {
       <Helmet title="Organizations You Follow - We Vote" />
       <h1 className="h1">Build Your Network</h1>
       <FollowingFilter following_type={this.getFollowingType()} />
-      <a className="fa-pull-right" onClick={this.toggleEditMode.bind(this)}>{this.state.editMode ? "Done Editing" : "Edit"}</a>
+      <a className="fa-pull-right"
+         tabIndex="0"
+         onKeyDown={this.onKeyDownEditMode.bind(this)}
+         onClick={this.toggleEditMode.bind(this)}>{this.state.editMode ? "Done Editing" : "Edit"}</a>
         <p>
           Organizations, public figures and other voters you currently follow. <em>We will never sell your email</em>.
         </p>


### PR DESCRIPTION
Thanks to Adit for pairing with me at Code for SF to solve this one!  in case the commit name wasn't clear, this allows users to use the tab key to highlight the bookmark button for the ballot item they are viewing, and to press the enter or space key to bookmark the item once it is highlighted.

*EDIT*
added similar functionality to all buttons, links, and other clickable objects I could find that weren't previously focusable with tab and didn't trigger on spacebar or enter.