### PR TITLE
Changes to allow the cancellation of subscriptions, and support for Webhooks from Stripe.

### DIFF
--- a/src/js/actions/DonateActions.jsx
+++ b/src/js/actions/DonateActions.jsx
@@ -2,8 +2,17 @@ import Dispatcher from "../dispatcher/Dispatcher";
 
 module.exports = {
 
+  donationCancelSubscriptionAction: function (subscription_id) {
+    Dispatcher.loadEndpoint("donationCancelSubscription", { subscription_id: subscription_id });
+  },
+
+  donationRefund: function (charge) {
+    Dispatcher.loadEndpoint("donationRefund", { charge: charge });
+  },
+
   donationWithStripe: function (token, email, donation_amount, monthly_donation) {
     Dispatcher.loadEndpoint("donationWithStripe", { token: token, email: email, donation_amount: donation_amount,
-                            monthly_donation: monthly_donation });
-  }
+      monthly_donation: monthly_donation });
+  },
+
 };

--- a/src/js/components/Donation/DonationCancelSubscription.jsx
+++ b/src/js/components/Donation/DonationCancelSubscription.jsx
@@ -1,0 +1,78 @@
+import React, { Component, PropTypes } from "react";
+import { Table, Modal, Button } from "react-bootstrap";
+import DonateActions from "../../actions/DonateActions";
+import moment from "moment";
+
+
+export default class DonationCancelSubscription extends Component {
+  static propTypes = {
+    item: PropTypes.object,
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      showModal: false,
+      cancelling: false,
+    };
+  }
+
+  close () {
+    this.setState({ showModal: false });
+  }
+
+  open () {
+    this.setState({ showModal: true });
+  }
+
+  cancel (subscription_id) {
+    this.setState({ cancelling: true });
+    console.log("CANCEL");
+    DonateActions.donationCancelSubscriptionAction(subscription_id);
+    this.setState({ showModal: false });
+  }
+
+  render () {
+    const {item} = this.props;
+      return <div>
+        <Button bsSize="small" onClick={this.open.bind(this)} >
+          Cancel Subscription
+        </Button>
+
+        <Modal show={this.state.showModal} onHide={this.close.bind(this)}>
+          <Modal.Header closeButton>
+            <Modal.Title>Cancel Subscription</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>
+            <Table striped condensed hover responsive>
+               <tbody>
+                  <tr>
+                    <td>Created:</td><td>{moment.utc(item.created).local().format("MMM D, h:mm a")}</td>
+                  </tr>
+                  <tr>
+                    <td>Monthly payment:</td><td>{item.amount}</td>
+                  </tr>
+                  <tr>
+                    <td>Funding:</td><td>{item.funding}</td>
+                  </tr>
+                  <tr>
+                    <td>Card brand:</td><td>{item.brand}</td>
+                  </tr>
+                  <tr>
+                    <td>&nbsp;&nbsp;Card ends with:</td><td>{item.last4}</td>
+                  </tr>
+                  <tr>
+                    <td>&nbsp;&nbsp;Card expires:</td><td>{item.exp_month + "/" + item.exp_year}</td>
+                  </tr>
+               </tbody>
+            </Table>
+          </Modal.Body>
+          <Modal.Footer>
+            <Button onClick={this.close.bind(this)}>I changed my mind</Button>
+            <Button onClick={this.cancel.bind(this, item.subscription_id)}>Cancel this subscription</Button>
+          </Modal.Footer>
+        </Modal>
+      </div>;
+  }
+}
+//item.subscription_id

--- a/src/js/components/Donation/DonationForm.jsx
+++ b/src/js/components/Donation/DonationForm.jsx
@@ -46,7 +46,7 @@ export default class DonationForm extends Component {
     }
   }
 
