### PR TITLE
Update measures layout on ballot page, remove support/oppose labels in mobile view

### DIFF
--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -83,13 +83,19 @@ export default class MeasureItemCompressed extends Component {
       <div className="card-main__content">
         <h2 className="card-main__display-name">
           { this.props.link_to_ballot_item_page ?
-            <div>
-              <Link to={"/measure/" + we_vote_id}>
-                {ballot_item_display_name}
-                <span className="card-main__measure-read-more-link">learn&nbsp;more</span>
-              </Link>
+            <div className="card-main__ballot-name-group">
+              <div className="card-main__ballot-name-item card-main__ballot-name">
+                <Link to={"/measure/" + we_vote_id}>
+                  {ballot_item_display_name}
+                </Link>
+              </div>
+              <div className="card-main__ballot-name-item">
+                <Link to={"/measure/" + we_vote_id}>
+                  <span className="card-main__ballot-read-more-link hidden-xs">learn&nbsp;more</span>
+                </Link>
+              </div>
             </div> :
-              ballot_item_display_name
+            ballot_item_display_name
           }
         </h2>
         <BookmarkToggle we_vote_id={we_vote_id} type="MEASURE"/>

--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -19,7 +19,7 @@ export default class MeasureItemCompressed extends Component {
     ballot_item_display_name: PropTypes.string.isRequired,
     link_to_ballot_item_page: PropTypes.bool,
     measure_url: PropTypes.string,
-    _toggleMeasureModal: PropTypes.func
+    _toggleMeasureModal: PropTypes.func,
   };
 
   constructor (props) {
@@ -43,7 +43,7 @@ export default class MeasureItemCompressed extends Component {
     this.supportStoreListener.remove();
   }
 
-  _onGuideStoreChange (){
+  _onGuideStoreChange () {
     // We just want to trigger a re-render
     this.setState({ transitioning: false });
     // console.log("_onGuideStoreChange");
@@ -52,36 +52,20 @@ export default class MeasureItemCompressed extends Component {
   _onSupportStoreChange () {
     this.setState({
       supportProps: SupportStore.get(this.props.we_vote_id),
-      transitioning: false
+      transitioning: false,
     });
   }
   render () {
-    //console.log("this.props", this.props);
-    const { supportProps } = this.state;
-    let support_count = 0;
-    if (supportProps && supportProps.support_count) {
-      // Only show ItemSupportOpposeCounts if your network has something to say
-      support_count = supportProps.support_count;
-    }
-    let oppose_count = 0;
-    if (supportProps && supportProps.oppose_count) {
-      // Only show ItemSupportOpposeCounts if your network has something to say
-      oppose_count = supportProps.oppose_count;
-    }
-
-    let ballot_item_display_name = this.props.ballot_item_display_name;
-    let measure_subtitle = this.props.measure_subtitle;
-    let measure_text = this.props.measure_text;  // Not currently defined
-    let we_vote_id = this.props.we_vote_id;
-    let measureLink = "/measure/" + we_vote_id;
-    let goToMeasureLink = function () { browserHistory.push(measureLink); };
+    let { ballot_item_display_name, measure_subtitle, measure_text, we_vote_id } = this.props;
 
     measure_subtitle = capitalizeString(measure_subtitle);
     ballot_item_display_name = capitalizeString(ballot_item_display_name);
 
+    let measureGuidesList = GuideStore.getVoterGuidesToFollowForBallotItemId(we_vote_id);
+
     let measure_for_modal = {
       ballot_item_display_name: ballot_item_display_name,
-      voter_guides_to_follow_for_ballot_item_id: GuideStore.getVoterGuidesToFollowForBallotItemId(this.props.we_vote_id),
+      voter_guides_to_follow_for_ballot_item_id: measureGuidesList,
       kind_of_ballot_item: this.props.kind_of_ballot_item,
       link_to_ballot_item_page: this.props.link_to_ballot_item_page,
       measure_subtitle: measure_subtitle,
@@ -90,9 +74,9 @@ export default class MeasureItemCompressed extends Component {
       measure_we_vote_id: this.props.we_vote_id,
       position_list: this.props.position_list
     };
+
     // To get position_list
     // TODO DALE var measure = MeasureStore.get(this.state.measure_we_vote_id) || {};
-
 
     return <div className="card-main measure-card">
       <a name={we_vote_id} />
@@ -100,69 +84,50 @@ export default class MeasureItemCompressed extends Component {
         <h2 className="card-main__display-name">
           { this.props.link_to_ballot_item_page ?
             <div>
-              <Link to={measureLink}>{ballot_item_display_name}
-              <span className="card-main__measure-read-more-link">learn&nbsp;more</span></Link>
+              <Link to={"/measure/" + we_vote_id}>
+                {ballot_item_display_name}
+                <span className="card-main__measure-read-more-link">learn&nbsp;more</span>
+              </Link>
             </div> :
               ballot_item_display_name
           }
         </h2>
         <BookmarkToggle we_vote_id={we_vote_id} type="MEASURE"/>
         {/* Measure information */}
-        <div
-          className={ this.props.link_to_ballot_item_page ?
-          "u-cursor--pointer" : null }
-          onClick={ this.props.link_to_ballot_item_page ?
-          goToMeasureLink : null }
-        >
+        <div className={ this.props.link_to_ballot_item_page ? "u-cursor--pointer" : null }
+             onClick={ this.props.link_to_ballot_item_page ? () => browserHistory.push("/measure/" + we_vote_id) : null }>
           {measure_subtitle}
         </div>
-        { this.props.measure_text ?
-          <div className="measure_text">{measure_text}</div> :
-          null }
+        { measure_text ? <div className="measure_text">{measure_text}</div> : null }
 
-        {/* This is the area *under* the measure title/text */}
-        <div className={"u-flex" + (this.props.link_to_ballot_item_page ?
-                " u-cursor--pointer" : "") } >
+        {/* Opinion Items */}
+        <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
+          {/* Positions in Your Network */}
+          <div className={ this.props.link_to_ballot_item_page ? "u-cursor--pointer" : null }
+               onClick={ this.props.link_to_ballot_item_page ? () => this.props._toggleMeasureModal(measure_for_modal) : null }>
+            <ItemSupportOpposeCounts we_vote_id={we_vote_id}
+                                     supportProps={this.state.supportProps}
+                                     guideProps={measureGuidesList}
+                                     type="MEASURE" />
+          </div>
 
-          {/* Needed to force following flex area to the right */}
-          <div className="MeasureItem__summary u-flex-auto" />
+          {/* Possible Voter Guides to Follow (Desktop) */}
+          <div onClick={ this.props.link_to_ballot_item_page ? () => this.props._toggleMeasureModal(measure_for_modal) : null }>
+            { measureGuidesList && measureGuidesList.length ?
+              <ItemTinyOpinionsToFollow ballotItemWeVoteId={we_vote_id}
+                                        organizationsToFollow={measureGuidesList}
+                                        maximumOrganizationDisplay={this.state.maximum_organization_display}
+                                        supportProps={this.state.supportProps} /> : null }
+          </div>
 
-          <div className="u-flex u-items-center">
-            {/* *** "Positions in your Network" bar OR items you can follow *** */}
-            <div className="u-flex-none u-justify-end u-push--md">
-              <span className={ this.props.link_to_ballot_item_page ?
-                      "u-cursor--pointer" :
-                      null }
-              >
-              { support_count || oppose_count ?
-                <span onClick={ this.props.link_to_ballot_item_page ?
-                      ()=>{this.props._toggleMeasureModal(measure_for_modal);} :
-                      null } >
-                  <ItemSupportOpposeCounts we_vote_id={we_vote_id} supportProps={this.state.supportProps}
-                                           type="MEASURE" />
-                </span> :
-                <span onClick={ this.props.link_to_ballot_item_page ?
-                      ()=>{this.props._toggleMeasureModal(measure_for_modal);} :
-                      null } >
-                {/* Show possible voter guides to follow */}
-                { GuideStore.getVoterGuidesToFollowForBallotItemId(we_vote_id) && GuideStore.getVoterGuidesToFollowForBallotItemId(we_vote_id).length !== 0 ?
-                  <ItemTinyOpinionsToFollow ballotItemWeVoteId={we_vote_id}
-                                            organizationsToFollow={GuideStore.getVoterGuidesToFollowForBallotItemId(we_vote_id)}
-                                            maximumOrganizationDisplay={this.state.maximum_organization_display}/> :
-                  <span /> }
-                </span> }
-              </span>
-            </div>
-
-            {/* *** Choose Support or Oppose *** */}
-            <div className="u-flex-none u-justify-end">
-              <ItemActionBar ballot_item_we_vote_id={we_vote_id}
-                             supportProps={this.state.supportProps}
-                             shareButtonHide
-                             commentButtonHide
-                             transitioniing={this.state.transitioning}
-                             type="MEASURE" />
-            </div>
+          {/* Support or Oppose */}
+          <div className="u-cursor--pointer">
+            <ItemActionBar ballot_item_we_vote_id={we_vote_id}
+                           supportProps={this.state.supportProps}
+                           shareButtonHide
+                           commentButtonHide
+                           transitioniing={this.state.transitioning}
+                           type="MEASURE" />
           </div>
         </div>
       </div> {/* END .card-main__content */}

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -78,8 +78,8 @@ export default class OfficeItemCompressed extends Component {
         <div className="u-flex u-stack--sm">
           <h2 className="u-f3">
             { this.props.link_to_ballot_item_page ?
-              <div className="card-main__office-name-group">
-                <div className="card-main__office-name-item card-main__office-name">
+              <div className="card-main__ballot-name-group">
+                <div className="card-main__ballot-name-item card-main__ballot-name">
                   <Link to={officeLink}>
                     <TextTruncate line={1}
                                   truncateText="…"
@@ -87,9 +87,9 @@ export default class OfficeItemCompressed extends Component {
                                   textTruncateChild={null} />
                   </Link>
                 </div>
-                <div className="card-main__office-name-item">
+                <div className="card-main__ballot-name-item">
                   <Link to={officeLink}>
-                    <span className="card-main__office-read-more-link hidden-xs">learn&nbsp;more</span>
+                    <span className="card-main__ballot-read-more-link hidden-xs">learn&nbsp;more</span>
                   </Link>
                 </div>
               </div> :

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -134,16 +134,16 @@ export default class OfficeItemCompressed extends Component {
                 {/* Opinion Items */}
                 <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
                   {/* Positions in Your Network */}
-                  <div className="u-cursor--pointer"
+                  <div className={ this.props.link_to_ballot_item_page ? "u-cursor--pointer" : null }
                        onClick={ this.props.link_to_ballot_item_page ? () => this.props._toggleCandidateModal(one_candidate) : null }>
                     <ItemSupportOpposeCounts we_vote_id={candidateId}
                                              supportProps={candidateSupportStore}
                                              guideProps={candidateGuidesList}
-                                             type="CANDIDATE"/>
+                                             type="CANDIDATE" />
                   </div>
 
                   {/* Possible Voter Guides to Follow (Desktop) */}
-                  { candidateGuidesList && candidateGuidesList.length !== 0 ?
+                  { candidateGuidesList && candidateGuidesList.length ?
                     <ItemTinyOpinionsToFollow ballotItemWeVoteId={candidateId}
                                               organizationsToFollow={candidateGuidesList}
                                               maximumOrganizationDisplay={this.state.maximum_organization_display}

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -142,7 +142,7 @@ export default class ItemActionBar extends Component {
                 </span>
                 { is_support ?
                   <span
-                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label__position-at-state" }>Support</span> :
+                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label item-actionbar__position-at-state" }>Support</span> :
                   <span
                     className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Support</span>
                 }
@@ -154,7 +154,7 @@ export default class ItemActionBar extends Component {
                 </span>
                 { is_oppose ?
                   <span
-                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label__position-at-state" }>Oppose</span> :
+                    className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label item-actionbar__position-at-state" }>Oppose</span> :
                   <span
                     className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Oppose</span>
                 }

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -201,20 +201,20 @@ $candidate-font-size: .875rem;
       overflow: hidden;
     }
 
-    &__office-name-group {
+    &__ballot-name-group {
       display: block;
     }
 
-    &__office-name-item {
+    &__ballot-name-item {
       display: inline-block;
       float: left;
     }
 
-    &__office-name {
+    &__ballot-name {
       font-weight: 600;
     }
 
-    &__office-read-more-link {
+    &__ballot-read-more-link {
       margin-left: $space-sm;
       font-family: $body-font-stack;
       font-size: 14px;

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -13,10 +13,10 @@ $red: #ff4921;
     @include breakpoints (max mid-small) {
       display: none; // Hide Support/Oppose button labels on small screens
     }
+  }
 
-    &__position-at-state {
-      color: $gray-pale;
-    }
+  &__position-at-state {
+    color: $gray-pale;
   }
 
   .support-at-state {


### PR DESCRIPTION
The layout of each measure item on the ballot page has been updated to match that of each office item (except for the measure description, which may be updated as a separate issue if needed).

#1029 

UPDATE: the latest commit also resolves issue #981.