### PR TITLE
Updated styling of support/oppose ItemActionBar. Hiding "Remaining Decisions" on phones. Hiding "Your Voter Guide" until voter is signed in. Fixed display order of support/oppose icons on candidate page.

### DIFF
--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -28,7 +28,7 @@ export default class MeasureItemCompressed extends Component {
     this.state = {
       transitioning: false,
       showModal: false,
-      maximum_organization_display: 5
+      maximum_organization_display: 4,
     };
   }
 

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -23,7 +23,7 @@ export default class OfficeItemCompressed extends Component {
     super(props);
     this.state = {
       transitioning: false,
-      maximum_organization_display: 5
+      maximum_organization_display: 4
     };
   }
 
@@ -69,7 +69,7 @@ export default class OfficeItemCompressed extends Component {
               ballot_item_display_name
           }
         </h2>
-        <Link to={officeLink}><span className="card-main__office-read-more-link">learn more</span></Link>
+        <Link to={officeLink}><span className="card-main__office-read-more-link hidden-xs">learn more</span></Link>
         <BookmarkAction we_vote_id={we_vote_id} type="OFFICE"/>
 
         <div className={this.props.link_to_ballot_item_page ?

--- a/src/js/components/Navigation/BallotFilter.jsx
+++ b/src/js/components/Navigation/BallotFilter.jsx
@@ -16,7 +16,7 @@ export default class BallotFilter extends Component {
         <span>All Items</span>
       </Link>
 
-      <Link to={{ pathname: "/ballot", query: { type: "filterRemaining" } }} className={ ballot_type === "CHOICES_REMAINING" ? "active btn btn-default" : "btn btn-default"}>
+      <Link to={{ pathname: "/ballot", query: { type: "filterRemaining" } }} className={"hidden-xs " + (ballot_type === "CHOICES_REMAINING" ? "active btn btn-default" : "btn btn-default")}>
         <span>Remaining Decisions</span>
       </Link>
 

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -141,7 +141,7 @@ export default class HeaderBar extends Component {
   }
 
   accountMenu () {
-    var { linked_organization_we_vote_id, signed_in_facebook, signed_in_twitter, twitter_screen_name } = this.props.voter;
+    var { is_signed_in, linked_organization_we_vote_id, signed_in_facebook, signed_in_twitter, twitter_screen_name } = this.props.voter;
 
     let show_your_page_from_twitter = signed_in_twitter && twitter_screen_name;
     let show_your_page_from_facebook = signed_in_facebook && linked_organization_we_vote_id && !show_your_page_from_twitter;
@@ -179,7 +179,7 @@ export default class HeaderBar extends Component {
               </li> :
               null
             }
-            { !show_your_page_from_twitter && !show_your_page_from_facebook ?
+            { !show_your_page_from_twitter && !show_your_page_from_facebook && is_signed_in ?
               <li>
                 <Link onClick={this.hideAccountMenu.bind(this)} to="/yourpage">
                   <div>

--- a/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
+++ b/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
@@ -70,8 +70,30 @@ export default class ItemTinyPositionBreakdownList extends Component {
       orgs_not_shown_count = this.state.position_list.length - MAXIMUM_ORGANIZATION_DISPLAY;
     }
     let organizations_to_display = [];
+    let temp_organizations_to_display = [];
+    // Put the voter's icon first
+    if (this.props.supportProps && this.state.voter) {
+      let show_voter_position = false;
+      if (this.props.supportProps.is_support && this.props.showSupport) {
+        show_voter_position = true;
+      } else if (this.props.supportProps.is_oppose && this.props.showOppose) {
+        show_voter_position = true;
+      }
+      if (show_voter_position) {
+        one_organization = {
+          organization_we_vote_id: this.state.voter.we_vote_id,
+          voter_guide_image_url_tiny: this.state.voter.voter_photo_url_tiny,
+          voter_guide_display_name: this.state.voter.full_name
+        };
+        let voter_organization_tiny_display = <OrganizationTinyDisplay key={one_organization.organization_we_vote_id}
+                                                                       showPlaceholderImage
+                                                                       {...one_organization} />;
+        organizations_to_display.push(voter_organization_tiny_display);
+      }
+    }
+    // Add the icons of other organizations now
     if (this.state.position_list) {
-      organizations_to_display = this.state.position_list.map((one_position) => {
+      temp_organizations_to_display = this.state.position_list.map((one_position) => {
         // Filter out the positions that we don't want to display
         if (this.props.showSupport && one_position.is_support_or_positive_rating) {
           // When in showSupport mode, continue if it is a positive position
@@ -135,26 +157,7 @@ export default class ItemTinyPositionBreakdownList extends Component {
           </OverlayTrigger>;
         }
       });
-    }
-    // Now weave in the voter's position
-    if (this.props.supportProps && this.state.voter) {
-      let show_voter_position = false;
-      if (this.props.supportProps.is_support && this.props.showSupport) {
-        show_voter_position = true;
-      } else if (this.props.supportProps.is_oppose && this.props.showOppose) {
-        show_voter_position = true;
-      }
-      if (show_voter_position) {
-        one_organization = {
-          organization_we_vote_id: this.state.voter.we_vote_id,
-          voter_guide_image_url_tiny: this.state.voter.voter_photo_url_tiny,
-          voter_guide_display_name: this.state.voter.full_name
-        };
-        let voter_organization_tiny_display = <OrganizationTinyDisplay key={one_organization.organization_we_vote_id}
-                                                                       showPlaceholderImage
-                                                                       {...one_organization} />;
-        organizations_to_display.push(voter_organization_tiny_display);
-      }
+      organizations_to_display.push(temp_organizations_to_display);
     }
 
     return <span className="guidelist card-child__list-group">

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -61,12 +61,13 @@ export default class ItemActionBar extends Component {
 
     var {support_count, oppose_count, is_support, is_oppose } = this.props.supportProps;
     if (support_count === undefined || oppose_count === undefined || is_support === undefined || is_oppose === undefined){
-      // console.log("support_count: ", support_count, ", oppose_count: ", oppose_count, ", is_support: ", is_support, ", is_oppose: ", is_oppose);
       return null;
     }
-    const stance_button_class = "item-actionbar__btn item-actionbar__btn--oppose btn btn-default";
     const icon_size = 18;
     var icon_color = "#999";
+    // TODO Refactor the way we color the icons
+    var support_icon_color = is_support ? "white" : "#999";
+    var oppose_icon_color = is_oppose ? "white" : "#999";
     var url_being_shared;
     if (this.props.type === "CANDIDATE") {
       url_being_shared = web_app_config.WE_VOTE_URL_PROTOCOL + web_app_config.WE_VOTE_HOSTNAME + "/candidate/" + this.props.ballot_item_we_vote_id;
@@ -76,17 +77,29 @@ export default class ItemActionBar extends Component {
     const share_icon = <span className="btn__icon"><Icon name="share-icon" width={icon_size} height={icon_size} color={icon_color} /></span>;
     return <div className={ this.props.shareButtonHide ? "item-actionbar--inline" : "item-actionbar" }>
             <div className={"btn-group" + (!this.props.shareButtonHide ? " u-inline--sm" : "")}>
-              <button className={is_support ? `${stance_button_class} highlight_thumb_green` : stance_button_class} onClick={this.supportItem.bind(this, is_support)}>
+              {/* Start of Support Button */}
+              <button className={"item-actionbar__btn item-actionbar__btn--support btn btn-default" + (is_support ? " support-at-state" : "")} onClick={this.supportItem.bind(this, is_support)}>
                 <span className="btn__icon">
-                  <Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={icon_color} />
+                  <Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={support_icon_color} />
                 </span>
-                <span className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Support</span>
+                { is_support ?
+                  <span
+                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label__position-at-state" }>Support</span> :
+                  <span
+                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Support</span>
+                }
               </button>
-              <button className={is_oppose ? `${stance_button_class} highlight_thumb_red` : stance_button_class} onClick={this.opposeItem.bind(this, is_oppose)}>
+              {/* Start of Oppose Button */}
+              <button className={"item-actionbar__btn item-actionbar__btn--oppose btn btn-default" + (is_oppose ? " oppose-at-state" : "")} onClick={this.opposeItem.bind(this, is_oppose)}>
                 <span className="btn__icon">
-                  <Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={icon_color} />
+                  <Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={oppose_icon_color} />
                 </span>
-                <span className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Oppose</span>
+                { is_oppose ?
+                  <span
+                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label__position-at-state" }>Oppose</span> :
+                  <span
+                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Oppose</span>
+                }
               </button>
             </div>
       { this.props.commentButtonHide ?

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -1,4 +1,7 @@
 
+$green: #76d00b;
+$red: #ff4921;
+
 // This style is for when the item-actionbar is on its own line
 .item-actionbar {
   display: flex;
@@ -10,6 +13,18 @@
     @include breakpoints (max mid-small) {
       display: none; // Hide Support/Oppose button labels on small screens
     }
+
+    &__position-at-state {
+      color: $gray-pale;
+    }
+  }
+
+  .support-at-state {
+    background-color: $green;
+  }
+
+  .oppose-at-state {
+    background-color: $red;
   }
 }
 
@@ -26,17 +41,17 @@
     display: none; // Hide Support/Oppose button labels on all screens
     //}
   }
-  
+
   .btn-group {
     display: flex;
     flex-wrap: nowrap;
   }
 
-  .highlight_thumb_green {
-    border: 4px solid green;
+  .support-at-state {
+    background-color: $green;
   }
 
-  .highlight_thumb_red {
-    border: 4px solid red;
+  .oppose-at-state {
+    background-color: $red;
   }
 }


### PR DESCRIPTION
Updated styling of support/oppose ItemActionBar. Hiding "Remaining Decisions" on phones. Hiding "Your Voter Guide" until voter is signed in. Fixed display order of support/oppose icons on candidate page.