### PR TITLE
positions in network bar now shows red and green

### DIFF
--- a/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
@@ -39,7 +39,18 @@ export default class ItemSupportOpposeCounts extends Component {
 
     var isEmpty = support_count === 0 && oppose_count === 0;
 
+    var isSupportAndOppose = support_count !== 0 && oppose_count !== 0;
+
     var isMajoritySupport = support_count >= oppose_count;
+
+    var backgroundBarClassName;
+    if (isSupportAndOppose && isMajoritySupport) {
+      backgroundBarClassName = "network-positions__bar-well red-bar";
+        } else if (isSupportAndOppose && !isMajoritySupport) {
+      backgroundBarClassName = "network-positions__bar-well green-bar";
+        } else {
+      backgroundBarClassName = "network-positions__bar-well";
+    }
 
     return <div className="network-positions">
       <div className="network-positions__bar-label">
@@ -55,7 +66,7 @@ export default class ItemSupportOpposeCounts extends Component {
           <span className="sr-only"> Support</span>
         </div>
       </div>
-      <div className="network-positions__bar-well">
+      <div className={backgroundBarClassName}>
         { isMajoritySupport ?
           <div className="network-positions__bar network-positions__bar--majority network-positions__bar--support" style={!isEmpty ? barStyle : emptyBarStyle}>
             <span className="sr-only">{this.percentageMajority()}% Supports</span>

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -1,10 +1,11 @@
 // Network Positions bar (ItemSupportOpposeCounts)
 
+  $green: #76D00B;
+  $red: #FF4921;
+
 .network-positions {
   $bar-height: 10px;
   $icon-size: 20px;
-  $green: #76D00B;
-  $red: #FF4921;
   position: relative;
   display: flex;
   margin-top: .5rem;
@@ -20,7 +21,11 @@
     border-radius: 3em;
     background-color: $gray-light;
     overflow: hidden;
+
   }
+
+
+
 
   &__bar-label {
     position: absolute;
@@ -70,3 +75,9 @@
   }
 
 }
+.red-bar {
+      background-color: $red;
+    }
+.green-bar {
+      background-color: $green;
+    }


### PR DESCRIPTION
After design talks with Cara and Dale, this PR makes the following change to the "positions in your network" color bar:
if there are people in your network who oppose AND who support a ballot item, the bar will show the percentage who support in green and who oppose in red (e.g. if 2 support and one oppose, the bar will be 2/3 green and 1/3 red)
if there are no positions in the network, it will remain the default light gray, and if all members of your network support or oppose the entire bar will still show the appropriate color.