### PR TITLE
Remove margin bottom on story view well

### DIFF
--- a/src/sass/components/_intro-story.scss
+++ b/src/sass/components/_intro-story.scss
@@ -4,6 +4,10 @@
     min-height: 100%;
     padding: 0px;
   }
+
+  .well {
+    margin-bottom: 0;
+  }
 }
 
 .intro-story {


### PR DESCRIPTION
### Changes included this pull request?

Looks like the margin bottom that the well class that is coming from
Bootstrap is causing some viewport overflow issues. When the well class
is encapsulated inside fo the story view with a 0 margin, I am able to
see the dots all of the time. Note that this was only tested in Chrome
Dev Tools, not on any devices.
