### PR TITLE
Fix GettingStartedBarItem titles, set minimum height for intro modals, top-align input address in mobile

### DIFF
--- a/src/js/components/Ballot/SelectAddressModal.jsx
+++ b/src/js/components/Ballot/SelectAddressModal.jsx
@@ -16,7 +16,7 @@ export default class SelectAddressModal extends Component {
   }
 
   render () {
-    return <Modal show onHide={this.props.toggleFunction} className="ballot-election-list ballot-election-list__modal" >
+    return <Modal show onHide={this.props.toggleFunction} className="ballot-election-list ballot-election-list__modal ballot-election-list__modal-mobile" >
       <Modal.Header closeButton onHide={this.props.toggleFunction}>
         <Modal.Title className="ballot-election-list__h1">Enter address where you are registered to vote</Modal.Title>
       </Modal.Header>

--- a/src/js/components/Navigation/GettingStartedBarItem.jsx
+++ b/src/js/components/Navigation/GettingStartedBarItem.jsx
@@ -3,7 +3,7 @@ import { Link } from "react-router";
 
 const GettingStartedBarItem = props =>
   <Link onClick={props.show} className={ "header-getting-started-nav__item header-getting-started-nav__item--has-icon"}>
-    <span className="header-getting-started-nav__item-image-wrapper" title="Issues">
+    <span className="header-getting-started-nav__item-image-wrapper" title={props.title}>
       { props.completed ?
         <img className="glyphicon nav-getting-started__image-checked"
           src="/img/global/svg-icons/check-mark-v2-21x21.svg" /> :

--- a/src/sass/components/_ballotElectionList.scss
+++ b/src/sass/components/_ballotElectionList.scss
@@ -16,6 +16,12 @@
     bottom: 0;
     left: 0;
     overflow: auto;
+
+    &-mobile {
+      @include breakpoints(small mid-small) {
+        top: 0;
+      }
+    }
   }
 
   &__h1 {

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -1,5 +1,6 @@
 .intro-modal {
   padding: $space-none;
+  min-height: 480px;
   height: 100%;
   width: 100%;
   color: $white;


### PR DESCRIPTION
Fixed the title of each link in the getting started header bar. Forced a minimum height of 480px to the intro modals to fix height and incorrect button placement on some modals. Changed the position of the SelectAddress modal to the top of the page in mobile mode (#1045).