### PR TITLE
Revert some behavior around popovers, and improve tap target.

### DIFF
--- a/src/js/components/VoterGuide/ItemTinyOpinionsToFollow.jsx
+++ b/src/js/components/VoterGuide/ItemTinyOpinionsToFollow.jsx
@@ -105,8 +105,12 @@ export default class ItemTinyOpinionsToFollow extends Component {
 
         this.popover_state[org_id] = {show: false, timer: null};
 
+        let voterGuideInlineDisplay;
+
         if (this.mobile) {
-          return <Link key={`tiny-link-${org_id}`} to={voterGuideLink} className="u-no-underline">
+          voterGuideInlineDisplay = <OrganizationTinyDisplay {...one_organization} showPlaceholderImage />
+        } else {
+          voterGuideInlineDisplay = <Link key={`tiny-link-${org_id}`} to={voterGuideLink} className="u-no-underline">
             <OrganizationTinyDisplay {...one_organization}
                                     showPlaceholderImage />
           </Link>;
@@ -130,14 +134,13 @@ export default class ItemTinyOpinionsToFollow extends Component {
             ref={`overlay-${org_id}`}
             onMouseOver={() => this.onTriggerEnter(org_id)}
             onMouseOut={() => this.onTriggerLeave(org_id)}
+            onExiting={() => this.onTriggerLeave(org_id)}
+            trigger={["focus", "hover"]}
             rootClose
             placement="bottom"
             overlay={organizationPopover}>
           <span className="position-rating__source with-popover">
-            <Link key={`tiny-link-${org_id}`} to={voterGuideLink} className="u-no-underline">
-              <OrganizationTinyDisplay {...one_organization}
-                                      showPlaceholderImage />
-            </Link>
+            {voterGuideInlineDisplay}
           </span>
         </OverlayTrigger>;
       }

--- a/src/sass/components/_ballotList.scss
+++ b/src/sass/components/_ballotList.scss
@@ -26,8 +26,8 @@
 // For display of tiny thumbnail images for organizational voter guides
 .organization-image-tiny {
   margin-left: 3px;
-  max-width: 25px;
-  border-radius: 2px;
+  width: 30px;
+  border-radius: 3px;
   @include breakpoints(small) {
     // TODO DALE this seems to always get set
     // max-width: 20px;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Addresses issue #676.

### Changes included this pull request?
- Fixes the mobile behavior to open the popover again.
- Makes the tap target for the org tiny images a little bigger (we will need to use slightly larger images).