### PR TITLE
#745 Make Twitter link active 

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -9,6 +9,7 @@ import ItemTinyOpinionsToFollow from "../VoterGuide/ItemTinyOpinionsToFollow";
 import ItemTinyPositionBreakdownList from "../Position/ItemTinyPositionBreakdownList";
 import OfficeNameText from "../Widgets/OfficeNameText";
 import BookmarkToggle from "../Bookmarks/BookmarkToggle";
+import ParsedTwitterDescription from "../Twitter/ParsedTwitterDescription";
 import SupportStore from "../../stores/SupportStore";
 import {abbreviateNumber} from "../../utils/textFormat";
 import {numberWithCommas} from "../../utils/textFormat";
@@ -162,11 +163,10 @@ export default class CandidateItem extends Component {
           { twitter_description ?
             <div className={ "u-stack--sm" + (this.props.link_to_ballot_item_page ? " card-main__description-container--truncated" : " card-main__description-container")}>
               <div>
-                <p className="card-main__description">
-                    {twitter_description}
-                </p>
+                <ParsedTwitterDescription
+                  twitter_description={twitter_description}
+                />
               </div>
-
               <Link to={candidateLink}>
                 { this.props.link_to_ballot_item_page ? <span className="card-main__read-more-pseudo" /> : null }
               </Link>

--- a/src/js/components/Twitter/ParsedTwitterDescription.jsx
+++ b/src/js/components/Twitter/ParsedTwitterDescription.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const ParsedTwitterDescription = (props) => {
+  const parseTextForTwitterLinks = (text) => {
+    let locations = [];
+    let parsedLocations = [];
+
+    // find all instances of twitter links within the passed text
+    const findHttpsTCo = (fullText, start) => {
+      let str = fullText.slice(start);
+      let twitterFound = str.indexOf("https://t.co/");
+      if (twitterFound >= 0) {
+        str = str.slice(twitterFound);
+        let spaceFound = str.indexOf(" ");
+        if (spaceFound >= 0) {
+          locations.push([start + twitterFound, start + twitterFound + spaceFound]);
+          findHttpsTCo(fullText, start + twitterFound + spaceFound);
+        } else {
+          // if no space is found after twitterFound, assume the link is at the very end of fullText and use end of fullText as the endpoint
+          locations.push([start + twitterFound, fullText.length]);
+        }
+      }
+    };
+    findHttpsTCo(text, 0);
+
+    // use these locations of twitter links to make an array marking all areas of text versus links
+    let gapPointer = 0;
+    if (!locations.length) {
+      parsedLocations.push({type: "text", location: [0, text.length]});
+    } else {
+      locations.forEach((location) => {
+        if (location[0] !== gapPointer) {
+          parsedLocations.push({type: "text", location: [gapPointer, location[0] - 1]});
+        }
+        parsedLocations.push({type: "link", location: [location[0], location[1]]});
+        gapPointer = location[1] + 1;
+      });
+      if (locations[locations.length - 1][1] < text.length - 1) {
+        parsedLocations.push({type: "text", location: [locations[locations.length - 1][1] + 1, text.length]});
+      }
+    }
+    return parsedLocations;
+  };
+
+  let parsedTwitterDescription = parseTextForTwitterLinks(props.twitter_description);
+
+  return (
+    <p className="card-main__description">
+      {
+        //eslint-disable-next-line no-extra-parens
+        parsedTwitterDescription.map((snippet, i) => (
+          snippet.type === "text" ?
+            <span
+              key={i}
+            >
+              {props.twitter_description.slice(snippet.location[0], snippet.location[1])}&nbsp;
+            </span> :
+            <span
+              key={i}
+            >
+              <a
+                href={props.twitter_description.slice(snippet.location[0], snippet.location[1])}
+                target={props.twitter_description.slice(snippet.location[0] + 8, snippet.location[1])}
+              >
+                {props.twitter_description.slice(snippet.location[0], snippet.location[1])}
+              </a>&nbsp;
+            </span>
+        ))
+      }
+    </p>
+  );
+};
+
+ParsedTwitterDescription.propTypes = {
+  twitter_description: PropTypes.string,
+};
+
+export default ParsedTwitterDescription;

--- a/src/js/components/Twitter/TwitterAccountCard.jsx
+++ b/src/js/components/Twitter/TwitterAccountCard.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import ParsedTwitterDescription from "../Twitter/ParsedTwitterDescription";
 import ImageHandler from "../../components/ImageHandler";
 import { abbreviateNumber, numberWithCommas, removeTwitterNameFromDescription } from "../../utils/textFormat";
 
@@ -35,7 +36,9 @@ export default class TwitterAccountCard extends Component {
             <div className="card-main__media-object-content">
               <div className="card-main__display-name">{displayName}</div>
               { twitterDescriptionMinusName ?
-                <p className="card-main__description">{twitterDescriptionMinusName}</p> :
+                <ParsedTwitterDescription
+                  twitter_description={twitterDescriptionMinusName}
+                /> :
                 null
               }
               { twitter_handle ?

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
+import ParsedTwitterDescription from "../Twitter/ParsedTwitterDescription";
 import ImageHandler from "../../components/ImageHandler";
 import LoadingWheel from "../../components/LoadingWheel";
 import { numberWithCommas, removeTwitterNameFromDescription } from "../../utils/textFormat";
@@ -45,7 +46,9 @@ export default class OrganizationCard extends Component {
           <h3 className="card-main__display-name">{displayName}</h3>
         </Link>
         { twitterDescriptionMinusName && !this.props.turn_off_description ?
-          <p className="card-main__description">{twitterDescriptionMinusName}</p> :
+          <ParsedTwitterDescription
+            twitter_description={twitterDescriptionMinusName}
+          /> :
           <p className="card-main__description" />
         }
         <div>

--- a/src/js/components/VoterGuide/OrganizationVoterGuideCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideCard.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
+import ParsedTwitterDescription from "../Twitter/ParsedTwitterDescription";
 import LoadingWheel from "../../components/LoadingWheel";
 import FollowToggle from "../../components/Widgets/FollowToggle";
 import { numberWithCommas, removeTwitterNameFromDescription } from "../../utils/textFormat";
@@ -49,7 +50,11 @@ export default class OrganizationVoterGuideCard extends Component {
         <FollowToggle we_vote_id={organization_we_vote_id} />
         <br />
         { twitterDescriptionMinusName && !this.props.turn_off_description ?
-          <p className="card-main__description">{twitterDescriptionMinusName}</p> :
+          <p className="card-main__description">
+            <ParsedTwitterDescription
+              twitter_description={twitterDescriptionMinusName}
+            />
+          </p> :
           <p className="card-main__description" />
         }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Issue #745 
### Changes included this pull request?
created ParsedTwitterDescription component to convert https://t.co/someParam into active links opened in new windows
This component now used by 
- CandidateItem
- TwitterAccountCard
- OrganizationCard
- OrganizationVoterGuideCard