### PR TITLE
header profile should always show the account menu #696

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "object-assign": "^4.0.1",
     "react": "^15.4.2",
     "react-bootstrap-toggle": "^1.2.19",
-    "react-burger-menu": "^1.10.10",
     "react-copy-to-clipboard": "^4.2.3",
     "react-dom": "^15.4.2",
     "react-headroom": "^2.1.3",

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -5,13 +5,6 @@ import NavigatorInHeader from "./NavigatorInHeader";
 import SearchAllBox from "../SearchAllBox";
 import BookmarkStore from "../../stores/BookmarkStore";
 var Icon = require("react-svg-icons");
-const ReactBurgerMenu = require("react-burger-menu").push;
-
-var menuStyles = {
-  bmMenu: {
-    height: "100vh"
-  }
-};
 
 export default class HeaderBar extends Component {
   static propTypes = {
@@ -21,7 +14,9 @@ export default class HeaderBar extends Component {
 
   constructor (props) {
     super(props);
-    this.state = { bookmarks: [] };
+    this.state = { bookmarks: [], accountMenuOpen: false };
+    this.toggleAccountMenu = this.toggleAccountMenu.bind(this);
+    this.hideAccountMenu = this.hideAccountMenu.bind(this);
   }
 
   componentDidMount () {
@@ -39,57 +34,27 @@ export default class HeaderBar extends Component {
     this.setState({bookmarks: BallotStore.bookmarks });
   }
 
-  hide () {
-    const menuButton = document.querySelector(".bm-burger-button > button");
-    menuButton.click();
+  toggleAccountMenu () {
+    this.setState({accountMenuOpen: !this.state.accountMenuOpen});
   }
 
-  render () {
-    var { pathname } = this.props;
-    var { linked_organization_we_vote_id, signed_in_facebook, signed_in_twitter, twitter_screen_name, voter_photo_url } = this.props.voter;
+  hideAccountMenu () {
+    this.setState({accountMenuOpen: false});
+  }
 
-    let image_placeholder = "";
-    let speaker_type = "V";  // TODO DALE make this dynamic
-    if (speaker_type === "O") {
-        image_placeholder = <span id= "anonIcon" className="position-statement__avatar"><Icon name="avatar-generic" width={34} height={34} /></span>;
-    } else {
-        image_placeholder = <span id= "anonIcon" className="position-statement__avatar"><Icon name="avatar-generic" width={34} height={34} /></span>;
-    }
+  accountMenu () {
+
+    var { linked_organization_we_vote_id, signed_in_facebook, signed_in_twitter, twitter_screen_name } = this.props.voter;
 
     let show_your_page_from_twitter = signed_in_twitter && twitter_screen_name;
     let show_your_page_from_facebook = signed_in_facebook && linked_organization_we_vote_id && !show_your_page_from_twitter;
 
-    return <header className="page-header">
-      <div className="page-header__content">
-        <Link to="/ballot" className="page-logo h4 fullscreen">
-          We Vote
-          <span className="page-logo__version"> alpha</span>
-        </Link>
+    let accountMenuOpen = this.state.accountMenuOpen ? "account-menu-open" : "";
 
-        <Link to="/ballot" className="page-logo h4 mobile">
-          WV
-        </Link>
-        <NavigatorInHeader pathname={pathname} />
-        <SearchAllBox />
-
-      <ReactBurgerMenu
-        customBurgerIcon={
-            <div id ="mobileAvatar">
-              {voter_photo_url ?
-                <div id="avatarContainer">
-                    <img className="position-statement__avatar"
-                          src={voter_photo_url}
-                          id="navIcon"
-                     />
-                </div> : image_placeholder}
-             </div> }
-           className="burgerNav"
-           pageWrapId={ "" }
-           outerContainerId={ "app" }
-           styles={ menuStyles }
-           right
-        >
-        <div className="device-menu--mobile">
+    return (
+      <div className={accountMenuOpen}>
+      <div className="page-overlay" onClick={this.hideAccountMenu} />
+      <div className="account-menu">
           <ul className="nav nav-stacked">
             <li>
               <div><span className="we-vote-promise">Our Promise: We'll never sell your email.</span></div>
@@ -99,16 +64,8 @@ export default class HeaderBar extends Component {
           <ul className="nav nav-stacked">
             { show_your_page_from_twitter ?
               <li>
-                <Link onClick={this.hide.bind(this)} to={"/" + twitter_screen_name}>
+                <Link onClick={this.hideAccountMenu.bind(this)} to={"/" + twitter_screen_name}>
                   <div>
-                    { voter_photo_url ?
-                      <img
-                        className="position-statement__avatar"
-                        src={voter_photo_url}
-                        width="34px"
-                        id="leftAvatar"
-                      /> :
-                      image_placeholder }
                     <span className="header-slide-out-menu-text-left">Your Voter Guide</span>
                   </div>
                 </Link>
@@ -117,14 +74,8 @@ export default class HeaderBar extends Component {
             }
             { show_your_page_from_facebook ?
               <li>
-                <Link onClick={this.hide.bind(this)} to={"/voterguide/" + linked_organization_we_vote_id}>
+                <Link onClick={this.hideAccountMenu.bind(this)} to={"/voterguide/" + linked_organization_we_vote_id}>
                   <div>
-                    { voter_photo_url ?
-                      <img className="position-statement__avatar"
-                            src={voter_photo_url}
-                            width="34px"
-                      /> :
-                      image_placeholder }
                     <span className="header-slide-out-menu-text-left">Your Voter Guide</span>
                   </div>
                 </Link>
@@ -133,7 +84,7 @@ export default class HeaderBar extends Component {
             }
             { !show_your_page_from_twitter && !show_your_page_from_facebook ?
               <li>
-                <Link onClick={this.hide.bind(this)} to="/yourpage">
+                <Link onClick={this.hideAccountMenu.bind(this)} to="/yourpage">
                   <div>
                     <span className="header-slide-out-menu-text-left">Your Voter Guide</span>
                   </div>
@@ -142,7 +93,7 @@ export default class HeaderBar extends Component {
               null
             }
             <li>
-              <Link onClick={this.hide.bind(this)} to="/more/sign_in">
+              <Link onClick={this.hideAccountMenu.bind(this)} to="/more/sign_in">
                 <div>
                   <span className="header-slide-out-menu-text-left">Your Account</span>
                 </div>
@@ -150,22 +101,22 @@ export default class HeaderBar extends Component {
             </li>
             { this.state.bookmarks && this.state.bookmarks.length ?
               <li>
-                <Link onClick={this.hide.bind(this)} to="/bookmarks">
+                <Link onClick={this.hideAccountMenu.bind(this)} to="/bookmarks">
                   <div>
                     <span className="header-slide-out-menu-text-left">Your Bookmarked Items</span>
                   </div>
                 </Link>
               </li> :
               null }
-            <li className="mobile">
-              <Link onClick={this.hide.bind(this)} to="/more/about">
+            <li className="">
+              <Link onClick={this.hideAccountMenu.bind(this)} to="/more/about">
                 <div>
                   <span className="header-slide-out-menu-text-left">About <strong>We Vote</strong></span>
                 </div>
               </Link>
             </li>
-            <li className="mobile">
-              <Link onClick={this.hide.bind(this)} to="/more/donate">
+            <li className="">
+              <Link onClick={this.hideAccountMenu.bind(this)} to="/more/donate">
                 <div>
                   <span className="header-slide-out-menu-text-left">Donate</span>
                 </div>
@@ -174,23 +125,54 @@ export default class HeaderBar extends Component {
           </ul>
           <span className="terms-and-privacy">
             <br />
-            <Link onClick={this.hide.bind(this)} to="/more/terms">Terms of Service</Link>&nbsp;&nbsp;&nbsp;<Link onClick={this.hide.bind(this)} to="/more/privacy">Privacy Policy</Link>
+            <Link onClick={this.hideAccountMenu.bind(this)} to="/more/terms">Terms of Service</Link>&nbsp;&nbsp;&nbsp;<Link onClick={this.hideAccountMenu.bind(this)} to="/more/privacy">Privacy Policy</Link>
           </span>
         </div>
-      </ReactBurgerMenu>
-      <div id = "desktopAvatar">
-        { voter_photo_url ?
-            <div id="avatarContainer">
-              <img
-                className="position-statement__avatar"
-                src={voter_photo_url}
-                width="34px"
-                id="leftAvatar"
-              />
-            </div> :
-            image_placeholder }
-        </div>
       </div>
-    </header>;
+    );
+  }
+
+  imagePlaceholder (speaker_type) {
+    let image_placeholder = "";
+    if (speaker_type === "O") {
+        image_placeholder = <span id= "anonIcon" className="position-statement__avatar"><Icon name="avatar-generic" width={34} height={34} /></span>;
+    } else {
+        image_placeholder = <span id= "anonIcon" className="position-statement__avatar"><Icon name="avatar-generic" width={34} height={34} /></span>;
+    }
+    return image_placeholder;
+  }
+
+  render () {
+    var { pathname } = this.props;
+    var { voter_photo_url } = this.props.voter;
+    let speaker_type = "V";  // TODO DALE make this dynamic
+
+    return (
+      <header className="page-header">
+        <div className="page-header__content">
+          <Link to="/ballot" className="page-logo h4 fullscreen">
+            We Vote
+            <span className="page-logo__version"> alpha</span>
+          </Link>
+
+          <Link to="/ballot" className="page-logo h4 mobile">
+            WV
+          </Link>
+          <NavigatorInHeader pathname={pathname} />
+          <SearchAllBox />
+
+          <div id="avatar" onClick={this.toggleAccountMenu}>
+            {voter_photo_url ?
+              <div id="avatarContainer">
+                  <img className="position-statement__avatar"
+                        src={voter_photo_url}
+                        id="navIcon"
+                   />
+              </div> : this.imagePlaceholder(speaker_type)}
+           </div>
+        </div>
+        {this.accountMenu()}
+      </header>
+    );
   }
 }

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -10,7 +10,7 @@ $icon-color-hover: $gray-dark;
 
 // Header Nav
 // ================================
-.donate,.about,.deskOnly,.fullscreen,#desktopAvatar{
+.donate,.about,.deskOnly,.fullscreen {
   display: none;
   @include breakpoints(nav){ // 2
     display: block;
@@ -31,6 +31,54 @@ $icon-color-hover: $gray-dark;
   display: none;
 }
 
+.account-menu {
+  max-width: 320px;
+  position: absolute;
+  right: 0;
+  top: 50px;
+  background-color: #fff;
+  opacity: 0;
+  padding: 1rem;
+  transition: opacity 0.25s ease-in-out;
+  z-index: 2;
+}
+
+.account-menu:before{
+    content:'';
+    display:block;
+    width:0;
+    height:0;
+    position:absolute;
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid #fff;
+    border-right:8px solid transparent;
+    border-left:8px solid transparent;
+    right:10px;
+    top:-16px;
+}
+
+.page-overlay {
+  position: fixed;
+  width: 200vw;
+  height: 200vh;
+  top: -10px;
+  left: -10px;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 2;
+  pointer-events: none;
+  transition: opacity 0.4s ease-in-out;
+  opacity: 0;
+}
+
+.account-menu-open .page-overlay {
+  display: block;
+  opacity: 1;
+  pointer-events: all;
+}
+
+.account-menu-open .account-menu {
+  opacity: 1;
+}
 
 .header-nav {
   display: flex; // 1
@@ -129,10 +177,10 @@ $icon-color-hover: $gray-dark;
 // ================================
 
 div {
-  &#mobileAvatar {
+  &#avatar {
     bottom: 20px;
-    position: relative;
     right: 10px;
+    z-index: 3; //to float above the account menu option grey div
   }
   &#avatarContainer {
     width: 36px;
@@ -141,15 +189,4 @@ div {
       width: 33px;
     }
   }
-  &#desktopAvatar {
-    top: 2px;
-    position: relative;
-  }
-}
-
-.bm-burger-button button {
-    left: -10px !important;
-    top: -20px !important;
-    width: 32px !important;
-    height: 32px !important;
 }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#696 

### Changes included this pull request?
I pulled out react-burger-menu as it was about 100k and wasn't being used for much.  Replaced it with some css, and kept the profile photo clicking consistent across viewport sizes.  I also lightly refactored the menu part of the component into it's own method to keep the main component a little more focused. The profile image will toggle the menu, as does clicking in the grey overlay.  I took a guess on the opacity of the overlay, not sure if there's a preferred style for them.  Happy to take feedback on this somewhat significant change. 

It now looks like:

![small-menu](https://cloud.githubusercontent.com/assets/627/23645291/47ff3cda-02c0-11e7-8536-a5d3f0163336.png)

![large-menu](https://cloud.githubusercontent.com/assets/627/23645290/47fe49c4-02c0-11e7-9900-e2ea9ba5510b.png)


