### PR TITLE
Redesign organizations to follow as grid, add descriptions to each organization and issue square,  fix ESLint styling

### DIFF
--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -103,34 +103,34 @@ export default class BallotIntroFollowAdvisers extends Component {
     // These are the organizations that a voter might want to follow based on the issues the voter is following.
     let voter_guides_to_follow_by_issues_followed = this.state.voter_guides_to_follow_by_issues_followed || [];
 
-    const voter_guides_to_follow_by_issues_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) => {
-      return <OrganizationFollowToggle
+    const voter_guides_to_follow_by_issues_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) =>
+      <OrganizationFollowToggle
         key={voter_guide.organization_we_vote_id}
         organization_we_vote_id={voter_guide.organization_we_vote_id}
         organization_name={voter_guide.voter_guide_display_name}
         organization_description={voter_guide.twitter_description}
-        organization_image_url={voter_guide.voter_guide_image_url_tiny}
+        organization_image_url={voter_guide.voter_guide_image_url_large}
         on_organization_follow={this.onOrganizationFollow}
         on_organization_stop_following={this.onOrganizationStopFollowing}
-        />;
-    });
+        grid="col-4 col-sm-2" />
+    );
 
     // These are organizations based on the upcoming election
     let voter_guides_to_follow_all = [];
     if (this.state.voter_guides_to_follow_all) {
       voter_guides_to_follow_all = this.state.voter_guides_to_follow_all;
     }
-    const voter_guides_to_follow_all_for_display = voter_guides_to_follow_all.map((voter_guide) => {
-      return <OrganizationFollowToggle
+    const voter_guides_to_follow_all_for_display = voter_guides_to_follow_all.map((voter_guide) =>
+      <OrganizationFollowToggle
         key={voter_guide.organization_we_vote_id}
         organization_we_vote_id={voter_guide.organization_we_vote_id}
         organization_name={voter_guide.voter_guide_display_name}
         organization_description={voter_guide.twitter_description}
-        organization_image_url={voter_guide.voter_guide_image_url_tiny}
+        organization_image_url={voter_guide.voter_guide_image_url_large}
         on_organization_follow={this.onOrganizationFollow}
         on_organization_stop_following={this.onOrganizationStopFollowing}
-        />;
-    });
+        grid="col-4 col-sm-2" />
+    );
 
     return <div className="intro-modal">
       <div className="intro-modal__h1">Follow organizations</div>
@@ -143,18 +143,14 @@ export default class BallotIntroFollowAdvisers extends Component {
           </div>
           <div className="intro-modal-vertical-scroll-contain">
             <div className="intro-modal-vertical-scroll card">
-              { voter_guides_to_follow_by_issues_for_display.length ?
-                voter_guides_to_follow_by_issues_for_display :
-                <span>NOT voter_guides_to_follow_by_issues_for_display</span>
-              }
-              { voter_guides_to_follow_all_for_display.length ?
-                voter_guides_to_follow_all_for_display :
-                <span>NOT voter_guides_to_follow_all_for_display</span>
-              }
-              { voter_guides_to_follow_by_issues_for_display.length || voter_guides_to_follow_all_for_display.length ?
-                null :
-                <h4 className="intro-modal__default-text">There are no more organizations to follow!</h4>
-              }
+              <div className="row intro-modal__grid">
+                { voter_guides_to_follow_by_issues_for_display.length ? voter_guides_to_follow_by_issues_for_display : null }
+                { voter_guides_to_follow_all_for_display.length ? voter_guides_to_follow_all_for_display : null }
+                { voter_guides_to_follow_by_issues_for_display.length || voter_guides_to_follow_all_for_display.length ?
+                  null :
+                  <h4 className="intro-modal__default-text">There are no more organizations to follow!</h4>
+                }
+              </div>
             </div>
           </div>
         </div>

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -156,7 +156,7 @@ export default class BallotIntroFollowIssues extends Component {
       </div>
       <div className="intro-modal-vertical-scroll-contain">
         <div className="intro-modal-vertical-scroll card">
-          <div className="row intro-modal__issue-grid">
+          <div className="row intro-modal__grid">
             { issue_list.length ? issue_list_for_display : <h4 className="intro-modal__default-text">No issues to display.</h4> }
           </div>
         </div>

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -146,6 +146,8 @@ export default class BallotIntroFollowIssues extends Component {
           on_issue_stop_following={this.onIssueStopFollowing}
           edit_mode={edit_mode}
           grid="col-4 col-sm-2" />;
+      } else {
+        return null;
       }
     });
 

