### PR TITLE
Prioritize loading styles for loading screen

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -89,7 +89,7 @@ gulp.task('compile-bootstrap', function() {
 
 // Compile main stylesheet and copy to Build directory
 gulp.task("sass", function () {
-  return gulp.src("./src/sass/main.scss")
+  return gulp.src("./src/sass/{main,loading-screen}.scss")
   .pipe(sourcemaps.init())
   .on("error", function (err) { console.error(err); })
   .pipe(sass({ style: 'expanded' }))

--- a/src/index.html
+++ b/src/index.html
@@ -50,7 +50,7 @@
             color: #fff;
             ">We Vote
           </h1>
-          <div class="u-loading-spinner u-loading-spinner--light">Loading...</div>
+          <div class="u-loading-spinner u-loading-spinner--light">Loading We Vote...</div>
         </div>
       </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
   <meta property="og:title"         content="We Vote" />
   <meta property="og:description"   content="Putting you in the driver's seat of American democracy." />
   <meta property="og:image"         content="https://raw.githubusercontent.com/wevote/WebApp/develop/wevotelogo.png" />
+  <link href="/css/loading-screen.css" rel="stylesheet" />
   <script>
     <!-- Google Tag Manager -->
     (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -37,8 +38,19 @@
           justify-content: center;
           align-items: center;
           font-size: 30px;
-          color: #fff;
-          flex-direction: column;">Loading We Vote
+          color: #337ec9;
+          flex-direction: column;
+          font-family: "Roboto Slab", sans-serif;
+          text-align: center;
+          ">
+          <h1 style="
+            font-family: 'Roboto Slab', sans-serif;
+            font-size: 32px;
+            font-weight: normal;
+            color: #fff;
+            ">We Vote
+          </h1>
+          <div class="u-loading-spinner u-loading-spinner--light">Loading...</div>
         </div>
       </div>
     </div>

--- a/src/sass/loading-screen.scss
+++ b/src/sass/loading-screen.scss
@@ -1,0 +1,30 @@
+@import 'base/variables';
+@import 'base/mixins';
+@import 'components/loading-spinner';
+@import url(https://fonts.googleapis.com/css?family=Roboto+Slab:400,700);
+
+
+$loading-screen-color: #337ec9;
+
+.loading-screen {
+  display: flex;
+  position: fixed;
+  height: 100vh;
+  width: 100vw;
+  top: 0;
+  left: 0;
+  background-color: $loading-screen-color;
+  justify-content: center;
+  align-items: center;
+  font-size: 30px;
+  color: #fff;
+  flex-direction: column;
+
+  .h1 {
+    font-family: $heading-font-stack;
+    font-size: 22px;
+    font-weight: normal;
+    margin-top: 20px;
+    margin-bottom: 10px;
+  }
+}


### PR DESCRIPTION
### Issue:
Deferring all stylesheets in #765 caused some wonky text flashing:
![we-vote-loading-without-styling](https://cloud.githubusercontent.com/assets/160662/24584462/ca1159b6-1723-11e7-8f25-8b55188e949f.gif)

### Changes
This PR lets index.html load a dedicated stylesheet for loading screen styles, along with redundant inline styling to avoid the flashes of unstyled text.

BTW - why is `bundle.js` so huge?! Is there a way this can be broken up to get the essentials for the app loaded first and the let everything else load progressively?

FYI: @Anoninnyc 