### PR TITLE
Server side issue 431, Persist and use facebook background offsets.

### DIFF
--- a/src/js/actions/FacebookActions.js
+++ b/src/js/actions/FacebookActions.js
@@ -26,10 +26,13 @@ module.exports = {
     Dispatcher.loadEndpoint("facebookDisconnect");
   },
 
+  /* Sept 6, 2017, We now use the Facebook "games" api "invitable_friends" data on the fly from the webapp, and no
+  longer attempt to use the more limited "friends" api call from the server
   facebookFriendsAction: function () {
-    Dispatcher.loadEndpoint("facebookFriendsAction", {});
+     Dispatcher.loadEndpoint("facebookFriendsAction", {});
     FriendActions.suggestedFriendList();
   },
+  */
 
   getFacebookProfilePicture: function (userId) {
       if (window.FB) {
@@ -137,18 +140,17 @@ module.exports = {
   },
 
   // Save incoming data from Facebook
+  // For offsets, see https://developers.facebook.com/docs/graph-api/reference/cover-photo/
   voterFacebookSignInData: function (data) {
     console.log("FacebookActions voterFacebookSignInData, data:", data);
     let background = false;
-    if (data.cover && data.cover.source)
-      background = data.cover.source;
-    // For offsets, see https://developers.facebook.com/docs/graph-api/reference/cover-photo/
     let offset_x = false;
-    if (data.cover && data.cover.offset_x)
-      offset_x = data.cover.offset_x;
     let offset_y = false;
-    if (data.cover && data.cover.offset_y)
-      offset_y = data.cover.offset_y;
+    if (data.cover && data.cover.source) {
+      background = data.cover.source;
+      offset_x = data.cover.offset_x;  // zero is a valid value so can't use the short-circuit operation " || false"
+      offset_y = data.cover.offset_y;  // zero is a valid value so can't use the short-circuit operation " || false"
+    }
     Dispatcher.loadEndpoint("voterFacebookSignInSave", {
       facebook_user_id: data.id || false,
       facebook_email: data.email || false,
@@ -157,8 +159,8 @@ module.exports = {
       facebook_last_name: data.last_name || false,
       facebook_profile_image_url_https: data.url || false,
       facebook_background_image_url_https: background,
-      facebook_background_image_offset_x: offset_x, // Not supported on API server yet
-      facebook_background_image_offset_y: offset_y, // Not supported on API server yet
+      facebook_background_image_offset_x: offset_x,
+      facebook_background_image_offset_y: offset_y,
       save_auth_data: false,
       save_profile_data: true
     });

--- a/src/js/stores/FacebookStore.js
+++ b/src/js/stores/FacebookStore.js
@@ -168,7 +168,9 @@ class FacebookStore extends FluxMapStore {
         // console.log("FacebookStore voterFacebookSignInRetrieve, facebook_sign_in_verified: ", action.res.facebook_sign_in_verified);
         if (action.res.facebook_sign_in_verified) {
           VoterActions.voterRetrieve();
+          /* Sept 6, 2017, has been replaced by facebook Game API friends list
           FacebookActions.facebookFriendsAction();
+          */
         }
         return {
           ...state,
@@ -208,11 +210,13 @@ class FacebookStore extends FluxMapStore {
           emailData: {}
         };
 
+      /* Sept 6, 2017, has been replaced by facebook Game API friends list
       case "facebookFriendsAction":
         return {
           ...state,
           facebook_friends_list: action.res.facebook_friends_list,
          };
+      */
 
       case FacebookConstants.FACEBOOK_SIGN_IN_DISCONNECT:
         this.disconnectFromFacebook();


### PR DESCRIPTION
Zero can be a valid value for facebook offsets, so handle data structure
accordingly.
Also remove the old facebookFriendsAction that asked facebook to send
all your fb friends via the "friends" API, which no longer worked for
our purposes.  Now we call the "games" API from the client to get a list
of your fb friends.