### PR TITLE
Add basic print formatting (for ballot) and light cleanup for Ballot Item 

### DIFF
--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from "react";
 import { browserHistory } from "react-router";
 import BallotActions from "../../actions/BallotActions";
 import VoterActions from "../../actions/VoterActions";
-let moment = require('moment');
+let moment = require("moment");
 
 export default class BallotElectionList extends Component {
 

--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -115,7 +115,7 @@ export default class MeasureItemCompressed extends Component {
           {/*Mobile ballot info*/}
         <div
           className={ this.props.link_to_ballot_item_page ?
-          "u-cursor--pointer mobile-subtitle" : null }
+          "u-cursor--pointer visible-xs" : null }
           onClick={ this.props.link_to_ballot_item_page ?
           goToMeasureLink : null }
         >
@@ -128,7 +128,7 @@ export default class MeasureItemCompressed extends Component {
 
               <div className="MeasureItem__summary u-flex-auto u-inline--sm">
                 <div className={ this.props.link_to_ballot_item_page ?
-                        "u-cursor--pointer desktop-subtitle" : null }
+                        "u-cursor--pointer hidden-xs" : null }
                       onClick={ this.props.link_to_ballot_item_page ?
                         goToMeasureLink : null }>{measure_subtitle}</div>
                 { this.props.measure_text ?

--- a/src/js/components/Ballot/MeasureItemReadyToVote.jsx
+++ b/src/js/components/Ballot/MeasureItemReadyToVote.jsx
@@ -58,7 +58,7 @@ export default class MeasureItemReadyToVote extends Component {
       <div className="card-main__content">
         <div className="u-flex u-items-center">
 
-        <div className="u-flex-auto u-inline--sm u-cursor--pointer">
+        <div className="u-flex-auto u-cursor--pointer">
           <h2 className="card-main__display-name">
             { this.props.link_to_ballot_item_page ?
               <Link to={measureLink}>{ballot_item_display_name}</Link> :
@@ -69,29 +69,39 @@ export default class MeasureItemReadyToVote extends Component {
 
         {
           supportProps && supportProps.is_support ?
-         <div className="u-flex-none u-justify-end u-inline--sm"> Supported by you &nbsp; <img src="/img/global/svg-icons/thumbs-up-color-icon.svg"
-               className="card-main__position-icon-vote" width="24" height="24" /></div> :
+         <div className="u-flex-none u-justify-end">
+           <span className="u-inline--xs">Supported by you</span>
+           <img src="/img/global/svg-icons/thumbs-up-color-icon.svg" width="24" height="24" />
+         </div> :
           null
         }
         {
           supportProps && supportProps.is_oppose ?
-            <div className="u-flex-none u-justify-end u-inline--sm"> Opposed by you &nbsp; <img src="/img/global/svg-icons/thumbs-down-color-icon.svg" className="card-main__position-icon-vote" width="24" height="24" /></div> :
+            <div className="u-flex-none u-justify-end">
+              <span className="u-inline--xs">Opposed by you</span>
+              <img src="/img/global/svg-icons/thumbs-down-color-icon.svg" width="24" height="24" />
+            </div> :
               null
         }
         {
           supportProps && !supportProps.is_support && !supportProps.is_oppose && supportProps.support_count > supportProps.oppose_count ?
-          <div className="u-flex-none u-justify-end u-inline--sm"> Your network supports &nbsp; <img src= "/img/global/icons/up-arrow-color-icon.svg" className="network-positions__support-icon" width="20" height="20" /></div> :
+          <div className="u-flex-none u-justify-end">
+            <span className="u-inline--xs">Your network supports</span>
+            <img src= "/img/global/icons/up-arrow-color-icon.svg" className="network-positions__support-icon" width="20" height="20" />
+          </div> :
           null
         }
         {
           supportProps && !supportProps.is_support && !supportProps.is_oppose && supportProps.support_count < supportProps.oppose_count ?
-          <div className="u-flex-none u-justify-end u-inline--sm">
-             Your network opposes &nbsp; <img src= "/img/global/icons/down-arrow-color-icon.svg" className="network-positions__oppose-icon" width="20" height="20" /></div> :
+          <div className="u-flex-none u-justify-end">
+             <span className="u-inline--xs">Your network opposes</span>
+             <img src= "/img/global/icons/down-arrow-color-icon.svg" className="network-positions__oppose-icon" width="20" height="20" />
+           </div> :
           null
         }
         {
           supportProps && !supportProps.is_support && !supportProps.is_oppose && supportProps.support_count === supportProps.oppose_count ?
-          <div className="u-flex-none u-justify-end u-inline--sm"> Your network is undecided &nbsp; </div> :
+          <div className="u-flex-none u-justify-end">Your network is undecided</div> :
           null
         }
 

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -73,28 +73,29 @@ export default class OfficeItemCompressed extends Component {
               <span onClick={ this.props.link_to_ballot_item_page ?
                               ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
                               null }
-                    className="h5 mobileCandName">
-                <ImageHandler className="card-main__avatar"
-                              sizeClassName="icon-candidate-small "
+                    className="visible-xs u-stack--sm">
+                <ImageHandler className="card-main__avatar u-inline--sm"
+                              sizeClassName="icon-candidate-small u-inline--sm "
                               imageUrl={one_candidate.candidate_photo_url}
                               alt="candidate-photo"
                               kind_of_ballot_item="CANDIDATE" />
-                 <span className="mobileCandNameText">{one_candidate.ballot_item_display_name}</span>
+                 <span className="h5">{one_candidate.ballot_item_display_name}</span>
               </span>
               <div className="u-flex u-items-center">
                 {/* *** Candidate name *** */}
-                <div className="u-flex-auto u-inline--sm u-cursor--pointer"
+                <div className="u-flex u-flex-auto u-inline--sm u-cursor--pointer"
                     onClick={ this.props.link_to_ballot_item_page ?
                               ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
                               null }>
-                  <span className="hidden-xs">
-                    <ImageHandler className="card-main__avatar"
-                                  sizeClassName="icon-candidate-small "
+                  <div className="hidden-xs">
+                    <ImageHandler className="card-main__avatar u-inline--sm"
+                                  sizeClassName="icon-candidate-small u-inline--sm "
                                   imageUrl={one_candidate.candidate_photo_url}
                                   alt="candidate-photo"
                                   kind_of_ballot_item="CANDIDATE" />
-                  </span>
-              <span className="h5 desktopCandName">{one_candidate.ballot_item_display_name}</span>
+
+              <span className="h5">{one_candidate.ballot_item_display_name}</span>
+              </div>
                 </div>
 
                 {/* *** "Positions in your Network" bar OR items you can follow *** */}

--- a/src/js/components/Ballot/OfficeItemReadyToVote.jsx
+++ b/src/js/components/Ballot/OfficeItemReadyToVote.jsx
@@ -112,30 +112,35 @@ export default class OfficeItemReadyToVote extends Component {
               {/* *** Candidate name *** */}
               { SupportStore.get(one_candidate.we_vote_id) && SupportStore.get(one_candidate.we_vote_id).is_support ?
                 <div className="u-flex u-items-center">
-                  <div className="u-flex-auto u-inline--sm u-cursor--pointer" onClick={ this.props.link_to_ballot_item_page ?
+                  <div className="u-flex-auto u-cursor--pointer" onClick={ this.props.link_to_ballot_item_page ?
                   goToOfficeLink : null }>
-                    <h2 className="h5 desktopCandName">
+                    <h2 className="h5 hidden-xs">
                     {one_candidate.ballot_item_display_name}
                     </h2>
                   </div>
 
-                  <div className="u-flex-none u-justify-end u-inline--sm">Supported by you &nbsp; <img src="/img/global/svg-icons/thumbs-up-color-icon.svg"
-                    className="card-main__position-icon-vote" width="24" height="24" /></div>
+                  <div className="u-flex-none u-justify-end">
+                    <span className="u-inline--xs">Supported by you</span>
+                    <img src="/img/global/svg-icons/thumbs-up-color-icon.svg" width="24" height="24" />
+                  </div>
                 </div> :
 
                   candidate_with_most_support === one_candidate.ballot_item_display_name ?
 
                 <div className="u-flex u-items-center">
-                  <div className="u-flex-auto u-inline--sm u-cursor--pointer" onClick={ this.props.link_to_ballot_item_page ?
+                  <div className="u-flex-auto u-cursor--pointer" onClick={ this.props.link_to_ballot_item_page ?
                     goToOfficeLink : null }>
-                    <h2 className="h5 desktopCandName">
+                    <h2 className="h5 hidden-xs">
                       {one_candidate.ballot_item_display_name}
                     </h2>
                   </div>
-                  <div className="u-flex-none u-justify-end u-inline--sm">Your network supports &nbsp; <img src="/img/global/icons/up-arrow-color-icon.svg" className="network-positions__support-icon" width="20" height="20" /></div>
+                  <div className="u-flex-none u-justify-end">
+                    <span className="u-inline--xs">Your network supports</span>
+                    <img src="/img/global/icons/up-arrow-color-icon.svg" className="network-positions__support-icon" width="20" height="20" />
+                  </div>
                 </div> :
                   is_support_array === 0 && candidate_with_most_support !== one_candidate.ballot_item_display_name && !voter_supports_at_least_one_candidate ?
-                  <div className="u-flex-none u-justify-end u-inline--sm">Your network is undecided</div> :
+                  <div className="u-flex-none u-justify-end">Your network is undecided</div> :
                     null}
               {/* *** "Positions in your Network" bar OR items you can follow *** */}
           </div>)
@@ -145,7 +150,7 @@ export default class OfficeItemReadyToVote extends Component {
             <span>
               { at_least_one_candidate_chosen ?
                 null :
-                <div className="pull-right">Your network is undecided</div> }
+                <div className="u-tr">Your network is undecided</div> }
             </span> }
         </div>
       </div>

--- a/src/js/components/Friends/AddFriendsByEmailBulk.jsx
+++ b/src/js/components/Friends/AddFriendsByEmailBulk.jsx
@@ -91,7 +91,7 @@ export default class AddFriendsByEmail extends Component {
 
   friendInvitationByEmailSend (e) {
     e.preventDefault();
-    FriendActions.friendInvitationByEmailSend("","","",this.state.email_addresses, this.state.add_friends_message, this.state.sender_email_address);
+    FriendActions.friendInvitationByEmailSend("", "", "", this.state.email_addresses, this.state.add_friends_message, this.state.sender_email_address);
     this.setState({
       loading: true,
       email_addresses: "",

--- a/src/js/components/Friends/AddFriendsByFacebook.jsx
+++ b/src/js/components/Friends/AddFriendsByFacebook.jsx
@@ -64,7 +64,7 @@ export default class AddFriendsByFacebook extends Component {
 
   friendInvitationByEmailSend (e) {
     e.preventDefault();
-    FriendActions.friendInvitationByEmailSend("", "", "",this.state.email_addresses, this.state.add_friends_message);
+    FriendActions.friendInvitationByEmailSend("", "", "", this.state.email_addresses, this.state.add_friends_message);
     this.setState({
       loading: true,
       email_addresses: "",

--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -108,7 +108,7 @@ export default class SearchAllBox extends Component {
     // Hide the hamburger navigation and site name
     // TODO: convert to flux action
     // for the global nav
-   
+
     this.siteLogoText.addClass("hideItem");
     this.ballot.addClass("deskOnly");
     this.requests.addClass("deskOnly");

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -345,7 +345,7 @@ export default class Ballot extends Component {
       </Modal>;
 
     // This modal will show a users ballot guides from previous and current elections.
-    const SelectBallotModal = <Modal show={this.state.showSelectBallotModal} onHide={()=>{this._toggleSelectBallotModal()}}
+    const SelectBallotModal = <Modal show={this.state.showSelectBallotModal} onHide={()=>{this._toggleSelectBallotModal();}}
       className="ballot-election-list ballot-election-list__modal">
       <Modal.Header closeButton>
         <Modal.Title className="ballot-election-list__h1">See Ballot from Another Election</Modal.Title>
@@ -354,7 +354,7 @@ export default class Ballot extends Component {
         <BallotElectionList ballot_election_list={this.state.ballot_election_list}
           _toggleSelectBallotModal={this._toggleSelectBallotModal}/>
       </Modal.Body>
-    </Modal>
+    </Modal>;
 
     let ballot = this.state.ballot;
     var voter_address = VoterStore.getAddress();
@@ -416,7 +416,8 @@ export default class Ballot extends Component {
         <Helmet title="Ballot - We Vote" />
         <BrowserPushMessage incomingProps={this.props} />
         <OverlayTrigger placement="top" overlay={electionTooltip} >
-          <h1 className="h1 ballot__election-name">{election_name}
+          <h1 className="h1 ballot__election-name">
+            <span className="u-inline--sm">{election_name}</span>
             {this.state.ballot_election_list.length > 1 ? <img src={"/img/global/icons/gear-icon.png"} className="hidden-print" role="button" onClick={this._toggleSelectBallotModal}
              alt={"view your ballots"}/> : null}
           </h1>

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -417,15 +417,15 @@ export default class Ballot extends Component {
         <BrowserPushMessage incomingProps={this.props} />
         <OverlayTrigger placement="top" overlay={electionTooltip} >
           <h1 className="h1 ballot__election-name">{election_name}
-            {this.state.ballot_election_list.length > 1 ? <span><img src={"/img/global/icons/gear-icon.png"} role="button" onClick={this._toggleSelectBallotModal}
-             alt={"view your ballots"}/></span> : null}
+            {this.state.ballot_election_list.length > 1 ? <img src={"/img/global/icons/gear-icon.png"} className="hidden-print" role="button" onClick={this._toggleSelectBallotModal}
+             alt={"view your ballots"}/> : null}
           </h1>
         </OverlayTrigger>
         <p className="ballot__date_location">
           {voter_address}
-          <span> (<Link to="/settings/location">Edit</Link>)</span>
+          <span className="hidden-print"> (<Link to="/settings/location">Edit</Link>)</span>
         </p>
-        <div className="ballot__filter"><BallotFilter ballot_type={this.getBallotType()} /></div>
+        <div className="ballot__filter hidden-print"><BallotFilter ballot_type={this.getBallotType()} /></div>
       </div>
       {/* TO BE DISCUSSED ballot_caveat !== "" ?
         <div className="alert alert alert-info alert-dismissible" role="alert">n
@@ -434,14 +434,15 @@ export default class Ballot extends Component {
         </div> : null
       */}
       {emptyBallot}
-
-      { in_ready_to_vote_mode ?
-        ballot.map( (item) => <BallotItemReadyToVote key={item.we_vote_id} {...item} />) :
-        ballot.map( (item) => <BallotItemCompressed _toggleCandidateModal={this._toggleCandidateModal}
-                                                    _toggleMeasureModal={this._toggleMeasureModal}
-                                                    key={item.we_vote_id}
-                                                    {...item} />)
-      }
-      </div>;
+      <div className="BallotList">
+        { in_ready_to_vote_mode ?
+          ballot.map( (item) => <BallotItemReadyToVote key={item.we_vote_id} {...item} />) :
+          ballot.map( (item) => <BallotItemCompressed _toggleCandidateModal={this._toggleCandidateModal}
+                                                      _toggleMeasureModal={this._toggleMeasureModal}
+                                                      key={item.we_vote_id}
+                                                      {...item} />)
+        }
+      </div>
+    </div>;
   }
 }

--- a/src/sass/base/_fonts.scss
+++ b/src/sass/base/_fonts.scss
@@ -55,10 +55,6 @@
 i.icon-candidate-small.icon-main.icon-icon-person-placeholder-6-1 {
     vertical-align: middle;
 }
-.icon-icon-person-placeholder-6-1 + span.mobileCandNameText {
-    bottom: 2px;
-    position: relative;
-}
 .icon-icon-org-placeholder-6-2:before {
     content: "c";
 }

--- a/src/sass/base/_mixins.scss
+++ b/src/sass/base/_mixins.scss
@@ -59,3 +59,11 @@
   overflow: hidden;
   white-space: nowrap;
 }
+
+// Print mixin
+
+@mixin print {
+  @media print {
+    @content;
+  }
+}

--- a/src/sass/components/_ballotList.scss
+++ b/src/sass/components/_ballotList.scss
@@ -1,3 +1,9 @@
+.BallotList {
+  @include print {
+    column-count: 2;
+  }
+}
+
 .BallotItem {
   position: relative;
   margin-bottom: 1em;

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -25,6 +25,9 @@
     position: relative;
     padding: 15px $item-padding 10px;
     font-size: 14px; // remove once global defaults are set
+    @include print {
+      padding: 0;
+    }
 
     &__content {
       position: relative;
@@ -45,6 +48,10 @@
             @include breakpoints(mid-small){
               display: none;
             }
+       }
+       @include print {
+         border-top: 1px solid $gray-mid;
+         padding-top: 1em;
        }
     }
 
@@ -106,6 +113,9 @@
       vertical-align: middle;
       @include breakpoints(mid-small) {
         font-size: 24px;
+      }
+      @include print {
+        font-size: 18px;
       }
     }
 
@@ -307,4 +317,3 @@
 .bm-burger-button button {
   color:red;
 }
-

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -31,28 +31,10 @@
 
     &__content {
       position: relative;
-      & .h5.mobileCandName {
-        @include breakpoints(mid-small){
-          display: none;
-        }
+      @include print {
+        border-top: 1px solid $gray-mid;
+        padding-top: 1em;
       }
-       & .desktopCandName, .desktop-subtitle {
-          display: none;
-          @include breakpoints(mid-small){
-            display: initial;
-          }
-        }
-
-        & .mobile-subtitle {
-          display: block;
-            @include breakpoints(mid-small){
-              display: none;
-            }
-       }
-       @include print {
-         border-top: 1px solid $gray-mid;
-         padding-top: 1em;
-       }
     }
 
     &__media_object {
@@ -98,10 +80,6 @@
       display: inline-block;
       margin-right: 5px;
       vertical-align: text-bottom;
-    }
-    &__position-icon-vote {
-      display: inline-block;
-      margin-right: 5px;
     }
 
     &__display-name {

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -93,3 +93,4 @@
 // ===============================================
 
 @import 'overrides/overrides.scss';
+@import 'overrides/print.scss';

--- a/src/sass/overrides/_print.scss
+++ b/src/sass/overrides/_print.scss
@@ -1,0 +1,21 @@
+@media print {
+  body {
+    background-color: #fff !important;
+    color: #000;
+  }
+  .headroom-wrapper,
+  .page-header__container,
+  .sidebar-menu {
+    display: none;
+  }
+  .container-main {
+    width: 100%;
+  }
+  // 'No print' utility class from Bootstrap is .hidden-print
+  %hidden-print {
+    display: none;
+  }
+  a[href]::after {
+    content: ""; // Override Bootstrap styles adding href
+  }
+}


### PR DESCRIPTION
- Addresses #707 - Adds basic print formatting cleanup for `/ballot`. 
  - Removing high level app/layout sections can be targeted in `_print.scss`. Smaller individual elements can be hidden for print with `.hidden-print`
- Addresses #704 - I tried to find a good balance of doing some cleanup but not getting too deep in the weeds. 
- Also resolved a few random linter warnings