### PR TITLE
Fix padding problem on some views

### DIFF
--- a/src/js/routes/Intro/IntroStory.jsx
+++ b/src/js/routes/Intro/IntroStory.jsx
@@ -35,10 +35,12 @@ export default class IntroStory extends Component {
 
   componentWillMount () {
     document.body.style.backgroundColor = "#A3A3A3";
+    document.body.className = "story-view";
   }
 
   componentWillUnmount () {
     document.body.style.backgroundColor = null;
+    document.body.className = "";
   }
 
   render () {

--- a/src/sass/components/_intro-story.scss
+++ b/src/sass/components/_intro-story.scss
@@ -1,3 +1,11 @@
+.story-view {
+  .container-main {
+    margin: 0px;
+    min-height: 100%;
+    padding: 0px;
+  }
+}
+
 .intro-story {
   background-color: $gray-dark;
   padding: 0;
@@ -8,6 +16,7 @@
   @include breakpoints (max large){
     height: 100vh;
   }
+
 }
 
 .intro-story__h1 {
@@ -190,12 +199,6 @@
 
 .slick-dots {
   bottom: 2em;
-}
-
-.container-main {
-  margin: 0px;
-  min-height: 100%;
-  padding: 0px;
 }
 
 .well {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

https://github.com/wevote/WebApp/issues/624

### Changes included this pull request?

Looks like the intro story was overriding the container-main padding so
there is an introduction to a class that is added for the intro story
view on the body that encapsulates the container-main and then removes
that class on any other view so that the container-main will inherit the
regular padding that it has.