-  _openStripeModal (event:Object) {
+  _openStripeModal (event) {
     event.preventDefault();
     this.stripeHandler.open({
       name: "We Vote",
@@ -54,8 +54,6 @@ export default class DonationForm extends Component {
       zipCode: true,
       amount: this.props.donationAmount,
       panelLabel: "Donate ",
-//      dataCurrency: "" <-- we might want to enable this with some sort of geocoding(default is usd)
-// stripe doesn't support editable pre-filled email fields nor optional email fields (they are required)
     });
   }
 

--- a/src/js/components/Donation/DonationListForm.jsx
+++ b/src/js/components/Donation/DonationListForm.jsx
@@ -21,20 +21,32 @@ export default class DonationListForm extends Component {
 
   componentWillUnmount () {
     this.voterStoreListener.remove();
-  }
+   }
 
   _onVoterStoreChange () {
     this.setState({journal: VoterStore.getVoterDonationHistory()});
   }
 
+  handleSelect (selectedKey) {
+    this.setState({
+      activeKey: selectedKey
+    });
+    if ( selectedKey === 2) {
+      // It takes a 2 to 30 seconds for the charge to come back from the first charge on a subscription,
+      VoterActions.voterRefreshDonations();
+    }
+  }
 
   render () {
     if (this.state.journal && this.state.journal.length > 0) {
       return (
-        <Tabs defaultActiveKey={1} id="tabbed_donation_history">
-          <Tab eventKey={1} title="Donations"><DonationList displayDonations/></Tab>
-          <Tab eventKey={2} title="Subscriptions"><DonationList displayDonations={false}/></Tab>
-        </Tabs>
+        <div>
+          <input type="hidden" value={this.state.activeKey} />
+          <Tabs defaultActiveKey={1} activeKey={this.state.activeKey} onSelect={this.handleSelect} id="tabbed_donation_history">
+              <Tab eventKey={1} title="Donations"><DonationList displayDonations/></Tab>
+              <Tab eventKey={2} title="Subscriptions"><DonationList displayDonations={false}/></Tab>
+          </Tabs>
+        </div>
       );
     } else {
       return <span />;

--- a/src/js/routes/More/DonateThankYou.jsx
+++ b/src/js/routes/More/DonateThankYou.jsx
@@ -14,6 +14,10 @@ export default class DonateThankYou extends Component {
         <h1 className="h4">Thank you for your donation!</h1>
         <h1>&nbsp;</h1>
         <h1>&nbsp;</h1>
+        <p>
+          New subscriptions may take a few minutes to appear in this list.  The first payment for new subscriptions may also be delayed.
+        </p>
+        <p/><p/>
         <div>
           <DonationListForm />
         </div>

--- a/src/js/stores/DonateStore.js
+++ b/src/js/stores/DonateStore.js
@@ -15,6 +15,18 @@ class DonateStore extends FluxMapStore {
     return this.getState().donation_response_received;
   }
 
+  donation_cancel_has_completed () {
+    this.setState({ donation_cancel_completed: true });
+  }
+
+  donation_refund_has_completed () {
+    this.setState({ donation_refund_completed: true });
+  }
+
+  donation_subscription_has_been_updated () {
+    this.setState({ donation_subscription_updated: true });
+  }
+
   reduce (state, action) {
 
     switch (action.type) {
@@ -30,8 +42,22 @@ class DonateStore extends FluxMapStore {
         };
 
       case "error-donateRetrieve":
-        console.log(action);
+        console.log("error-donateRetrieve" + action);
         return state;
+
+      case "donationCancelSubscription":
+        console.log("donationCancelSubscription: " + action);
+        return {
+          subscription_id: action.res.subscription_id,
+          donation_cancel_completed: false,
+        };
+
+      case "donationRefund":
+        console.log("donationRefund: " + action);
+        return {
+          charge: action.res.charge,
+          donation_refund_completed: false,
+        };
 
       default:
         return state;


### PR DESCRIPTION
In DonateActions support for the new endpoints for CancelSubscription and Refunds.
New class DonationCancelSubscription.jsx
In DonationList, show "waiting" for subscriptions that have been
created but have not received their card info from the Webhook. Don't
show the info button on one-time donations if the donation is more than
30 days old.  30 days is \set on the server side in an environment
variable "STRIPE_REFUND_DAYS".
In DonationList -- the Webhook that adds the card info to the
subscription (that is in the DB, but is incomplete) takes 5 to 30
seconds. So we can't just block for all that time, so everytime you
enter the subscriptions tab, we do a
oterActions.voterRefreshDonations() to update the data. Simple, but
should be good enough.
In DonateStore add support for the new endpoints.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