--- a/src/js/components/Ballot/BallotIntroOrganizations.jsx
+++ b/src/js/components/Ballot/BallotIntroOrganizations.jsx
@@ -90,17 +90,17 @@ export default class BallotIntroFollowAdvisers extends Component {
   render () {
     let voter_guides_to_follow_by_issues_followed = this.state.voter_guides_to_follow_by_issues_followed || [];
 
-    const voter_guides_to_follow_by_issues_followed_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) => {
-      return <OrganizationFollowToggle
+    const voter_guides_to_follow_by_issues_followed_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) =>
+      <OrganizationFollowToggle
         key={voter_guide.organization_we_vote_id}
         organization_we_vote_id={voter_guide.organization_we_vote_id}
         organization_name={voter_guide.voter_guide_display_name}
         organization_description={voter_guide.twitter_description}
-        organization_image_url={voter_guide.voter_guide_image_url_medium}
+        organization_image_url={voter_guide.voter_guide_image_url_large}
         on_organization_follow={this.onOrganizationFollow}
         on_organization_stop_following={this.onOrganizationStopFollowing}
-        />;
-    });
+        grid="col-4 col-sm-2" />
+    );
 
     return <div className="intro-modal">
       <div className="intro-modal__h1">Follow Organizations or People</div>
@@ -108,10 +108,12 @@ export default class BallotIntroFollowAdvisers extends Component {
       <br/>
       <div className="intro-modal-vertical-scroll-contain">
         <div className="intro-modal-vertical-scroll card">
-          { voter_guides_to_follow_by_issues_followed_for_display.length ?
-            voter_guides_to_follow_by_issues_followed_for_display :
-            <h4>No organizations to display</h4>
-          }
+          <div className="row intro-modal__grid">
+            { voter_guides_to_follow_by_issues_followed_for_display.length ?
+              voter_guides_to_follow_by_issues_followed_for_display :
+              <h4>No organizations to display</h4>
+            }
+          </div>
         </div>
       </div>
       <div className="intro-modal__p">

--- a/src/js/components/Ballot/OrganizationFollowToggle.jsx
+++ b/src/js/components/Ballot/OrganizationFollowToggle.jsx
@@ -58,7 +58,7 @@ export default class OrganizationFollowToggle extends Component {
         <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.organization_name}</h4>
         { this.props.organization_description && this.props.organization_description.length ?
           <OverlayTrigger placement="top" overlay={<Tooltip id="organizationDescriptionTooltip">{this.props.organization_description}</Tooltip>}>
-            <i className="fa fa-info-circle fa-lg intro-modal__square-details" aria-hidden="true" />
+            <i className="fa fa-info-circle fa-lg hidden-xs hidden-sm intro-modal__square-details" aria-hidden="true" />
           </OverlayTrigger> :
           null
         }

--- a/src/js/components/Ballot/OrganizationFollowToggle.jsx
+++ b/src/js/components/Ballot/OrganizationFollowToggle.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from "react";
+import React, { Component, PropTypes } from "react";
+import { Tooltip, OverlayTrigger } from "react-bootstrap";
 import OrganizationActions from "../../actions/OrganizationActions";
 import ImageHandler from "../ImageHandler";
 
@@ -55,6 +56,12 @@ export default class OrganizationFollowToggle extends Component {
                       imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
                       alt="Following" /> }
         <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.organization_name}</h4>
+        { this.props.organization_description && this.props.organization_description.length ?
+          <OverlayTrigger placement="top" overlay={<Tooltip id="organizationDescriptionTooltip">{this.props.organization_description}</Tooltip>}>
+            <i className="fa fa-info-circle fa-lg intro-modal__square-details" aria-hidden="true" />
+          </OverlayTrigger> :
+          null
+        }
       </div>
     );
   }

