### PR TITLE
Add linter to require variables for color properties

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -16,9 +16,10 @@
     "rule-empty-line-before": null,
     "selector-no-id": true,
     "shorthand-property-no-redundant-values": null,
-    "sh-waqar/declaration-use-variable": [["border-radius"]]
+    "sh-waqar/declaration-use-variable": [["border-radius", "/color/"]]
   },
   "ignoreFiles": [
-    "**/vendor/**/*.scss"
+    "**/vendor/**/*.scss",
+    "**/_normalize.scss"
   ]
 }

--- a/docs/working/STYLING.md
+++ b/docs/working/STYLING.md
@@ -33,7 +33,7 @@ Use these prefixes for any custom classes. This helps keep classes scoped and id
 - `c-` Components - For reusable components
 - `js-` Javascript hooks - Use a unique class when a script needs it for manipulation
 - `analytics-` Tracking hooks for analytics (use shorter prefix?)
-- `is-` UI states (e.g. `.is-selected`, `.is-active`)
+- `is-` UI states (e.g. `.nav-item.is-selected`, `.dropdown-menu.is-active`) Declarations must be chained or scoped to element or component classes
 
 ### BEM Naming Conventions
 Components, Objects, and small scoped sections should use the BEM naming convention: (`component__child--modifier`).

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
   },
   "repository": "https://github.com/wevote/webapp.git",
   "pre-commit": [
-    "test"
+    "test",
+    "lint",
+    "lint-css"
   ]
 }

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -169,11 +169,11 @@ export default class Application extends Component {
               </div>
             </div> :
             <div className="row">
-              <div className="col-4 sidebar-menu">
+              <div className="col-md-4 hidden-xs sidebar-menu">
                 {/* Depending on which page we are on, show a different left area. */}
                 { pathname === "/ballot" ? <BallotLeft /> : null }
               </div>
-              <div className="col-8-container col-8 container-main">
+              <div className="col-md-8 container-main">
                 { this.props.children }
               </div>
             </div> }

--- a/src/js/components/Navigation/BallotLeft.jsx
+++ b/src/js/components/Navigation/BallotLeft.jsx
@@ -17,7 +17,7 @@ export default class BallotLeft extends Component {
     let search = window.location.search ? window.location.search : "";
     let currentUrl = window.location.pathname + search;
 
-    return <li className={url === currentUrl ? "active-link list-group-item" : "list-group-item"}>
+    return <li className={"list-group-item" + (url === currentUrl ? " is-active" : "")}>
         <Link to={url}><div><span className="header-menu-text-left">{label}</span></div></Link>
       </li>;
   }
@@ -36,28 +36,26 @@ export default class BallotLeft extends Component {
     // let show_your_page_from_twitter = this.props.signed_in_twitter && this.props.twitter_screen_name;
     // let show_your_page_from_facebook = this.props.signed_in_facebook && linked_organization_we_vote_id && !show_your_page_from_twitter;
 
-    return <div>
-      <div className="device-menu--large">
-        <ul className="list-group">
-          <li className="list-group-item">
-            <span className="we-vote-promise">Our Promise: We'll never sell your email.</span>
-          </li>
-        </ul>
-        <h4 className="text-left" />
-        <ul className="list-group">
-          <li className="list-group-item">
-            <h3 className="h3">Step 1: Find Trusted Advisers</h3>
-            <strong><Link to="/opinions">Find organizations</Link> that you trust, and follow them.</strong><br />
-            <br />
-            When you follow an organization, their advice will make it easier for you to make decisions.
-          </li>
-        </ul>
-        <h4 className="text-left" />
-        <span className="terms-and-privacy">
+    return <div className="u-inset__v--md">
+      <ul className="list-group">
+        <li className="list-group-item">
+          <span className="we-vote-promise">Our Promise: We'll never sell your email.</span>
+        </li>
+      </ul>
+      <h4 className="text-left" />
+      <ul className="list-group">
+        <li className="list-group-item">
+          <h3 className="h3">Step 1: Find Trusted Advisers</h3>
+          <strong><Link to="/opinions">Find organizations</Link> that you trust, and follow them.</strong><br />
           <br />
-          <Link to="/more/terms">Terms of Service</Link>&nbsp;&nbsp;&nbsp;<Link to="/more/privacy">Privacy Policy</Link>
-        </span>
-      </div>
-      </div>;
+          When you follow an organization, their advice will make it easier for you to make decisions.
+        </li>
+      </ul>
+      <h4 className="text-left" />
+      <span className="terms-and-privacy">
+        <br />
+        <Link to="/more/terms">Terms of Service</Link>&nbsp;&nbsp;&nbsp;<Link to="/more/privacy">Privacy Policy</Link>
+      </span>
+    </div>;
   }
 }

