### PR TITLE
Adjust size and position of various intro modal elements, fix intro modal button width and placement

### DIFF
--- a/src/js/components/Issues/IssueFollowToggleSquare.jsx
+++ b/src/js/components/Issues/IssueFollowToggleSquare.jsx
@@ -16,7 +16,7 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
     }
 
     return this.state.is_following ?
-      <div className="col-6 col-sm-3 col-lg-2 intro-modal__issue-square" onClick={this.onIssueStopFollowing}>
+      <div className="col-4 col-sm-2 intro-modal__issue-square" onClick={this.onIssueStopFollowing}>
         <ImageHandler sizeClassName="intro-modal__issue-square-image u-cursor--pointer intro-modal__issue-square-following"
                       imageUrl={ issue_image_url }
                       alt={this.props.issue_name}
@@ -26,7 +26,7 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
                       alt="Following" />
         <h4 className="intro-modal__white-space intro-modal__issue-square-name">{this.props.issue_name}</h4>
       </div> :
-      <div className="col-6 col-sm-3 col-lg-2 intro-modal__issue-square" onClick={this.onIssueFollow}>
+      <div className="col-4 col-sm-2 intro-modal__issue-square" onClick={this.onIssueFollow}>
         <ImageHandler sizeClassName="intro-modal__issue-square-image u-cursor--pointer"
                       imageUrl={ issue_image_url }
                       alt={this.props.issue_name}

--- a/src/js/components/Issues/IssueFollowToggleSquare.jsx
+++ b/src/js/components/Issues/IssueFollowToggleSquare.jsx
@@ -16,7 +16,7 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
     }
 
     return this.state.is_following ?
-      <div className="col-4 col-sm-3 intro-modal__issue-square" onClick={this.onIssueStopFollowing}>
+      <div className="col-6 col-sm-3 col-lg-2 intro-modal__issue-square" onClick={this.onIssueStopFollowing}>
         <ImageHandler sizeClassName="intro-modal__issue-square-image u-cursor--pointer intro-modal__issue-square-following"
                       imageUrl={ issue_image_url }
                       alt={this.props.issue_name}
@@ -26,7 +26,7 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
                       alt="Following" />
         <h4 className="intro-modal__white-space intro-modal__issue-square-name">{this.props.issue_name}</h4>
       </div> :
-      <div className="col-4 col-sm-3 intro-modal__issue-square" onClick={this.onIssueFollow}>
+      <div className="col-6 col-sm-3 col-lg-2 intro-modal__issue-square" onClick={this.onIssueFollow}>
         <ImageHandler sizeClassName="intro-modal__issue-square-image u-cursor--pointer"
                       imageUrl={ issue_image_url }
                       alt={this.props.issue_name}

--- a/src/sass/base/_variables.scss
+++ b/src/sass/base/_variables.scss
@@ -159,7 +159,11 @@ $breakpoints: (
   'large': 960px,
   'wide': 1024px,
   'nav': 695px,
-  'iphone5':375px
+  'iphone5': 375px,
+  'xsmall-bootstrap': 576px,
+  'small-bootstrap': 768px,
+  'medium-bootstrap': 992px,
+  'large-bootstrap': 1200px,
 ) !default;
 
 

--- a/src/sass/components/_ballotList.scss
+++ b/src/sass/components/_ballotList.scss
@@ -79,8 +79,12 @@
   // top: 20%;
   transform: translateY(-50%);
 
-  @include breakpoints(992px) {
-    width: 768px;
+  @include breakpoints(large) {
+    width: 880px;
+  }
+
+  @include breakpoints(medium large) {
+    width: 750px;
   }
 }
 

--- a/src/sass/components/_ballotList.scss
+++ b/src/sass/components/_ballotList.scss
@@ -78,6 +78,10 @@
   position: relative;
   // top: 20%;
   transform: translateY(-50%);
+
+  @include breakpoints(992px) {
+    width: 768px;
+  }
 }
 
 .BallotItemsSummary {

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -115,17 +115,17 @@
   &__button {
     position: absolute;
     bottom: 36px;
-    width: 180px;
+    width: 19%;
   }
 
   &__button-follow,
   &__button-disabled {
-    width: 180px;
+    width: 19%;
   }
 
   &__button-wrap {
     display: flex;
-    justify-content: center;
+    justify-content: space-around;
   }
 
   &__span {
@@ -322,6 +322,27 @@
       left: 12px;
       font-size: .875rem;
       text-shadow: 1px 1px 2px rgba($black, .6);
+
+      @include breakpoints (xsmall-bootstrap small-bootstrap) {
+        right: 10px;
+        bottom: 10px;
+        left: 10px;
+        font-size: .65rem;
+      }
+
+      @include breakpoints (iphone5 mid-small) {
+        right: 10px;
+        bottom: 10px;
+        left: 10px;
+        font-size: .65rem;
+      }
+
+      @include breakpoints (max iphone5) {
+        right: 8px;
+        bottom: 8px;
+        left: 8px;
+        font-size: .6rem;
+      }
     }
   }
 }

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -5,16 +5,18 @@
   width: 100%;
   color: $white;
   text-align: center;
