### PR TITLE
Do not silently fail when the voter address does not find a close by ballot.

### DIFF
--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -5,6 +5,7 @@ import { browserHistory } from "react-router";
 import LoadingWheel from "../components/LoadingWheel";
 import VoterActions from "../actions/VoterActions";
 import VoterStore from "../stores/VoterStore";
+import BallotStore from "../stores/BallotStore";
 
 export default class AddressBox extends Component {
   static propTypes = {
@@ -16,7 +17,8 @@ export default class AddressBox extends Component {
       super(props);
       this.state = {
         loading: false,
-        voter_address: ""
+        voter_address: "",
+        ballotCaveat: "",
       };
 
     this.updateVoterAddress = this.updateVoterAddress.bind(this);
@@ -25,14 +27,19 @@ export default class AddressBox extends Component {
   }
 
   componentDidMount () {
-    this.setState({ voter_address: VoterStore.getAddress() });
+    this.setState({
+      voter_address: VoterStore.getAddress(),
+      ballotCaveat: BallotStore.getBallotCaveat()
+    });
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
+    this.ballotStoreListener = BallotStore.addListener(this._onBallotStoreChange.bind(this));
     let addressAutocomplete = new google.maps.places.Autocomplete(this.refs.autocomplete);
     this.googleAutocompleteListener = addressAutocomplete.addListener("place_changed", this._placeChanged.bind(this, addressAutocomplete));
   }
 
   componentWillUnmount (){
     this.voterStoreListener.remove();
+    this.ballotStoreListener.remove();
     this.googleAutocompleteListener.remove();
   }
 
@@ -45,6 +52,10 @@ export default class AddressBox extends Component {
     } else {
       this.setState({ voter_address: VoterStore.getAddress(), loading: false });
     }
+  }
+
+  _onBallotStoreChange () {
+      this.setState({ ballotCaveat: BallotStore.getBallotCaveat() });
   }
 
   _ballotLoaded (){
@@ -91,18 +102,17 @@ export default class AddressBox extends Component {
     }
     return <div>
         <form onSubmit={this.voterAddressSave}>
-        <input
-          type="text"
-          value={this.state.voter_address}
-          onKeyDown={this.handleKeyPress}
-          onChange={this.updateVoterAddress}
-          name="address"
-          className="form-control"
-          ref="autocomplete"
-          placeholder="Enter address where you are registered to vote"
-        />
+          <input
+            type="text"
+            value={this.state.voter_address}
+            onKeyDown={this.handleKeyPress}
+            onChange={this.updateVoterAddress}
+            name="address"
+            className="form-control"
+            ref="autocomplete"
+            placeholder="Enter address where you are registered to vote"
+          />
         </form>
-
         <div>
           <Button
             className="pull-right"
@@ -110,6 +120,7 @@ export default class AddressBox extends Component {
             bsStyle="primary">
             Save</Button>
         </div>
+      <p/><h4>{this.state.ballotCaveat}</h4>
       </div>;
   }
 }

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -55,6 +55,10 @@ class BallotStore extends FluxMapStore {
     return this.getState().ballots[civicId].polling_location_we_vote_id_source;
   }
 
+  getBallotCaveat() {
+    return this.getState().ballotCaveat || "";
+  }
+
   get bookmarks (){
     let civicId = VoterStore.election_id();
     if (!this.getState().ballots || !this.getState().ballots[civicId] ){ return undefined; }
@@ -130,6 +134,7 @@ class BallotStore extends FluxMapStore {
 
     let key;
     let newBallot = {};
+    let ballotCaveat = '';
 
     switch (action.type) {
 
@@ -162,10 +167,14 @@ class BallotStore extends FluxMapStore {
         } else {
           key = action.res.google_civic_election_id;
           newBallot[key] = action.res;
+          if (newBallot[key].ballot_found === false ) {
+            ballotCaveat = newBallot[key].ballot_caveat;
+          }
 
           return {
             ...state,
-            ballots: assign({}, state.ballots, newBallot )
+            ballots: assign({}, state.ballots, newBallot ),
+            ballotCaveat: ballotCaveat
           };
         }
 


### PR DESCRIPTION
The server had already been sending back ballotCaveat ... the reason
why the address was not accepted from /settings/location.  Now we store
ballotCaveat in the BallotStore, and listen for changes to it in the
AddressBox, and display the reason why we keep displaying the address
box.  Previously we were silently failing.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
