### PR TITLE
fix broken js selector (broken test)

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -72,7 +72,7 @@ const links = {
   donate: function (active) {
 
     var jsx =
-      <Link to="/more/donate" className={ "donate-header-icon header-nav__item header-nav__item--has-icon hidden-xs" + (active ? " active-icon" : "")}>
+      <Link to="/more/donate" className={ "header-nav__item--donate header-nav__item header-nav__item--has-icon hidden-xs" + (active ? " active-icon" : "")}>
         <img className = "glyphicon" src="/img/global/svg-icons/glyphicons-20-heart-empty.svg" />
         <span className="header-nav__label">
           Donate
@@ -347,7 +347,7 @@ export default class HeaderBar extends Component {
             { voter_orientation_complete ? connect(pathname === "/more/connect") : null }
 
             { voter_orientation_complete ?
-              <Link onClick={this.toggleAboutMenu} className={ "about-header-icon header-nav__item header-nav__item--has-icon hidden-xs" + (pathname === "/more/about" ? " active-icon" : "")}>
+              <Link onClick={this.toggleAboutMenu} className={ "header-nav__item header-nav__item--about header-nav__item--has-icon hidden-xs" + (pathname === "/more/about" ? " active-icon" : "")}>
                 <span className="header-nav__icon--about">About</span>
                 <span className="header-nav__label">
                 We Vote
@@ -355,7 +355,7 @@ export default class HeaderBar extends Component {
                 <div>{this.aboutMenu()}</div>
               </Link> :
               <div>
-                <Link to="/more/about" className={ "about-header-icon header-nav__item" + (pathname === "/more/about" ? " active-icon" : "")}>
+                <Link to="/more/about" className={ "header-nav__item header-nav__item--about" + (pathname === "/more/about" ? " active-icon" : "")}>
                   <span className="header-nav__icon--about">About</span>
                   <span className="header-nav__label">
                   We Vote
@@ -382,7 +382,7 @@ export default class HeaderBar extends Component {
 
           { voter_orientation_complete ? <div className="header-nav__avatar-wrapper u-cursor--pointer u-flex-none" onClick={this.toggleAccountMenu}>
             {voter_photo_url_medium ?
-              <div className="header-nav__avatar-container">
+              <div id="js-header-avatar" className="header-nav__avatar-container">
                   <img className="header-nav__avatar"
                         src={voter_photo_url_medium}
                         height={34}

--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -47,9 +47,9 @@ export default class SearchAllBox extends Component {
     this.ballot = $(".header-nav__item:nth-child(1)");
     this.requests = $(".header-nav__item:nth-child(2)");
     this.connect = $(".header-nav__item:nth-child(3)");
-    this.avatar = $("#avatarContainer");
-    this.about = document.getElementsByClassName("about-header-icon")[0];
-    this.donate = document.getElementsByClassName("donate-header-icon")[0];
+    this.avatar = $("#js-header-avatar");
+    this.about = document.getElementsByClassName("header-nav__item--about")[0];
+    this.donate = document.getElementsByClassName("header-nav__item--donate")[0];
     // When we first enter we want to retrieve values to have for a click in the search box
     let text_from_search_field = this.props.text_from_search_field;
 
@@ -133,8 +133,8 @@ export default class SearchAllBox extends Component {
       $(".ballot-header-icon").removeClass("hidden-xs");
       $(".connect-header-icon").removeClass("hidden-xs");
       $(".requests-header-icon").removeClass("hidden-xs");
-      $(".about-header-icon").removeClass("hidden");
-      $(".donate-header-icon").removeClass("hidden");
+      $(".header-nav__item--about").removeClass("hidden");
+      $(".header-nav__item--donate").removeClass("hidden");
       this.hideResults();
     }, 250);
   }


### PR DESCRIPTION
Sorry! It looks like I broke the build. This should fix it.

### Comments on naming
I broke the relevant handle by replacing an `id` with a `className` and didn't notice it was being referenced by js. Here are my loose thoughts around conventions to address this.
- Only use `id`s for unique elements that js interacts with (not for styling - there's now a linter rule in place for this)
- When using `className`s as js hooks, prepend them with `js-` to clarify they are hooks and not for styling. The `js-` name-spacing can also be used for `id`s but is more important to avoid confusion with `className`s
- Always try to use an appropriately descriptive (and unique) name for `id`s and `className`s. Aside from adding clarity, it makes it easier to search the codebase for related code.

FYI: @DaleMcGrew @bigethan @Anoninnyc 