-  @include breakpoints (mid-small) {
-    min-height: 508px;
-  }
 
   &__h1 {
     font-weight: 700;
     font-size: 30px;
     padding: $space-md $space-none $space-sm;
-    @include breakpoints (max medium) {
-      font-size: 16px;
+
+    @include breakpoints (mid-small medium) {
+      font-size: 24px;
+    }
+
+    @include breakpoints (max mid-small) {
+      font-size: 18px;
     }
   }
   &__h1--alt {
@@ -112,11 +114,8 @@
 
   &__button {
     position: absolute;
-    bottom: 42px;
+    bottom: 36px;
     width: 180px;
-    @include breakpoints (max mid-small) {
-      bottom: 0;
-    }
   }
 
   &__button-follow,
@@ -140,8 +139,14 @@
   &__top-description {
     font-size: 20px;
     padding-bottom: $space-md;
-    @include breakpoints (max medium) {
-      font-size: 16px;
+
+    @include breakpoints (mid-small medium) {
+      font-size: 18px;
+      padding-bottom: $space-sm;
+    }
+
+    @include breakpoints (max mid-small) {
+      font-size: 14px;
       padding-bottom: $space-sm;
     }
   }
@@ -317,12 +322,6 @@
       left: 12px;
       font-size: .875rem;
       text-shadow: 1px 1px 2px rgba($black, .6);
-      @include breakpoints (max mid-small) {
-        right: 10px;
-        bottom: 10px;
-        left: 10px;
-        font-size: .675rem;
-      }
     }
   }
 }
@@ -356,10 +355,15 @@
 }
 
 .intro-modal-vertical-scroll-contain {
-  max-height: 30vh;
+  max-height: 40vh;
   overflow-y: auto;
+
+  @include breakpoints (mid-small medium) {
+    max-height: 42vh;
+  }
+
   @include breakpoints (max mid-small) {
-    max-height: calc(100vh - 284px);
+    max-height: calc(100vh - 256px);
   }
 }
 
@@ -394,6 +398,11 @@
   }
 }
 
+.slick-list,
+.slick-track {
+  height: 100%;
+}
+
 .slick-dots {
   bottom: 0;
 }
@@ -407,5 +416,9 @@
 .calc-height {
   @include breakpoints (max mid-small) {
     height: calc(100vh - 52px);
+  }
+
+  @include breakpoints (mid-small) {
+    height: 64vh;
   }
 }

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -376,15 +376,15 @@
 }
 
 .intro-modal-vertical-scroll-contain {
-  max-height: 40vh;
+  height: 40vh;
   overflow-y: auto;
 
   @include breakpoints (mid-small medium) {
-    max-height: 42vh;
+    height: 42vh;
   }
 
   @include breakpoints (max mid-small) {
-    max-height: calc(100vh - 256px);
+    height: calc(100vh - 256px);
   }
 }
 

--- a/src/sass/components/_modal-content.scss
+++ b/src/sass/components/_modal-content.scss
@@ -1,5 +1,5 @@
 .background-brand-blue {
-  & .modal-content {
+  .modal-content {
     background-color: $brand-blue;
   }
 }

--- a/src/sass/routes/_welcome.scss
+++ b/src/sass/routes/_welcome.scss
@@ -146,11 +146,11 @@ $cta-color: #fb2f2f;
       padding: $space-none $space-lg;
       height: 66px;
 
-      @include breakpoints (medium 992px) {
+      @include breakpoints (small-bootstrap medium-bootstrap) {
         height: 110px;
       }
 
-      @include breakpoints (max medium) {
+      @include breakpoints (max small-bootstrap) {
         padding: $space-none;
       }
 


### PR DESCRIPTION
Increased the height and width of the intro modal, as well as the number of issues shown per row, on desktop displays. Increased the height of the vertical scroll container to `40vh`-`42vh` (not quite `50vh` as suggested in #1062, but I think it looks big enough the way it is now). Adjusted the size and positioning of various text elements in the modal. Fixed an issue where the bottom navigation button is not positioned correctly on some displays, and adjusted the button's width. Added breakpoint variables that align with Bootstrap's breakpoints.