### PR TITLE
Add new style linter rules

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -15,11 +15,16 @@
     "number-leading-zero": "never",
     "rule-empty-line-before": null,
     "selector-no-id": true,
+    "selector-no-type": [true, {
+      "ignoreTypes": ["a"]
+    }],
     "shorthand-property-no-redundant-values": null,
-    "sh-waqar/declaration-use-variable": [["border-radius", "/color/"]]
+    "sh-waqar/declaration-use-variable": [["border-radius", "/color/"]],
+    "string-quotes": "single",
   },
   "ignoreFiles": [
     "**/vendor/**/*.scss",
-    "**/_normalize.scss"
+    "**/_normalize.scss",
+    "**/overrides/_print.scss"
   ]
 }

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -19,7 +19,12 @@
       "ignoreTypes": ["a"]
     }],
     "shorthand-property-no-redundant-values": null,
-    "sh-waqar/declaration-use-variable": [["border-radius", "/color/"]],
+    "sh-waqar/declaration-use-variable": [[
+      "border-radius",
+      "/color/",
+      "/margin/",
+      "/padding/"
+    ]],
     "string-quotes": "single",
   },
   "ignoreFiles": [

--- a/docs/working/STYLING.md
+++ b/docs/working/STYLING.md
@@ -45,7 +45,7 @@ Styles that reference React components should use the same Camel Case naming con
 
 ## Helpers
 
-1. Avoid using raw (numeric) values for style declarations. Always try to use a context-appropriate 'token' or variable instead.
+1. Avoid using raw (numeric) values for style declarations. Always try to use a context-appropriate 'token' or variable instead. (Linter rules are in place to require variables for certain properties.)
 
 
 ### Use Tokens/Variables (avoid raw values)

--- a/src/js/routes/More/About.jsx
+++ b/src/js/routes/More/About.jsx
@@ -16,7 +16,7 @@ export default class About extends Component {
   render () {
     return <div className="about-us">
       <Helmet title="About Us - We Vote"/>
-      <div className="container-fluid card">
+      <div className="card u-inset--md">
         <h1 className="h1">About We Vote</h1>
         <div className="btn-toolbar">
           <a className="btn btn-social-icon btn-twitter" href="https://twitter.com/WeVote" target="_blank">
@@ -38,277 +38,278 @@ export default class About extends Component {
           </a>
         </div>
 
-        <br />
+
         <ReactPlayer url="https://player.vimeo.com/video/121315141" width="300px" height="231px"/>
         <div className="our-story">
           <h3 className="h3">A Nonprofit Startup</h3>
-          We Vote is made of two 501(c)(3) and 501(c)(4) nonpartisan nonprofit organizations based in
-          Oakland, California. This site is managed by the 501(c)(4), We Vote USA. Our
-          software is open source, and our work is driven by the nearly 100 volunteers who have contributed so far.
-          Inspired by groups like <a href="http://codeforsanfrancisco.org/" target="_blank">Code for America&nbsp;<i
-          className="fa fa-external-link"/>
+          <p>
+            We Vote is made of two 501(c)(3) and 501(c)(4) nonpartisan nonprofit organizations based in Oakland, California. This site is managed by the 501(c)(4), We Vote USA. Our software is open source, and our work is driven by the nearly 100 volunteers who have contributed so far. Inspired by groups like <a href="http://codeforsanfrancisco.org/" target="_blank">Code for America&nbsp;<i className="fa fa-external-link" />
         </a> and the <a href="https://www.mozilla.org/en-US/foundation/" target="_blank">Mozilla Foundation&nbsp;<i
-          className="fa fa-external-link"/></a>, we use technology to
-          make democracy stronger by increasing voter turnout.<br />
+          className="fa fa-external-link" /></a>, we use technology to
+          make democracy stronger by increasing voter turnout.
+        </p>
 
           <h3 className="h3">We Vote Board Members &amp; Advisers</h3>
-          <div className="row centered team-members-list">
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive"
+          <div className="row">
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo"
                               imageUrl="/img/global/photos/Jenifer_Fernandez_Ancona-200x200.jpg"
                               alt="Jenifer Fernandez Ancona"/>
                 <div className="media-body">
-                  <h4><strong>Jenifer Fernandez Ancona</strong>, Co-Founder &amp; c4 Board Chair</h4>
-                <h5 className="xx-small hidden-xs">
-                  VP, Strategy &amp; Member Engagement at the Women Donors Network.<br />
-                  <br />
-                </h5>
+                  <h4 className="team-member__name"><strong>Jenifer Fernandez Ancona</strong></h4>
+                  <p className="team-member__title">Co-Founder &amp; c4 Board Chair</p>
+                <p className="xx-small hidden-xs">
+                  VP, Strategy &amp; Member Engagement at the Women Donors Network.
+                  </p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Tiana_Epps_Johnson-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Tiana_Epps_Johnson-200x200.jpg"
                               alt="Tiana Epps-Johnson"/>
                 <div className="media-body">
-                  <h4><strong>Tiana Epps-Johnson</strong>, Senior Adviser</h4>
-                <h5 className="xx-small hidden-xs">
+                  <h4 className="team-member__name"><strong>Tiana Epps-Johnson</strong></h4>
+                  <p className="team-member__title">Senior Adviser</p>
+                <p className="xx-small hidden-xs">
                   Exec. Dir. of CTCL, software for election administrators. Former Voting Info Project &amp;
-                  Harvard Ash Center for Democratic Governance and Innovation.<br />
-                  <br />
-                </h5>
+                  Harvard Ash Center for Democratic Governance and Innovation.
+                  </p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Debra_Cleaver-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Debra_Cleaver-200x200.jpg"
                               alt="Debra Cleaver"/>
                 <div className="media-body">
-                  <h4><strong>Debra Cleaver</strong>, c3 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
+                  <h4 className="team-member__name"><strong>Debra Cleaver</strong></h4>
+                  <p className="team-member__title">c3 Board Member</p>
+              <p className="xx-small hidden-xs">
                 Founder &amp; CEO of VOTE.org, the web's most heavily trafficked site for accurate voting
-                information.<br />
-                <br />
-              </h5>
+                information.
+              </p>
                 </div>
               </div>
             </div>
-            <div className="clearfix visible-xs-block"/>{/* After every 3 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Tory_Gavito-200x200.jpg"
+
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Tory_Gavito-200x200.jpg"
                               alt="Tory Gavito"/>
                 <div className="media-body">
-                  <h4><strong>Tory Gavito</strong>, c4 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
-                Exec. Dir. at Texas Future Project.<br />
-                <br />
-              </h5>
+                  <h4 className="team-member__name"><strong>Tory Gavito</strong></h4>
+                  <p className="team-member__title">c4 Board Member</p>
+                  <p className="xx-small hidden-xs">
+                    Exec. Dir. at Texas Future Project.
+                  </p>
                 </div>
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>{/* After every 4 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Lawrence_Grodeska-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Lawrence_Grodeska-200x200.jpg"
                               alt="Lawrence Grodeska"/>
                 <div className="media-body">
-                  <h4><strong>Lawrence Grodeska</strong>, c3 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
-                Civic Tech communications and innovation at CivicMakers. Formerly at Change.org.<br />
-                <br />
-              </h5>
+                  <h4 className="team-member__name"><strong>Lawrence Grodeska</strong></h4>
+                  <p className="team-member__title">c3 Board Member</p>
+                  <p className="xx-small hidden-xs">
+                    Civic Tech communications and innovation at CivicMakers. Formerly at Change.org.
+                  </p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Dale_McGrew-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Dale_McGrew-200x200.jpg"
                               alt="Dale John McGrew"/>
                 <div className="media-body">
-                  <h4><strong>Dale John McGrew</strong>, Co-Founder / CTO &amp; c3 + c4 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
-                Managed large software projects for companies like Disney and over 60 nonprofits.<br />
-                <br />
-              </h5>
+                  <h4 className="team-member__name"><strong>Dale John McGrew</strong></h4>
+                  <p className="team-member__title">Co-Founder / CTO &amp; c3 + c4 Board Member</p>
+                  <p className="xx-small hidden-xs">
+                    Managed large software projects for companies like Disney and over 60 nonprofits.
+                  </p>
                 </div>
               </div>
             </div>
-            <div className="clearfix visible-xs-block"/>{/* After every 3 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Barbara_Shannon-200x200.jpg"
+
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Barbara_Shannon-200x200.jpg"
                               alt="Barbara Shannon"/>
                 <div className="media-body">
-                  <h4><strong>Barbara Shannon</strong>, c3 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
-                Adviser to entrepreneurs and C-level Fortune 500 leaders. MBA The Wharton School.<br />
-                <br />
-              </h5>
+                  <h4 className="team-member__name"><strong>Barbara Shannon</strong></h4>
+                  <p className="team-member__title">c3 Board Member</p>
+                  <p className="xx-small hidden-xs">
+                    Adviser to entrepreneurs and C-level Fortune 500 leaders. MBA The Wharton School.
+                  </p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Anat_Shenker_Osario-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Anat_Shenker_Osario-200x200.jpg"
                               alt="Anat Shenker-Osorio"/>
                 <div className="media-body">
-                  <h4><strong>Anat Shenker-Osorio</strong>, c4 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
-                Communications expert, researcher and political pundit.
-                <br />
-                <br />
-              </h5>
+                  <h4 className="team-member__name"><strong>Anat Shenker-Osorio</strong></h4>
+                  <p className="team-member__title">c4 Board Member</p>
+                  <p className="xx-small hidden-xs">
+                    Communications expert, researcher and political pundit.
+                  </p>
                 </div>
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>{/* After every 4 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Betsy_Sikma-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Betsy_Sikma-200x200.jpg"
                               alt="Betsy Sikma"/>
                 <div className="media-body">
-                  <h4><strong>Betsy Sikma</strong>, c3 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
-                <br />
-                <br />
-              </h5>
+                  <h4 className="team-member__name"><strong>Betsy Sikma</strong></h4>
+                  <p className="team-member__title">c3 Board Member</p>
                 </div>
               </div>
             </div>
-            <div className="clearfix visible-xs-block"/>{/* After every 3 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/William_Winters-200x200.jpg"
+
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/William_Winters-200x200.jpg"
                               alt="William Winters"/>
                 <div className="media-body">
-                  <h4><strong>William Winters</strong>, c4 Board Member</h4>
-              <h5 className="xx-small hidden-xs">
-                Campaign Manager at Color Of Change, CEL &amp; Change.org.
-                <br />
-                <br />
-              </h5>
+                  <h4 className="team-member__name"><strong>William Winters</strong></h4>
+                  <p className="team-member__title">c4 Board Member</p>
+                  <p className="xx-small hidden-xs">
+                    Campaign Manager at Color Of Change, CEL &amp; Change.org.
+                  </p>
                 </div>
               </div>
             </div>
           </div>
 
           <h3 className="h3">We Vote Staff</h3>
-          <div className="row centered team-members-list">
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Alicia_Prevost-200x200.jpg"
+          <div className="row">
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Alicia_Prevost-200x200.jpg"
                               alt="Alicia Prevost"/>
                 <div className="media-body">
-                  <h4><strong>Alicia Prevost</strong>, Executive Director</h4>
+                  <h4 className="team-member__name"><strong>Alicia Prevost</strong></h4>
+                  <p className="team-member__title">Executive Director</p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Dale_McGrew-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Dale_McGrew-200x200.jpg"
                               alt="Dale John McGrew"/>
                 <div className="media-body">
-                  <h4><strong>Dale John McGrew</strong>, Co-Founder / CTO</h4>
+                  <h4 className="team-member__name"><strong>Dale John McGrew</strong></h4>
+                  <p className="team-member__title">Co-Founder / CTO</p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Sarah_Clements-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Sarah_Clements-200x200.jpg"
                               alt="Sarah Clements"/>
                 <div className="media-body">
-                  <h4><strong>Sarah Clements</strong>, Engineering Intern</h4>
+                  <h4 className="team-member__name"><strong>Sarah Clements</strong></h4>
+                  <p className="team-member__title">Engineering Intern</p>
                 </div>
               </div>
             </div>
-            <div className="clearfix visible-xs-block"/>{/* After every 3 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Irene_Florez-200x200.jpg"
+
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Irene_Florez-200x200.jpg"
                               alt="Irene Florez"/>
                 <div className="media-body">
-                  <h4><strong>Irene Florez</strong>, Engineering Intern</h4>
+                  <h4 className="team-member__name"><strong>Irene Florez</strong></h4>
+                  <p className="team-member__title">Engineering Intern</p>
                 </div>
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>{/* After every 4 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Jeff_French-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Jeff_French-200x200.jpg"
                               alt="Jeff French"/>
                 <div className="media-body">
-                  <h4><strong>Jeff French</strong>, Lead Designer</h4>
+                  <h4 className="team-member__name"><strong>Jeff French</strong></h4>
+                  <p className="team-member__title">Lead Designer</p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Anisha_Jain-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Anisha_Jain-200x200.jpg"
                               alt="Anisha Jain"/>
                 <div className="media-body">
-                  <h4><strong>Anisha Jain</strong>, Sr. Software Engineer</h4>
+                  <h4 className="team-member__name"><strong>Anisha Jain</strong></h4>
+                  <p className="team-member__title">Sr. Software Engineer</p>
                 </div>
               </div>
             </div>
-            <div className="clearfix visible-xs-block"/>{/* After every 3 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Judy_Johnson-200x200.jpg"
+
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Judy_Johnson-200x200.jpg"
                               alt="Judy Johnson"/>
                 <div className="media-body">
-                  <h4><strong>Judy Johnson</strong>, Operations</h4>
+                  <h4 className="team-member__name"><strong>Judy Johnson</strong></h4>
+                  <p className="team-member__title">Operations</p>
                 </div>
               </div>
             </div>
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Neelam_Joshi-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Neelam_Joshi-200x200.jpg"
                               alt="Neelam Joshi"/>
                 <div className="media-body">
-                  <h4><strong>Neelam Joshi</strong>, Sr. Software Engineer</h4>
+                  <h4 className="team-member__name"><strong>Neelam Joshi</strong></h4>
+                  <p className="team-member__title">Sr. Software Engineer</p>
                 </div>
               </div>
             </div>
             <div className="clearfix visible-sm-block visible-md-block visible-lg-block"/>{/* After every 4 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Ciero_Kilpatrick-200x200.jpg"
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Ciero_Kilpatrick-200x200.jpg"
                               alt="Ciero Kilpatrick"/>
                 <div className="media-body">
-                  <h4><strong>Ciero Kilpatrick</strong>, User Experience Design Intern</h4>
+                  <h4 className="team-member__name"><strong>Ciero Kilpatrick</strong></h4>
+                  <p className="team-member__title">User Experience Design Intern</p>
                 </div>
               </div>
             </div>
-            <div className="clearfix visible-xs-block"/>{/* After every 3 */}
-            <div className="col-4 col-sm-3 col-md-3 team-member">
-              <div className="media">
-                <ImageHandler className="img-responsive" imageUrl="/img/global/photos/Eric_Ogawa-200x200.jpg"
+
+            <div className="col-4 col-sm-3">
+              <div className="team-member">
+                <ImageHandler className="img-responsive team-member__photo" imageUrl="/img/global/photos/Eric_Ogawa-200x200.jpg"
                               alt="Eric"/>
                 <div className="media-body">
-                  <h4><strong>Eric Ogawa</strong>, User Experience Design Intern</h4>
+                  <h4 className="team-member__name"><strong>Eric Ogawa</strong></h4>
+                  <p className="team-member__title">User Experience Design Intern</p>
                 </div>
               </div>
             </div>
           </div>
 
           <h3 className="h3">Our Story</h3>
-          After meeting in Oakland in the spring of 2013, We Vote co-founders Dale McGrew, Jenifer Fernandez Ancona, Dan Ancona,
-          and their families became fast friends and bought a home together,
-          forming an intentional community. Through
-          daily conversations, the idea of a nonprofit social voter network was born.
-          &quot;We&#39;re living our values,&quot; says Jenifer. We Vote would be a community for voters, they
-          decided, created
-          from a communal home of people concerned about where this country is heading. Being an open
-          source, volunteer-driven project means anyone can contribute. Kind of like democracy.<br />
-
+          <p>
+            After meeting in Oakland in the spring of 2013, We Vote co-founders Dale McGrew, Jenifer Fernandez Ancona, Dan Ancona, and their families became fast friends and bought a home together, forming an intentional community. Through daily conversations, the idea of a nonprofit social voter network was born.
+            &quot;We&#39;re living our values,&quot; says Jenifer. We Vote would be a community for voters, they
+            decided, created
+            from a communal home of people concerned about where this country is heading. Being an open
+            source, volunteer-driven project means anyone can contribute. Kind of like democracy.
+          </p>
           <h3 className="h3">Credits &amp; Gratitude</h3>
-          <Link to="/more/credits/">We are thankful for our volunteers, our board of directors, and the
-            organizations</Link> that are critical to our work.<br />
+          <p>
+            <Link to="/more/credits/">We are thankful for our volunteers, our board of directors, and the organizations</Link> that are critical to our work.
+          </p>
 
-          <br />
         </div>
       </div>
     </div>;

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -14,20 +14,20 @@ body {
   min-height: 100%;
   position: relative;
   @include breakpoints($max-page-container-width) {
-    margin: 0 auto;
+    margin: $space-none $space-auto;
   }
 }
 
 .page-content-container {
-  margin: 0 auto;
+  margin: $space-none $space-auto;
   max-width: $max-page-container-width;
   position: relative;
   z-index: 0;
 }
 
 .container-main {
-  padding-top: 15px;
-  padding-bottom: 3em;
+  padding-top: $space-md;
+  padding-bottom: $space-xl;
 }
 
 *,

--- a/src/sass/base/_base.scss
+++ b/src/sass/base/_base.scss
@@ -1,3 +1,5 @@
+// stylelint-disable selector-no-type
+
 html {
   box-sizing: border-box;
   height: 100%;
@@ -41,3 +43,5 @@ a {
 img {
   max-width: 100%;
 }
+
+// stylelint-enable

--- a/src/sass/base/_fonts.scss
+++ b/src/sass/base/_fonts.scss
@@ -6,19 +6,19 @@
 
 
 @font-face {
-  font-family: "app-fonts";
-  src: url("../fonts/app-fonts.eot");
+  font-family: 'app-fonts';
+  src: url('../fonts/app-fonts.eot');
   src:
-    url("../fonts/app-fonts.eot?#iefix") format("embedded-opentype"),
-    url("../fonts/app-fonts.woff") format("woff"),
-    url("../fonts/app-fonts.ttf") format("truetype"),
-    url("../fonts/app-fonts.svg#app-fonts") format("svg");
+    url('../fonts/app-fonts.eot?#iefix') format('embedded-opentype'),
+    url('../fonts/app-fonts.woff') format('woff'),
+    url('../fonts/app-fonts.ttf') format('truetype'),
+    url('../fonts/app-fonts.svg#app-fonts') format('svg');
   font-weight: normal;
   font-style: normal;
 }
 
 [data-icon]::before {
-  font-family: "app-fonts" !important;
+  font-family: 'app-fonts' !important;
   content: attr(data-icon);
   font-style: normal !important;
   font-weight: normal !important;
@@ -30,9 +30,9 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-[class^="icon-"]::before,
-[class*=" icon-"]::before {
-  font-family: "app-fonts" !important;
+[class^='icon-']::before,
+[class*=' icon-']::before {
+  font-family: 'app-fonts' !important;
   font-style: normal !important;
   font-weight: normal !important;
   font-variant: normal !important;
@@ -45,39 +45,39 @@
 
 
 .icon-icon-vote-3-4::before {
-  content: "a";
+  content: 'a';
 }
 .icon-icon-person-placeholder-6-1::before {
-  content: "b";
+  content: 'b';
   vertical-align: middle;
   position: relative;
   bottom: .5rem;
 }
-i.icon-candidate-small.icon-main.icon-icon-person-placeholder-6-1 {
+.icon-candidate-small.icon-main.icon-icon-person-placeholder-6-1 {
   vertical-align: middle;
 }
 .icon-icon-org-placeholder-6-2::before {
-  content: "c";
+  content: 'c';
   vertical-align: middle;
   font-size: 1.6em;
 }
 .icon-icon-more-opinions-2-2::before {
-  content: "d";
+  content: 'd';
 }
 .icon-icon-connect-1-3::before {
-  content: "e";
+  content: 'e';
   font-size: 1.25em;
 }
 .icon-icon-add-friends-2-1::before {
-  content: "f";
+  content: 'f';
 }
 .icon-icon-activity-1-4::before {
-  content: "g";
+  content: 'g';
   font-size: 1.25em;
   line-height: .5;
 }
 .icon-icon-connect1-3::before {
-  content: "h";
+  content: 'h';
 }
 
 .icon-xl {

--- a/src/sass/base/_mixins.scss
+++ b/src/sass/base/_mixins.scss
@@ -2,8 +2,8 @@
 // This file contains all application-wide Sass mixins.
 // ----------------------------------------------------------------------------
 
-@import "./mixins/breakpoints";
-@import "./mixins/media-object";
+@import './mixins/breakpoints';
+@import './mixins/media-object';
 
 
 /// Event wrapper
@@ -43,7 +43,7 @@
 @mixin clearfix {
   &::before,
   &::after {
-    content: " ";
+    content: ' ';
     display: table;
   }
   &::after {

--- a/src/sass/base/_typography.scss
+++ b/src/sass/base/_typography.scss
@@ -1,6 +1,8 @@
 $base-font-size: 16px;
 $html-base-size: 16px;
 
+// stylelint-disable selector-no-type
+
 h1,
 h2,
 h3,
@@ -28,3 +30,9 @@ body {
   font-family: $body-font-stack;
   line-height: 1.4;
 }
+
+p {
+  max-width: 50em;
+}
+
+// stylelint-enable

--- a/src/sass/base/_variables.scss
+++ b/src/sass/base/_variables.scss
@@ -34,6 +34,7 @@ $space-sm:   8px;
 $space-md:  16px;
 $space-lg:  32px;
 $space-xl:  64px;
+$space-auto: auto; // this is currently required because the 'declaration-use-variable' linter doesn't allow for specific value exceptions when requriing variables
 
 
 // Inset: padding
@@ -80,6 +81,10 @@ $radius-md: 8px;
 $radius-rounded: 100rem;
 
 
+// Misc spacing
+$gutter-width: 30px; // from Bootstrap
+$half-gutter-width: $gutter-width/2; // from Bootstrap
+$gutter-offset: -$gutter-width/2;
 
 // ===========================================
 // Colors

--- a/src/sass/bootstrap.scss
+++ b/src/sass/bootstrap.scss
@@ -9,6 +9,8 @@
 // TODO Create Bootstrap overrides partial
 
 // Overrides - needs to be rethought - allow margin-top when following another element (* + h1, etc. ?)
+
+// stylelint-disable selector-no-type
 h1,
 h2,
 h3,
@@ -17,3 +19,4 @@ h5,
 h6 {
   margin: $space-none;
 }
+// stylelint-enable

--- a/src/sass/bootstrap/_bootstrap-variables.scss
+++ b/src/sass/bootstrap/_bootstrap-variables.scss
@@ -1,4 +1,4 @@
-@import "base/variables";
+@import 'base/variables';
 $bootstrap-sass-asset-helper: false !default;
 
 //== Colors
@@ -79,9 +79,9 @@ $font-size-h6: 1rem !default;
 
 // [converter] If $bootstrap-sass-asset-helper if used, provide path relative to the assets load path.
 // [converter] This is because some asset helpers, such as Sprockets, do not work with file-relative paths.
-$icon-font-path: if($bootstrap-sass-asset-helper, "bootstrap/", "../fonts/") !default;
+$icon-font-path: if($bootstrap-sass-asset-helper, 'bootstrap/', '../fonts/') !default;
 
 //** File name for all font files.
-// $icon-font-name:          "glyphicons-halflings-regular" !default;
+// $icon-font-name:          'glyphicons-halflings-regular' !default;
 //** Element ID within SVG icon file.
-// $icon-font-svg-id:        "glyphicons_halflingsregular" !default;
+// $icon-font-svg-id:        'glyphicons_halflingsregular' !default;

--- a/src/sass/bootstrap/bootstrap-custom.scss
+++ b/src/sass/bootstrap/bootstrap-custom.scss
@@ -7,52 +7,52 @@
  */
 
 // Core variables and mixins
-@import "bootstrap/variables";
-@import "bootstrap/mixins";
+@import 'bootstrap/variables';
+@import 'bootstrap/mixins';
 
 // Reset and dependencies
-// @import "bootstrap/normalize";
-@import "bootstrap/print";
-@import "bootstrap/glyphicons";
+// @import 'bootstrap/normalize';
+@import 'bootstrap/print';
+@import 'bootstrap/glyphicons';
 
 // Core CSS
-@import "bootstrap/scaffolding";
-@import "bootstrap/type";
-@import "bootstrap/code";
-// @import "bootstrap/grid"; // Use Bootstrap 4 grid system (using flex)
-@import "bootstrap/tables";
-@import "bootstrap/forms";
-@import "bootstrap/buttons";
+@import 'bootstrap/scaffolding';
+@import 'bootstrap/type';
+@import 'bootstrap/code';
+// @import 'bootstrap/grid'; // Use Bootstrap 4 grid system (using flex)
+@import 'bootstrap/tables';
+@import 'bootstrap/forms';
+@import 'bootstrap/buttons';
 
 // Components
-@import "bootstrap/component-animations";
-@import "bootstrap/dropdowns";
-@import "bootstrap/button-groups";
-@import "bootstrap/input-groups";
-@import "bootstrap/navs";
-@import "bootstrap/navbar";
-@import "bootstrap/breadcrumbs";
-@import "bootstrap/pagination";
-@import "bootstrap/pager";
-@import "bootstrap/labels";
-@import "bootstrap/badges";
-@import "bootstrap/jumbotron";
-@import "bootstrap/thumbnails";
-@import "bootstrap/alerts";
-@import "bootstrap/progress-bars";
-@import "bootstrap/media";
-@import "bootstrap/list-group";
-@import "bootstrap/panels";
-@import "bootstrap/responsive-embed";
-@import "bootstrap/wells";
-@import "bootstrap/close";
+@import 'bootstrap/component-animations';
+@import 'bootstrap/dropdowns';
+@import 'bootstrap/button-groups';
+@import 'bootstrap/input-groups';
+@import 'bootstrap/navs';
+@import 'bootstrap/navbar';
+@import 'bootstrap/breadcrumbs';
+@import 'bootstrap/pagination';
+@import 'bootstrap/pager';
+@import 'bootstrap/labels';
+@import 'bootstrap/badges';
+@import 'bootstrap/jumbotron';
+@import 'bootstrap/thumbnails';
+@import 'bootstrap/alerts';
+@import 'bootstrap/progress-bars';
+@import 'bootstrap/media';
+@import 'bootstrap/list-group';
+@import 'bootstrap/panels';
+@import 'bootstrap/responsive-embed';
+@import 'bootstrap/wells';
+@import 'bootstrap/close';
 
 // Components w/ JavaScript
-@import "bootstrap/modals";
-@import "bootstrap/tooltip";
-@import "bootstrap/popovers";
-@import "bootstrap/carousel";
+@import 'bootstrap/modals';
+@import 'bootstrap/tooltip';
+@import 'bootstrap/popovers';
+@import 'bootstrap/carousel';
 
 // Utility classes
-@import "bootstrap/utilities";
-@import "bootstrap/responsive-utilities";
+@import 'bootstrap/utilities';
+@import 'bootstrap/responsive-utilities';

--- a/src/sass/components/_about.scss
+++ b/src/sass/components/_about.scss
@@ -1,14 +1,21 @@
+.team-member {
+  margin-bottom: $space-md;
+  &__photo {
+    border-radius: $radius-sm;
+    margin-bottom: $space-sm;
+  }
+  &__name {
+    line-height: 1.2;
+  }
+  &__title {
+    font-style: italic;
+  }
+}
 .team-members-list {
-  padding: 0 5px;
+  padding-right: $space-xs;
+  padding-left: $space-xs;
   .team-member {
-    padding: 0 5px;
-    h4 {
-      font-size: 14px;
-    }
-    h5 {
-      font-size: 12px;
-      font-weight: normal;
-      line-height: 1.4;
-    }
+    padding-right: $space-xs;
+    padding-left: $space-xs;
   }
 }

--- a/src/sass/components/_ballotList.scss
+++ b/src/sass/components/_ballotList.scss
@@ -6,7 +6,7 @@
 
 .BallotItem {
   position: relative;
-  margin-bottom: 1em;
+  margin-bottom: $space-md;
 
   &__display-name {
     font-family: $heading-font-stack;
@@ -15,7 +15,7 @@
     @include breakpoints(max mid-small) {
       font-size: 18px;
       max-width: 100%;
-      padding-right: 30px; // TODO: adjust for bookmark icon
+      // padding-right: 30px; // TODO: adjust for bookmark icon
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -25,7 +25,7 @@
 
 // For display of tiny thumbnail images for organizational voter guides
 .organization-image-tiny {
-  margin-left: 3px;
+  margin-left: $space-xs;
   width: 30px;
   border-radius: $radius-sm;
   @include breakpoints(small) {

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -23,7 +23,7 @@
 
 // For icons on buttons
 .btn__icon {
-  margin-right: .3em;
+  margin-right: $space-xs;
   display: inline-block;
   vertical-align: middle;
   line-height: 1;

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -3,17 +3,22 @@
 @include media-object('.card-main__media-object', '.card-main__media-object-anchor', '.card-main__media-object-content');
 
 .card {
-  $item-padding: 15px;
+  $item-padding: $space-md;
   background-color: $white;
   border-radius: $radius-xs;
   box-shadow: $default-box-shadow;
-  margin-bottom: 20px;
+  margin-bottom: $space-md;
   @include clearfix;
   @include breakpoints(max mid-small) {
-    margin-right: -15px;
-    margin-bottom: 10px;
-    margin-left: -15px;
+    margin-bottom: $space-sm;
     border-radius: $radius-none;
+    [class^='col'] & {
+      margin-right: $gutter-offset;
+      margin-left: $gutter-offset;
+    }
+  }
+  &__body {
+    padding: $space-md;
   }
 
   // ----------------------------------------
@@ -23,17 +28,17 @@
 
   &-main { // primary subject of card
     position: relative;
-    padding: 15px $item-padding 10px;
+    padding: $space-md $item-padding $space-sm;
     font-size: 14px; // remove once global defaults are set
     @include print {
-      padding: 0;
+      padding: $space-none;
     }
 
     &__content {
       position: relative;
       @include print {
         border-top: 1px solid $gray-mid;
-        padding-top: 1em;
+        padding-top: $space-md;
       }
     }
 
@@ -88,7 +93,7 @@
 
     &__position-icon {
       display: inline-block;
-      margin-right: 5px;
+      margin-right: $space-xs;
       vertical-align: text-bottom;
     }
 
@@ -101,8 +106,8 @@
       display: inline-block;
       font-size: 18px;
       font-weight: 700;
-      margin-right: 24px; // space for bookmark button
-      margin-bottom: $space-md;
+      // margin-right: 24px; // space for bookmark button
+      margin-bottom: $space-sm;
       vertical-align: middle;
       @include breakpoints(mid-small) {
         font-size: 18px;
@@ -123,6 +128,7 @@
         $line-height: 25px;
         $text-container-height: $line-height * 2;
         $read-more-width: 7em;
+        $truncated-text-spacer: $space-xs;
         overflow: hidden;
         position: relative;
         height: $text-container-height;
@@ -131,14 +137,14 @@
         &::before {
           content: '';
           float: left;
-          width: 5px;
+          width: $truncated-text-spacer;
           height: $text-container-height;
         }
 
         > *:first-child {
           float: right;
           width: 100%;
-          margin-left: -5px;
+          margin-left: -($truncated-text-spacer); // stylelint-disable-line sh-waqar/declaration-use-variable
         }
 
         &::after {
@@ -146,11 +152,11 @@
           box-sizing: content-box;
           float: right;
           position: relative;
-          top: -$line-height;
+          top: -($line-height);
           left: 100%;
           width: $read-more-width;
-          margin-left: -$read-more-width;
-          padding-right: 5px;
+          margin-left: -($read-more-width);  // stylelint-disable-line sh-waqar/declaration-use-variable
+          padding-right: $space-xs;
           text-align: right;
           background-size: 100% 100%;
           background: linear-gradient(to right, rgba(255, 255, 255, 0), white 15%, white); // stylelint-disable-line declaration-block-no-shorthand-property-overrides
@@ -161,7 +167,7 @@
     }
 
     &__candidate-read-more-link {
-      margin-left: 10px;
+      margin-left: $space-sm;
       top: 0;
       font-family: $body-font-stack;
       font-size: 14px;
@@ -173,7 +179,7 @@
     }
 
     &__measure-read-more-link {
-      margin-left: 10px;
+      margin-left: $space-sm;
       font-family: $body-font-stack;
       font-size: 14px;
       font-weight: 100 !important;
@@ -184,7 +190,7 @@
     }
 
     &__office-read-more-link {
-      margin-left: 10px;
+      margin-left: $space-sm;
       font-family: $body-font-stack;
       font-size: 14px;
       font-weight: 100 !important;
@@ -215,25 +221,25 @@
   .card-child {
     position: relative;
     padding: $item-padding;
-    margin-top: -1px;
+    margin-top: -1px; // stylelint-disable-line sh-waqar/declaration-use-variable
     background-color: $gray-pale;
     border-top: 1px solid $gray-lighter;
     border-bottom: 1px solid $gray-lighter;
     @include breakpoints(max mid-small) {
-      margin-left: -$item-padding;
-      margin-right: -$item-padding;
+      margin-left: -($item-padding); // stylelint-disable-line sh-waqar/declaration-use-variable
+      margin-right: -($item-padding); // stylelint-disable-line sh-waqar/declaration-use-variable
     }
 
     &__list-group {
-      padding: 0;
-      margin: 0;
+      padding: $space-none;
+      margin: $space-none;
       @include breakpoints(max mid-small) {
-        padding: 0 $item-padding;
+        padding: $space-none $item-padding;
       }
       .card__additional-heading {
         @include breakpoints(max mid-small) {
-          margin-right: 0;
-          margin-left: 0;
+          margin-right: $space-none;
+          margin-left: $space-none;
         }
       }
     }
@@ -265,7 +271,7 @@
     &__display-name {
       font-family: $heading-font-stack;
       // font-size: 18px;
-      margin-bottom: .2em;
+      margin-bottom: $space-xs;
       flex: auto;
     }
 
@@ -273,34 +279,34 @@
       display: flex;
       align-items: flex-end;
       .btn {
-        margin: 0 5px 0 0;
+        margin: $space-none $space-xs $space-none $space-none;
       }
       .twitter-followers__badge {
-        margin: 5px 0;
+        margin: $space-xs $space-none;
       }
       @include breakpoints(medium) {
         flex-direction: column;
         .btn {
-          margin: 0 0 5px;
+          margin: $space-none $space-none $space-xs;
         }
         .twitter-followers__badge {
-          margin: 0;
+          margin: $space-none;
         }
       }
     }
 
     &__additional {
       display: flex;
-      margin-top: .5em;
+      margin-top: $space-sm;
       @include breakpoints(medium) {
         flex-direction: column;
-        padding-left: 1em;
-        margin-top: inherit;
+        padding-left: $space-md;
+        margin-top: inherit; // stylelint-disable-line sh-waqar/declaration-use-variable
         text-align: right;
       }
     }
     &--not-followed &__additional {
-      margin-top: 1em; // for follow buttons
+      margin-top: $space-md; // for follow buttons
     }
 
     .bookmark-action {
@@ -329,11 +335,11 @@
   &__additional-heading {
     font-family: $heading-font-stack;
     font-size: 18px;
-    margin: 20px $item-padding 15px;
+    margin: $space-md $item-padding;
   }
 
   &__no-additional {
-    margin: 15px $item-padding;
+    margin: $space-md $item-padding;
   }
 }
 

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -129,7 +129,7 @@
         line-height: $line-height;
 
         &::before {
-          content: "";
+          content: '';
           float: left;
           width: 5px;
           height: $text-container-height;
@@ -142,7 +142,7 @@
         }
 
         &::after {
-          content: "\00A0 Read More";
+          content: '\00A0 Read More';
           box-sizing: content-box;
           float: right;
           position: relative;

--- a/src/sass/components/_friends.scss
+++ b/src/sass/components/_friends.scss
@@ -1,6 +1,6 @@
 .invite-inputs {
   position: relative;
-  margin-bottom: 0;
+  margin-bottom: $space-none;
 }
 
 .invite-inputs .input-group {

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -4,16 +4,16 @@ $page-header-color: #1c1a33;
   // required overrides for Bootstrap :(
   border: none;
   @include clearfix;
-  padding-right: 15px; // $grid-gutter-width/2
-  padding-bottom: 0; // override to avoid Bootstrap collision
-  padding-left: 15px; // $grid-gutter-width/2
-  margin: 0 auto;
+  padding-right: $half-gutter-width;
+  padding-bottom: $space-none; // override to avoid Bootstrap collision
+  padding-left: $half-gutter-width; // $grid-gutter-width/2
+  margin: $space-none auto;
   max-width: $max-page-container-width;
   position: relative;
 
   &__container {
     background-color: $page-header-color;
-    padding: $space-sm 0;
+    padding: $space-sm $space-none;
   }
   &__content { // additional element to exclue Burger Menu element
     display: flex;
@@ -22,7 +22,7 @@ $page-header-color: #1c1a33;
   }
 
   &__search {
-    margin: 0;
+    margin: $space-none;
     position: relative;
     width: 100%;
   }
@@ -30,9 +30,9 @@ $page-header-color: #1c1a33;
 
 .page-logo {
   white-space: nowrap;
-  margin: 0 $space-md 0 0; // zeros to override Bootstrap h4
-  margin-top: -$space-sm;
-  margin-bottom: -$space-sm;
+  margin: $space-none $space-md $space-none $space-none; // zeros to override Bootstrap h4
+  margin-top: -$space-sm; // stylelint-disable-line sh-waqar/declaration-use-variable
+  margin-bottom: -$space-sm; // stylelint-disable-line sh-waqar/declaration-use-variable
   padding: $space-sm;
   &,
   &:hover,
@@ -64,7 +64,7 @@ $page-header-color: #1c1a33;
 }
 
 .site-search {
-  padding: 0 $space-md;
+  padding: $space-none $space-md;
 
   &__input-field {
     border: none; // override Bootstrap
@@ -92,7 +92,7 @@ $page-header-color: #1c1a33;
   $search-result-highlight-color: #d9edf7;
   background-color: $white;
   box-shadow: 5px 5px 10px rgba(0, 0, 0, .2);
-  margin: 0 1em;
+  margin: $space-none $space-md;
   position: absolute;
   top: 36px;
   right: 0;
@@ -130,10 +130,10 @@ $page-header-color: #1c1a33;
   display: inline-block;
   width: 30px;
   font-size: 30px;
-  margin: 0 12px 0 0;
+  margin-right: $space-md;
   height: 30px;
   &__filler {
-    padding: 0 21px;
+    padding: $space-none $space-md;
   }
   @include breakpoints(max nav) {
     display: none;

--- a/src/sass/components/_intro-story.scss
+++ b/src/sass/components/_intro-story.scss
@@ -126,66 +126,66 @@
 
 .background--image1 {
   @include breakpoints (small) {
-    background-image: url("/img/global/intro-story/slide1-flagpole-mountains-698x600.jpg");
+    background-image: url('/img/global/intro-story/slide1-flagpole-mountains-698x600.jpg');
   }
   @include breakpoints (large) {
     //Image for desktop has to be a very specific size otherwise it will tile or wrap
     // onto the next slide (due to div width of react-slick carousel) - approx 1000 width works fine
-    background-image: url("/img/global/intro-story/slide1-flagpole-mountains-1000x600.jpg");
+    background-image: url('/img/global/intro-story/slide1-flagpole-mountains-1000x600.jpg');
   }
 }
 
 .background--image2 {
   @include breakpoints (small) {
-    background-image: url("/img/global/intro-story/slide2-lady-liberty-698x600.jpg");
+    background-image: url('/img/global/intro-story/slide2-lady-liberty-698x600.jpg');
   }
   @include breakpoints (large) {
-    background-image: url("/img/global/intro-story/slide2-lady-liberty-1000x600.jpg");
+    background-image: url('/img/global/intro-story/slide2-lady-liberty-1000x600.jpg');
   }
 }
 
 .background--image3 {
   @include breakpoints (small) {
-    background-image: url("/img/global/intro-story/slide3-historic-place-698x600.jpg");
+    background-image: url('/img/global/intro-story/slide3-historic-place-698x600.jpg');
   }
   @include breakpoints (large) {
-    background-image: url("/img/global/intro-story/slide3-historic-place-1000x600.jpg");
+    background-image: url('/img/global/intro-story/slide3-historic-place-1000x600.jpg');
   }
 }
 
 .background--image4 {
   @include breakpoints (small) {
-    background-image: url("/img/global/intro-story/slide4-working-together-698x600.jpg");
+    background-image: url('/img/global/intro-story/slide4-working-together-698x600.jpg');
   }
   @include breakpoints (large) {
-    background-image: url("/img/global/intro-story/slide4-working-together-1000x600.jpg");
+    background-image: url('/img/global/intro-story/slide4-working-together-1000x600.jpg');
   }
 }
 
 .background--image5 {
   @include breakpoints (small) {
-    background-image: url("/img/global/intro-story/slide5-flagpole-698x600.jpg");
+    background-image: url('/img/global/intro-story/slide5-flagpole-698x600.jpg');
   }
   @include breakpoints (large) {
-    background-image: url("/img/global/intro-story/slide5-flagpole-1000x600.jpg");
+    background-image: url('/img/global/intro-story/slide5-flagpole-1000x600.jpg');
   }
 }
 
 .background--image6 {
   @include breakpoints (small) {
-    background-image: url("/img/global/intro-story/slide6-flag-building-698x600.jpg");
+    background-image: url('/img/global/intro-story/slide6-flag-building-698x600.jpg');
   }
   @include breakpoints (large) {
-    background-image: url("/img/global/intro-story/slide6-flag-building-1000x600.jpg");
+    background-image: url('/img/global/intro-story/slide6-flag-building-1000x600.jpg');
   }
 }
 
 .background--image7 {
   @include breakpoints (small) {
-    background-image: url("/img/global/intro-story/slide7-american-bicycle-698x600.jpg");
+    background-image: url('/img/global/intro-story/slide7-american-bicycle-698x600.jpg');
   }
   @include breakpoints (large) {
-    background-image: url("/img/global/intro-story/slide7-american-bicycle-1000x600.jpg");
+    background-image: url('/img/global/intro-story/slide7-american-bicycle-1000x600.jpg');
   }
 }
 

--- a/src/sass/components/_intro-story.scss
+++ b/src/sass/components/_intro-story.scss
@@ -1,6 +1,6 @@
 .intro-story {
   background-color: $gray-dark;
-  padding: 0;
+  padding: $space-none;
   height: 600px;
   width: 100%;
   color: $white;
@@ -11,7 +11,7 @@
   &__h1 {
     font-weight: 700;
     font-size: 30px;
-    padding: 40px 0 20px;
+    padding: $space-lg $space-none $space-md;
     @include breakpoints (max large) {
       font-size: 22px;
     }
@@ -19,14 +19,14 @@
   &__h1--alt {
     font-weight: 700;
     font-size: 30px;
-    padding-top: 40px;
+    padding-top: $space-lg;
     @include breakpoints (max large) {
       font-size: 22px;
     }
   }
 
   &__h2 {
-    padding-top: 20px;
+    padding-top: $space-md;
     font-size: 20px;
     @include breakpoints (max large) {
       font-size: 18px;
@@ -34,27 +34,27 @@
   }
 
   &__padding {
-    padding: 20px;
+    padding: $space-md;
     @include breakpoints (max large) {
-      padding-top: 20px;
-      padding-bottom: 15px;
+      padding-top: $space-md;
+      padding-bottom: $space-md;
     }
   }
 
   &__padding-top {
-    padding-top: 15px;
+    padding-top: $space-md;
   }
 
   &__padding--btm {
-    padding-bottom: 30px;
+    padding-bottom: $space-lg;
   }
 
   &__padding-btn {
-    padding-top: 40px;
-    padding-bottom: 50px;
+    padding-top: $space-lg;
+    padding-bottom: $space-lg;
     @include breakpoints (max large) {
-      padding-top: 30px;
-      padding-bottom: 15px;
+      padding-top: $space-lg;
+      padding-bottom: $space-md;
     }
   }
 
@@ -201,7 +201,7 @@
   @include breakpoints (small mid-small) {
     height: 30px;
     width: 30px;
-    padding: 5px;
+    padding: $space-xs;
   }
 }
 
@@ -209,14 +209,14 @@
 
 .story-view {
   .container-main {
-    margin: 0;
+    margin: $space-none;
     min-height: 100%;
-    padding: 0;
+    padding: $space-none;
   }
 
   .well {
-    margin-bottom: 0;
-    border: 0;
+    margin-bottom: $space-none;
+    border: none;
   }
 }
 

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -6,8 +6,8 @@ $red: #ff4921;
 .item-actionbar {
   display: flex;
   border-top: 1px solid $gray-lighter;
-  margin: 1em 0;
-  padding-top: 10px;
+  margin: $space-md $space-none;
+  padding-top: $space-sm;
 
   &__position-btn-label {
     @include breakpoints (max mid-small) {
@@ -32,7 +32,7 @@ $red: #ff4921;
 // This style is for when the item-actionbar is added to a line with other elements (like for a candidate on ballot page)
 .item-actionbar--inline {
   display: flex;
-  padding-top: 0;
+  padding-top: $space-none;
   justify-content: flex-end;
   flex: auto;
 

--- a/src/sass/components/_itemPositionStatementActionBar.scss
+++ b/src/sass/components/_itemPositionStatementActionBar.scss
@@ -1,5 +1,5 @@
 
-@include media-object(".position-statement", ".position-statement__avatar", ".position-statement__input-group");
+@include media-object('.position-statement', '.position-statement__avatar', '.position-statement__input-group');
 
 .position-statement {
   display: flex;
@@ -30,7 +30,7 @@
     line-height: $line-height;
 
     &::before {
-      content: "";
+      content: '';
       float: left;
       width: 5px;
       height: $text-container-height;
@@ -43,7 +43,7 @@
     }
 
     &::after {
-      content: "\00A0 Edit";
+      content: '\00A0 Edit';
 
       box-sizing: content-box;
       float: right;

--- a/src/sass/components/_itemPositionStatementActionBar.scss
+++ b/src/sass/components/_itemPositionStatementActionBar.scss
@@ -9,15 +9,15 @@
   &__avatar {
     overflow: hidden;
     border-radius: $radius-sm;
-    background: #fff;
+    background-color: $white;
     display: inline-block;
     flex-shrink: 0;
   }
 
   &__container {
     background-color: $gray-pale;
-    padding: 10px 15px;
-    margin: 0 -15px -10px -15px;
+    padding: $space-sm $space-md;
+    margin: $space-none (-$space-md) (-$space-sm);
   }
 
   &--truncated {
@@ -39,7 +39,7 @@
     > *:first-child {
       float: right;
       width: 100%;
-      margin-left: -5px;
+      margin-left: -($space-xs); // stylelint-disable-line sh-waqar/declaration-use-variable
     }
 
     &::after {
@@ -51,11 +51,11 @@
       top: -$line-height;
       left: 100%;
       width: $edit-position-width;
-      margin-left: -$edit-position-width;
-      padding-right: 5px;
+      margin-left: -($edit-position-width); // stylelint-disable-line sh-waqar/declaration-use-variable
+      padding-right: $space-xs;
       text-align: right;
       background-size: 100% 100%;
-      background: linear-gradient(to right, rgba(255, 255, 255, 0), white 15%, white); // stylelint-disable-line declaration-block-no-shorthand-property-overrides
+      background: linear-gradient(to right, rgba($white, 0), $white 15%, $white); // stylelint-disable-line declaration-block-no-shorthand-property-overrides
       font-style: normal;
       color: $link-color;
       cursor: pointer;

--- a/src/sass/components/_loading-spinner.scss
+++ b/src/sass/components/_loading-spinner.scss
@@ -6,7 +6,7 @@ $loader-size: .8rem;
 .u-loading-spinner {
   $dark-spinner: rgba($gray-dark, .7);
   $light-spinner: rgba($white, .7);
-  margin: 0 auto ($loader-size * 2) auto;
+  margin: $space-none $space-auto ($loader-size * 2) $space-auto;
   position: relative;
   text-indent: -9999em;
   transform: translateZ(0);
@@ -49,7 +49,7 @@ $loader-size: .8rem;
   }
   &__wrapper {
     @include clearfix;
-    margin: 20px auto 40px auto;
+    margin: $space-md $space-auto $space-lg $space-auto;
   }
 }
 

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -119,7 +119,7 @@ $header-height: 54px;
 
     &.donate {
       padding: $space-none;
-      & > img.glyphicon {
+      & > .glyphicon {
         max-width: 100%;
         width: 29px;
       }

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -17,7 +17,7 @@ $header-height: 54px;
   right: 15px;
   background-color: $white;
   opacity: 0;
-  padding: 1rem;
+  padding: $space-md;
   transition: opacity .25s ease-in-out;
   z-index: 2;
   pointer-events: none;
@@ -89,12 +89,13 @@ $header-height: 54px;
     position: relative;
     width: 60px;
     height: $header-height;
-    margin-top: -.5em; // temporary offsets for .page-header__container padding
-    margin-bottom: -.5em;
     padding: $space-sm;
     color: $white;
     opacity: .8;
     text-align: center;
+    // temporary offsets for .page-header__container padding
+    margin-top: -.5em; // stylelint-disable-line sh-waqar/declaration-use-variable
+    margin-bottom: -.5em; // stylelint-disable-line sh-waqar/declaration-use-variable
     &--has-icon {
       justify-content: space-between;
     }
@@ -129,7 +130,7 @@ $header-height: 54px;
     font-size: 1rem;
   }
   &__icon--about {
-    padding: 1px;
+    padding: $space-xxs;
   }
 
   &__avatar {

--- a/src/sass/components/_position.scss
+++ b/src/sass/components/_position.scss
@@ -6,11 +6,11 @@
 @include media-object('.explicit-position', '.explicit-position__icon', '.explicit-position__text', $margin: 5px);
 
 .explicit-position__icon {
-  margin-top: 2px;
+  margin-top: $space-xxs;
 }
 
 .explicit-position__text {
-  padding-top: .2em;
+  padding-top: $space-xs;
   color: $gray-dark;
 }
 

--- a/src/sass/loading-screen.scss
+++ b/src/sass/loading-screen.scss
@@ -24,7 +24,7 @@ $loading-screen-color: #337ec9;
     font-family: $heading-font-stack;
     font-size: 22px;
     font-weight: normal;
-    margin-top: 20px;
-    margin-bottom: 10px;
+    margin-top: $space-md;
+    margin-bottom: $space-sm;
   }
 }

--- a/src/sass/mixins/_breakpoints.scss
+++ b/src/sass/mixins/_breakpoints.scss
@@ -43,7 +43,7 @@ $mappy-queries: () !default;
 // $query : <string> from $mappy-queries key
 @mixin mappy-query($query, $mappy-queries: $mappy-queries) {
   @if not map-has-key($mappy-queries, $query) {
-    @error "#{$mappy-queries} does not contain #{$query}";
+    @error '#{$mappy-queries} does not contain #{$query}';
   }
 
   $mappy-map: map-get($mappy-queries, $query);
@@ -74,11 +74,11 @@ $mappy-queries: () !default;
   @each $key, $value in $media-map {
     @if $value and $value != 0 {
       @if $media-string == (()) {
-        $media-string: append($media-string, unquote("(#{$key}: #{$value})"));
+        $media-string: append($media-string, unquote('(#{$key}: #{$value})'));
       }
 
       @else {
-        $media-string: append($media-string, unquote("and (#{$key}: #{$value})"));
+        $media-string: append($media-string, unquote('and (#{$key}: #{$value})'));
       }
     }
   }
@@ -175,7 +175,7 @@ $mappy-queries: () !default;
     }
 
     @else if $_key {
-      @warn unquote('"Mappy Breakpoints is missing value for media feature "#{$_key}""');
+      @warn unquote(''Mappy Breakpoints is missing value for media feature '#{$_key}''');
     }
     $_i: $_i + 1;
   }
@@ -187,7 +187,7 @@ $mappy-queries: () !default;
 // Checks if $query given is one of the following:
 // 1) Is a $key in the $breakpoints map
 // 2) Is a number
-// 3) Is a "max", "max-width" or "max-height" string
+// 3) Is a 'max', 'max-width' or 'max-height' string
 @function mappy-validate($query, $breakpoints) {
   $_return: null;
 
@@ -199,7 +199,7 @@ $mappy-queries: () !default;
     $_return: $query;
   }
 
-  @else if $query == "max" or $query == "max-height" or $query == "max-width" {
+  @else if $query == 'max' or $query == 'max-height' or $query == 'max-width' {
     $_return: 0;
   }
 
@@ -214,14 +214,14 @@ $mappy-queries: () !default;
 // Checks and converts px values to em. Leave other units untouched.
 
 // @function mappy-convert-to-em($val) {
-//   @if unit($val) == "px" or $val == 0 {
+//   @if unit($val) == 'px' or $val == 0 {
 //     @return mappy-em($val);
-//   } @else if unit($val) == "em" {
+//   } @else if unit($val) == 'em' {
 //     @return $val;
-//   } @else if unit($val) == "rem" {
+//   } @else if unit($val) == 'rem' {
 //     @return mappy-strip-unit($val) * 1em;
 //   } @else {
-//     @error unquote("Breakpoint value must have a unit if it's a number");
+//     @error unquote('Breakpoint value must have a unit if it's a number');
 //   }
 // }
 
@@ -250,10 +250,10 @@ $mappy-queries: () !default;
   @for $i from 1 through $len {
     $e: nth($list, $i);
     @if $i == $len {
-      $res: unquote("#{$res}#{$e}");
+      $res: unquote('#{$res}#{$e}');
     }
     @else {
-      $res: unquote("#{$res}#{$e}#{$glue}");
+      $res: unquote('#{$res}#{$e}#{$glue}');
     }
   }
 

--- a/src/sass/mixins/_media-object.scss
+++ b/src/sass/mixins/_media-object.scss
@@ -35,7 +35,7 @@
     }
     #{unquote($img)} {
       float: $position;
-      img { display: block; }
+      display: block;
       @if $margin > 0 {
         @if $position == 'left' {
           margin-right: $margin;


### PR DESCRIPTION
### Adds new style linter rules
- Requires variables for `border-radius`, `margin`, and `padding` properties
- Disallows element 'type selectors' (i.e. avoid targeting elements `h1`, `form`, `span`, etc. – stick to class names)
- Require single quotes in stylesheets (I don't have a strong preference between single and double as long as we stay consistent)


### Workarounds...
_Due to some current limitations with the linter rule, some workarounds are required._
- Variables are still required for values like `0`, `auto`, and `inherit` so I've created `$space-none` and `$space-auto` to address this, even though they feel like unnecessary abstractions. If exceptions are eventually supported by the linter, these will be easy to convert back.
- Variable values turned negative are not supported (e.g. `-($variable)`), and because it feels more confusing to created explicit variables for most negative values, in most cases it's reasonable to just disable the linter rule for declarations that match this pattern. (`// stylelint-disable-line [linter-rule]`)