--- a/src/js/components/Ballot/OrganizationFollowToggle.jsx
+++ b/src/js/components/Ballot/OrganizationFollowToggle.jsx
@@ -1,5 +1,4 @@
 import React, {Component, PropTypes} from "react";
-import {Button} from "react-bootstrap";
 import OrganizationActions from "../../actions/OrganizationActions";
 import ImageHandler from "../ImageHandler";
 
@@ -11,6 +10,7 @@ export default class OrganizationFollowToggle extends Component {
     organization_image_url: PropTypes.string,
     on_organization_follow: PropTypes.func.isRequired,
     on_organization_stop_following: PropTypes.func.isRequired,
+    grid: PropTypes.string.isRequired,
   };
 
   constructor (props) {
@@ -43,41 +43,19 @@ export default class OrganizationFollowToggle extends Component {
 
   render () {
     if (!this.state) { return <div />; }
+    let { is_following } = this.state;
 
-    return this.state.is_following ?
-      <div className="u-flex u-items-center u-justify-between card-main intro-modal__text-dark">
-        <div className="intro-modal__hide-sm intro-modal__margin-right">
-          <ImageHandler className="intro-modal__hide-sm hidden-xs card-main__avatar-compressed o-media-object__anchor u-self-start u-push--sm"
-                        sizeClassName="icon-org-small u-push--sm "
-                        alt="organization-photo"
-                        kind_of_image="ORGANIZATION"
-                        imageUrl={this.props.organization_image_url}
-          />
-        </div>
-        <span className="intro-modal__span intro-modal__margin-right">
-          <h4 className="card-main__candidate-name intro-modal__white-space">{this.props.organization_name}</h4>
-          <p className="intro-modal__small intro-modal__ellipsis intro-modal__hide-sm">{this.props.organization_description}</p>
-        </span>
-        <Button bsStyle="warning" bsSize="small" onClick={this.onOrganizationStopFollowing.bind(this)}>
-          <span>Following</span>
-        </Button>
-      </div> :
-      <div className="u-flex u-items-center u-justify-between card-main intro-modal__text-dark">
-        <div className="intro-modal__hide-sm intro-modal__margin-right">
-          <ImageHandler className="intro-modal__hide-sm hidden-xs card-main__avatar-compressed o-media-object__anchor u-self-start u-push--sm"
-                        sizeClassName="icon-org-small u-push--sm "
-                        alt="organization-photo"
-                        kind_of_image="ORGANIZATION"
-                        imageUrl={this.props.organization_image_url}
-          />
-        </div>
-        <span className="intro-modal__span intro-modal__margin-right" onClick={this.onOrganizationFollow.bind(this)}>
-          <h4 className="card-main__candidate-name intro-modal__white-space">{this.props.organization_name}</h4>
-          <p className="intro-modal__small intro-modal__ellipsis intro-modal__hide-sm">{this.props.organization_description}</p>
-        </span>
-        <Button bsStyle="info" bsSize="small" onClick={this.onOrganizationFollow.bind(this)}>
-          <span>Follow</span>
-        </Button>
-      </div>;
+    return (
+      <div className={this.props.grid + " intro-modal__square u-cursor--pointer"} onClick={ is_following ? this.onOrganizationStopFollowing : this.onOrganizationFollow }>
+        <ImageHandler sizeClassName={ is_following ? "intro-modal__square-image intro-modal__square-following" : "intro-modal__square-image" }
+                      imageUrl={this.props.organization_image_url}
+                      kind_of_image="ORGANIZATION"
+                      alt="organization-photo" />
+        { is_following && <ImageHandler className="intro-modal__square-check-mark"
+                      imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
+                      alt="Following" /> }
+        <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.organization_name}</h4>
+      </div>
+    );
   }
 }

