### PR TITLE
Compact position layout

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -13,7 +13,8 @@ const del = require("del");
 const server = require("./server");
 
 const config = {
-    bootstrapDir: './node_modules/bootstrap-sass'
+    bootstrapDir: './node_modules/bootstrap-sass',
+    bootstrap4Dir: './node_modules/bootstrap'
 };
 
 const PRODUCTION = process.env.NODE_ENV === "production";
@@ -73,7 +74,8 @@ gulp.task("server", PRODUCTION ? () => server(PRODUCTION) : function () {
 gulp.task('compile-bootstrap', function() {
     return gulp.src('./src/sass/bootstrap.scss')
     .pipe(sass({
-        includePaths: [config.bootstrapDir + '/assets/stylesheets'],
+        includePaths: [config.bootstrapDir + '/assets/stylesheets',
+                      config.bootstrap4Dir]
     }))
     .pipe(gulp.dest("./build/css/"));
 });

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "babel-preset-stage-0": "^6.16.0",
     "babelify": "^7.3.0",
     "blue-tape": "^1.0.0",
+    "bootstrap": "^4.0.0-alpha.6",
     "bootstrap-sass": "^3.3.7",
     "browser-sync": "^2.18.6",
     "browserify": "^13.3.0",

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -114,7 +114,7 @@ export default class Application extends Component {
         <div className="page-content-container">
           <div className="container-fluid">
             <div className="row">
-              <div className="col-xs-12 container-main">
+              <div className="col-12 container-main">
                 { this.props.children }
               </div>
             </div>
@@ -132,10 +132,10 @@ export default class Application extends Component {
       <div className="page-content-container">
         <div className="container-fluid">
           <div className="row">
-            <div className="col-xs-4 sidebar-menu">
+            <div className="col-4 sidebar-menu">
               { voter.is_signed_in ? <MoreMenu {...voter} /> : <MoreMenu /> }
             </div>
-            <div className="col-xs-8-container col-xs-8 container-main">
+            <div className="col-8-container col-8 container-main">
               { this.props.children }
             </div>
           </div>

--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -149,7 +149,7 @@ export default class CandidateItem extends Component {
           }
           </p>
           { twitter_description ?
-            <div className={ this.props.link_to_ballot_item_page ? "card-main__description-container--truncated" : "card-main__description-container"}>
+            <div className={ "u-stack--sm" + (this.props.link_to_ballot_item_page ? " card-main__description-container--truncated" : " card-main__description-container")}>
               <div>
                 <p className="card-main__description">
                     {twitter_description}
@@ -166,9 +166,7 @@ export default class CandidateItem extends Component {
             </div> :
             null
           }
-          <span className={ this.props.link_to_ballot_item_page ?
-                  "card-main__network-positions u-cursor--pointer" :
-                  "card-main__network-positions" }
+          <div className={"card-main__network-positions u-stack--sm" +  this.props.link_to_ballot_item_page && " u-cursor--pointer"}
                 onClick={ this.props.link_to_ballot_item_page ?
                   goToCandidateLink : null }
           >
@@ -200,8 +198,8 @@ export default class CandidateItem extends Component {
                                                supportProps={this.state.supportProps} />
               </span> :
               <span>ItemTinyPositionBreakdownList NOT shown</span> }
-               */}
-          </span>
+            */}
+          </div>
 
         </div> {/* END .card-main__media-object-content */}
       </div> {/* END .card-main__media-object */}

--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -92,7 +92,7 @@ export default class MeasureItem extends Component {
           }
 
           <div className="row" style={{ paddingBottom: "0.5rem" }}>
-            <div className="col-xs-12" />
+            <div className="col-12" />
           </div>
           <span className={ this.props.link_to_ballot_item_page ?
                   "u-cursor--pointer" :

--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -109,10 +109,10 @@ export default class MeasureItemCompressed extends Component {
         <StarAction we_vote_id={we_vote_id} type="MEASURE"/>
 
         {/* This is the area *under* the measure title */}
-        <div className={ this.props.link_to_ballot_item_page ?
-                "u-cursor--pointer u-flex row" : "u-flex row" } >
+        <div className={"u-flex" + (this.props.link_to_ballot_item_page ?
+                " u-cursor--pointer" : "") } >
 
-              <div className="col-md-6 u-flex-none">
+              <div className="MeasureItem__summary u-flex-auto u-inline--sm">
                 <div className={ this.props.link_to_ballot_item_page ?
                         "u-cursor--pointer" : null }
                       onClick={ this.props.link_to_ballot_item_page ?
@@ -123,7 +123,7 @@ export default class MeasureItemCompressed extends Component {
               </div>
 
               {/* *** "Positions in your Network" bar OR items you can follow *** */}
-              <div className="col-md-3 u-tr">
+              <div className="u-flex-none u-justify-end u-inline--sm">
                 <span className={ this.props.link_to_ballot_item_page ?
                         "u-cursor--pointer" :
                         null }
@@ -148,7 +148,7 @@ export default class MeasureItemCompressed extends Component {
               </div>
 
               {/* *** Choose Support or Oppose *** */}
-              <td className="col-md-3">
+              <td className="u-flex-none u-justify-end">
                 <ItemActionBar ballot_item_we_vote_id={we_vote_id}
                                supportProps={this.state.supportProps}
                                shareButtonHide

--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -109,11 +109,10 @@ export default class MeasureItemCompressed extends Component {
         <StarAction we_vote_id={we_vote_id} type="MEASURE"/>
 
         {/* This is the area *under* the measure title */}
-        <table className={ this.props.link_to_ballot_item_page ?
-                "u-cursor--pointer table table-condensed" : "table table-condensed" } >
-          <tbody>
-            <tr>
-              <td className="col-md-6">
+        <div className={ this.props.link_to_ballot_item_page ?
+                "u-cursor--pointer u-flex row" : "u-flex row" } >
+
+              <div className="col-md-6 u-flex-none">
                 <div className={ this.props.link_to_ballot_item_page ?
                         "u-cursor--pointer" : null }
                       onClick={ this.props.link_to_ballot_item_page ?
@@ -121,10 +120,10 @@ export default class MeasureItemCompressed extends Component {
                 { this.props.measure_text ?
                   <div className="measure_text">{measure_text}</div> :
                   null }
-              </td>
+              </div>
 
               {/* *** "Positions in your Network" bar OR items you can follow *** */}
-              <td className="col-md-3 u-tr u-inset__minimum-width--100px">
+              <div className="col-md-3 u-tr">
                 <span className={ this.props.link_to_ballot_item_page ?
                         "u-cursor--pointer" :
                         null }
@@ -146,10 +145,10 @@ export default class MeasureItemCompressed extends Component {
                     <span /> }
                   </span> }
                 </span>
-              </td>
+              </div>
 
               {/* *** Choose Support or Oppose *** */}
-              <td className="col-md-3 u-inset__minimum-width--120px">
+              <td className="col-md-3">
                 <ItemActionBar ballot_item_we_vote_id={we_vote_id}
                                supportProps={this.state.supportProps}
                                shareButtonHide
@@ -157,9 +156,7 @@ export default class MeasureItemCompressed extends Component {
                                transitioniing={this.state.transitioning}
                                type="MEASURE" />
               </td>
-            </tr>
-          </tbody>
-        </table>
+        </div>
       </div> {/* END .card-main__content */}
     </div>;
   }

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -67,14 +67,13 @@ export default class OfficeItemCompressed extends Component {
         </h2>
         <StarAction we_vote_id={we_vote_id} type="OFFICE"/>
 
-        <table className={ this.props.link_to_ballot_item_page ?
-                "table table-condensed" : "table table-condensed" } >
-          <tbody>
+        <div className={this.props.link_to_ballot_item_page ?
+                "u-cursor--pointer" : null } >
           { this.props.candidate_list.map( (one_candidate) =>
             <div key={one_candidate.we_vote_id} className="u-stack--md">
-              <div className="row">
+              <div className="u-flex u-items-center">
                 {/* *** Candidate name *** */}
-                <div className="col-12 col-sm u-cursor--pointer"
+                <div className="u-flex-auto u-inline--sm u-cursor--pointer"
                     onClick={ this.props.link_to_ballot_item_page ?
                               ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
                               null }>
@@ -85,11 +84,11 @@ export default class OfficeItemCompressed extends Component {
                                   alt="candidate-photo"
                                   kind_of_ballot_item="CANDIDATE" />
                   </span>
-                  {one_candidate.ballot_item_display_name}
+                  <span className="h5">{one_candidate.ballot_item_display_name}</span>
                 </div>
 
                 {/* *** "Positions in your Network" bar OR items you can follow *** */}
-                <div className="col-5 col-sm-3 u-tr">
+                <div className="u-flex-none u-justify-end u-inline--sm">
                   {/* Decide whether to show the "Positions in your network" bar or the options of voter guides to follow */}
                   { SupportStore.get(one_candidate.we_vote_id) && ( SupportStore.get(one_candidate.we_vote_id).oppose_count || SupportStore.get(one_candidate.we_vote_id).support_count) ?
                     <span className="u-cursor--pointer"
@@ -116,7 +115,7 @@ export default class OfficeItemCompressed extends Component {
                 </div>
 
                 {/* *** Choose Support or Oppose *** */}
-                <div className="col-5 col-sm-3 u-cursor--pointer">
+                <div className="u-flex-none u-cursor--pointer">
                   <ItemActionBar ballot_item_we_vote_id={one_candidate.we_vote_id}
                                  supportProps={SupportStore.get(one_candidate.we_vote_id)}
                                  shareButtonHide
@@ -127,8 +126,7 @@ export default class OfficeItemCompressed extends Component {
               </div>{/* end .row */}
             </div>)
           }
-          </tbody>
-        </table>
+        </div>
       </div>
     </div>;
   }

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -71,59 +71,61 @@ export default class OfficeItemCompressed extends Component {
                 "table table-condensed" : "table table-condensed" } >
           <tbody>
           { this.props.candidate_list.map( (one_candidate) =>
-            <tr key={one_candidate.we_vote_id}>
-              {/* *** Candidate name *** */}
-              <td className="col-md-6 u-cursor--pointer"
-                  onClick={ this.props.link_to_ballot_item_page ?
-                            ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
-                            null }>
-                <span className="hidden-xs">
-                  <ImageHandler className="card-main__avatar"
-                                sizeClassName="icon-candidate-small "
-                                imageUrl={one_candidate.candidate_photo_url}
-                                alt="candidate-photo"
-                                kind_of_ballot_item="CANDIDATE" />
-                </span>
-                {one_candidate.ballot_item_display_name}
-              </td>
-
-              {/* *** "Positions in your Network" bar OR items you can follow *** */}
-              <td className="col-md-3 u-tr u-inset__minimum-width--100px">
-                {/* Decide whether to show the "Positions in your network" bar or the options of voter guides to follow */}
-                { SupportStore.get(one_candidate.we_vote_id) && ( SupportStore.get(one_candidate.we_vote_id).oppose_count || SupportStore.get(one_candidate.we_vote_id).support_count) ?
-                  <span className="u-cursor--pointer"
-                        onClick={ this.props.link_to_ballot_item_page ?
-                        ()=>{this.props._toggleCandidateModal(one_candidate);} :
-                        null } >
-                    <ItemSupportOpposeCounts we_vote_id={one_candidate.we_vote_id}
-                                             supportProps={SupportStore.get(one_candidate.we_vote_id)}
-                                             type="CANDIDATE"/>
-                  </span> :
-                  <span>
-                    {/* Show possible voter guides to follow */}
-                    { GuideStore.toFollowListForBallotItemById(one_candidate.we_vote_id) && GuideStore.toFollowListForBallotItemById(one_candidate.we_vote_id).length !== 0 ?
-                      <span className="u-cursor--pointer"
-                            onClick={ this.props.link_to_ballot_item_page ?
-                            ()=>{this.props._toggleCandidateModal(one_candidate);} :
-                            null } >
-                        <ItemTinyOpinionsToFollow ballotItemWeVoteId={one_candidate.we_vote_id}
-                                                  organizationsToFollow={GuideStore.toFollowListForBallotItemById(one_candidate.we_vote_id)}/>
-                      </span> :
-                      <span /> }
+            <div key={one_candidate.we_vote_id} className="u-stack--md">
+              <div className="row">
+                {/* *** Candidate name *** */}
+                <div className="col-12 col-sm u-cursor--pointer"
+                    onClick={ this.props.link_to_ballot_item_page ?
+                              ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
+                              null }>
+                  <span className="hidden-xs">
+                    <ImageHandler className="card-main__avatar"
+                                  sizeClassName="icon-candidate-small "
+                                  imageUrl={one_candidate.candidate_photo_url}
+                                  alt="candidate-photo"
+                                  kind_of_ballot_item="CANDIDATE" />
                   </span>
-                }
-              </td>
+                  {one_candidate.ballot_item_display_name}
+                </div>
 
-              {/* *** Choose Support or Oppose *** */}
-              <td className="col-md-3 u-cursor--pointer">
-                <ItemActionBar ballot_item_we_vote_id={one_candidate.we_vote_id}
-                               supportProps={SupportStore.get(one_candidate.we_vote_id)}
-                               shareButtonHide
-                               commentButtonHide
-                               transitioniing={this.state.transitioning}
-                               type="CANDIDATE" />
-              </td>
-            </tr>)
+                {/* *** "Positions in your Network" bar OR items you can follow *** */}
+                <div className="col-5 col-sm-3 u-tr">
+                  {/* Decide whether to show the "Positions in your network" bar or the options of voter guides to follow */}
+                  { SupportStore.get(one_candidate.we_vote_id) && ( SupportStore.get(one_candidate.we_vote_id).oppose_count || SupportStore.get(one_candidate.we_vote_id).support_count) ?
+                    <span className="u-cursor--pointer"
+                          onClick={ this.props.link_to_ballot_item_page ?
+                          ()=>{this.props._toggleCandidateModal(one_candidate);} :
+                          null } >
+                      <ItemSupportOpposeCounts we_vote_id={one_candidate.we_vote_id}
+                                               supportProps={SupportStore.get(one_candidate.we_vote_id)}
+                                               type="CANDIDATE"/>
+                    </span> :
+                    <span>
+                      {/* Show possible voter guides to follow */}
+                      { GuideStore.toFollowListForBallotItemById(one_candidate.we_vote_id) && GuideStore.toFollowListForBallotItemById(one_candidate.we_vote_id).length !== 0 ?
+                        <span className="u-cursor--pointer"
+                              onClick={ this.props.link_to_ballot_item_page ?
+                              ()=>{this.props._toggleCandidateModal(one_candidate);} :
+                              null } >
+                          <ItemTinyOpinionsToFollow ballotItemWeVoteId={one_candidate.we_vote_id}
+                                                    organizationsToFollow={GuideStore.toFollowListForBallotItemById(one_candidate.we_vote_id)}/>
+                        </span> :
+                        <span /> }
+                    </span>
+                  }
+                </div>
+
+                {/* *** Choose Support or Oppose *** */}
+                <div className="col-5 col-sm-3 u-cursor--pointer">
+                  <ItemActionBar ballot_item_we_vote_id={one_candidate.we_vote_id}
+                                 supportProps={SupportStore.get(one_candidate.we_vote_id)}
+                                 shareButtonHide
+                                 commentButtonHide
+                                 transitioniing={this.state.transitioning}
+                                 type="CANDIDATE" />
+                </div>
+              </div>{/* end .row */}
+            </div>)
           }
           </tbody>
         </table>

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -115,7 +115,7 @@ export default class OfficeItemCompressed extends Component {
               </td>
 
               {/* *** Choose Support or Oppose *** */}
-              <td className="col-md-3 u-inset__minimum-width--120px u-cursor--pointer">
+              <td className="col-md-3 u-cursor--pointer">
                 <ItemActionBar ballot_item_we_vote_id={one_candidate.we_vote_id}
                                supportProps={SupportStore.get(one_candidate.we_vote_id)}
                                shareButtonHide

--- a/src/js/components/Navigation/NavigatorInFooter.jsx
+++ b/src/js/components/Navigation/NavigatorInFooter.jsx
@@ -7,7 +7,7 @@ const links = {
     var icon = "glyphicon glyphicon-list-alt glyphicon-line-adjustment nav-icon";
 
     var jsx =
-      <div className="col-xs-3 center-block text-center">
+      <div className="col-3 center-block text-center">
         <Link to="/ballot" className={ "footer-nav__item" + (active ? " active-icon" : "")}>
 
           <span className={icon} title="Ballot" />
@@ -25,7 +25,7 @@ const links = {
     var icon = "glyphicon glyphicon-inbox glyphicon-line-adjustment nav-icon";
 
     var jsx =
-      <div className="col-xs-3 center-block text-center">
+      <div className="col-3 center-block text-center">
         <Link to="/requests" className={ "footer-nav__item" + (active ? " active-icon" : "")}>
           <span className={icon} title="Requests">
             {number_of_incoming_friend_requests ?
@@ -46,7 +46,7 @@ const links = {
     var icon = "glyphicon icon-icon-connect-1-3 nav-icon";
 
     var jsx =
-      <div className="col-xs-3 center-block text-center">
+      <div className="col-3 center-block text-center">
         <Link to="/more/connect" className={ "footer-nav__item" + (active ? " active-icon" : "")}>
           <span className={icon} title="Connect" />
           <br/>
@@ -63,7 +63,7 @@ const links = {
     var icon = "glyphicon icon-icon-activity-1-4 nav-icon";
 
     var jsx =
-      <div className="col-xs-3 center-block text-center">
+      <div className="col-3 center-block text-center">
         <Link to="/activity" className={ "footer-nav__item" + (active ? " active-icon" : "")}>
           <span className={icon} title="Activity" />
           <br/>

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -78,29 +78,29 @@ export default class ItemActionBar extends Component {
       <span className="btn__icon"><Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={icon_color} /></span> :
       <span className="btn__icon"><Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={icon_color} /></span>;
     const share_icon = <span className="btn__icon"><Icon name="share-icon" width={icon_size} height={icon_size} color={icon_color} /></span>;
-    return <div className={ this.props.shareButtonHide ? "item-actionbar-inline" : "item-actionbar" }>
+    return <div className={ this.props.shareButtonHide ? "item-actionbar--inline" : "item-actionbar" }>
       { //Show the position voter has taken
         is_oppose || is_support ?
         <PositionDropdown removePositionFunction={remove_position_function} positionIcon={position_icon} positionText={position_text}/> :
         // Voter hasn't supported or opposed, show both options
-        <div className="btn-group u-inline--sm">
+        <div className={"btn-group" + (!this.props.shareButtonHide ? " u-inline--sm" : "")}>
           <button className="item-actionbar__btn item-actionbar__btn--support btn btn-default" onClick={this.supportItem.bind(this)}>
             <span className="btn__icon">
               <Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={icon_color} />
             </span>
-            <span className={ this.props.shareButtonHide ? "item-actionbar-inline__position-btn-label" : "item-actionbar__position-btn-label" }>Support</span>
+            <span className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Support</span>
           </button>
           <button className="item-actionbar__btn item-actionbar__btn--oppose btn btn-default" onClick={this.opposeItem.bind(this)}>
             <span className="btn__icon">
               <Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={icon_color} />
             </span>
-            <span className={ this.props.shareButtonHide ? "item-actionbar-inline__position-btn-label" : "item-actionbar__position-btn-label" }>Oppose</span>
+            <span className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Oppose</span>
           </button>
         </div>
       }
       { this.props.commentButtonHide ?
         null :
-         <button className="item-actionbar__btn item-actionbar__btn--comment btn btn-default" onClick={this.props.toggleFunction}>
+         <button className="item-actionbar__btn item-actionbar__btn--comment btn btn-default u-inline--sm" onClick={this.props.toggleFunction}>
             <span className="btn__icon">
               <Icon name="comment-icon" width={icon_size} height={icon_size} color={icon_color} />
             </span>

--- a/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
@@ -62,7 +62,7 @@ export default class ItemSupportOpposeCounts extends Component {
         }
       </div>*/}
       <div className="network-positions__support">
-        <img src={!isEmpty && isMajoritySupport ? "/img/global/icons/up-arrow-color-icon.svg" : "/img/global/icons/up-arrow-gray-icon.svg"} className="network-positions__support-icon" width="20" height="20" />
+        <img src={!isEmpty && isMajoritySupport ? "/img/global/icons/up-arrow-color-icon.svg" : "/img/global/icons/up-arrow-gray-icon.svg"} className="network-positions__support-icon u-inline--xs" width="20" height="20" />
         <div className="network-positions__count">
           {!isEmpty ? support_count : null}
           <span className="sr-only"> Support</span>
@@ -80,11 +80,11 @@ export default class ItemSupportOpposeCounts extends Component {
       </div>
 
       <div className="network-positions__oppose">
-        <img src={!isEmpty && !isMajoritySupport ? "/img/global/icons/down-arrow-color-icon.svg" : "/img/global/icons/down-arrow-gray-icon.svg"} className="network-positions__oppose-icon" width="20" height="20" />
-        <div className="network-positions__count">
+        <div className="network-positions__count u-inline--xs">
           {!isEmpty ? oppose_count : null}
           <span className="sr-only"> Oppose</span>
         </div>
+        <img src={!isEmpty && !isMajoritySupport ? "/img/global/icons/down-arrow-color-icon.svg" : "/img/global/icons/down-arrow-gray-icon.svg"} className="network-positions__oppose-icon" width="20" height="20" />
       </div>
     </div>;
   }

--- a/src/js/components/Widgets/PositionDropdown.jsx
+++ b/src/js/components/Widgets/PositionDropdown.jsx
@@ -34,7 +34,7 @@ export default class PositionDropdown extends Component {
     const onClick = this.state.open ? this.closeDropdown.bind(this) : this.openDropdown.bind(this);
     const dropdownClass = this.state.open ? " open" : "";
 
-    return <div className={"btn-group u-inline--sm" + dropdownClass}>
+    return <div className={"btn-group" + dropdownClass}>
       <button onBlur={this.onButtonBlur.bind(this)} onClick={onClick} className="dropdown-toggle item-actionbar__btn item-actionbar__btn--position-selected btn btn-default">
         {positionIcon} {positionText} <span className="caret" />
       </button>

--- a/src/js/routes/More/About.jsx
+++ b/src/js/routes/More/About.jsx
@@ -95,7 +95,7 @@ export default class About extends Component {
 
           <h3 className="h3">We Vote Board Members</h3>
           <div className="row centered">
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive"
                               imageUrl="/img/global/photos/Jenifer_Fernandez_Ancona-200x200.jpg"
@@ -109,7 +109,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Tiana_Epps_Johnson-200x200.jpg"
                               alt="Tiana Epps-Johnson"/>
@@ -123,7 +123,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Debra_Cleaver-200x200.jpg"
                               alt="Debra Cleaver"/>
@@ -138,7 +138,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-xs-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Tory_Gavito-200x200.jpg"
                               alt="Tory Gavito"/>
@@ -152,7 +152,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Lawrence_Grodeska-200x200.jpg"
                               alt="Lawrence Grodeska"/>
@@ -165,7 +165,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Dale_McGrew-200x200.jpg"
                               alt="Dale John McGrew"/>
@@ -179,7 +179,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-xs-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Barbara_Shannon-200x200.jpg"
                               alt="Barbara Shannon"/>
@@ -192,7 +192,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Anat_Shenker_Osario-200x200.jpg"
                               alt="Anat Shenker-Osorio"/>
@@ -207,7 +207,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/William_Winters-200x200.jpg"
                               alt="William Winters"/>
@@ -225,7 +225,7 @@ export default class About extends Component {
 
           <h3 className="h3">We Vote Staff</h3>
           <div className="row centered">
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Sarah_Clements-200x200.jpg"
                               alt="Sarah Clements"/>
@@ -234,7 +234,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Irene_Florez-200x200.jpg"
                               alt="Irene Florez"/>
@@ -243,7 +243,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Jeff_French-200x200.jpg"
                               alt="Jeff French"/>
@@ -253,7 +253,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-xs-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Anisha_Jain-200x200.jpg"
                               alt="Anisha Jain"/>
@@ -263,7 +263,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Judy_Johnson-200x200.jpg"
                               alt="Judy Johnson"/>
@@ -272,7 +272,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Neelam_Joshi-200x200.jpg"
                               alt="Neelam Joshi"/>
@@ -282,7 +282,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-xs-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Ciero_Kilpatrrick-200x200.jpg"
                               alt="Ciero Kilpatrick"/>
@@ -291,7 +291,7 @@ export default class About extends Component {
                 </div>
               </div>
             </div>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Dale_McGrew-200x200.jpg"
                               alt="Dale John McGrew"/>
@@ -305,7 +305,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Colette_Phair-200x200.jpg"
                               alt="Colette Phair"/>
@@ -319,7 +319,7 @@ export default class About extends Component {
               </div>
             </div>
             <div className="clearfix visible-xs-block"/>
-            <div className="col-xs-4 col-sm-3 col-md-3">
+            <div className="col-4 col-sm-3 col-md-3">
               <div className="media">
                 <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Eric_Ogawa-200x200.jpg"
                               alt="Eric"/>

--- a/src/sass/bootstrap.scss
+++ b/src/sass/bootstrap.scss
@@ -4,6 +4,7 @@
 
 @import 'bootstrap/bootstrap-variables';
 @import 'bootstrap/bootstrap-custom';
+@import 'dist/css/bootstrap-grid'; // a compiled version of Bootstrap 4's grid system (using flexbox)
 
 // TODO Create Bootstrap overrides partial
 

--- a/src/sass/bootstrap/_bootstrap-variables.scss
+++ b/src/sass/bootstrap/_bootstrap-variables.scss
@@ -65,6 +65,11 @@ $btn-border-radius-base:         $border-radius-base !default;
 $btn-border-radius-large:        $border-radius-large !default;
 $btn-border-radius-small:        $border-radius-small !default;
 
+//== Typography
+//
+//## Font, line-height, and color for body text, headings, and more.
+
+$font-size-h5: 1rem;
 
 
 // == Iconography

--- a/src/sass/bootstrap/bootstrap-custom.scss
+++ b/src/sass/bootstrap/bootstrap-custom.scss
@@ -19,7 +19,7 @@
 @import "bootstrap/scaffolding";
 @import "bootstrap/type";
 @import "bootstrap/code";
-@import "bootstrap/grid";
+// @import "bootstrap/grid"; // Use Bootstrap 4 grid system (using flex)
 @import "bootstrap/tables";
 @import "bootstrap/forms";
 @import "bootstrap/buttons";

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -78,7 +78,7 @@
       display: inline-block;
       font-size: 18px;
       margin-right: 24px; // space for bookmark button
-      margin-bottom: .5rem;
+      margin-bottom: $space-md;
       vertical-align: middle;
       @include breakpoints(mid-small) {
         font-size: 24px;

--- a/src/sass/components/_device-menu.scss
+++ b/src/sass/components/_device-menu.scss
@@ -20,10 +20,14 @@
 
 @include breakpoints(max nav){
   .sidebar-menu {
-    // display: none;
+    // Hacky grid system overrides
+    display: none;
   }
-  .col-xs-8-container {
+  .col-8-container {
+    // Hacky grid system overrides
     width: 100%;
+    max-width: 100%;
+    flex: 0 0 100%;
   }
   .container-main {
     margin-bottom: -72px;

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -11,22 +11,23 @@
       display: none; // Hide Support/Oppose button labels on small screens
     }
   }
-  &__btn--comment {
-    margin-right: .5em;
-  }
 }
 
 
 // This style is for when the item-actionbar is added to a line with other elements (like for a candidate on ballot page)
-.item-actionbar-inline {
+.item-actionbar--inline {
   display: flex;
-  border-top: 1px solid $gray-lighter;
-  margin: 1em 0;
   padding-top: 0px;
+  justify-content: flex-end;
+  flex: auto;
 
   &__position-btn-label {
     //@include breakpoints (max large) {
       display: none; // Hide Support/Oppose button labels on all screens
     //}
+  }
+  .btn-group {
+    display: flex;
+    flex-wrap: nowrap;
   }
 }

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -9,13 +9,15 @@
   position: relative;
   display: flex;
   align-items: center;
+  flex: 5 0 130px;
+  min-width: 130px; // flex-basis not being respected (Chrome)
 
   &__bar-well {
     display: block;
     position: relative;
     margin-right: $space-sm;
     margin-left: $space-sm;
-    flex-grow: 5;
+    flex: 5 0 48px;
     height: $bar-height;
     border-radius: 3em;
     background-color: $gray-light;

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -8,14 +8,13 @@
   $icon-size: 20px;
   position: relative;
   display: flex;
-  //margin-top: .5rem;
+  align-items: center;
 
   &__bar-well {
     display: block;
     position: relative;
-    margin-top: ($icon-size - $bar-height) / 2;
-    margin-right: 5px;
-    margin-left: 5px;
+    margin-right: $space-sm;
+    margin-left: $space-sm;
     flex-grow: 5;
     height: $bar-height;
     border-radius: 3em;
@@ -45,16 +44,14 @@
 
   &__support,
   &__oppose {
-    overflow: visible;
-    width: $icon-size;
-    display: flex; // temp - rewrite
+    display: flex;
+    align-items: center;
+    flex: none;
   }
 
   &__count {
     text-align: center;
-    padding-top: 3px;
     color: $gray-dark;
-    min-height: 1.5em; // spacer for .network-positions__bar-label
   }
 
   &__bar--support {

--- a/src/sass/utility/_u-layout.scss
+++ b/src/sass/utility/_u-layout.scss
@@ -57,7 +57,3 @@
 .u-inset__v--md { padding-top: $space-md; padding-bottom: $space-md; }
 .u-inset__v--lg { padding-top: $space-lg; padding-bottom: $space-lg; }
 .u-inset__v--xl { padding-top: $space-xl; padding-bottom: $space-xl; }
-
-// Spacing
-.u-inset__minimum-width--100px { min-width: 100px; }
-.u-inset__minimum-width--120px { min-width: 120px; }

--- a/src/sass/utility/_u-typography.scss
+++ b/src/sass/utility/_u-typography.scss
@@ -58,14 +58,6 @@
 
 // Alignment
 
-.u-tr {
-  text-align: right;
-}
-
-.u-tc {
-  text-align: center;
-}
-
-.u-tl {
-  text-align: left;
-}
+.u-tr { text-align: right; }
+.u-tc { text-align: center; }
+.u-tl { text-align: left; }


### PR DESCRIPTION
**This PR:**
- Cleans up layout for 'compressed' office and measure views
- Switches grid system over to the Bootstrap 4 version using flexbox. Even though this wasn't ultimately used for this layout update, it will provide some new layout options moving forward.

**To note:**
- spacing is still not ideal on small screens due to the button width of selected [support/oppose] position dropdowns
- Measure descriptions are not set up to span the full width on smaller screens. We can address this separately.
- For additional layout/design updates, better design specifications would be useful.

resolves #654 