### PR TITLE
Make intro modal buttons fixed width, election modal buttons full width, text truncated and centered

### DIFF
--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -1,7 +1,8 @@
 import React, { Component, PropTypes } from "react";
+import TextTruncate from "react-text-truncate";
 import VoterActions from "../../actions/VoterActions";
 import { cleanArray } from "../../utils/textFormat";
-let moment = require("moment");
+import moment from "moment";
 
 export default class BallotElectionList extends Component {
 
@@ -10,7 +11,7 @@ export default class BallotElectionList extends Component {
     toggleFunction: PropTypes.func.isRequired,
   };
 
-  constructor (props){
+  constructor (props) {
     super(props);
     this.state = {};
   }
@@ -29,10 +30,13 @@ export default class BallotElectionList extends Component {
       item.election_date > currentDate ?
       <div key={index}>
         <dl className="list-unstyled text-center">
-          <button type="button" className="btn btn-success"
-            onClick={this.updateBallot.bind(this, item.originalTextForMapSearch, simpleSave, item.googleCivicElectionId)}>
-            See {item.election_description_text} <span><img src={"/img/global/icons/Circle-Arrow.png"}/></span><br />
-            <span className="ballot-election-list__h2 pull-left"> {moment(item.election_date).format("MMMM Do, YYYY")}</span>
+          <button type="button" className="btn btn-success ballot-election-list__button"
+                  onClick={this.updateBallot.bind(this, item.originalTextForMapSearch, simpleSave, item.googleCivicElectionId)}>
+            <TextTruncate line={1}
+                          truncateText="…"
+                          text={item.election_description_text}
+                          textTruncateChild={null} />
+            <div className="ballot-election-list__h2">{moment(item.election_date).format("MMMM Do, YYYY")}</div>
           </button>
         </dl>
       </div> :
@@ -45,10 +49,13 @@ export default class BallotElectionList extends Component {
       null :
       <div key={index}>
         <dl className="list-unstyled text-center">
-          <button type="button" className="btn btn-success"
-            onClick={this.updateBallot.bind(this, item.originalTextForMapSearch, simpleSave, item.googleCivicElectionId)}>
-            See {item.election_description_text} <span><img src={"/img/global/icons/Circle-Arrow.png"}/></span><br />
-            <span className="ballot-election-list__h2 pull-left"> {moment(item.election_date).format("MMMM Do, YYYY")}</span>
+          <button type="button" className="btn btn-success ballot-election-list__button"
+                  onClick={this.updateBallot.bind(this, item.originalTextForMapSearch, simpleSave, item.googleCivicElectionId)}>
+            <TextTruncate line={1}
+                          truncateText="…"
+                          text={item.election_description_text}
+                          textTruncateChild={null} />
+            <div className="ballot-election-list__h2">{moment(item.election_date).format("MMMM Do, YYYY")}</div>
           </button>
         </dl>
       </div>
@@ -56,12 +63,12 @@ export default class BallotElectionList extends Component {
     priorElectionList = cleanArray(priorElectionList);
 
     return <div>
-      { upcomingElectionList && upcomingElectionList.length > 0 ?
+      { upcomingElectionList && upcomingElectionList.length ?
         <h4 className="h4">Upcoming Election(s)</h4> :
         null }
       {upcomingElectionList}
 
-      { priorElectionList && priorElectionList.length > 0 ?
+      { priorElectionList && priorElectionList.length ?
         <h4 className="h4">Prior Election(s)</h4> :
         null }
       {priorElectionList}

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -1,8 +1,9 @@
 import React, { Component, PropTypes } from "react";
-import TextTruncate from "react-text-truncate";
 import VoterActions from "../../actions/VoterActions";
 import { cleanArray } from "../../utils/textFormat";
 import moment from "moment";
+
+const MAXIMUM_NUMBER_OF_CHARACTERS_TO_SHOW = 36;
 
 export default class BallotElectionList extends Component {
 
@@ -32,10 +33,10 @@ export default class BallotElectionList extends Component {
         <dl className="list-unstyled text-center">
           <button type="button" className="btn btn-success ballot-election-list__button"
                   onClick={this.updateBallot.bind(this, item.originalTextForMapSearch, simpleSave, item.googleCivicElectionId)}>
-            <TextTruncate line={1}
-                          truncateText="…"
-                          text={item.election_description_text}
-                          textTruncateChild={null} />
+            { item.election_description_text.length < MAXIMUM_NUMBER_OF_CHARACTERS_TO_SHOW ?
+              <span>{item.election_description_text}&nbsp;<img src={"/img/global/icons/Circle-Arrow.png"}/></span> :
+              <span>{item.election_description_text.substring(0, MAXIMUM_NUMBER_OF_CHARACTERS_TO_SHOW - 3)}...&nbsp;<img src={"/img/global/icons/Circle-Arrow.png"}/></span>
+            }
             <div className="ballot-election-list__h2">{moment(item.election_date).format("MMMM Do, YYYY")}</div>
           </button>
         </dl>
@@ -51,10 +52,10 @@ export default class BallotElectionList extends Component {
         <dl className="list-unstyled text-center">
           <button type="button" className="btn btn-success ballot-election-list__button"
                   onClick={this.updateBallot.bind(this, item.originalTextForMapSearch, simpleSave, item.googleCivicElectionId)}>
-            <TextTruncate line={1}
-                          truncateText="…"
-                          text={item.election_description_text}
-                          textTruncateChild={null} />
+            { item.election_description_text.length < MAXIMUM_NUMBER_OF_CHARACTERS_TO_SHOW ?
+              <span>{item.election_description_text}&nbsp;<img src={"/img/global/icons/Circle-Arrow.png"}/></span> :
+              <span>{item.election_description_text.substring(0, MAXIMUM_NUMBER_OF_CHARACTERS_TO_SHOW - 3)}...&nbsp;<img src={"/img/global/icons/Circle-Arrow.png"}/></span>
+            }
             <div className="ballot-election-list__h2">{moment(item.election_date).format("MMMM Do, YYYY")}</div>
           </button>
         </dl>

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -151,8 +151,8 @@ export default class BallotIntroFollowIssues extends Component {
     return (
     <div className="intro-modal">
       <div className="intro-modal__h1">
-        Follow { remaining_issues ? remaining_issues : "" }
-        &nbsp;Issues You Care About
+        Follow{ remaining_issues ? " " + remaining_issues : null }
+        &nbsp;Issue{ remaining_issues !== 1 ? "s" : null } You Care About
       </div>
       <div className="intro-modal-vertical-scroll-contain">
         <div className="intro-modal-vertical-scroll card">

--- a/src/js/components/Ballot/BallotIntroModal.jsx
+++ b/src/js/components/Ballot/BallotIntroModal.jsx
@@ -50,7 +50,7 @@ export default class BallotIntroModal extends Component {
             <img src="/img/global/icons/x-close.png" alt="close" />
           </a>
         </div>
-        <Slider dotsClass="slick-dots intro-modal__gray-dots intro-modal__bottom-sm"
+        <Slider dotsClass="slick-dots intro-modal__gray-dots"
                 className="calc-height intro-modal__height-full"
                 ref="slider" {...slider_settings}>
           <div className="intro-modal__height-full" key={1}><BallotIntroMission next={this._nextSliderPage}/></div>

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -76,10 +76,10 @@ export default class OfficeItemCompressed extends Component {
       <a name={we_vote_id} />
       <div className="card-main__content">
         <div className="u-flex u-stack--sm">
-          <h2 className="u-f3">
+          <h2 className="u-f3 card-main__ballot-name">
             { this.props.link_to_ballot_item_page ?
               <div className="card-main__ballot-name-group">
-                <div className="card-main__ballot-name-item card-main__ballot-name">
+                <div className="card-main__ballot-name-item">
                   <Link to={officeLink}>
                     <TextTruncate line={1}
                                   truncateText="…"
@@ -93,7 +93,10 @@ export default class OfficeItemCompressed extends Component {
                   </Link>
                 </div>
               </div> :
-              ballot_item_display_name
+              <TextTruncate line={1}
+                            truncateText="…"
+                            text={ballot_item_display_name}
+                            textTruncateChild={null} />
             }
           </h2>
           <BookmarkToggle we_vote_id={we_vote_id} type="OFFICE" />

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -167,10 +167,10 @@ export default class OfficeItemCompressed extends Component {
           </div>;
         })}
 
-        { !this.state.display_all_candidates_flag && remaining_candidates_to_display_count > 0 ?
+        { !this.state.display_all_candidates_flag && remaining_candidates_to_display_count ?
           <Link onClick={this.toggleDisplayAllCandidates}>
             <span className="u-items-center">
-              Click&nbsp;to&nbsp;show&nbsp;{remaining_candidates_to_display_count}&nbsp;more&nbsp;candidates...</span>
+              Click&nbsp;to&nbsp;show&nbsp;{remaining_candidates_to_display_count}&nbsp;more&nbsp;candidate{ remaining_candidates_to_display_count !== 1 ? "s" : null }...</span>
           </Link> : null
         }
         { this.state.display_all_candidates_flag && this.props.candidate_list.length > NUMBER_OF_CANDIDATES_TO_DISPLAY ?

--- a/src/sass/components/_ballotElectionList.scss
+++ b/src/sass/components/_ballotElectionList.scss
@@ -1,12 +1,14 @@
 .ballot-election-list {
   font-size: 12px;
   text-align: center;
-  .modal-header {
-    border-bottom: 0;
-  }
   @include breakpoints (max large) {
     width: 100%;
   }
+
+  .modal-header {
+    border-bottom: 0;
+  }
+
   &__modal {
     position: absolute;
     top: 20%;
@@ -14,8 +16,8 @@
     bottom: 0;
     left: 0;
     overflow: auto;
-    overflow-y: auto;
   }
+
   &__h1 {
     font-family: $heading-font-stack;
     font-size: 30px;
@@ -26,7 +28,12 @@
       font-size: 16px;
     }
   }
+
   &__h2 {
     font-size: 12px;
+  }
+
+  &__button {
+    width: 100%;
   }
 }

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -108,18 +108,15 @@
   &__button {
     position: absolute;
     bottom: 42px;
-    width: 20%;
+    width: 180px;
     @include breakpoints (max mid-small) {
       bottom: 0;
     }
   }
 
-  &__button-follow {
-    width: 20%;
-  }
-
+  &__button-follow,
   &__button-disabled {
-    width: 20%;
+    width: 180px;
   }
 
   &__button-wrap {
@@ -264,10 +261,6 @@
     opacity: 1;
   }
   /* stylelint-enable */
-
-  &__bottom-sm {
-    bottom: 1em !important;
-  }
 
   &__description-text {
     @extend .intro-modal__p;


### PR DESCRIPTION
Set the width of the intro modal buttons to a constant 180 pixels to fix the appearance of the buttons on moble (#1044). Fixed the grammar of the messages in the candidate list and issues modal when count is at 1. Changed the election modal buttons so that it covers the full width of the modal, all text is centered, and text is hard-limited to a set number of characters (#860). Fixed an issue with the slick dots appearing in the wrong place for certain modals.