--- a/src/js/components/Connect/CheckBox.jsx
+++ b/src/js/components/Connect/CheckBox.jsx
@@ -29,11 +29,11 @@ export default class CheckBox extends Component {
   render () {
     const { isChecked } = this.state;
     return (
-      <div className={this.props.grid + " friends-list__square"} onClick={this.toggleCheckboxChange}>
-        <ImageHandler sizeClassName={"friends-list__square-image u-cursor--pointer" + (isChecked && " friends-list__square-following")}
+      <div className={this.props.grid + " friends-list__square u-cursor--pointer"} onClick={this.toggleCheckboxChange}>
+        <ImageHandler sizeClassName={ isChecked ? "friends-list__square-image friends-list__square-following" : "friends-list__square-image" }
                       imageUrl={this.props.friendImage}
                       alt={this.props.friendName} />
-        { isChecked && <ImageHandler className="friends-list__square-check-mark u-cursor--pointer"
+        { isChecked && <ImageHandler className="friends-list__square-check-mark"
                       imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
                       alt="Inviting" /> }
         <h4 className="intro-modal__white-space friends-list__square-name">{this.props.friendName}</h4>

--- a/src/js/components/Connect/FacebookFriendsDisplay.jsx
+++ b/src/js/components/Connect/FacebookFriendsDisplay.jsx
@@ -10,6 +10,7 @@ export default class FacebookFriendsDisplay extends Component {
 
   static propTypes = {
     maximumFriendDisplay: PropTypes.number,
+    facebookInvitableFriendsList: PropTypes.array,
     facebookInvitableFriendsImageWidth: PropTypes.number,
     facebookInvitableFriendsImageHeight: PropTypes.number,
   };

--- a/src/js/components/Issues/IssueFollowToggleSquare.jsx
+++ b/src/js/components/Issues/IssueFollowToggleSquare.jsx
@@ -16,34 +16,34 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
     }
 
     if (this.props.read_only === true && !this.props.edit_mode){
-      return <div className={this.props.grid + " intro-modal__issue-square"}>
-        <ImageHandler sizeClassName="intro-modal__issue-square-image intro-modal__issue-square-following"
+      return <div className={this.props.grid + " intro-modal__square"}>
+        <ImageHandler sizeClassName="intro-modal__square-image intro-modal__square-following"
                       imageUrl={ issue_image_url }
                       alt={this.props.issue_name}
                       kind_of_image="ISSUE-PHOTO" />
-        <ImageHandler className="intro-modal__issue-square-check-mark"
+        <ImageHandler className="intro-modal__square-check-mark"
                       imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
                       alt="Following" />
-        <h4 className="intro-modal__white-space intro-modal__issue-square-name">{this.props.issue_name}</h4>
+        <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.issue_name}</h4>
       </div>;
     } else {
       return this.state.is_following ?
-        <div className={this.props.grid + " intro-modal__issue-square"} onClick={this.onIssueStopFollowing}>
-          <ImageHandler sizeClassName="intro-modal__issue-square-image u-cursor--pointer intro-modal__issue-square-following"
+        <div className={this.props.grid + " intro-modal__square"} onClick={this.onIssueStopFollowing}>
+          <ImageHandler sizeClassName="intro-modal__square-image u-cursor--pointer intro-modal__square-following"
                         imageUrl={ issue_image_url }
                         alt={this.props.issue_name}
                         kind_of_image="ISSUE-PHOTO" />
-          <ImageHandler className="intro-modal__issue-square-check-mark u-cursor--pointer"
+          <ImageHandler className="intro-modal__square-check-mark u-cursor--pointer"
                         imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
                         alt="Following" />
-          <h4 className="intro-modal__white-space intro-modal__issue-square-name">{this.props.issue_name}</h4>
+          <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.issue_name}</h4>
         </div> :
-        <div className={this.props.grid + " intro-modal__issue-square"} onClick={this.onIssueFollow}>
-          <ImageHandler sizeClassName="intro-modal__issue-square-image u-cursor--pointer"
+        <div className={this.props.grid + " intro-modal__square"} onClick={this.onIssueFollow}>
+          <ImageHandler sizeClassName="intro-modal__square-image u-cursor--pointer"
                         imageUrl={ issue_image_url }
                         alt={this.props.issue_name}
                         kind_of_image="ISSUE-PHOTO" />
-          <h4 className="intro-modal__white-space intro-modal__issue-square-name">{this.props.issue_name}</h4>
+          <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.issue_name}</h4>
         </div>
       ;
     }

--- a/src/js/components/Issues/IssueFollowToggleSquare.jsx
+++ b/src/js/components/Issues/IssueFollowToggleSquare.jsx
@@ -28,18 +28,18 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
       </div>;
     } else {
       return this.state.is_following ?
-        <div className={this.props.grid + " intro-modal__square"} onClick={this.onIssueStopFollowing}>
-          <ImageHandler sizeClassName="intro-modal__square-image u-cursor--pointer intro-modal__square-following"
+        <div className={this.props.grid + " intro-modal__square u-cursor--pointer"} onClick={this.onIssueStopFollowing}>
+          <ImageHandler sizeClassName="intro-modal__square-image intro-modal__square-following"
                         imageUrl={ issue_image_url }
                         alt={this.props.issue_name}
                         kind_of_image="ISSUE-PHOTO" />
-          <ImageHandler className="intro-modal__square-check-mark u-cursor--pointer"
+          <ImageHandler className="intro-modal__square-check-mark"
                         imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
                         alt="Following" />
           <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.issue_name}</h4>
         </div> :
