### PR TITLE
Fix CheckBox behavior after leaving FacebookInvitableFriends page

### DIFF
--- a/src/js/components/Connect/CheckBox.jsx
+++ b/src/js/components/Connect/CheckBox.jsx
@@ -15,9 +15,6 @@ export default class CheckBox extends Component {
     this.state = {
         isChecked: false,
     };
-  }
-
-  componentDidMount () {
     this.toggleCheckboxChange = this.toggleCheckboxChange.bind(this);
   }
 


### PR DESCRIPTION
Fixes #1094 by making the 'this' binding persist even after leaving the page.