### PR TITLE
Add Invites button disabled after 5 rows displayed

### DIFF
--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -411,8 +411,8 @@ export default class AddFriendsByEmail extends Component {
         <div>
           <form onSubmit={this.prepareApiArraysFromForm.bind(this)}>
             <div className="container-fluid">
-              <div className="row">
-                <div className="form-group col-xs-6 col-sm-6 col-md-6">
+              <div className="row invite-inputs">
+                <div className="form-group col-12 col-sm-12 col-md-6">
                   <label>Email Address</label>
                   <div className="input-group">
                     <input type="text" name="friend1_email_address"
@@ -422,7 +422,7 @@ export default class AddFriendsByEmail extends Component {
                       placeholder="name@domain.com"/>
                 </div>
               </div>
-              <div className="form-group col-xs-3 col-sm-3 col-md-3">
+              <div className="form-group col-6 col-sm-6 col-md-3">
                 <label>First Name</label>
                 <div className="input-group">
                   <input type="text" name="friend1_first_name"
@@ -432,7 +432,7 @@ export default class AddFriendsByEmail extends Component {
                      placeholder="Optional"/>
                 </div>
               </div>
-              <div className="form-group col-xs-3 col-sm-3 col-md-3">
+              <div className="form-group col-6 col-sm-6 col-md-3">
                 <label>Last Name</label>
                 <div className="input-group">
                   <input type="text" name="friend1_last_name"
@@ -444,9 +444,8 @@ export default class AddFriendsByEmail extends Component {
               </div>
             </div>
             {this.state.row2_open ?
-              <div className="row">
-                <span className="close right" name="row2_open" aria-label="Close" onClick={this.closeRow2.bind(this)}><span aria-hidden="true">&times;</span></span>
-                <div className="form-group col-xs-6 col-sm-6 col-md-6">
+              <div className="row invite-inputs">
+                <div className="form-group col-12 col-sm-12 col-md-6">
                   <label>Email Address</label>
                   <div className="input-group">
                     <input type="text" name="friend2_email_address"
@@ -456,7 +455,7 @@ export default class AddFriendsByEmail extends Component {
                        placeholder="name@domain.com"/>
                   </div>
                 </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>First Name</label>
                     <div className="input-group">
                       <input type="text" name="friend2_first_name"
@@ -466,7 +465,7 @@ export default class AddFriendsByEmail extends Component {
                         placeholder="Optional"/>
                     </div>
                   </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>Last Name</label>
                   <div className="input-group">
                     <input type="text" name="friend2_last_name"
@@ -476,12 +475,12 @@ export default class AddFriendsByEmail extends Component {
                       placeholder="Optional"/>
                   </div>
                 </div>
+                <span className="close close-on-right" name="row2_open" aria-label="Close" onClick={this.closeRow2.bind(this)}><span aria-hidden="true">&times;</span></span>
               </div> :
             null}
             {this.state.row3_open ?
-              <div className="row">
-                <span className="close right" aria-label="Close" onClick={this.closeRow3.bind(this)}><span aria-hidden="true">&times;</span></span>
-                <div className="form-group col-xs-6 col-sm-6 col-md-6">
+              <div className="row invite-inputs">
+                <div className="form-group col-12 col-sm-12 col-md-6">
                   <label>Email Address</label>
                   <div className="input-group">
                     <input type="text" name="friend3_email_address"
@@ -491,7 +490,7 @@ export default class AddFriendsByEmail extends Component {
                        placeholder="name@domain.com"/>
                   </div>
                 </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>First Name</label>
                     <div className="input-group">
                       <input type="text" name="friend3_first_name"
@@ -501,7 +500,7 @@ export default class AddFriendsByEmail extends Component {
                         placeholder="Optional"/>
                     </div>
                   </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>Last Name</label>
                   <div className="input-group">
                     <input type="text" name="friend3_last_name"
@@ -511,12 +510,12 @@ export default class AddFriendsByEmail extends Component {
                       placeholder="Optional"/>
                   </div>
                 </div>
+                <span className="close close-on-right" aria-label="Close" onClick={this.closeRow3.bind(this)}><span aria-hidden="true">&times;</span></span>
               </div> :
             null}
             {this.state.row4_open ?
-              <div className="row">
-                <span className="close right" aria-label="Close" onClick={this.closeRow4.bind(this)}><span aria-hidden="true">&times;</span></span>
-                <div className="form-group col-xs-6 col-sm-6 col-md-6">
+              <div className="row invite-inputs">
+                <div className="form-group col-12 col-sm-12 col-md-6">
                   <label>Email Address</label>
                   <div className="input-group">
                     <input type="text" name="friend4_email_address"
@@ -526,7 +525,7 @@ export default class AddFriendsByEmail extends Component {
                        placeholder="name@domain.com"/>
                   </div>
                 </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>First Name</label>
                     <div className="input-group">
                       <input type="text" name="friend4_first_name"
@@ -536,7 +535,7 @@ export default class AddFriendsByEmail extends Component {
                         placeholder="Optional"/>
                     </div>
                   </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>Last Name</label>
                   <div className="input-group">
                     <input type="text" name="friend4_last_name"
@@ -546,12 +545,12 @@ export default class AddFriendsByEmail extends Component {
                       placeholder="Optional"/>
                   </div>
                 </div>
+                <span className="close close-on-right" aria-label="Close" onClick={this.closeRow4.bind(this)}><span aria-hidden="true">&times;</span></span>
               </div> :
             null}
             {this.state.row5_open ?
-              <div className="row">
-                <span className="close right" aria-label="Close" onClick={this.closeRow5.bind(this)}><span aria-hidden="true">&times;</span></span>
-                <div className="form-group col-xs-6 col-sm-6 col-md-6">
+              <div className="row invite-inputs">
+                <div className="form-group col-12 col-sm-12 col-md-6">
                   <label>Email Address</label>
                   <div className="input-group">
                     <input type="text" name="friend5_email_address"
@@ -561,7 +560,7 @@ export default class AddFriendsByEmail extends Component {
                        placeholder="name@domain.com"/>
                   </div>
                 </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>First Name</label>
                     <div className="input-group">
                       <input type="text" name="friend5_first_name"
@@ -571,7 +570,7 @@ export default class AddFriendsByEmail extends Component {
                         placeholder="Optional"/>
                     </div>
                   </div>
-                <div className="form-group col-xs-3 col-sm-3 col-md-3">
+                <div className="form-group col-6 col-sm-6 col-md-3">
                   <label>Last Name</label>
                   <div className="input-group">
                     <input type="text" name="friend5_last_name"
@@ -581,6 +580,7 @@ export default class AddFriendsByEmail extends Component {
                       placeholder="Optional"/>
                   </div>
                 </div>
+                <span className="close close-on-right" aria-label="Close" onClick={this.closeRow5.bind(this)}><span aria-hidden="true">&times;</span></span>
               </div> :
             null}
             <span>

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -47,6 +47,8 @@ export default class AddFriendsByEmail extends Component {
         on_friend_invitations_sent_step: false,
         voter: {},
       };
+
+      this.allRowsOpen.bind(this);
   }
 
   componentDidMount () {
@@ -385,6 +387,10 @@ export default class AddFriendsByEmail extends Component {
       this.setState({ row5_open: true});
   }
 
+  allRowsOpen () {
+    return this.state.row2_open && this.state.row3_open && this.state.row4_open && this.state.row5_open;
+  }
+
 	render () {
 
     var { loading } = this.state;
@@ -587,7 +593,7 @@ export default class AddFriendsByEmail extends Component {
               <Button
                 tabIndex="0"
                 onClick={this.addAnotherInvitation.bind(this)}
-                disabled={!this.state.friend1_email_address}
+                disabled={!this.state.friend1_email_address || this.allRowsOpen()}
               >
                 <span>+ Add another invitation</span>
               </Button>

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -346,30 +346,30 @@ export default class AddFriendsByEmail extends Component {
   }
 
   closeRow2 () {
-    this.setState ({ friend2_email_address: ""});
-    this.setState ({ friend2_first_name: ""});
-    this.setState ({ friend2_last_name: ""});
+    this.setState({ friend2_email_address: ""});
+    this.setState({ friend2_first_name: ""});
+    this.setState({ friend2_last_name: ""});
     this.setState({ row2_open: false});
   }
 
   closeRow3 () {
-    this.setState ({ friend3_email_address: ""});
-    this.setState ({ friend3_first_name: ""});
-    this.setState ({ friend3_last_name: ""});
+    this.setState({ friend3_email_address: ""});
+    this.setState({ friend3_first_name: ""});
+    this.setState({ friend3_last_name: ""});
     this.setState({ row3_open: false});
   }
 
   closeRow4 () {
-    this.setState ({ friend4_email_address: ""});
-    this.setState ({ friend4_first_name: ""});
-    this.setState ({ friend4_last_name: ""});
+    this.setState({ friend4_email_address: ""});
+    this.setState({ friend4_first_name: ""});
+    this.setState({ friend4_last_name: ""});
     this.setState({ row4_open: false});
   }
 
   closeRow5 () {
-   this.setState ({ friend5_email_address: ""});
-    this.setState ({ friend5_first_name: ""});
-    this.setState ({ friend5_last_name: ""});
+   this.setState({ friend5_email_address: ""});
+    this.setState({ friend5_first_name: ""});
+    this.setState({ friend5_last_name: ""});
     this.setState({ row5_open: false});
   }
 

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -583,7 +583,7 @@ export default class AddFriendsByEmail extends Component {
                 <span className="close close-on-right" aria-label="Close" onClick={this.closeRow5.bind(this)}><span aria-hidden="true">&times;</span></span>
               </div> :
             null}
-            <span>
+            <div className="row invite-inputs">
               <Button
                 tabIndex="0"
                 onClick={this.addAnotherInvitation.bind(this)}
@@ -591,7 +591,7 @@ export default class AddFriendsByEmail extends Component {
               >
                 <span>+ Add another invitation</span>
               </Button>
-            </span>
+            </div>
           </div>
 
           </form>

--- a/src/sass/components/_friends.scss
+++ b/src/sass/components/_friends.scss
@@ -3,6 +3,10 @@
   margin-bottom: 20px;
 }
 
+.invite-inputs .input-group {
+  width: 100%;
+}
+
 .close-on-right {
   position: absolute;
   top: 2rem;

--- a/src/sass/components/_friends.scss
+++ b/src/sass/components/_friends.scss
@@ -1,0 +1,10 @@
+.invite-inputs {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+.close-on-right {
+  position: absolute;
+  top: 2rem;
+  right: -5px;
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -74,6 +74,7 @@
 @import 'components/itemActionBar';
 @import 'components/itemPositionStatementActionBar';
 @import 'components/starAction';
+@import 'components/friends';
 
 // -------------------------------
 // Sections


### PR DESCRIPTION
Fix for issue #699.

• add helper function to check if all rows are already displayed (returns boolean);
• if so, disable "Add another invitation" button;
• add a bit of margin to bottom of button.