-        <div className={this.props.grid + " intro-modal__square"} onClick={this.onIssueFollow}>
-          <ImageHandler sizeClassName="intro-modal__square-image u-cursor--pointer"
+        <div className={this.props.grid + " intro-modal__square u-cursor--pointer"} onClick={this.onIssueFollow}>
+          <ImageHandler sizeClassName="intro-modal__square-image"
                         imageUrl={ issue_image_url }
                         alt={this.props.issue_name}
                         kind_of_image="ISSUE-PHOTO" />

--- a/src/js/components/Issues/IssueFollowToggleSquare.jsx
+++ b/src/js/components/Issues/IssueFollowToggleSquare.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Tooltip, OverlayTrigger } from "react-bootstrap";
 import ImageHandler from "../ImageHandler";
 import IssueFollowToggle from "./IssueFollowToggle";
 
@@ -15,7 +16,7 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
       // issue_image_url = "/img/global/issues/" + issue_name_base + "-110x110.jpg";
     }
 
-    if (this.props.read_only === true && !this.props.edit_mode){
+    if (this.props.read_only === true && !this.props.edit_mode) {
       return <div className={this.props.grid + " intro-modal__square"}>
         <ImageHandler sizeClassName="intro-modal__square-image intro-modal__square-following"
                       imageUrl={ issue_image_url }
@@ -25,6 +26,12 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
                       imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
                       alt="Following" />
         <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.issue_name}</h4>
+        { this.props.issue_description && this.props.issue_description.length ?
+          <OverlayTrigger placement="top" overlay={<Tooltip id="organizationDescriptionTooltip">{this.props.issue_description}</Tooltip>}>
+            <i className="fa fa-info-circle fa-lg hidden-xs hidden-sm intro-modal__square-details" aria-hidden="true" />
+          </OverlayTrigger> :
+          null
+        }
       </div>;
     } else {
       return this.state.is_following ?
@@ -37,6 +44,12 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
                         imageUrl="/img/global/svg-icons/check-mark-v2-40x43.svg"
                         alt="Following" />
           <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.issue_name}</h4>
+          { this.props.issue_description && this.props.issue_description.length ?
+            <OverlayTrigger placement="top" overlay={<Tooltip id="organizationDescriptionTooltip">{this.props.issue_description}</Tooltip>}>
+              <i className="fa fa-info-circle fa-lg hidden-xs hidden-sm intro-modal__square-details" aria-hidden="true" />
+            </OverlayTrigger> :
+            null
+          }
         </div> :
         <div className={this.props.grid + " intro-modal__square u-cursor--pointer"} onClick={this.onIssueFollow}>
           <ImageHandler sizeClassName="intro-modal__square-image"
