### PR TITLE
Redesign Facebook friends list, modify issues text size and styling

### DIFF
--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -153,7 +153,7 @@ export default class BallotIntroFollowAdvisers extends Component {
               }
               { voter_guides_to_follow_by_issues_for_display.length || voter_guides_to_follow_all_for_display.length ?
                 null :
-                <h4>There are no more organizations to follow!</h4>
+                <h4 className="intro-modal__default-text">There are no more organizations to follow!</h4>
               }
             </div>
           </div>

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -157,7 +157,7 @@ export default class BallotIntroFollowIssues extends Component {
       <div className="intro-modal-vertical-scroll-contain">
         <div className="intro-modal-vertical-scroll card">
           <div className="row intro-modal__issue-grid">
-            { issue_list.length ? issue_list_for_display : <h4>No issues to display</h4> }
+            { issue_list.length ? issue_list_for_display : <h4 className="intro-modal__default-text">No issues to display.</h4> }
           </div>
         </div>
       </div>

--- a/src/js/components/Connect/CheckBox.jsx
+++ b/src/js/components/Connect/CheckBox.jsx
@@ -9,17 +9,18 @@ export default class CheckBox extends Component {
     handleCheckboxChange: PropTypes.func.isRequired,
   };
 
-  state = {
-      isChecked: false,
+  constructor (props) {
+    super(props);
+    this.state = {
+        isChecked: false,
+    };
   }
 
-  toggleCheckboxChange = () => {
+  toggleCheckboxChange () {
     const { friendId, friendName } = this.props;
-    this.setState(({ isChecked }) => (
-      {
-        isChecked: !isChecked,
-      }
-    ));
+    this.setState({
+      isChecked: !this.state.isChecked,
+    });
     this.props.handleCheckboxChange(friendId, friendName);
   }
 

--- a/src/js/components/Connect/CheckBox.jsx
+++ b/src/js/components/Connect/CheckBox.jsx
@@ -6,6 +6,7 @@ export default class CheckBox extends Component {
     friendId: PropTypes.string.isRequired,
     friendName: PropTypes.string,
     friendImage: PropTypes.string,
+    grid: PropTypes.string,
     handleCheckboxChange: PropTypes.func.isRequired,
   };
 
@@ -14,6 +15,10 @@ export default class CheckBox extends Component {
     this.state = {
         isChecked: false,
     };
+  }
+
+  componentDidMount () {
+    this.toggleCheckboxChange = this.toggleCheckboxChange.bind(this);
   }
 
   toggleCheckboxChange () {
@@ -25,17 +30,17 @@ export default class CheckBox extends Component {
   }
 
   render () {
-    const { friendId, friendName, friendImage } = this.props;
     const { isChecked } = this.state;
-    return <div onClick={this.toggleCheckboxChange}>
-        <input type="checkbox"
-          value={friendId}
-          checked={isChecked}
-        />
-        &nbsp;
-        <ImageHandler imageUrl={friendImage} className="" sizeClassName="icon-lg" />
-        &nbsp;
-        {friendName}
-      </div>;
+    return (
+      <div className={this.props.grid + " friends-list__square"} onClick={this.toggleCheckboxChange}>
+        <ImageHandler sizeClassName={"friends-list__square-image u-cursor--pointer" + (isChecked && " friends-list__square-following")}
+                      imageUrl={this.props.friendImage}
+                      alt={this.props.friendName} />
+        { isChecked && <ImageHandler className="friends-list__square-check-mark u-cursor--pointer"
+                      imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
+                      alt="Inviting" /> }
+        <h4 className="intro-modal__white-space friends-list__square-name">{this.props.friendName}</h4>
+      </div>
+    );
   }
 }

--- a/src/js/components/Network/NetworkIssuesToFollow.jsx
+++ b/src/js/components/Network/NetworkIssuesToFollow.jsx
@@ -74,7 +74,7 @@ export default class NetworkIssuesToFollow extends Component {
               {
                 this.state.issues_to_follow && this.state.issues_to_follow.length ?
                   issue_list_for_display :
-                  null
+                  <h4 className="intro-modal__default-text">There are no more issues to follow!</h4>
               }
             </div>
           </div>

--- a/src/js/routes/FacebookInvitableFriends.jsx
+++ b/src/js/routes/FacebookInvitableFriends.jsx
@@ -48,8 +48,8 @@ export default class FacebookInvitableFriends extends Component {
       facebook_logged_in: false,
       facebook_auth_response: {},
       facebook_invitable_friends: FacebookStore.facebookInvitableFriends(),
-      facebook_invitable_friends_image_width: 48,
-      facebook_invitable_friends_image_height: 48,
+      facebook_invitable_friends_image_width: 148,
+      facebook_invitable_friends_image_height: 148,
       add_friends_message: "Please join me in preparing for the upcoming election.",
       saving: false,
       search_filter: false,
@@ -310,16 +310,14 @@ export default class FacebookInvitableFriends extends Component {
       facebook_invitable_friends_list = this.state.facebook_invitable_friends_filtered_by_search;
     }
 
-    const facebook_friend_list_for_display = facebook_invitable_friends_list.map( (friend) => {
-        return <div key={friend.id} className="card-child">
-          <CheckBox
-            friendId={friend.id}
-            friendName={friend.name}
-            friendImage={friend.picture.data.url}
-            handleCheckboxChange={this.toggleCheckBox.bind(this)}
-          />
-        </div>;
-      });
+    const facebook_friend_list_for_display = facebook_invitable_friends_list.map( (friend) =>
+      <CheckBox key={friend.id}
+                friendId={friend.id}
+                friendName={friend.name}
+                friendImage={friend.picture.data.url}
+                grid="col-4 col-sm-2"
+                handleCheckboxChange={this.toggleCheckBox.bind(this)} />
+    );
 
     return <div className="opinion-view">
       <Helmet title="Your Facebook Friends - We Vote" />
@@ -338,11 +336,13 @@ export default class FacebookInvitableFriends extends Component {
                    onChange={this.searchFacebookFriends.bind(this)} />
             <form onSubmit={this.sendInviteRequestToFacebookFriends.bind(this)}>
               <div className="display-in-column-with-vertical-scroll-contain">
-                <div className="display-in-column-with-vertical-scroll">
-                  { facebook_invitable_friends_list.length > 0 ?
-                    facebook_friend_list_for_display :
-                    <h4>No friends found with the search string '{this.state.search_term}'.</h4>
-                  }
+                <div className="display-in-column-with-vertical-scroll card">
+                  <div className="row friends-list__grid">
+                    { facebook_invitable_friends_list.length ?
+                      facebook_friend_list_for_display :
+                      <h4 className="friends-list__default-text">No friends found with the search string '{this.state.search_term}'.</h4>
+                    }
+                  </div>
                 </div>
               </div>
               <br />

--- a/src/js/routes/IssuesFollowed.jsx
+++ b/src/js/routes/IssuesFollowed.jsx
@@ -89,9 +89,9 @@ export default class IssuesFollowed extends Component {
           <div className="network-issues-list voter-guide-list card">
             <div className="card-child__list-group">
               {
-                this.state.issues_followed.length > 0 ?
+                issue_list.length ?
                   issue_list_for_display :
-                  null
+                  <h4 className="intro-modal__default-text">You are not following any issues yet.</h4>
               }
             </div>
           </div>

--- a/src/sass/components/_friends.scss
+++ b/src/sass/components/_friends.scss
@@ -14,15 +14,84 @@
 }
 
 .display-in-column-with-vertical-scroll {
-  -webkit-column-count: 2;
-  -moz-column-count: 2;
-  column-count: 2;
+  border-radius: $radius-sm;
+  -webkit-column-count: 1;
+  -moz-column-count: 1;
+  column-count: 1;
   -webkit-column-gap: 0;
   -moz-column-gap: 0;
   column-gap: 0;
 }
 
 .display-in-column-with-vertical-scroll-contain {
-  height: 200px;
+  height: calc(100vh - 384px);
   overflow-y: auto;
+}
+
+.friends-list {
+  &__grid {
+    padding: $space-none $space-md;
+  }
+
+  &__square {
+    position: relative;
+    text-align: left;
+    padding: $space-xs;
+
+    &-image {
+      height: 100%;
+      width: 100%;
+      border: 1px solid $gray-border;
+      border-radius: $space-sm;
+      filter: brightness(90%) contrast(90%);
+    }
+
+    &-following {
+      filter: brightness(60%);
+    }
+
+    &-check-mark {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transform: scale(.5);
+    }
+
+    &-name {
+      position: absolute;
+      right: 12px;
+      bottom: 12px;
+      left: 12px;
+      font-size: .875rem;
+      color: $white;
+      text-shadow: 1px 1px 2px rgba($black, .6);
+
+      @include breakpoints (xsmall-bootstrap small-bootstrap) {
+        right: 10px;
+        bottom: 10px;
+        left: 10px;
+        font-size: .65rem;
+      }
+
+      @include breakpoints (iphone5 mid-small) {
+        right: 10px;
+        bottom: 10px;
+        left: 10px;
+        font-size: .65rem;
+      }
+
+      @include breakpoints (max iphone5) {
+        right: 8px;
+        bottom: 8px;
+        left: 8px;
+        font-size: .6rem;
+      }
+    }
+  }
+
+  &__default-text {
+    width: 100%;
+    padding: $space-md;
+    text-align: center;
+  }
 }

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -287,6 +287,13 @@
     @extend .intro-modal__padding-top;
   }
 
+  &__default-text {
+    width: 100%;
+    color: $black;
+    padding: $space-md;
+    text-align: center;
+  }
+
   &__issue-grid {
     padding: $space-none $space-md;
   }

--- a/src/sass/components/_network.scss
+++ b/src/sass/components/_network.scss
@@ -56,4 +56,42 @@ $follow-card-title-color: #fff;
     float: left;
     color: $follow-card-title-color;
   }
+
+  .intro-modal__issue-square-name {
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+    left: 10px;
+    font-size: .65rem;
+    color: $white;
+    text-shadow: 1px 1px 2px rgba($black, .6);
+
+    @include breakpoints (small-bootstrap medium-bootstrap) {
+      right: 8px;
+      bottom: 8px;
+      left: 8px;
+      font-size: .5rem;
+    }
+
+    @include breakpoints (xsmall-bootstrap small-bootstrap) {
+      right: 8px;
+      bottom: 8px;
+      left: 8px;
+      font-size: .6rem;
+    }
+
+    @include breakpoints (iphone5 mid-small) {
+      right: 10px;
+      bottom: 10px;
+      left: 10px;
+      font-size: .65rem;
+    }
+
+    @include breakpoints (max iphone5) {
+      right: 8px;
+      bottom: 8px;
+      left: 8px;
+      font-size: .6rem;
+    }
+  }
 }


### PR DESCRIPTION
Display the Facebook friends to invite list as a grid similar to that of issues to follow (#951). Add and style default text inside each grid whenever there are no items in them. Fix the font size of the issues grid text in the network page.