### PR TITLE
Fix layout of ballot intro modals, add autofocus to address input

### DIFF
--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -115,6 +115,7 @@ export default class AddressBox extends Component {
             className="form-control"
             ref="autocomplete"
             placeholder="Enter address where you are registered to vote"
+            autoFocus
           />
         </form>
         <div>

--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -23,7 +23,7 @@ export default class BallotIntroFollowAdvisers extends Component {
       followed_organizations: [],
       voter_guides_to_follow_by_issues_followed: GuideStore.getVoterGuidesToFollowByIssuesFollowed(),
       voter_guides_to_follow_all: GuideStore.getVoterGuidesToFollowAll(),
-      next_button_text: NEXT_BUTTON_TEXT
+      next_button_text: NEXT_BUTTON_TEXT,
     };
 
     this.onOrganizationFollow = this.onOrganizationFollow.bind(this);
@@ -45,7 +45,7 @@ export default class BallotIntroFollowAdvisers extends Component {
   _onGuideStoreChange () {
     this.setState({
       voter_guides_to_follow_by_issues_followed: GuideStore.getVoterGuidesToFollowByIssuesFollowed(),
-      voter_guides_to_follow_all: GuideStore.getVoterGuidesToFollowAll()
+      voter_guides_to_follow_all: GuideStore.getVoterGuidesToFollowAll(),
     });
   }
 
@@ -57,7 +57,7 @@ export default class BallotIntroFollowAdvisers extends Component {
       this.setState({
         description_text: "",
         followed_organizations: new_followed_organizations,
-        next_button_text: NEXT_BUTTON_TEXT
+        next_button_text: NEXT_BUTTON_TEXT,
       });
     }
   }
@@ -97,10 +97,7 @@ export default class BallotIntroFollowAdvisers extends Component {
 
   render () {
     // These are the organizations that a voter might want to follow based on the issues the voter is following.
-    let voter_guides_to_follow_by_issues_followed = [];
-    if (this.state.voter_guides_to_follow_by_issues_followed) {
-      voter_guides_to_follow_by_issues_followed = this.state.voter_guides_to_follow_by_issues_followed;
-    }
+    let voter_guides_to_follow_by_issues_followed = this.state.voter_guides_to_follow_by_issues_followed || [];
 
     const voter_guides_to_follow_by_issues_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) => {
       return <OrganizationFollowToggle
@@ -133,11 +130,11 @@ export default class BallotIntroFollowAdvisers extends Component {
 
     return <div className="intro-modal">
       <div className="intro-modal__h1">Follow Organizations</div>
-      { voter_guides_to_follow_by_issues_for_display.length > 0 ?
+      { voter_guides_to_follow_by_issues_for_display.length ?
         <div>
           <div className="intro-modal-vertical-scroll-contain">
             <div className="intro-modal-vertical-scroll card">
-              { voter_guides_to_follow_by_issues_for_display.length > 0 ?
+              { voter_guides_to_follow_by_issues_for_display.length ?
                 voter_guides_to_follow_by_issues_for_display :
                 <h4>No organizations to display</h4>
               }
@@ -154,7 +151,7 @@ export default class BallotIntroFollowAdvisers extends Component {
         <div>
           <div className="intro-modal-vertical-scroll-contain">
             <div className="intro-modal-vertical-scroll card">
-              { voter_guides_to_follow_all_for_display.length > 0 ?
+              { voter_guides_to_follow_all_for_display.length ?
                 voter_guides_to_follow_all_for_display :
                 <h4>No organizations to display</h4>
               }

--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -140,7 +140,7 @@ export default class BallotIntroFollowAdvisers extends Component {
               }
             </div>
           </div>
-          <div className="intro-modal-description-text">
+          <div className="intro-modal__description-text">
             { this.state.description_text ?
               this.state.description_text :
               <span>Great work! Based on your issues, these organizations or people

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -22,7 +22,7 @@ export default class BallotIntroFollowIssues extends Component {
       description_text: INITIAL_DESCRIPTION_TEXT,
       followed_issues: [],
       issues: [],
-      next_button_text: NEXT_BUTTON_TEXT
+      next_button_text: NEXT_BUTTON_TEXT,
     };
   }
 
@@ -97,10 +97,7 @@ export default class BallotIntroFollowIssues extends Component {
   }
 
   render () {
-    var issue_list = [];
-    if (this.state.issues) {
-      issue_list = this.state.issues;
-    }
+    let issue_list = this.state.issues || [];
 
     let edit_mode = true;
     const issue_list_for_display = issue_list.map((issue) => {
@@ -127,7 +124,7 @@ export default class BallotIntroFollowIssues extends Component {
         </div>
       </div>
       <div className="intro-modal__p intro-modal__height-min-100 intro-modal__padding-top">
-        { this.state.description_text }
+        {this.state.description_text}
       </div>
       <br/>
       <div className="intro-modal__button-wrap">

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -123,7 +123,7 @@ export default class BallotIntroFollowIssues extends Component {
           }
         </div>
       </div>
-      <div className="intro-modal__p intro-modal__height-min-100 intro-modal__padding-top">
+      <div className="intro-modal__description-text">
         {this.state.description_text}
       </div>
       <br/>

--- a/src/js/components/Ballot/BallotIntroModal.jsx
+++ b/src/js/components/Ballot/BallotIntroModal.jsx
@@ -7,7 +7,7 @@ import BallotIntroFollowAdvisers from "./BallotIntroFollowAdvisers";
 import BallotIntroPositionBar from "./BallotIntroPositionBar";
 
 
-export default class BallotIntoModal extends Component {
+export default class BallotIntroModal extends Component {
   // This Modal is shown to the user, when user visits the ballot page for first time only
 
   static propTypes = {

--- a/src/js/components/Ballot/BallotIntroModal.jsx
+++ b/src/js/components/Ballot/BallotIntroModal.jsx
@@ -50,10 +50,8 @@ export default class BallotIntoModal extends Component {
             <img src="/img/global/icons/x-close.png" alt="close" />
           </a>
         </div>
-        <h1>H1</h1>
-        <h2>h2</h2>
         <Slider dotsClass="slick-dots intro-modal__gray-dots intro-modal__bottom-sm"
-                className="calc-height intro-modal__height-full child-height-full"
+                className="calc-height intro-modal__height-full"
                 ref="slider" {...slider_settings}>
           <div className="intro-modal__height-full" key={1}><BallotIntroMission next={this._nextSliderPage}/></div>
           <div className="intro-modal__height-full" key={2}><BallotIntroFollowIssues next={this._nextSliderPage}/></div>

--- a/src/js/components/Ballot/BallotIntroOrganizations.jsx
+++ b/src/js/components/Ballot/BallotIntroOrganizations.jsx
@@ -22,7 +22,7 @@ export default class BallotIntroFollowAdvisers extends Component {
       description_text: "",
       followed_organizations: [],
       voter_guides_to_follow_by_issues_followed: [],
-      next_button_text: NEXT_BUTTON_TEXT
+      next_button_text: NEXT_BUTTON_TEXT,
     };
   }
 
@@ -51,7 +51,7 @@ export default class BallotIntroFollowAdvisers extends Component {
       this.setState({
         description_text: "",
         followed_organizations: new_followed_organizations,
-        next_button_text: NEXT_BUTTON_TEXT
+        next_button_text: NEXT_BUTTON_TEXT,
       });
     }
   }
@@ -88,10 +88,7 @@ export default class BallotIntroFollowAdvisers extends Component {
   }
 
   render () {
-    var voter_guides_to_follow_by_issues_followed = [];
-    if (this.state.voter_guides_to_follow_by_issues_followed) {
-      voter_guides_to_follow_by_issues_followed = this.state.voter_guides_to_follow_by_issues_followed;
-    }
+    let voter_guides_to_follow_by_issues_followed = this.state.voter_guides_to_follow_by_issues_followed || [];
 
     const voter_guides_to_follow_by_issues_followed_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) => {
       return <OrganizationFollowToggle
@@ -111,14 +108,14 @@ export default class BallotIntroFollowAdvisers extends Component {
       <br/>
       <div className="intro-modal-vertical-scroll-contain">
         <div className="intro-modal-vertical-scroll card">
-          { voter_guides_to_follow_by_issues_followed_for_display.length > 0 ?
+          { voter_guides_to_follow_by_issues_followed_for_display.length ?
             voter_guides_to_follow_by_issues_followed_for_display :
             <h4>No organizations to display</h4>
           }
         </div>
       </div>
       <div className="intro-story__h2">
-        { this.state.description_text }
+        {this.state.description_text}
       </div>
       <br/>
       <div className="intro-modal__button-wrap">

--- a/src/js/components/Ballot/BallotIntroOrganizations.jsx
+++ b/src/js/components/Ballot/BallotIntroOrganizations.jsx
@@ -104,7 +104,7 @@ export default class BallotIntroFollowAdvisers extends Component {
 
     return <div className="intro-modal">
       <div className="intro-modal__h1">Follow Organizations or People</div>
-      <div className="intro-story__h2">These are organizations or people that might share your values. Follow them to see their recommendations.</div>
+      <div className="intro-modal__h2">These are organizations or people that might share your values. Follow them to see their recommendations.</div>
       <br/>
       <div className="intro-modal-vertical-scroll-contain">
         <div className="intro-modal-vertical-scroll card">
@@ -114,7 +114,7 @@ export default class BallotIntroFollowAdvisers extends Component {
           }
         </div>
       </div>
-      <div className="intro-story__h2">
+      <div className="intro-modal__p">
         {this.state.description_text}
       </div>
       <br/>

--- a/src/js/components/Ballot/BallotIntroPositionBar.jsx
+++ b/src/js/components/Ballot/BallotIntroPositionBar.jsx
@@ -22,7 +22,7 @@ export default class BallotIntroPositionBar extends Component {
         </div>
       </div>
       <div className="intro-modal__button-wrap">
-        <button type="button" className="btn btn-success intro-modal__button" onClick={this.props.next}>See Your Ballot &nbsp;&nbsp;&gt;</button>
+        <button type="button" className="btn btn-success intro-modal__button" onClick={this.props.next}>See Your Ballot&nbsp;&gt;</button>
       </div>
     </div>;
   }

--- a/src/js/components/Ballot/BallotIntroPositionBar.jsx
+++ b/src/js/components/Ballot/BallotIntroPositionBar.jsx
@@ -13,7 +13,7 @@ export default class BallotIntroPositionBar extends Component {
   render () {
     return <div className="intro-modal">
       <div className="intro-modal__h1">Congratulations!</div>
-      <div className="intro-story__h2">Now that you have a network, you will see a position bar next to ballot items with your network's positions.</div>
+      <div className="intro-modal__h2">Now that you have a network, you will see a position bar next to ballot items with your network's positions.</div>
       <div className="intro-modal__position-wrap">
         <img className="intro-modal__position-img" src="/img/global/icons/position-bar-v1-265x43.png" alt="position bar" />
         <div className="intro-modal__position-description-wrap">

--- a/src/js/components/Navigation/HeaderGettingStartedBar.jsx
+++ b/src/js/components/Navigation/HeaderGettingStartedBar.jsx
@@ -111,7 +111,7 @@ export default class HeaderGettingStartedBar extends Component {
 
     const BallotIntroFollowIssuesModal = <Modal bsClass="background-brand-blue modal"
                                     show={this.state.showBallotIntroFollowIssues}
-                                    onHide={()=>{this._toggleBallotIntroFollowIssues(this);}}>
+                                    onHide={() => this._toggleBallotIntroFollowIssues(this)}>
         <Modal.Body>
           <div className="intro-modal__close">
             <a onClick={this._toggleBallotIntroFollowIssues} className="intro-modal__close-anchor">
@@ -121,14 +121,14 @@ export default class HeaderGettingStartedBar extends Component {
           <Slider dotsClass="slick-dots intro-modal__gray-dots" className="calc-height" ref="slider" {...slider_settings}>
             <div key={1}><BallotIntroFollowIssues next={this._nextSliderPage}/></div>
             <div key={2}><BallotIntroFollowAdvisers next={this._nextSliderPage}/></div>
-            <div key={3}><BallotIntroPositionBar next={this._nextSliderPage}/></div>
+            <div key={3}><BallotIntroPositionBar next={this._toggleBallotIntroFollowIssues}/></div>
           </Slider>
         </Modal.Body>
       </Modal>;
 
     const BallotIntroOrganizationsModal = <Modal bsClass="background-brand-blue modal"
                                     show={this.state.showBallotIntroOrganizations}
-                                    onHide={()=>{this._toggleBallotIntroOrganizations(this);}}>
+                                    onHide={() => this._toggleBallotIntroOrganizations(this)}>
         <Modal.Body>
           <div className="intro-modal__close">
             <a onClick={this._toggleBallotIntroOrganizations} className="intro-modal__close-anchor">
@@ -137,14 +137,14 @@ export default class HeaderGettingStartedBar extends Component {
           </div>
           <Slider dotsClass="slick-dots intro-modal__gray-dots" className="calc-height" ref="slider" {...slider_settings}>
             <div key={1}><BallotIntroOrganizations next={this._nextSliderPage}/></div>
-            <div key={2}><BallotIntroPositionBar next={this._nextSliderPage}/></div>
+            <div key={2}><BallotIntroPositionBar next={this._toggleBallotIntroOrganizations}/></div>
           </Slider>
         </Modal.Body>
       </Modal>;
 
     const BallotIntroPositionsModal = <Modal bsClass="background-brand-blue modal"
                                     show={this.state.showBallotIntroPositions}
-                                    onHide={()=>{this._toggleBallotIntroPositions(this);}}>
+                                    onHide={() => this._toggleBallotIntroPositions(this)}>
         <Modal.Body>
           <div className="intro-modal__close">
             <a onClick={this._toggleBallotIntroPositions} className="intro-modal__close-anchor">
@@ -153,14 +153,14 @@ export default class HeaderGettingStartedBar extends Component {
           </div>
           <Slider dotsClass="slick-dots intro-modal__gray-dots" className="calc-height" ref="slider" {...slider_settings}>
             <div key={1}><BallotIntroPositions next={this._nextSliderPage}/></div>
-            <div key={2}><BallotIntroPositionBar next={this._nextSliderPage}/></div>
+            <div key={2}><BallotIntroPositionBar next={this._toggleBallotIntroPositions}/></div>
           </Slider>
         </Modal.Body>
       </Modal>;
 
     const BallotIntroFriendsModal = <Modal bsClass="background-brand-blue modal"
                                     show={this.state.showBallotIntroFriends}
-                                    onHide={()=>{this._toggleBallotIntroFriends(this);}}>
+                                    onHide={() => this._toggleBallotIntroFriends(this)}>
         <Modal.Body>
           <div className="intro-modal__close">
             <a onClick={this._toggleBallotIntroFriends} className="intro-modal__close-anchor">
@@ -169,14 +169,14 @@ export default class HeaderGettingStartedBar extends Component {
           </div>
           <Slider dotsClass="slick-dots intro-modal__gray-dots" className="calc-height" ref="slider" {...slider_settings}>
             <div key={1}><BallotIntroFriends next={this._nextSliderPage}/></div>
-            <div key={2}><BallotIntroPositionBar next={this._nextSliderPage}/></div>
+            <div key={2}><BallotIntroPositionBar next={this._toggleBallotIntroFriends}/></div>
           </Slider>
         </Modal.Body>
       </Modal>;
 
     const BallotIntroShareModal = <Modal bsClass="background-brand-blue modal"
                                     show={this.state.showBallotIntroShare}
-                                    onHide={()=>{this._toggleBallotIntroShare(this);}}>
+                                    onHide={() => this._toggleBallotIntroShare(this)}>
         <Modal.Body>
           <div className="intro-modal__close">
             <a onClick={this._toggleBallotIntroShare} className="intro-modal__close-anchor">
@@ -185,14 +185,14 @@ export default class HeaderGettingStartedBar extends Component {
           </div>
           <Slider dotsClass="slick-dots intro-modal__gray-dots" className="calc-height" ref="slider" {...slider_settings}>
             <div key={1}><BallotIntroShare next={this._nextSliderPage}/></div>
-            <div key={2}><BallotIntroPositionBar next={this._nextSliderPage}/></div>
+            <div key={2}><BallotIntroPositionBar next={this._toggleBallotIntroShare}/></div>
           </Slider>
         </Modal.Body>
       </Modal>;
 
     const BallotIntroVoteModal = <Modal bsClass="background-brand-blue modal"
                                     show={this.state.showBallotIntroVote}
-                                    onHide={()=>{this._toggleBallotIntroVote(this);}}>
+                                    onHide={() => this._toggleBallotIntroVote(this)}>
         <Modal.Body>
           <div className="intro-modal__close">
             <a onClick={this._toggleBallotIntroVote} className="intro-modal__close-anchor">
@@ -201,7 +201,7 @@ export default class HeaderGettingStartedBar extends Component {
           </div>
           <Slider dotsClass="slick-dots intro-modal__gray-dots" className="calc-height" ref="slider" {...slider_settings}>
             <div key={1}><BallotIntroVote next={this._nextSliderPage}/></div>
-            <div key={2}><BallotIntroPositionBar next={this._nextSliderPage}/></div>
+            <div key={2}><BallotIntroPositionBar next={this._toggleBallotIntroVote}/></div>
           </Slider>
         </Modal.Body>
       </Modal>;

--- a/src/js/components/Navigation/HeaderGettingStartedBar.jsx
+++ b/src/js/components/Navigation/HeaderGettingStartedBar.jsx
@@ -221,23 +221,23 @@ export default class HeaderGettingStartedBar extends Component {
               source="/img/global/svg-icons/organizations-v2-31x26.svg"
               title="Organizations"
               completed={this.state.ballot_intro_organizations_completed} />
-            {/* Positions Icon & Modal
-            <GettingStartedBarItem show={this._toggleBallotIntroPositions}
+            {/* Positions Icon & Modal */}
+            {/* <GettingStartedBarItem show={this._toggleBallotIntroPositions}
               source="/img/global/svg-icons/stance-v1-59x32.svg"
               title="Positions"
               completed={this.state.ballot_intro_positions_completed} /> */}
-            {/* Friends Icon & Modal
-            <GettingStartedBarItem show={this._toggleBallotIntroFriends}
+            {/* Friends Icon & Modal */}
+            {/* <GettingStartedBarItem show={this._toggleBallotIntroFriends}
               source="/img/global/svg-icons/friends-v2-59x28.svg"
               title="Friends"
               completed={this.state.ballot_intro_friends_completed} /> */}
-            {/* Share Icon & Modal
-            <GettingStartedBarItem show={this._toggleBallotIntroShare}
+            {/* Share Icon & Modal */}
+            {/* <GettingStartedBarItem show={this._toggleBallotIntroShare}
               source="/img/global/svg-icons/share-v2-28x24.svg"
               title="Share"
               completed={this.state.ballot_intro_share_completed} /> */}
-            {/* Vote Icon & Modal
-            <GettingStartedBarItem show={this._toggleBallotIntroVote}
+            {/* Vote Icon & Modal */}
+            {/* <GettingStartedBarItem show={this._toggleBallotIntroVote}
               source="/img/global/svg-icons/vote-v6-28x28.svg"
               title="Vote"
               completed={this.state.ballot_intro_vote_completed} /> */}

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -7,24 +7,24 @@
   &__h1 {
     font-weight: 700;
     font-size: 30px;
-    padding: $space-sm $space-none $space-md;
-    @include breakpoints (max large) {
-      font-size: 22px;
+    padding: $space-md $space-none $space-md;
+    @include breakpoints (max medium) {
+      font-size: 16px;
     }
   }
   &__h1--alt {
     font-weight: 700;
     font-size: 30px;
     padding-top: $space-lg;
-    @include breakpoints (max large) {
-      font-size: 22px;
+    @include breakpoints (max medium) {
+      font-size: 16px;
     }
   }
 
   &__h2 {
     font-size: 20px;
-    @include breakpoints (max large) {
-      font-size: 18px;
+    @include breakpoints (max medium) {
+      font-size: 16px;
     }
   }
 
@@ -43,8 +43,11 @@
     }
   }
 
-  &__height-min-100 {
+  &__responsive-height {
     min-height: 100px;
+    @include breakpoints (mid-small medium) {
+      min-height: 120px;
+    }
   }
 
   &__height-full {
@@ -60,7 +63,7 @@
     position: absolute;
     top: $space-none;
     right: $space-none;
-    width: $space-lg;
+    width: $space-md * 1.25;
     z-index: 9999;
     @include breakpoints (max mid-small) {
       width: $space-md;
@@ -73,7 +76,7 @@
   }
 
   &__p {
-    font-size: $base-font-size;
+    font-size: $base-font-size * .875;
   }
 
   &__position-wrap {
@@ -105,6 +108,9 @@
   &__button {
     position: absolute;
     bottom: 42px;
+    @include breakpoints (max mid-small) {
+      bottom: 0;
+    }
   }
 
   &__button-wrap {
@@ -255,7 +261,9 @@
   }
 
   &__description-text {
-    padding-top: $space-md;
+    @extend .intro-modal__p;
+    @extend .intro-modal__responsive-height;
+    @extend .intro-modal__padding-top;
   }
 }
 
@@ -291,7 +299,7 @@
   max-height: 30vh;
   overflow-y: auto;
   @include breakpoints (max mid-small) {
-    max-height: 40vh;
+    max-height: calc(100vh - 284px);
   }
 }
 
@@ -327,7 +335,7 @@
 }
 
 .slick-dots {
-  bottom: 2em;
+  bottom: 0 !important;
 }
 
 .facebook-intro-connect,


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

#974, #1036 

### Changes included this pull request?

Fixes the layout of the modals shown in the ballot intro. Adds the autofocus attribute to the edit address text input so users can start typing their address without clicking on it first.