### PR TITLE
Individual friend invite with first_name, last_name, email_address

### DIFF
--- a/src/js/actions/FriendActions.js
+++ b/src/js/actions/FriendActions.js
@@ -29,9 +29,13 @@ module.exports = {
     } );
   },
 
-  friendInvitationByEmailSend: function (email_addresses, invitation_message, sender_email_address) {
+  friendInvitationByEmailSend: function ( email_address_array, first_name_array, last_name_array, email_addresses,
+                                          invitation_message, sender_email_address) {
     Dispatcher.loadEndpoint("friendInvitationByEmailSend",
       {
+        email_address_array: email_address_array,
+        first_name_array: first_name_array,
+        last_name_array: last_name_array,
         email_addresses_raw: email_addresses,
         invitation_message: invitation_message,
         sender_email_address: sender_email_address


### PR DESCRIPTION
1) Added a email validation function
2) Original file of Add friends moved to a new file for bulk email invitations
3) modified add friends to incorporate first_name, last_name, email_address
4) API changes to process request in the backend

### What github.com/wevote/WebApp/issues does this fix?
635
### Changes included this pull request?