@@ -44,6 +57,12 @@ export default class IssueFollowToggleSquare extends IssueFollowToggle {
                         alt={this.props.issue_name}
                         kind_of_image="ISSUE-PHOTO" />
           <h4 className="intro-modal__white-space intro-modal__square-name">{this.props.issue_name}</h4>
+          { this.props.issue_description && this.props.issue_description.length ?
+            <OverlayTrigger placement="top" overlay={<Tooltip id="organizationDescriptionTooltip">{this.props.issue_description}</Tooltip>}>
+              <i className="fa fa-info-circle fa-lg hidden-xs hidden-sm intro-modal__square-details" aria-hidden="true" />
+            </OverlayTrigger> :
+            null
+          }
         </div>
       ;
     }

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -82,7 +82,7 @@ export default class OrganizationPositionItem extends Component {
     // console.log("signed_in_with_this_organization: ", signed_in_with_this_organization);
     var signed_in_twitter = this.state.voter === undefined ? false : this.state.voter.signed_in_twitter;
     var signed_in_with_this_twitter_account = false;
-    if (signed_in_twitter && this.state.voter.twitter_screen_name != null) {
+    if (signed_in_twitter && this.state.voter.twitter_screen_name !== null) {
       signed_in_with_this_twitter_account = this.state.voter.twitter_screen_name.toLowerCase() === organization_twitter_handle_being_viewed.toLowerCase();
     }
     var signed_in_facebook = this.state.voter === undefined ? false : this.state.voter.signed_in_facebook;

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -145,7 +145,7 @@ export default class ItemActionBar extends Component {
     } else {
       supportButtonSelectedPopOverText += ".";
     }
-    
+
     if (is_public_position) {
       supportButtonSelectedPopOverText += " Your support will be visible to the public.";
     } else {

--- a/src/js/routes/More/ToolsToShareOnOtherWebsites.jsx
+++ b/src/js/routes/More/ToolsToShareOnOtherWebsites.jsx
@@ -33,6 +33,8 @@ export default class ToolsToShareOnOtherWebsites extends React.Component {
           <li>We recommend putting each tool on its own page so you don’t overwhelm your visitors</li>
         </ul>
 
+        {/* eslint quotes: [1, "double", { "allowTemplateLiterals": true }] */}
+
         <h4 className="h2">Free voter registration tool from Vote.org</h4>
         {/* enclose html within {` and `} to make them literal string in JSX */}
         <CodeCopier>

--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -16,7 +16,7 @@ class VoterStore extends FluxMapStore {
     return {
       voter: {
         interface_status_flags: 0,
-        state_code_from_ip_address: '',
+        state_code_from_ip_address: "",
       },
       address: {},
       email_address_status: {},

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -294,11 +294,11 @@
     text-align: center;
   }
 
-  &__issue-grid {
+  &__grid {
     padding: $space-none $space-md;
   }
 
-  &__issue-square {
+  &__square {
     position: relative;
     text-align: left;
     padding: $space-xs;

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -351,6 +351,27 @@
         font-size: .6rem;
       }
     }
+
+    &-details {
+      position: absolute;
+      top: 12px;
+      right: 12px;
+
+      @include breakpoints (xsmall-bootstrap small-bootstrap) {
+        top: 10px;
+        right: 10px;
+      }
+
+      @include breakpoints (iphone5 mid-small) {
+        top: 10px;
+        right: 10px;
+      }
+
+      @include breakpoints (max iphone5) {
+        top: 8px;
+        right: 8px;
+      }
+    }
   }
 }
 

--- a/src/sass/components/_network.scss
+++ b/src/sass/components/_network.scss
@@ -52,12 +52,12 @@ $follow-card-title-color: #fff;
 .network-issues-list {
   padding: $network-issue-list-padding;
 
-  .intro-modal__issue-square {
+  .intro-modal__square {
     float: left;
     color: $follow-card-title-color;
   }
 
-  .intro-modal__issue-square-name {
+  .intro-modal__square-name {
     position: absolute;
     right: 10px;
     bottom: 10px;


### PR DESCRIPTION
Redesigned the list of organizations in the ballot intro modal as a grid similar to the issues grid. Added an icon to each issue or organization square that reveals the issue or organization description on hover (if there is one). Removed the remaining ESLint warnings.