--- a/src/js/components/SearchAllBox.js
+++ b/src/js/components/SearchAllBox.js
@@ -276,7 +276,7 @@ export default class SearchAllBox extends Component {
               let capitalized_title = capitalizeString(one_result.result_title);
               let search_result_classes = classNames({
                 "search-container__results": true,
-                "search-container__results__highlighted": idx === this.state.selected_index
+                "search-container__results--highlighted": idx === this.state.selected_index
               });
 
               return <Link key={one_result.we_vote_id}

--- a/src/js/routes/More/About.jsx
+++ b/src/js/routes/More/About.jsx
@@ -27,13 +27,13 @@ export default class About extends Component {
             <span className="fa fa-facebook"/>
           </a>
 
-          <a className="btn btn-email" href="http://eepurl.com/cx_frP" target="_blank">
+          <a className="btn btn--email" href="http://eepurl.com/cx_frP" target="_blank">
             <span>
-              <span className="btn-email__icon glyphicon glyphicon-envelope"/> Join Newsletter
+              <span className="btn--email__icon glyphicon glyphicon-envelope"/> Join Newsletter
             </span>
           </a>
 
-          <a className="btn btn-social-icon btn-medium" href="https://medium.com/@WeVote" target="_blank">
+          <a className="btn btn-social-icon btn--medium" href="https://medium.com/@WeVote" target="_blank">
             <span className="fa fa-medium"/>
           </a>
         </div>

--- a/src/js/routes/More/FAQ.jsx
+++ b/src/js/routes/More/FAQ.jsx
@@ -25,9 +25,9 @@ export default class About extends Component {
             <span className="fa fa-facebook" />
           </a>
 
-          <a className="btn btn-email" href="http://eepurl.com/cx_frP" target="_blank">
+          <a className="btn btn--email" href="http://eepurl.com/cx_frP" target="_blank">
             <span>
-              <span className="btn-email__icon glyphicon glyphicon-envelope" /> Join Newsletter
+              <span className="btn--email__icon glyphicon glyphicon-envelope" /> Join Newsletter
             </span>
           </a>
 
@@ -35,7 +35,7 @@ export default class About extends Component {
             <span className="fa fa-github" />
           </a>
 
-          <a className="btn btn-social-icon btn-medium" href="https://medium.com/@WeVote" target="_blank">
+          <a className="btn btn-social-icon btn--medium" href="https://medium.com/@WeVote" target="_blank">
             <span className="fa fa-medium" />
           </a>
           </div>

--- a/src/js/routes/More/Organization.jsx
+++ b/src/js/routes/More/Organization.jsx
@@ -23,9 +23,9 @@ export default class Organization extends Component {
             <span className="fa fa-facebook"/>
           </a>
 
-          <a className="btn btn-email" href="http://eepurl.com/cx_frP" target="_blank">
+          <a className="btn btn--email" href="http://eepurl.com/cx_frP" target="_blank">
             <span>
-              <span className="btn-email__icon glyphicon glyphicon-envelope"/> Join Newsletter
+              <span className="btn--email__icon glyphicon glyphicon-envelope"/> Join Newsletter
             </span>
           </a>
 
@@ -33,7 +33,7 @@ export default class Organization extends Component {
             <span className="fa fa-github"/>
           </a>
 
-          <a className="btn btn-social-icon btn-medium" href="https://medium.com/@WeVote" target="_blank">
+          <a className="btn btn-social-icon btn--medium" href="https://medium.com/@WeVote" target="_blank">
             <span className="fa fa-medium"/>
           </a>
         </div>

--- a/src/js/routes/More/Vision.jsx
+++ b/src/js/routes/More/Vision.jsx
@@ -25,9 +25,9 @@ export default class Vision extends Component {
             <span className="fa fa-facebook"/>
           </a>
 
-          <a className="btn btn-email" href="http://eepurl.com/cx_frP" target="_blank">
+          <a className="btn btn--email" href="http://eepurl.com/cx_frP" target="_blank">
             <span>
-              <span className="btn-email__icon glyphicon glyphicon-envelope"/> Join Newsletter
+              <span className="btn--email__icon glyphicon glyphicon-envelope"/> Join Newsletter
             </span>
           </a>
 
@@ -35,7 +35,7 @@ export default class Vision extends Component {
             <span className="fa fa-github"/>
           </a>
 
-          <a className="btn btn-social-icon btn-medium" href="https://medium.com/@WeVote" target="_blank">
+          <a className="btn btn-social-icon btn--medium" href="https://medium.com/@WeVote" target="_blank">
             <span className="fa fa-medium"/>
           </a>
         </div>

--- a/src/js/routes/Network.jsx
+++ b/src/js/routes/Network.jsx
@@ -75,7 +75,7 @@ export default class Network extends Component {
           </Link>
           &nbsp;&nbsp;&nbsp;
 
-          <Link to="/friends/invitebyemail" className="btn btn-social btn-lg btn-email">
+          <Link to="/friends/invitebyemail" className="btn btn-social btn-lg btn--email">
             <i className="fa fa-envelope" />Invite Friends&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
           </Link>
           <br />

--- a/src/js/routes/Welcome.jsx
+++ b/src/js/routes/Welcome.jsx
@@ -28,13 +28,12 @@ export default class Intro extends Component {
 
     return <div>
       <Helmet title="Welcome to We Vote" />
-      <div className="u-f1">Heading One</div>
+      {/* <div className="u-f1">Heading One</div>
       <div className="u-f2">Heading Two</div>
       <div className="u-f3">Heading Three</div>
       <div className="u-f4">Heading Four</div>
       <div className="u-f5">Heading Five</div>
-      <div className="u-f6">Heading Six</div>
-
+      <div className="u-f6">Heading Six</div> */}
 
       <h1 className="h1">Welcome to We Vote!</h1>
       <p>We Vote is building the next generation of voting tech. We're creating a digital voter guide

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -4,7 +4,7 @@ html {
 }
 
 body {
-  background-color: #ebecee;
+  background-color: $app-background-color;
   height: 100%;
 }
 

--- a/src/sass/base/_fonts.scss
+++ b/src/sass/base/_fonts.scss
@@ -122,11 +122,11 @@ i.icon-candidate-small.icon-main.icon-icon-person-placeholder-6-1 {
 }
 
 .icon-main {
-  color: #a9a9a9;
+  color: $gray-mid;
 }
 
 .icon-org-resting-color {
-  color: #a9a9a9;
+  color: $gray-mid;
 }
 
 .icon-org-lg {

--- a/src/sass/base/_normalize.scss
+++ b/src/sass/base/_normalize.scss
@@ -144,7 +144,7 @@ h1 {
 
 mark {
   background: #ff0;
-  color: #000;
+  color: $black;
 }
 
 /**

--- a/src/sass/base/_variables.scss
+++ b/src/sass/base/_variables.scss
@@ -85,6 +85,9 @@ $radius-rounded: 100rem;
 // Colors
 // ===========================================
 
+$white: #fff;
+$black: #000;
+
 // Grays
 $gray-pale:    #f8f8f8 !default;
 $gray-lighter: #eee !default;
@@ -97,12 +100,14 @@ $gray-darker:  #333 !default;
 
 /// Main brand color
 /// @type Color
-$brand-color: #1c1a33 !default;
+$brand-color: #1c1a33 !default; // I'm guessing this probably wasn't intended to abstract to 'brand' color and was just put here to update the navbar. I've left this but unlinked the value for $page-header-color.  —Jeff
 
 /// Link color
 /// @type Color
 $link-color: #00749e !default; // mirrors Bootstrap variable - TODO: set single value globally
 $link-color-light: #969dff !default;
+
+$app-background-color: #ebecee;
 
 
 /// Popover Link Color
@@ -118,6 +123,8 @@ $text-color: $gray-darker !default;
 /// tentative color (can be adjusted)
 
 $selected-color: #0d546f !default;
+
+$modal-backdrop-color: rgba($black, .7);
 
 
 // ===========================================

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -1,21 +1,24 @@
 
 
 // Social button cusotmizations (on About page)
-.btn-email {
-  color: #fff;
-  background-color: #f0ad4e;
-  border-color: #d38312;
+.btn--email {
+  $email-btn-color: #f0ad4e;
+  $email-btn-border-color: darken($email-btn-color, 15%);
+  $email-btn-hover-color: darken($email-btn-color, 10%);
+  color: $white;
+  background-color: $email-btn-color;
+  border-color: $email-btn-border-color;
   &:hover {
-    background-color: #eda135;
-    color: #fff;
+    background-color: $email-btn-hover-color;
+    color: $white;
   }
   &__icon {
     height: 20px;
   }
 }
 
-.btn-medium {
-  border-color: #999;
+.btn--medium {
+  border-color: $gray-mid;
 }
 
 // For icons on buttons

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -4,7 +4,7 @@
 
 .card {
   $item-padding: 15px;
-  background-color: #fff;
+  background-color: $white;
   border-radius: $radius-xs;
   box-shadow: $default-box-shadow;
   margin-bottom: 20px;
@@ -339,8 +339,4 @@
 
 .card-popover {
   max-width: 350px;
-}
-
-.bm-burger-button button {
-  color: red;
 }

--- a/src/sass/components/_device-menu.scss
+++ b/src/sass/components/_device-menu.scss
@@ -1,46 +1,6 @@
 // Device Menu (App side-nav)
 // ===========================================
 
-.device-menu {
-  &--large {
-    display: none;
-    @include breakpoints(nav) {
-      display: block;
-      margin-top: 10px;
-    }
-  }
-  &--mobile {
-    display: block;
-    visibility: inherit;
-    @include breakpoints(nav) {
-      visibility: hidden;
-    }
-  }
-}
-
-@include breakpoints(max nav) {
-  .sidebar-menu {
-    // Hacky grid system overrides
-    display: none;
-  }
-  .col-8-container,
-  .col-12-container {
-    // Hacky grid system overrides
-    width: 100%;
-    max-width: 100%;
-    flex: 0 0 100%;
-  }
-  .container-main {
-    margin-bottom: -72px;
-    min-height: 100%;
-    padding-bottom: 72px;
-  }
-}
-
-.active-link {
-  font-weight: 600;
-  background-color: #d9edf7;
-}
 
 .header-slide-out-menu-text-left {
   font-size: 1.2rem;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -1,3 +1,4 @@
+$page-header-color: #1c1a33;
 
 .page-header {
   // required overrides for Bootstrap :(
@@ -11,9 +12,8 @@
   position: relative;
 
   &__container {
-    background-color: $brand-color;
-    // border-bottom: 1px solid $gray-border;
-    padding: .5em 0;
+    background-color: $page-header-color;
+    padding: $space-sm 0;
   }
   &__content { // additional element to exclue Burger Menu element
     display: flex;
@@ -30,26 +30,26 @@
 
 .page-logo {
   white-space: nowrap;
-  margin: 0 1em 0 0; // zeros to override Bootstrap h4
-  margin-top: -.5em;
-  margin-bottom: -.5em;
-  padding: 10px 8px;
+  margin: 0 $space-md 0 0; // zeros to override Bootstrap h4
+  margin-top: -$space-sm;
+  margin-bottom: -$space-sm;
+  padding: $space-sm;
   &,
   &:hover,
   &:focus,
   &:active {
-    color: #fff;
+    color: $white;
     text-decoration: none;
   }
   &:hover {
-    text-shadow: 0 0 3px rgba(255, 255, 255, .3);
+    text-shadow: 0 0 3px rgba($white, .3);
   }
 
   &__version {
-    color: #fff;
+    color: $white;
     opacity: .5;
     font-size: .7em;
-    margin-left: .3em;
+    margin-left: $space-xs;
     text-transform: uppercase;
     white-space: nowrap;
   }
@@ -64,7 +64,7 @@
 }
 
 .site-search {
-  padding: 0 1em;
+  padding: 0 $space-md;
 
   &__input-field {
     border: none; // override Bootstrap
@@ -89,7 +89,8 @@
 }
 
 .search-container {
-  background: #fff;
+  $search-result-highlight-color: #d9edf7;
+  background-color: $white;
   box-shadow: 5px 5px 10px rgba(0, 0, 0, .2);
   margin: 0 1em;
   position: absolute;
@@ -104,15 +105,14 @@
   }
 
   &__results {
-    background: #fff;
-    margin-bottom: .5em;
-    padding: .75em;
+    background-color: $white;
+    padding: $space-md;
     display: flex;
     font-size: 1rem;
     align-items: center;
 
-    &__highlighted {
-      background: #d9edf7;
+    &--highlighted {
+      background-color: $search-result-highlight-color;
     }
   }
 

--- a/src/sass/components/_intro-story.scss
+++ b/src/sass/components/_intro-story.scss
@@ -3,7 +3,7 @@
   padding: 0;
   height: 600px;
   width: 100%;
-  color: #fff;
+  color: $white;
   text-align: center;
   @include breakpoints (max large) {
     height: 100vh;
@@ -197,7 +197,7 @@
   top: 10px;
   right: 10px;
   z-index: 2;
-  color: #fff;
+  color: $white;
   @include breakpoints (small mid-small) {
     height: 30px;
     width: 30px;

--- a/src/sass/components/_loading-screen.scss
+++ b/src/sass/components/_loading-screen.scss
@@ -1,14 +1,15 @@
 .loading-screen {
+  $loading-screen-color: #337ec9;
   display: flex;
   position: fixed;
   height: 100vh;
   width: 100vw;
   top: 0;
   left: 0;
-  background-color: #337ec9;
+  background-color: $loading-screen-color;
   justify-content: center;
   align-items: center;
   font-size: 30px;
-  color: #fff;
+  color: $white;
   flex-direction: column;
 }

--- a/src/sass/components/_loading-spinner.scss
+++ b/src/sass/components/_loading-spinner.scss
@@ -4,6 +4,8 @@ $loader-delay-increment: -120ms;
 $loader-size: .8rem;
 
 .u-loading-spinner {
+  $dark-spinner: rgba($gray-dark, .7);
+  $light-spinner: rgba($white, .7);
   margin: 0 auto ($loader-size * 2) auto;
   position: relative;
   text-indent: -9999em;
@@ -23,13 +25,13 @@ $loader-size: .8rem;
     animation-timing-function: cubic-bezier(.5, 0, .5, 1);
     animation-iteration-count: infinite;
     animation-fill-mode: both;
-    color: rgba($gray-dark, .7);
+    color: $dark-spinner;
   }
   &--light {
     &,
     &::before,
     &::after {
-      color: rgba(#fff, .7);
+      color: $light-spinner;
     }
   }
   &::before {

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -15,7 +15,7 @@ $header-height: 54px;
   position: absolute;
   top: 50px;
   right: 15px;
-  background-color: #fff;
+  background-color: $white;
   opacity: 0;
   padding: 1rem;
   transition: opacity .25s ease-in-out;
@@ -44,7 +44,7 @@ $header-height: 54px;
   height: 200vh;
   top: -10px;
   left: -10px;
-  background: rgba(0, 0, 0, .7);
+  background-color: $modal-backdrop-color;
   z-index: 2;
   pointer-events: none;
   transition: opacity .4s ease-in-out;
@@ -68,6 +68,8 @@ $header-height: 54px;
 }
 
 .header-nav {
+  $nav-item-hover-color: darken($page-header-color, 5%);
+  $nav-item-active-color: darken($page-header-color, 10%);
   display: flex;
   align-items: center;
 
@@ -89,8 +91,8 @@ $header-height: 54px;
     height: $header-height;
     margin-top: -.5em; // temporary offsets for .page-header__container padding
     margin-bottom: -.5em;
-    padding: 8px;
-    color: #fff;
+    padding: $space-sm;
+    color: $white;
     opacity: .8;
     text-align: center;
     &--has-icon {
@@ -101,22 +103,22 @@ $header-height: 54px;
     &.active-icon,
     &:focus,
     &:hover {
-      color: #fff;
+      color: $white;
       opacity: 1;
       text-decoration: none;
     }
 
     &:active,
     &.active-icon {
-      background-color: rgba(0, 0, 0, .1);
+      background-color: $nav-item-active-color;
     }
 
     &:hover {
-      background-color: rgba(0, 0, 0, .3);
+      background-color: $nav-item-hover-color;
     }
 
     &.donate {
-      padding: 0;
+      padding: $space-none;
       & > img.glyphicon {
         max-width: 100%;
         width: 29px;
@@ -169,10 +171,11 @@ $header-height: 54px;
 .header-nav,
 .footer-nav {
   .badge-total {
+    $badge-color: #db4437;
     left: 1em;
     position: absolute;
     top: -7px;
     font-family: $body-font-stack;
-    background-color: #db4437; // Override for Bootstrap class .badge
+    background-color: $badge-color; // Override for Bootstrap class .badge
   }
 }

--- a/src/sass/components/_twitter-followers.scss
+++ b/src/sass/components/_twitter-followers.scss
@@ -8,14 +8,14 @@
     color: $gray-mid;
     display: inline-block;
     line-height: $size;
-    padding: 5px 0;
+    padding: $space-xs 0;
     white-space: nowrap;
   }
 
   &__icon {
     font-size: $size;
     color: $gray-light;
-    margin-right: 3px;
+    margin-right: $space-xs;
     vertical-align: bottom;
   }
 }

--- a/src/sass/loading-screen.scss
+++ b/src/sass/loading-screen.scss
@@ -17,7 +17,7 @@ $loading-screen-color: #337ec9;
   justify-content: center;
   align-items: center;
   font-size: 30px;
-  color: #fff;
+  color: $white;
   flex-direction: column;
 
   .h1 {

--- a/src/sass/overrides/_print.scss
+++ b/src/sass/overrides/_print.scss
@@ -1,7 +1,7 @@
 @media print {
   body {
-    background-color: #fff !important;
-    color: #000;
+    background-color: $white !important;
+    color: $black;
   }
   .headroom-wrapper,
   .page-header__container,


### PR DESCRIPTION
Adds another stylelint rule to require variables for color properties. 

All the rules to require variables for style properties are intended to reduce the introduction of custom values and to work from a set of established values with scoped names.

Variables should typically be added to the _variables.scss partial. If they happen to be specific to a specific component or element, they can be scoped to that component (ideally nested within the most encompassing context), but this sort of customization should still be done sparingly.
