### PR TITLE
Redesigned candidate display on ballot page

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "react-player": "^0.14.1",
     "react-router-scroll": "^0.4.1",
     "react-slick": "^0.14.5",
-    "react-text-truncate": "^0.8.3",
+    "react-text-truncate": "^0.11.2",
     "react-textarea-autosize": "^4.0.5",
     "superagent": "^3.3.1",
     "vinyl-buffer": "^1.0.0"

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Link, browserHistory } from "react-router";
+import TextTruncate from 'react-text-truncate';
 import GuideStore from "../../stores/GuideStore";
 import ImageHandler from "../ImageHandler";
 import ItemActionBar from "../Widgets/ItemActionBar";
@@ -44,7 +45,7 @@ export default class OfficeItemCompressed extends Component {
     this.supportStoreListener.remove();
   }
 
-  _onGuideStoreChange (){
+  _onGuideStoreChange () {
     this.setState({ transitioning: false });
   }
 
@@ -93,9 +94,7 @@ export default class OfficeItemCompressed extends Component {
           return <div key={candidateId} className="u-stack--md">
             <div className="o-media-object--center u-flex-auto u-min-50 u-push--sm u-stack--sm">
               {/* Candidate Image */}
-              <div onClick={ this.props.link_to_ballot_item_page ?
-                            ()=>{browserHistory.push("/candidate/" + candidateId);} :
-                            null }>
+              <div onClick={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null }>
                 <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
                               sizeClassName="icon-candidate-small u-push--sm "
                               imageUrl={one_candidate.candidate_photo_url_large}
@@ -105,11 +104,17 @@ export default class OfficeItemCompressed extends Component {
               <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
                 {/* Candidate Name */}
                 <h4 className="card-main__candidate-name u-f4">
-                  {one_candidate.ballot_item_display_name}
-                  <a onClick={ this.props.link_to_ballot_item_page ?
-                                ()=>{browserHistory.push("/candidate/" + candidateId);} :
-                                null }>
-                  <span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span></a>
+                  <a onClick={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null }>
+                    <TextTruncate
+                      line={1}
+                      truncateText="…"
+                      text={one_candidate.ballot_item_display_name}
+                      textTruncateChild={null}
+                    />
+                  </a>
+                  <a onClick={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null }>
+                    <span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span>
+                  </a>
                 </h4>
                 {/* Opinion Items */}
                 <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -97,8 +97,8 @@ export default class OfficeItemCompressed extends Component {
           let candidate_text = candidate_party_text + candidate_description_text;
 
           return <div key={candidateId} className="u-stack--md">
-            <div className="o-media-object--center u-flex-auto u-min-50 u-push--sm u-stack--sm">
-              {/* Candidate Image */}
+            <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
+              {/* Candidate Photo */}
               <div onClick={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null }>
                 <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
                               sizeClassName="icon-candidate-small u-push--sm "

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -90,7 +90,7 @@ export default class OfficeItemCompressed extends Component {
           { candidate_list_to_display.map( (one_candidate) =>
             <div key={one_candidate.we_vote_id} className="u-stack--md">
               <div className="u-flex u-items-center u-flex-wrap u-justify-between">
-                {/* *** Candidate name *** */}
+                {/* Candidate Image */}
                 <div className="u-flex u-cursor--pointer u-min-50"
                     onClick={ this.props.link_to_ballot_item_page ?
                               ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
@@ -103,45 +103,42 @@ export default class OfficeItemCompressed extends Component {
                                     alt="candidate-photo"
                                     kind_of_ballot_item="CANDIDATE" />
                       <div className="o-media-object__body">
-                        <h4 className="card-main__candidate-name u-f4"><a>{one_candidate.ballot_item_display_name}
-                          <span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span></a></h4>
-
+                        <h4 className="card-main__candidate-name u-f4">
+                          <a>{one_candidate.ballot_item_display_name}<span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span></a>
+                        </h4>
                       </div>
                     </div>
                   </div>
                 </div>
 
-                {/* *** "Positions in your Network" bar OR items you can follow *** */}
-                <div className="u-flex u-flex-auto u-justify-end u-items-center u-min-50">
-                  <div className="u-flex-none u-justify-end u-push--sm">
-                    {/* Decide whether to show the "Positions in your network" bar or the options of voter guides to follow */}
-                    { SupportStore.get(one_candidate.we_vote_id) && ( SupportStore.get(one_candidate.we_vote_id).oppose_count || SupportStore.get(one_candidate.we_vote_id).support_count) ?
-                      <span className="u-cursor--pointer"
+                {/* Flex Row 2: Opinion Items */}
+                <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
+                  {/* Positions in Your Network */}
+                  <div className="u-cursor--pointer"
+                        onClick={ this.props.link_to_ballot_item_page ?
+                        ()=>{this.props._toggleCandidateModal(one_candidate);} :
+                        null } >
+                    <ItemSupportOpposeCounts we_vote_id={one_candidate.we_vote_id}
+                                             supportProps={SupportStore.get(one_candidate.we_vote_id)}
+                                             type="CANDIDATE"/>
+                  </div>
+
+                  {/* Possible Voter Guides to Follow (Desktop) */}
+                  <div className="hidden-xs hidden-print">
+                    { GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id) && GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id).length !== 0 ?
+                      <div className="u-cursor--pointer"
                             onClick={ this.props.link_to_ballot_item_page ?
                             ()=>{this.props._toggleCandidateModal(one_candidate);} :
                             null } >
-                        <ItemSupportOpposeCounts we_vote_id={one_candidate.we_vote_id}
-                                                 supportProps={SupportStore.get(one_candidate.we_vote_id)}
-                                                 type="CANDIDATE"/>
-                      </span> :
-                      <span>
-                        {/* Show possible voter guides to follow */}
-                        { GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id) && GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id).length !== 0 ?
-                          <span className="u-cursor--pointer"
-                                onClick={ this.props.link_to_ballot_item_page ?
-                                ()=>{this.props._toggleCandidateModal(one_candidate);} :
-                                null } >
-                            <ItemTinyOpinionsToFollow ballotItemWeVoteId={one_candidate.we_vote_id}
-                                                      organizationsToFollow={GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id)}
-                                                      maximumOrganizationDisplay={this.state.maximum_organization_display}/>
-                          </span> :
-                          <span /> }
-                      </span>
-                    }
+                        <ItemTinyOpinionsToFollow ballotItemWeVoteId={one_candidate.we_vote_id}
+                                                  organizationsToFollow={GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id)}
+                                                  maximumOrganizationDisplay={this.state.maximum_organization_display}/>
+                      </div> :
+                      null }
                   </div>
 
-                  {/* *** Choose Support or Oppose *** */}
-                  <div className="u-flex-none u-cursor--pointer">
+                  {/* Support or Oppose */}
+                  <div className="u-cursor--pointer">
                     <ItemActionBar ballot_item_we_vote_id={one_candidate.we_vote_id}
                                    supportProps={SupportStore.get(one_candidate.we_vote_id)}
                                    shareButtonHide

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -78,8 +78,8 @@ export default class OfficeItemCompressed extends Component {
         <div className="u-flex u-stack--sm">
           <h2 className="u-f3">
             { this.props.link_to_ballot_item_page ?
-              <div style={{ display: "block", }}>
-                <div style={{ display: "inline-block", float: "left", }}>
+              <div className="card-main__office-name-group">
+                <div className="card-main__office-name-item card-main__office-name">
                   <Link to={officeLink}>
                     <TextTruncate line={1}
                                   truncateText="…"
@@ -87,7 +87,7 @@ export default class OfficeItemCompressed extends Component {
                                   textTruncateChild={null} />
                   </Link>
                 </div>
-                <div style={{ display: "inline-block", float: "left", }}>
+                <div className="card-main__office-name-item">
                   <Link to={officeLink}>
                     <span className="card-main__office-read-more-link hidden-xs">learn&nbsp;more</span>
                   </Link>

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -86,15 +86,15 @@ export default class OfficeItemCompressed extends Component {
           <BookmarkToggle we_vote_id={we_vote_id} type="OFFICE" />
         </div>
         { candidate_list_to_display.map( (one_candidate) => {
-          let candidate_id = one_candidate.we_vote_id;
-          let candidate_support_store = SupportStore.get(candidate_id);
-          let candidate_guides_list = GuideStore.getVoterGuidesToFollowForBallotItemId(candidate_id);
+          let candidateId = one_candidate.we_vote_id;
+          let candidateSupportStore = SupportStore.get(candidateId);
+          let candidateGuidesList = GuideStore.getVoterGuidesToFollowForBallotItemId(candidateId);
 
-          return <div key={candidate_id} className="u-stack--md">
+          return <div key={candidateId} className="u-stack--md">
             <div className="o-media-object--center u-flex-auto u-min-50 u-push--sm u-stack--sm">
               {/* Candidate Image */}
               <div onClick={ this.props.link_to_ballot_item_page ?
-                            ()=>{browserHistory.push("/candidate/" + candidate_id);} :
+                            ()=>{browserHistory.push("/candidate/" + candidateId);} :
                             null }>
                 <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
                               sizeClassName="icon-candidate-small u-push--sm "
@@ -107,7 +107,7 @@ export default class OfficeItemCompressed extends Component {
                 <h4 className="card-main__candidate-name u-f4">
                   {one_candidate.ballot_item_display_name}
                   <a onClick={ this.props.link_to_ballot_item_page ?
-                                ()=>{browserHistory.push("/candidate/" + candidate_id);} :
+                                ()=>{browserHistory.push("/candidate/" + candidateId);} :
                                 null }>
                   <span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span></a>
                 </h4>
@@ -118,22 +118,22 @@ export default class OfficeItemCompressed extends Component {
                         onClick={ this.props.link_to_ballot_item_page ?
                         ()=>{this.props._toggleCandidateModal(one_candidate);} :
                         null } >
-                    <ItemSupportOpposeCounts we_vote_id={candidate_id}
-                                             supportProps={candidate_support_store}
+                    <ItemSupportOpposeCounts we_vote_id={candidateId}
+                                             supportProps={candidateSupportStore}
                                              type="CANDIDATE"/>
                   </div>
 
                   {/* Possible Voter Guides to Follow (Desktop) */}
-                  { candidate_guides_list && candidate_guides_list.length !== 0 ?
-                    <ItemTinyOpinionsToFollow ballotItemWeVoteId={candidate_id}
-                                              organizationsToFollow={candidate_guides_list}
+                  { candidateGuidesList && candidateGuidesList.length !== 0 ?
+                    <ItemTinyOpinionsToFollow ballotItemWeVoteId={candidateId}
+                                              organizationsToFollow={candidateGuidesList}
                                               maximumOrganizationDisplay={this.state.maximum_organization_display}
-                                              supportProps={candidate_support_store} /> : null }
+                                              supportProps={candidateSupportStore} /> : null }
 
                   {/* Support or Oppose */}
                   <div className="u-cursor--pointer">
-                    <ItemActionBar ballot_item_we_vote_id={candidate_id}
-                                   supportProps={candidate_support_store}
+                    <ItemActionBar ballot_item_we_vote_id={candidateId}
+                                   supportProps={candidateSupportStore}
                                    shareButtonHide
                                    commentButtonHide
                                    transitioniing={this.state.transitioning}

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -120,6 +120,7 @@ export default class OfficeItemCompressed extends Component {
                         null } >
                     <ItemSupportOpposeCounts we_vote_id={candidateId}
                                              supportProps={candidateSupportStore}
+                                             guideProps={candidateGuidesList}
                                              type="CANDIDATE"/>
                   </div>
 

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -85,33 +85,29 @@ export default class OfficeItemCompressed extends Component {
           </h2>
           <BookmarkToggle we_vote_id={we_vote_id} type="OFFICE" />
         </div>
-          <div className={this.props.link_to_ballot_item_page ?
-                "u-cursor--pointer" : null } >
-          { candidate_list_to_display.map( (one_candidate) =>
-            <div key={one_candidate.we_vote_id} className="u-stack--md">
-              <div className="u-flex u-items-center u-flex-wrap u-justify-between">
-                {/* Candidate Image */}
-                <div className="u-flex u-cursor--pointer u-min-50"
-                    onClick={ this.props.link_to_ballot_item_page ?
-                              ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
-                              null }>
-                  <div className="u-push--sm u-stack--sm">
-                    <div className="o-media-object--center">
-                      <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-self-start u-push--sm"
-                                    sizeClassName="icon-candidate-small u-push--sm "
-                                    imageUrl={one_candidate.candidate_photo_url_large}
-                                    alt="candidate-photo"
-                                    kind_of_ballot_item="CANDIDATE" />
-                      <div className="o-media-object__body">
-                        <h4 className="card-main__candidate-name u-f4">
-                          <a>{one_candidate.ballot_item_display_name}<span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span></a>
-                        </h4>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Flex Row 2: Opinion Items */}
+        { candidate_list_to_display.map( (one_candidate) =>
+          <div key={one_candidate.we_vote_id} className="u-stack--md">
+            <div className="o-media-object--center u-flex-auto u-min-50 u-push--sm u-stack--sm">
+              {/* Candidate Image */}
+              <div onClick={ this.props.link_to_ballot_item_page ?
+                            ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
+                            null }>
+                <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
+                              sizeClassName="icon-candidate-small u-push--sm "
+                              imageUrl={one_candidate.candidate_photo_url_large}
+                              alt="candidate-photo"
+                              kind_of_ballot_item="CANDIDATE" />
+              </div>
+              <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
+                {/* Candidate Name */}
+                <h4 className="card-main__candidate-name u-f4">
+                  {one_candidate.ballot_item_display_name}
+                  <a onClick={ this.props.link_to_ballot_item_page ?
+                                ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
+                                null }>
+                  <span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span></a>
+                </h4>
+                {/* Opinion Items */}
                 <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
                   {/* Positions in Your Network */}
                   <div className="u-cursor--pointer"
@@ -148,22 +144,22 @@ export default class OfficeItemCompressed extends Component {
                   </div>
                 </div>
               </div>
-            </div>)
-          }
-          </div>
+            </div>
+          </div>)
+        }
 
-          { !this.state.display_all_candidates_flag && remaining_candidates_to_display_count > 0 ?
-            <Link onClick={this.toggleDisplayAllCandidates}>
-              <span className="u-items-center">
-                Click&nbsp;to&nbsp;show&nbsp;{remaining_candidates_to_display_count}&nbsp;more&nbsp;candidates...</span>
-            </Link> : null
-          }
-          { this.state.display_all_candidates_flag && this.props.candidate_list.length > NUMBER_OF_CANDIDATES_TO_DISPLAY ?
-            <BallotSideBarLink url={"#" + this.props.we_vote_id}
-                               label={"Click to show fewer candidates..."}
-                               displaySubtitles={false}
-                               onClick={this.toggleDisplayAllCandidates} /> : null
-          }
+        { !this.state.display_all_candidates_flag && remaining_candidates_to_display_count > 0 ?
+          <Link onClick={this.toggleDisplayAllCandidates}>
+            <span className="u-items-center">
+              Click&nbsp;to&nbsp;show&nbsp;{remaining_candidates_to_display_count}&nbsp;more&nbsp;candidates...</span>
+          </Link> : null
+        }
+        { this.state.display_all_candidates_flag && this.props.candidate_list.length > NUMBER_OF_CANDIDATES_TO_DISPLAY ?
+          <BallotSideBarLink url={"#" + this.props.we_vote_id}
+                             label={"Click to show fewer candidates..."}
+                             displaySubtitles={false}
+                             onClick={this.toggleDisplayAllCandidates} /> : null
+        }
       </div>
     </div>;
   }

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -85,12 +85,16 @@ export default class OfficeItemCompressed extends Component {
           </h2>
           <BookmarkToggle we_vote_id={we_vote_id} type="OFFICE" />
         </div>
-        { candidate_list_to_display.map( (one_candidate) =>
-          <div key={one_candidate.we_vote_id} className="u-stack--md">
+        { candidate_list_to_display.map( (one_candidate) => {
+          let candidate_id = one_candidate.we_vote_id;
+          let candidate_support_store = SupportStore.get(candidate_id);
+          let candidate_guides_list = GuideStore.getVoterGuidesToFollowForBallotItemId(candidate_id);
+
+          return <div key={candidate_id} className="u-stack--md">
             <div className="o-media-object--center u-flex-auto u-min-50 u-push--sm u-stack--sm">
               {/* Candidate Image */}
               <div onClick={ this.props.link_to_ballot_item_page ?
-                            ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
+                            ()=>{browserHistory.push("/candidate/" + candidate_id);} :
                             null }>
                 <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
                               sizeClassName="icon-candidate-small u-push--sm "
@@ -103,7 +107,7 @@ export default class OfficeItemCompressed extends Component {
                 <h4 className="card-main__candidate-name u-f4">
                   {one_candidate.ballot_item_display_name}
                   <a onClick={ this.props.link_to_ballot_item_page ?
-                                ()=>{browserHistory.push("/candidate/" + one_candidate.we_vote_id);} :
+                                ()=>{browserHistory.push("/candidate/" + candidate_id);} :
                                 null }>
                   <span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span></a>
                 </h4>
@@ -114,29 +118,22 @@ export default class OfficeItemCompressed extends Component {
                         onClick={ this.props.link_to_ballot_item_page ?
                         ()=>{this.props._toggleCandidateModal(one_candidate);} :
                         null } >
-                    <ItemSupportOpposeCounts we_vote_id={one_candidate.we_vote_id}
-                                             supportProps={SupportStore.get(one_candidate.we_vote_id)}
+                    <ItemSupportOpposeCounts we_vote_id={candidate_id}
+                                             supportProps={candidate_support_store}
                                              type="CANDIDATE"/>
                   </div>
 
                   {/* Possible Voter Guides to Follow (Desktop) */}
-                  <div className="hidden-xs hidden-print">
-                    { GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id) && GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id).length !== 0 ?
-                      <div className="u-cursor--pointer"
-                            onClick={ this.props.link_to_ballot_item_page ?
-                            ()=>{this.props._toggleCandidateModal(one_candidate);} :
-                            null } >
-                        <ItemTinyOpinionsToFollow ballotItemWeVoteId={one_candidate.we_vote_id}
-                                                  organizationsToFollow={GuideStore.getVoterGuidesToFollowForBallotItemId(one_candidate.we_vote_id)}
-                                                  maximumOrganizationDisplay={this.state.maximum_organization_display}/>
-                      </div> :
-                      null }
-                  </div>
+                  { candidate_guides_list && candidate_guides_list.length !== 0 ?
+                    <ItemTinyOpinionsToFollow ballotItemWeVoteId={candidate_id}
+                                              organizationsToFollow={candidate_guides_list}
+                                              maximumOrganizationDisplay={this.state.maximum_organization_display}
+                                              supportProps={candidate_support_store} /> : null }
 
                   {/* Support or Oppose */}
                   <div className="u-cursor--pointer">
-                    <ItemActionBar ballot_item_we_vote_id={one_candidate.we_vote_id}
-                                   supportProps={SupportStore.get(one_candidate.we_vote_id)}
+                    <ItemActionBar ballot_item_we_vote_id={candidate_id}
+                                   supportProps={candidate_support_store}
                                    shareButtonHide
                                    commentButtonHide
                                    transitioniing={this.state.transitioning}
@@ -145,8 +142,8 @@ export default class OfficeItemCompressed extends Component {
                 </div>
               </div>
             </div>
-          </div>)
-        }
+          </div>;
+        })}
 
         { !this.state.display_all_candidates_flag && remaining_candidates_to_display_count > 0 ?
           <Link onClick={this.toggleDisplayAllCandidates}>

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -1,15 +1,16 @@
 import React, { Component, PropTypes } from "react";
 import { Link, browserHistory } from "react-router";
 import TextTruncate from 'react-text-truncate';
+import { capitalizeString } from "../../utils/textFormat";
+import BallotSideBarLink from "../Navigation/BallotSideBarLink";
+import BookmarkToggle from "../Bookmarks/BookmarkToggle";
 import GuideStore from "../../stores/GuideStore";
 import ImageHandler from "../ImageHandler";
 import ItemActionBar from "../Widgets/ItemActionBar";
 import ItemSupportOpposeCounts from "../Widgets/ItemSupportOpposeCounts";
 import ItemTinyOpinionsToFollow from "../VoterGuide/ItemTinyOpinionsToFollow";
-import BookmarkToggle from "../Bookmarks/BookmarkToggle";
-import BallotSideBarLink from "../Navigation/BallotSideBarLink";
+import LearnMore from "../Widgets/LearnMore";
 import SupportStore from "../../stores/SupportStore";
-import { capitalizeString } from "../../utils/textFormat";
 
 const NUMBER_OF_CANDIDATES_TO_DISPLAY = 3;
 
@@ -105,24 +106,19 @@ export default class OfficeItemCompressed extends Component {
                 {/* Candidate Name */}
                 <h4 className="card-main__candidate-name u-f4">
                   <a onClick={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null }>
-                    <TextTruncate
-                      line={1}
-                      truncateText="…"
-                      text={one_candidate.ballot_item_display_name}
-                      textTruncateChild={null}
-                    />
-                  </a>
-                  <a onClick={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null }>
-                    <span className="card-main__candidate-read-more-link hidden-xs">learn&nbsp;more</span>
+                    <TextTruncate line={1}
+                                  truncateText="…"
+                                  text={one_candidate.ballot_item_display_name}
+                                  textTruncateChild={null} />
                   </a>
                 </h4>
+                <LearnMore text_to_display={one_candidate.party + " candidate. " + one_candidate.twitter_description}
+                           on_click={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null } />
                 {/* Opinion Items */}
                 <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
                   {/* Positions in Your Network */}
                   <div className="u-cursor--pointer"
-                        onClick={ this.props.link_to_ballot_item_page ?
-                        ()=>{this.props._toggleCandidateModal(one_candidate);} :
-                        null } >
+                       onClick={ this.props.link_to_ballot_item_page ? () => this.props._toggleCandidateModal(one_candidate) : null }>
                     <ItemSupportOpposeCounts we_vote_id={candidateId}
                                              supportProps={candidateSupportStore}
                                              guideProps={candidateGuidesList}

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Link, browserHistory } from "react-router";
-import TextTruncate from 'react-text-truncate';
+import TextTruncate from "react-text-truncate";
 import { capitalizeString } from "../../utils/textFormat";
 import BallotSideBarLink from "../Navigation/BallotSideBarLink";
 import BookmarkToggle from "../Bookmarks/BookmarkToggle";
@@ -127,8 +127,10 @@ export default class OfficeItemCompressed extends Component {
                                   textTruncateChild={null} />
                   </a>
                 </h4>
-                <LearnMore text_to_display={candidate_text}
-                           on_click={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null } />
+                <div className="card-main__candidate-description">
+                  <LearnMore text_to_display={candidate_text}
+                             on_click={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null } />
+                </div>
                 {/* Opinion Items */}
                 <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
                   {/* Positions in Your Network */}

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -92,6 +92,10 @@ export default class OfficeItemCompressed extends Component {
           let candidateSupportStore = SupportStore.get(candidateId);
           let candidateGuidesList = GuideStore.getVoterGuidesToFollowForBallotItemId(candidateId);
 
+          let candidate_party_text = one_candidate.party && one_candidate.party.length ? one_candidate.party + " candidate. " : "";
+          let candidate_description_text = one_candidate.twitter_description && one_candidate.twitter_description.length ? one_candidate.twitter_description : "";
+          let candidate_text = candidate_party_text + candidate_description_text;
+
           return <div key={candidateId} className="u-stack--md">
             <div className="o-media-object--center u-flex-auto u-min-50 u-push--sm u-stack--sm">
               {/* Candidate Image */}
@@ -112,7 +116,7 @@ export default class OfficeItemCompressed extends Component {
                                   textTruncateChild={null} />
                   </a>
                 </h4>
-                <LearnMore text_to_display={one_candidate.party + " candidate. " + one_candidate.twitter_description}
+                <LearnMore text_to_display={candidate_text}
                            on_click={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/candidate/" + candidateId) : null } />
                 {/* Opinion Items */}
                 <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -78,10 +78,21 @@ export default class OfficeItemCompressed extends Component {
         <div className="u-flex u-stack--sm">
           <h2 className="u-f3">
             { this.props.link_to_ballot_item_page ?
-              <Link to={officeLink}>
-                {ballot_item_display_name}
-                <span className="card-main__office-read-more-link hidden-xs">learn&nbsp;more</span>
-              </Link> :
+              <div style={{ display: "block", }}>
+                <div style={{ display: "inline-block", float: "left", }}>
+                  <Link to={officeLink}>
+                    <TextTruncate line={1}
+                                  truncateText="…"
+                                  text={ballot_item_display_name}
+                                  textTruncateChild={null} />
+                  </Link>
+                </div>
+                <div style={{ display: "inline-block", float: "left", }}>
+                  <Link to={officeLink}>
+                    <span className="card-main__office-read-more-link hidden-xs">learn&nbsp;more</span>
+                  </Link>
+                </div>
+              </div> :
               ballot_item_display_name
             }
           </h2>

--- a/src/js/components/VoterGuide/ItemTinyOpinionsToFollow.jsx
+++ b/src/js/components/VoterGuide/ItemTinyOpinionsToFollow.jsx
@@ -13,6 +13,7 @@ export default class ItemTinyOpinionsToFollow extends Component {
     organizationsToFollow: PropTypes.array,
     instantRefreshOn: PropTypes.bool,
     maximumOrganizationDisplay: PropTypes.number,
+    supportProps: PropTypes.object,
   };
 
   constructor (props) {
@@ -25,6 +26,7 @@ export default class ItemTinyOpinionsToFollow extends Component {
       organizations_to_follow: this.props.organizationsToFollow,
       ballot_item_we_vote_id: "",
       maximum_organization_display: this.props.maximumOrganizationDisplay,
+      supportProps: this.props.supportProps,
     };
   }
 
@@ -33,10 +35,11 @@ export default class ItemTinyOpinionsToFollow extends Component {
       organizations_to_follow: this.props.organizationsToFollow,
       ballot_item_we_vote_id: this.props.ballotItemWeVoteId,
       maximum_organization_display: this.props.maximumOrganizationDisplay,
+      supportProps: this.props.supportProps,
     });
   }
 
-  componentWillReceiveProps (nextProps){
+  componentWillReceiveProps (nextProps) {
     // console.log("ItemTinyOpinionsToFollow, componentWillReceiveProps, nextProps.organizationsToFollow:", nextProps.organizationsToFollow);
     //if (nextProps.instantRefreshOn ) {
       // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked
@@ -44,6 +47,7 @@ export default class ItemTinyOpinionsToFollow extends Component {
         organizations_to_follow: nextProps.organizationsToFollow,
         ballot_item_we_vote_id: nextProps.ballotItemWeVoteId,
         maximum_organization_display: nextProps.maximumOrganizationDisplay,
+        supportProps: nextProps.supportProps,
       });
     //}
   }
@@ -80,6 +84,14 @@ export default class ItemTinyOpinionsToFollow extends Component {
   render () {
     if (this.state.organizations_to_follow === undefined) {
       return null;
+    }
+
+    let is_empty;
+    if (this.state.supportProps !== undefined) {
+      let { support_count, oppose_count } = this.state.supportProps;
+      if (support_count !== undefined && oppose_count !== undefined) {
+        is_empty = support_count === 0 && oppose_count === 0;
+      }
     }
 
     let local_counter = 0;
@@ -169,7 +181,7 @@ export default class ItemTinyOpinionsToFollow extends Component {
       }
     });
 
-    return <span className="guidelist card-child__list-group">
+    return <span className={ is_empty ? "guidelist card-child__list-group" : "hidden-xs hidden-print guidelist card-child__list-group" }>
           {organizations_to_display}
       </span>;
   }

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -25,6 +25,7 @@ export default class ItemActionBar extends Component {
     super(props);
     this.state = {
       showSupportOrOpposeHelpModal: false,
+      supportProps: this.props.supportProps,
       transitioning: false,
     };
   }
@@ -33,8 +34,11 @@ export default class ItemActionBar extends Component {
     this.toggleSupportOrOpposeHelpModal = this.toggleSupportOrOpposeHelpModal.bind(this);
   }
 
-  componentWillReceiveProps () {
-    this.setState({transitioning: false});
+  componentWillReceiveProps (nextProps) {
+    this.setState({
+      transitioning: false,
+      supportProps: nextProps.supportProps,
+    });
   }
 
   supportItem (is_support) {

--- a/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
@@ -10,71 +10,70 @@ export default class ItemSupportOpposeCounts extends Component {
     this.state = { supportProps: this.props.supportProps };
   }
 
-  componentWillReceiveProps (nextProps){
-    this.setState({supportProps: nextProps.supportProps});
+  componentWillReceiveProps (nextProps) {
+    this.setState({ supportProps: nextProps.supportProps });
   }
 
-  percentageMajority (){
-    const {support_count, oppose_count} = this.state.supportProps;
+  percentageMajority () {
+    const { support_count, oppose_count } = this.state.supportProps;
     return Math.round(100 * Math.max(support_count, oppose_count) / (support_count + oppose_count));
   }
 
   render () {
-
-    if (this.state.supportProps === undefined){
+    if (this.state.supportProps === undefined) {
       return null;
     }
 
-    var {support_count, oppose_count, is_support, is_oppose } = this.state.supportProps;
-    if (support_count === undefined || oppose_count === undefined || is_support === undefined || is_oppose === undefined){
+    var { support_count, oppose_count, is_support, is_oppose } = this.state.supportProps;
+    if (support_count === undefined || oppose_count === undefined || is_support === undefined || is_oppose === undefined) {
       return null;
     }
 
-    var barStyle = {
+    var bar_style = {
       width: this.percentageMajority() + "%"
     };
 
-    var emptyBarStyle = {
+    var empty_bar_style = {
       borderWidth: "0"
     };
 
-    var isEmpty = support_count === 0 && oppose_count === 0;
+    var is_empty = support_count === 0 && oppose_count === 0;
 
-    var isSupportAndOppose = support_count !== 0 && oppose_count !== 0;
+    var is_support_and_oppose = support_count !== 0 && oppose_count !== 0;
 
-    var isMajoritySupport = support_count >= oppose_count;
+    var is_majority_support = support_count >= oppose_count;
 
-    var backgroundBarClassName;
-    if (isSupportAndOppose && isMajoritySupport) {
+    var background_bar_class_name;
+    if (is_support_and_oppose && is_majority_support) {
       // If there are both support and oppose positions, change the color of the bar background to the minority position
-      backgroundBarClassName = "network-positions__bar-well red-bar";
-    } else if (isSupportAndOppose && !isMajoritySupport) {
+      background_bar_class_name = "network-positions__bar-well red-bar";
+    } else if (is_support_and_oppose && !is_majority_support) {
       // If there are both support and oppose positions, change the color of the bar background to the minority position
-      backgroundBarClassName = "network-positions__bar-well green-bar";
+      background_bar_class_name = "network-positions__bar-well green-bar";
     } else {
-      backgroundBarClassName = "network-positions__bar-well";
+      background_bar_class_name = "network-positions__bar-well";
     }
 
     return <div className="network-positions">
-      {/*<div className="network-positions__bar-label">
-        {!isEmpty ?
+      {/* <div className="network-positions__bar-label">
+        { !is_empty ?
           "Positions in your network" :
           "No positions in your network"
         }
-      </div>*/}
+      </div> */}
       <div className="network-positions__support">
-        <img src={!isEmpty && isMajoritySupport ? "/img/global/icons/up-arrow-color-icon.svg" : "/img/global/icons/up-arrow-gray-icon.svg"} className="network-positions__support-icon u-push--xs" width="20" height="20" />
+        <img src={ !is_empty && is_majority_support ? "/img/global/icons/up-arrow-color-icon.svg" : "/img/global/icons/up-arrow-gray-icon.svg" } className="network-positions__support-icon u-push--xs" width="20" height="20" />
         <div className="network-positions__count">
-          {!isEmpty ? support_count : null}
+          { !is_empty ? support_count : null }
           <span className="sr-only"> Support</span>
         </div>
       </div>
-      <div className={backgroundBarClassName}>
-        { isMajoritySupport ?
-          <div className="network-positions__bar network-positions__bar--majority network-positions__bar--support" style={!isEmpty ? barStyle : emptyBarStyle}>
+      <div className={background_bar_class_name}>
+        { is_majority_support ?
+          <div className="network-positions__bar network-positions__bar--majority network-positions__bar--support" style={ !is_empty ? bar_style : empty_bar_style }>
             <span className="sr-only">{this.percentageMajority()}% Supports</span>
           </div> :
-          <div className="network-positions__bar network-positions__bar--majority network-positions__bar--oppose" style={!isEmpty ? barStyle : emptyBarStyle}>
+          <div className="network-positions__bar network-positions__bar--majority network-positions__bar--oppose" style={ !is_empty ? bar_style : empty_bar_style }>
             <span className="sr-only">{this.percentageMajority()}% Supports</span>
           </div>
         }
@@ -82,10 +81,10 @@ export default class ItemSupportOpposeCounts extends Component {
 
       <div className="network-positions__oppose">
         <div className="network-positions__count u-push--xs">
-          {!isEmpty ? oppose_count : null}
+          { !is_empty ? oppose_count : null }
           <span className="sr-only"> Oppose</span>
         </div>
-        <img src={!isEmpty && !isMajoritySupport ? "/img/global/icons/down-arrow-color-icon.svg" : "/img/global/icons/down-arrow-gray-icon.svg"} className="network-positions__oppose-icon" width="20" height="20" />
+        <img src={ !is_empty && !is_majority_support ? "/img/global/icons/down-arrow-color-icon.svg" : "/img/global/icons/down-arrow-gray-icon.svg" } className="network-positions__oppose-icon" width="20" height="20" />
       </div>
     </div>;
   }

--- a/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
@@ -2,16 +2,23 @@ import React, { Component, PropTypes } from "react";
 
 export default class ItemSupportOpposeCounts extends Component {
   static propTypes = {
-    supportProps: PropTypes.object
+    supportProps: PropTypes.object,
+    guideProps: PropTypes.array,
   };
 
   constructor (props) {
     super(props);
-    this.state = { supportProps: this.props.supportProps };
+    this.state = {
+      supportProps: this.props.supportProps,
+      guideProps: this.props.guideProps,
+    };
   }
 
   componentWillReceiveProps (nextProps) {
-    this.setState({ supportProps: nextProps.supportProps });
+    this.setState({
+      supportProps: nextProps.supportProps,
+      guideProps: nextProps.guideProps,
+    });
   }
 
   percentageMajority () {
@@ -24,26 +31,24 @@ export default class ItemSupportOpposeCounts extends Component {
       return null;
     }
 
-    var { support_count, oppose_count, is_support, is_oppose } = this.state.supportProps;
+    let { support_count, oppose_count, is_support, is_oppose } = this.state.supportProps;
     if (support_count === undefined || oppose_count === undefined || is_support === undefined || is_oppose === undefined) {
       return null;
     }
 
-    var bar_style = {
+    let bar_style = {
       width: this.percentageMajority() + "%"
     };
 
-    var empty_bar_style = {
+    let empty_bar_style = {
       borderWidth: "0"
     };
 
-    var is_empty = support_count === 0 && oppose_count === 0;
+    let is_empty = support_count === 0 && oppose_count === 0;
+    let is_support_and_oppose = support_count !== 0 && oppose_count !== 0;
+    let is_majority_support = support_count >= oppose_count;
 
-    var is_support_and_oppose = support_count !== 0 && oppose_count !== 0;
-
-    var is_majority_support = support_count >= oppose_count;
-
-    var background_bar_class_name;
+    let background_bar_class_name;
     if (is_support_and_oppose && is_majority_support) {
       // If there are both support and oppose positions, change the color of the bar background to the minority position
       background_bar_class_name = "network-positions__bar-well red-bar";
@@ -54,7 +59,7 @@ export default class ItemSupportOpposeCounts extends Component {
       background_bar_class_name = "network-positions__bar-well";
     }
 
-    return <div className="network-positions">
+    return <div className={ this.state.guideProps && this.state.guideProps.length && is_empty ? "hidden-xs hidden-print network-positions" : "network-positions" }>
       {/* <div className="network-positions__bar-label">
         { !is_empty ?
           "Positions in your network" :

--- a/src/js/components/Widgets/LearnMore.jsx
+++ b/src/js/components/Widgets/LearnMore.jsx
@@ -1,0 +1,121 @@
+import React, { Component, PropTypes } from "react";
+import TextTruncate from "react-text-truncate";
+
+export default class ReadMore extends Component {
+  static propTypes = {
+    text_to_display: PropTypes.node.isRequired,
+    show_more_text: PropTypes.node,
+    learn_more_text: PropTypes.node,
+    num_of_lines: PropTypes.number,
+    on_click: PropTypes.func.isRequired,
+  };
+
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      readMore: true,
+    };
+    this.showMore = this.showMore.bind(this);
+  }
+
+  showMore (event) {
+    event.preventDefault();
+    this.setState({
+      readMore: !this.state.readMore,
+    });
+  }
+
+  // this onKeyDown function is for accessibility: both toggle links
+  // have a tab index so that users can use tab key to select the link, and then
+  // press either space or enter (key codes 32 and 13, respectively) to toggle
+  onKeyDown (event) {
+    let enterAndSpaceKeyCodes = [13, 32];
+    if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
+      this.showMore(event);
+    }
+  }
+
+  render () {
+    let { text_to_display, show_more_text, num_of_lines, learn_more_text, on_click } = this.props;
+    // default prop valuess
+    if (num_of_lines === undefined) {
+      num_of_lines = 1;
+    }
+    if (show_more_text === undefined) {
+      show_more_text = "more";
+    }
+    if (learn_more_text === undefined) {
+      learn_more_text = "learn more";
+    }
+
+    // remove extra ascii carriage returns or other control text
+    text_to_display = text_to_display.replace(/[\x0D-\x1F]/g, "");
+    // convert text into array, splitting on line breaks
+    let expanded_text_array = text_to_display.replace(/(?:\r\n|\r|\n){2,}/g, "\r\n\r\n").split(/(?:\r\n|\r|\n)/g);
+
+    // There are cases where we would like to show line breaks when there is a little bit of text
+    let not_enough_text_to_truncate = false;
+    let all_lines_short = true;
+    let max_num_of_lines = num_of_lines;
+    // max number of lines shouldn't be greater than total number of line breaks hard coded
+    if (max_num_of_lines > expanded_text_array.length) {
+      max_num_of_lines = expanded_text_array.length;
+    }
+    for (var i = 0; i < max_num_of_lines; i++) {
+      if (expanded_text_array[i].length > 38) {
+        all_lines_short = false;
+        break;
+      }
+    }
+    if (expanded_text_array.length <= num_of_lines && all_lines_short) {
+      not_enough_text_to_truncate = true;
+    }
+
+    // wrap text in array in separate spans with html line breaks
+    let expanded_text_to_display = expanded_text_array.map((item, key) => {
+      if (key === 0) {
+        return <span key={key}>
+          {item}
+        </span>;
+      } else if (key >= expanded_text_array.length - 2 && item === "") {
+        return <span key={key}>
+          {item}
+        </span>;
+      } else {
+        return <span key={key}>
+          <br/>
+          {item}
+        </span>;
+      }
+    });
+
+    if (not_enough_text_to_truncate) {
+      return <span>{expanded_text_to_display}</span>;
+    }
+
+    if (this.state.readMore) {
+      return <span>
+        <TextTruncate
+          line={num_of_lines}
+          truncateText="..."
+          text={text_to_display}
+          textTruncateChild={<a tabIndex="0"
+            onClick={this.showMore}
+            onKeyDown={this.onKeyDown.bind(this)}>
+              {show_more_text}
+            </a>
+          }
+        />
+      </span>;
+    } else {
+      return <span tabIndex="0"> {expanded_text_to_display}&nbsp;&nbsp;
+        <a tabIndex="0"
+          onClick={on_click}
+          onKeyDown={this.onKeyDown.bind(this)}>
+          {learn_more_text}
+        </a>
+      </span>;
+    }
+  }
+}

--- a/src/sass/components/_ballot.scss
+++ b/src/sass/components/_ballot.scss
@@ -85,6 +85,11 @@ $tab-height-visible: $tab-height - $scrollbar-height;
     a:hover {
       background-color: $transparent;
     }
+
+    a.tab-default:focus,
+    a.tab-default:hover {
+      border-bottom: 6px solid $gray-mid;
+    }
   }
 
   // ===========================================

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -189,12 +189,24 @@
       overflow: hidden;
     }
 
+    &__office-name-group {
+      display: block;
+    }
+
+    &__office-name-item {
+      display: inline-block;
+      float: left;
+    }
+
+    &__office-name {
+      font-weight: 600;
+    }
+
     &__office-read-more-link {
       margin-left: $space-sm;
       font-family: $body-font-stack;
       font-size: 14px;
       font-weight: 100 !important;
-      color: $link-color;
       width: 100%;
       height: 100%;
       overflow: hidden;

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -1,5 +1,6 @@
 // 'Card' styling for Candidates, Organizations, etc.
 
+$candidate-font-size: .875rem;
 @include media-object('.card-main__media-object', '.card-main__media-object-anchor', '.card-main__media-object-content');
 
 .card {
@@ -98,7 +99,18 @@
     }
 
     &__candidate-name {
-      font-weight: 500;
+      font-size: $candidate-font-size;
+      font-weight: 600;
+    }
+
+    &__candidate-party-description {
+      font-size: $candidate-font-size;
+      color: $gray-dark;
+    }
+
+    &__candidate-description {
+      font-size: $candidate-font-size;
+      color: $gray-mid;
     }
 
     &__display-name {


### PR DESCRIPTION
The layout of each ballot item in the ballot page has been redesigned to fit the mock-up as closely as possible (except for the candidate name, which is still currently on a separate line). I also added some more custom styling and JavaScript implementation to handle what components are displayed in mobile mode. A new LearnMore component has been created from ReadMore so that there is a "learn more" link instead of a "less" link.

#972 