### PR TITLE
Implemented overflow for BallotFilter tabs

### DIFF
--- a/src/js/components/Navigation/BallotFilter.jsx
+++ b/src/js/components/Navigation/BallotFilter.jsx
@@ -14,19 +14,19 @@ export default class BallotFilter extends Component {
     const {ballot_type, length, length_remaining} = this.props;
 
     return <ul className="nav ballot__tabs">
-      <li>
+      <li className="tab-item">
         <Link to="/ballot" className={ballot_type === "ALL_BALLOT_ITEMS" ? "tab tab-active" : "tab tab-default"}>
           <span>All Items ({length})</span>
         </Link>
       </li>
 
-      <li>
+      <li className="tab-item">
         <Link to={{ pathname: "/ballot", query: { type: "filterRemaining" } }} className={ballot_type === "CHOICES_REMAINING" ? "tab tab-active" : "tab tab-default"}>
           <span>Remaining Decisions ({length_remaining})</span>
         </Link>
       </li>
 
-      <li>
+      <li className="tab-item">
         <Link to={{ pathname: "/ballot", query: { type: "filterReadyToVote" } }} className={ ballot_type === "READY_TO_VOTE" ? "tab tab-active" : "tab tab-default"}>
           <span>Vote!</span>
         </Link>

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -365,10 +365,12 @@ export default class Ballot extends Component {
               <EditAddress address={voter_address_object} _toggleSelectAddressModal={this._toggleSelectAddressModal} />
             </div>
             { text_for_map_search ?
-              <div className="ballot__filter hidden-print">
-                <BallotFilter ballot_type={this.getBallotType()}
-                              length={BallotStore.ballotLength}
-                              length_remaining={BallotStore.ballot_remaining_choices_length} />
+              <div className="ballot__filter-container">
+                <div className="ballot__filter hidden-print">
+                  <BallotFilter ballot_type={this.getBallotType()}
+                                length={BallotStore.ballotLength}
+                                length_remaining={BallotStore.ballot_remaining_choices_length} />
+                </div>
               </div> :
               null }
             <div className="visible-xs-block hidden-print">

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -342,7 +342,7 @@ export default class Ballot extends Component {
 
       <div className="row">
         <div className="col-md-12">
-          <div className="u-stack--lg ballot__heading">
+          <div className="ballot__heading">
             <Helmet title="Ballot - We Vote" />
             <BrowserPushMessage incomingProps={this.props} />
             { election_name ?
@@ -373,16 +373,16 @@ export default class Ballot extends Component {
                 </div>
               </div> :
               null }
-            <div className="visible-xs-block hidden-print">
-              <div className="BallotItemsSummary">
-                <a onClick={this._toggleBallotSummaryModal}>Summary of Ballot Items</a>
-              </div>
-            </div>
           </div>
         </div>
       </div>
       {emptyBallot}
-      <div className="row">
+      <div className="visible-xs-block hidden-print">
+        <div className="BallotItemsSummary">
+          <a onClick={this._toggleBallotSummaryModal}>Summary of Ballot Items</a>
+        </div>
+      </div>
+      <div className="row ballot__body">
         <div className="col-xs-12 col-md-8">
           <div className="BallotList">
           { in_ready_to_vote_mode ?

--- a/src/sass/components/_ballot.scss
+++ b/src/sass/components/_ballot.scss
@@ -5,6 +5,9 @@ $address-margin-xs: -4px 0 8px 0;
 $tab-padding: 0 0 4px 0;
 $tab-spacing: 24px;
 $transparent: transparent !important;
+$scrollbar-width: 20px;
+$tab-height: 47px;
+$tab-height-visible: $tab-height - $scrollbar-width;
 
 .ballot {
   // ===========================================
@@ -17,14 +20,14 @@ $transparent: transparent !important;
 
   &__filter-container {
     overflow: hidden;
-    height: 27px;
+    height: $tab-height-visible;
   }
 
   &__filter {
     white-space: nowrap;
     overflow-x: scroll;
     overflow-y: hidden;
-    height: 47px;
+    height: $tab-height;
   }
 
   &__header-group {
@@ -63,7 +66,7 @@ $transparent: transparent !important;
     margin-right: $minus-full-width;
     overflow: hidden;
 
-    li {
+    .tab-item {
       display: inline-block;
       float: none;
     }

--- a/src/sass/components/_ballot.scss
+++ b/src/sass/components/_ballot.scss
@@ -7,6 +7,10 @@ $tab-spacing: 24px;
 $transparent: transparent !important;
 
 .ballot {
+  // ===========================================
+  // Ballot Header
+  // ===========================================
+
   &__election-name {
     // TODO either add some properties to this class or delete it
   }
@@ -19,6 +23,7 @@ $transparent: transparent !important;
   &__filter {
     white-space: nowrap;
     overflow-x: scroll;
+    overflow-y: hidden;
     height: 47px;
   }
 
@@ -29,6 +34,7 @@ $transparent: transparent !important;
 
   &__heading {
     background-color: $white;
+    border-bottom: 1px solid #aaa;
     padding-top: $full-width;
     margin-top: $minus-full-width;
     padding-left: $full-width;
@@ -56,7 +62,6 @@ $transparent: transparent !important;
     padding-right: $full-width;
     margin-right: $minus-full-width;
     overflow: hidden;
-    border-bottom: 1px solid #aaa;
 
     li {
       display: inline-block;
@@ -69,7 +74,7 @@ $transparent: transparent !important;
     }
 
     .tab-active {
-      border-bottom: 2px solid $black;
+      border-bottom: 6px solid $black;
       color: $black;
     }
 
@@ -81,5 +86,13 @@ $transparent: transparent !important;
     a:hover {
       background-color: $transparent;
     }
+  }
+
+  // ===========================================
+  // Ballot Body
+  // ===========================================
+
+  &__body {
+    margin-top: $space-lg;
   }
 }

--- a/src/sass/components/_ballot.scss
+++ b/src/sass/components/_ballot.scss
@@ -11,8 +11,15 @@ $transparent: transparent !important;
     // TODO either add some properties to this class or delete it
   }
 
+  &__filter-container {
+    overflow: hidden;
+    height: 27px;
+  }
+
   &__filter {
-    // TODO either add some properties to this class or delete it
+    white-space: nowrap;
+    overflow-x: scroll;
+    height: 47px;
   }
 
   &__header-group {
@@ -51,10 +58,14 @@ $transparent: transparent !important;
     overflow: hidden;
     border-bottom: 1px solid #aaa;
 
+    li {
+      display: inline-block;
+      float: none;
+    }
+
     .tab {
       padding: $tab-padding;
       margin-right: $tab-spacing;
-      float: left;
     }
 
     .tab-active {

--- a/src/sass/components/_ballotList.scss
+++ b/src/sass/components/_ballotList.scss
@@ -1,5 +1,6 @@
 $full-width: 100%;
 $minus-full-width: -$full-width;
+$minus-space-md: -$space-md;
 
 .BallotList {
   @include print {
@@ -84,12 +85,12 @@ $minus-full-width: -$full-width;
 }
 
 .BallotItemsSummary {
-  background-color: $app-background-color;
   padding-top: $space-md;
   padding-left: $full-width;
   margin-left: $minus-full-width;
   padding-right: $full-width;
   margin-right: $minus-full-width;
+  margin-bottom: $minus-space-md;
   overflow: hidden;
   // Has the result of float center
   // float: right;

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -2,7 +2,7 @@ $icon-color-base: $gray-mid;
 $icon-color-active: $link-color;
 $icon-color-hover: $gray-dark;
 $header-height: 54px;
-$header-height-getting-started: 104px;
+$header-height-getting-started: 100px;
 
 // Header Nav
 // ================================


### PR DESCRIPTION
Using only SCSS (and rearranging some HTML), the ballot filter tabs now remain on one line and have the ability to horizontally scroll through them (in both desktop and moble versions). The only two minor issues right now are that the scrollbar below the tabs (which is supposed to be hidden) may still be visible if you change the zoom level in your browser, and there is a ton of extra space to the right of the tabs that you can scroll through.

#999 