### PR TITLE
Fix for Tab Wrapping Small Viewports

### DIFF
--- a/src/sass/overrides/_overrides.scss
+++ b/src/sass/overrides/_overrides.scss
@@ -14,3 +14,13 @@
 .pac-container {
   z-index: 1051 !important;
 }
+
+@media all and (max-width: 320px) {
+  .nav {
+    > li {
+      > a {
+        padding: 10px 5px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

This fixes issue where the 3rd tab wraps on smaller viewports such as the iPhone 5.

Fixes #881

### Changes included this pull request?

![881-fix](https://user-images.githubusercontent.com/442374/27003307-36ba3a22-4dc2-11e7-9e14-4ea178a9b338.png)
