### PR TITLE
Fixed (bad) issue with looping switch between two ballots. Added ability to unfollow an organization from ItemTinyPositionBreakdownList. Now caching positions so subsequent calls to voterGuidesToFollowRetrieve won't wipe out the position data.

### DIFF
--- a/src/js/actions/VoterGuideActions.js
+++ b/src/js/actions/VoterGuideActions.js
@@ -3,10 +3,9 @@ import Dispatcher from "../dispatcher/Dispatcher";
 module.exports = {
 
   voterGuidesToFollowRetrieve: function (election_id, search_string, add_voter_guides_not_from_election) {
-    const MAXIMUM_NUMBER_OF_GUIDES_TO_RETRIEVE = 300;
     Dispatcher.loadEndpoint("voterGuidesToFollowRetrieve", {
       google_civic_election_id: election_id,
-      maximum_number_to_retrieve: MAXIMUM_NUMBER_OF_GUIDES_TO_RETRIEVE,
+      maximum_number_to_retrieve: 300,
       search_string: search_string || "",
       add_voter_guides_not_from_election: add_voter_guides_not_from_election || false,
     });
@@ -58,6 +57,7 @@ module.exports = {
   },
 
   voterGuidesIgnoredRetrieve: function () {
+    // We do not currently limit the maximum_number_to_retrieve
     Dispatcher.loadEndpoint("voterGuidesIgnoredRetrieve");
   }
 

--- a/src/js/components/Ballot/CandidateModal.jsx
+++ b/src/js/components/Ballot/CandidateModal.jsx
@@ -167,7 +167,7 @@ export default class CandidateModal extends Component {
                 </div> :
                 null
               }
-            {/* Show voter guides to follow that relate to this measure */}
+            {/* Show voter guides to follow that relate to this candidate */}
               {this.state.voter_guides_to_follow_for_latest_ballot_item.length === 0 ?
                 <p className="card__no-additional">{NO_VOTER_GUIDES_TEXT}</p> :
                 <div>

--- a/src/js/components/Ballot/PositionsNotShownList.jsx
+++ b/src/js/components/Ballot/PositionsNotShownList.jsx
@@ -1,8 +1,11 @@
 import React, { Component, PropTypes } from "react";
+import { OverlayTrigger, Popover } from "react-bootstrap";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 import LoadingWheel from "../../components/LoadingWheel";
+import OrganizationCard from "../VoterGuide/OrganizationCard";
 
+// This component is used to display the "+X" list in the ItemTinyPositionBreakdownList
 export default class PositionsNotShownList extends Component {
   static propTypes = {
     positions_not_shown_list: PropTypes.array.isRequired
@@ -21,6 +24,7 @@ export default class PositionsNotShownList extends Component {
     var nothing_to_display = null;
 
     const positions_not_shown_display = this.props.positions_not_shown_list.map( (one_position) => {
+      // console.log("PositionsNotShownList, one_position: ", one_position);
       let speaker_we_vote_id = one_position.speaker_we_vote_id;
       let speaker_display_name = one_position.speaker_display_name;
       let speaker_image_url_https_tiny = one_position.speaker_image_url_https_tiny;
@@ -28,7 +32,22 @@ export default class PositionsNotShownList extends Component {
 
       // TwitterHandle-based link
       var speakerLink = speaker_twitter_handle ? "/" + speaker_twitter_handle : "/voterguide/" + speaker_we_vote_id;
+      let one_organization_for_organization_card = {
+            organization_we_vote_id: one_position.speaker_we_vote_id,
+            organization_name: one_position.speaker_display_name,
+            organization_photo_url_large: one_position.speaker_image_url_https_large,
+            organization_photo_url_tiny: one_position.speaker_image_url_https_tiny,
+            organization_twitter_handle: one_position.speaker_twitter_handle,
+            // organization_website: one_position.more_info_url,
+            twitter_description: "",
+            twitter_followers_count: 0,
+          };
 
+      // return <OrganizationCard organization={one_organization_for_organization_card}
+      //                          ballotItemWeVoteId={this.props.ballot_item_we_vote_id}
+      //                          followToggleOn />;
+
+      // Display the organization in a brief list
       return <div key={speaker_we_vote_id} className="card-main__media-object">
         {/* One Position on this Candidate */}
           <div className="card-child__media-object-anchor">

--- a/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
+++ b/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
@@ -24,6 +24,7 @@ export default class OrganizationsFollowedOnTwitter extends Component {
   }
 
   componentDidMount () {
+    console.log("OrganizationsFollowedOnTwitter componentDidMount");
     this.setState({
       organizations_followed_on_twitter: this.props.organizationsFollowedOnTwitter,
       maximum_organization_display: this.props.maximumOrganizationDisplay,

--- a/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
+++ b/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import { OverlayTrigger, Popover } from "react-bootstrap";
+import OrganizationCard from "../VoterGuide/OrganizationCard";
 import OrganizationTinyDisplay from "../VoterGuide/OrganizationTinyDisplay";
-import PositionItem from "../Ballot/PositionItem";
 import PositionsNotShownList from "../Ballot/PositionsNotShownList";
 import VoterStore from "../../stores/VoterStore";
 var Icon = require("react-svg-icons");
@@ -43,18 +43,18 @@ export default class ItemTinyPositionBreakdownList extends Component {
     });
   }
 
-  onTriggerEnter (org_id) {
-    this.refs[`overlay-${org_id}`].show();
+  onTriggerEnter (organization_we_vote_id) {
+    this.refs[`overlay-${organization_we_vote_id}`].show();
     this.show_popover = true;
     clearTimeout(this.hide_popover_timer);
   }
 
-  onTriggerLeave (org_id) {
+  onTriggerLeave (organization_we_vote_id) {
     this.show_popover = false;
     clearTimeout(this.hide_popover_timer);
     this.hide_popover_timer = setTimeout(() => {
-      if (!this.show_popover) {
-        this.refs[`overlay-${org_id}`].hide();
+      if (!this.show_popover && this.refs[`overlay-${organization_we_vote_id}`]) {
+        this.refs[`overlay-${organization_we_vote_id}`].hide();
       }
     }, 100);
   }
@@ -140,6 +140,8 @@ export default class ItemTinyPositionBreakdownList extends Component {
 
         local_counter++;
         if (local_counter > MAXIMUM_ORGANIZATION_DISPLAY) {
+          // We are in a loop here, and when we arrive at the first organization after our display limit,
+          //  we want to show a "drop down" with the remaining organizations.
           if (local_counter === MAXIMUM_ORGANIZATION_DISPLAY + 1) {
             // If here we want to show how many organizations there are to follow
             let organizationPopover = <Popover
@@ -166,24 +168,29 @@ export default class ItemTinyPositionBreakdownList extends Component {
           }
         } else {
           // If we made it to here, then we want to display the organization in a popover
+          // console.log("ItemTinyPositionBreakdownList, one_position:", one_position);
           one_organization = {
             organization_we_vote_id: one_position.speaker_we_vote_id,
-            voter_guide_image_url_tiny: one_position.speaker_image_url_https_tiny,
-            voter_guide_display_name: one_position.speaker_display_name
-          };
-          let org_id = one_organization.organization_we_vote_id;
+            organization_name: one_position.speaker_display_name,
+            organization_photo_url_large: one_position.speaker_image_url_https_large,
+            organization_photo_url_tiny: one_position.speaker_image_url_https_tiny,
+            organization_twitter_handle: one_position.speaker_twitter_handle,
+            // organization_website: one_position.more_info_url,
+            twitter_description: "",
+            twitter_followers_count: 0,
+         };
+          let organization_we_vote_id = one_organization.organization_we_vote_id;
           let organizationPopover = <Popover
-              id={`organization-popover-${org_id}`}
-              onMouseOver={() => this.onTriggerEnter(org_id)}
-              onMouseOut={() => this.onTriggerLeave(org_id)}>
+              id={`organization-popover-${organization_we_vote_id}`}
+              onMouseOver={() => this.onTriggerEnter(organization_we_vote_id)}
+              onMouseOut={() => this.onTriggerLeave(organization_we_vote_id)}>
               <section className="card">
                 <div className="card__additional">
                   <div>
                     <ul className="card-child__list-group">
-                      <PositionItem key={one_position.speaker_we_vote_id}
-                                    ballot_item_display_name={one_position.speaker_display_name}
-                                    position={one_position}
-                      />
+                      <OrganizationCard organization={one_organization}
+                                        ballotItemWeVoteId={this.props.ballotItemWeVoteId}
+                                        followToggleOn />
                     </ul>
                   </div>
               </div>
@@ -191,16 +198,16 @@ export default class ItemTinyPositionBreakdownList extends Component {
             </Popover>;
 
           return <OverlayTrigger
-              key={`trigger-${org_id}`}
-              ref={`overlay-${org_id}`}
-              onMouseOver={() => this.onTriggerEnter(org_id)}
-              onMouseOut={() => this.onTriggerLeave(org_id)}
+              key={`trigger-${organization_we_vote_id}`}
+              ref={`overlay-${organization_we_vote_id}`}
+              onMouseOver={() => this.onTriggerEnter(organization_we_vote_id)}
+              onMouseOut={() => this.onTriggerLeave(organization_we_vote_id)}
               rootClose
               placement="bottom"
               overlay={organizationPopover}>
             <span className="position-rating__source with-popover">
               <OrganizationTinyDisplay {...one_organization}
-                                     showPlaceholderImage />
+                                       showPlaceholderImage />
             </span>
           </OverlayTrigger>;
         }

--- a/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
+++ b/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
@@ -25,6 +25,7 @@ export default class EditPositionAboutCandidateModal extends Component {
   }
 
   componentDidMount () {
+    console.log("OrganizationsFollowedOnTwitter componentDidMount");
     this._onVoterStoreChange();
 
     this.organizationStoreListener = OrganizationStore.addListener(this._onOrganizationStoreChange.bind(this));
@@ -117,7 +118,9 @@ export default class EditPositionAboutCandidateModal extends Component {
       modal_contents = <div className="card">
               <div className="card-main candidate-card">
                 <FollowToggle we_vote_id={organization.organization_we_vote_id}/>
-                <OrganizationCard organization={organization} turn_off_description/>
+                <OrganizationCard organization={organization}
+                                  turn_off_description
+                                  followToggleOn/>
               </div>
             <ul className="list-group">
               <OrganizationPositionItem position={position}

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from "react";
+import CandidateStore from "../../stores/CandidateStore";
 import FollowToggle from "../Widgets/FollowToggle";
 import OrganizationActions from "../../actions/OrganizationActions";
 import VoterGuideDisplayForList from "./VoterGuideDisplayForList";
@@ -24,6 +25,8 @@ export default class GuideList extends Component {
 
   componentDidMount () {
     // console.log("GuideList componentDidMount");
+    // this.setState({
+    //   position_list_from_advisers_followed_by_voter: CandidateStore.getPositionList(this.props.candidate.we_vote_id),
     this.setState({
       organizations_to_follow: this.props.organizationsToFollow,
       ballot_item_we_vote_id: this.props.ballotItemWeVoteId
@@ -52,28 +55,38 @@ export default class GuideList extends Component {
       return null;
     }
 
-    const orgs = this.state.organizations_to_follow.map( (org) => {
-      if (org === undefined) {
+    let organization_position_for_this_ballot_item;
+
+    const organization_list = this.state.organizations_to_follow.map( (organization) => {
+      if (organization === undefined) {
         // console.log("GuideList org === undefined");
         return null;
       } else {
-        return <VoterGuideDisplayForList key={org.organization_we_vote_id} {...org}>
-          <FollowToggle we_vote_id={org.organization_we_vote_id}
+        // console.log("GuideList organization: ", organization);
+        organization_position_for_this_ballot_item = {};
+        if (!organization.is_support_or_positive_rating && !organization.is_oppose_or_negative_rating && !organization.is_information_only && this.state.ballot_item_we_vote_id && organization.organization_we_vote_id) {
+          organization_position_for_this_ballot_item = CandidateStore.getPositionAboutCandidateFromOrganization(this.state.ballot_item_we_vote_id, organization.organization_we_vote_id);
+          // console.log("GuideList organization_position_for_this_ballot_item: ", organization_position_for_this_ballot_item);
+        }
+        return <VoterGuideDisplayForList key={organization.organization_we_vote_id}
+                                         {...organization}
+                                         {...organization_position_for_this_ballot_item}>
+          <FollowToggle we_vote_id={organization.organization_we_vote_id}
                         hide_stop_following_button={this.props.hide_stop_following_button}/>
           { this.props.hide_ignore_button ?
             null :
             <button className="btn btn-default btn-sm"
-                    onClick={this.handleIgnore.bind(this, org.organization_we_vote_id)}>
+                    onClick={this.handleIgnore.bind(this, organization.organization_we_vote_id)}>
               Ignore
             </button> }
         </VoterGuideDisplayForList>;
       }
     });
-    // console.log("GuideList orgs: ", orgs);
+    // console.log("GuideList organization_list: ", organization_list);
 
     return <div className="guidelist card-child__list-group">
         <ReactCSSTransitionGroup transitionName="org-ignore" transitionEnterTimeout={500} transitionLeaveTimeout={300}>
-          {orgs}
+          {organization_list}
         </ReactCSSTransitionGroup>
       </div>;
   }

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -32,6 +32,7 @@ export default class OrganizationCard extends Component {
   }
 
   componentDidMount () {
+    // console.log("OrganizationCard, componentDidMount, this.props:", this.props);
     this.organizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
     if (this.props.organization && this.props.organization.organization_we_vote_id) {
       this.setState({
@@ -60,6 +61,7 @@ export default class OrganizationCard extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
+    // console.log("OrganizationCard, componentWillReceiveProps, nextProps:", nextProps);
     if (nextProps.organization && nextProps.organization.organization_we_vote_id) {
       this.setState({
         organization_we_vote_id: nextProps.organization.organization_we_vote_id,
@@ -68,7 +70,6 @@ export default class OrganizationCard extends Component {
     this.setState({
       ballot_item_we_vote_id: nextProps.ballotItemWeVoteId,
     });
-    // console.log("nextProps.organization (componentWillReceiveProps): ", this.props.organization);
     if (nextProps.organization && nextProps.organization.organization_we_vote_id && nextProps.ballotItemWeVoteId) {
       let organization_position = OrganizationStore.getOrganizationPositionByWeVoteId(nextProps.organization.organization_we_vote_id, nextProps.ballotItemWeVoteId);
       // console.log("organization_position (componentWillReceiveProps): ", organization_position);
@@ -94,19 +95,19 @@ export default class OrganizationCard extends Component {
   }
 
   render () {
-    if (!this.props.organization){
+    if (!this.state.organization_we_vote_id.length){
       return <div>{LoadingWheel}</div>;
     }
 
     const {organization_twitter_handle, twitter_description,
       organization_photo_url_large, organization_website,
-      organization_name, organization_we_vote_id} = this.props.organization; // twitter_followers_count,
+      organization_name} = this.props.organization; // twitter_followers_count,
 
     // If the displayName is in the twitterDescription, remove it from twitterDescription
     let displayName = organization_name ? organization_name : "";
     let twitterDescription = twitter_description ? twitter_description : "";
     let twitterDescriptionMinusName = removeTwitterNameFromDescription(displayName, twitterDescription);
-    var voterGuideLink = organization_twitter_handle ? "/" + organization_twitter_handle : "/voterguide/" + organization_we_vote_id;
+    var voterGuideLink = organization_twitter_handle ? "/" + organization_twitter_handle : "/voterguide/" + this.state.organization_we_vote_id;
 
     let position_description = "";
     if (this.state.organization_position) {

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -113,7 +113,9 @@ export default class OrganizationPositionItem extends Component {
 
     // TwitterHandle-based link
     let ballot_item_url = position.kind_of_ballot_item === "MEASURE" ? "/measure/" : "/candidate/";
-    let ballotItemLink = position.ballot_item_twitter_handle ? "/" + position.ballot_item_twitter_handle : ballot_item_url + position.ballot_item_we_vote_id;
+    // We are turning off links to twitter pages until we get politician pages working
+    //let ballotItemLink = position.ballot_item_twitter_handle ? "/" + position.ballot_item_twitter_handle : ballot_item_url + position.ballot_item_we_vote_id;
+    let ballotItemLink = ballot_item_url + position.ballot_item_we_vote_id;
     let position_description = "";
     let is_candidate = position.kind_of_ballot_item === "CANDIDATE";
     let ballot_item_display_name = "";

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -1,8 +1,8 @@
 import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
 import VoterGuideStore from "../../stores/VoterGuideStore";
-import OrganizationStore from "../../stores/OrganizationStore";
 import OrganizationActions from "../../actions/OrganizationActions";
+import OrganizationStore from "../../stores/OrganizationStore";
 import VoterStore from "../../stores/VoterStore";
 
 export default class FollowToggle extends Component {
@@ -22,15 +22,18 @@ export default class FollowToggle extends Component {
   }
 
   componentDidMount (){
+    // console.log("componentDidMount, this.props: ", this.props);
+    this._onOrganizationStoreChange();
+    this._onVoterStoreChange();
+    this.onVoterGuideStoreChange();
     // We need the voterGuideStoreListener until we take the follow functions out of OrganizationActions and VoterGuideStore
     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
     this.organizationStoreListener = OrganizationStore.addListener(this._onOrganizationStoreChange.bind(this));
-    this._onOrganizationStoreChange();
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
-    this._onVoterStoreChange();
   }
 
   componentWillUnmount (){
+    // console.log("componentWillUnmount, this.props.we_vote_id: ", this.props.we_vote_id);
     this.voterGuideStoreListener.remove();
     this.organizationStoreListener.remove();
     this.voterStoreListener.remove();

--- a/src/js/stores/CandidateStore.js
+++ b/src/js/stores/CandidateStore.js
@@ -2,12 +2,14 @@ var Dispatcher = require("../dispatcher/Dispatcher");
 var FluxMapStore = require("flux/lib/FluxMapStore");
 import OfficeActions from "../actions/OfficeActions";
 import OfficeStore from "../stores/OfficeStore";
+import { stringContains } from "../utils/textFormat";
 
 class CandidateStore extends FluxMapStore {
 
   getInitialState () {
     return {
       all_cached_candidates: {}, // Dictionary with candidate_we_vote_id as key and the candidate as value
+      all_cached_positions_about_candidates: {}, // Dictionary with candidate_we_vote_id as one key, organization_we_vote_id as the second key, and the position as value
       position_list_from_advisers_followed_by_voter: {}, // Dictionary with candidate_we_vote_id as key and list of positions as value
     };
   }
@@ -20,6 +22,11 @@ class CandidateStore extends FluxMapStore {
     return this.getState().position_list_from_advisers_followed_by_voter[candidate_we_vote_id] || [];
   }
 
+  getPositionAboutCandidateFromOrganization (candidate_we_vote_id, organization_we_vote_id) {
+    let positions_about_candidate = this.getState().all_cached_positions_about_candidates[candidate_we_vote_id] || [];
+    return positions_about_candidate[organization_we_vote_id] || [];
+  }
+
   reduce (state, action) {
 
     // Exit if we don't have a successful response (since we expect certain variables in a successful response below)
@@ -27,11 +34,14 @@ class CandidateStore extends FluxMapStore {
       return state;
 
     let all_cached_candidates;
+    let all_cached_positions_about_candidates;
     let ballot_item_we_vote_id;
     let candidate;
     let new_position_list;
+    let one_position;
     let position_list_for_candidate;
     let position_list_from_advisers_followed_by_voter;
+    let voter_guides;
 
     switch (action.type) {
 
@@ -65,6 +75,78 @@ class CandidateStore extends FluxMapStore {
         } else {
           return state;
         }
+
+      case "voterGuidesToFollowRetrieve":
+        // This code harvests the positions that are passed in along with voter guides,
+        //  and stores them so we can request them in cases where the response package for
+        //  voterGuidesToFollowRetrieve does not include the position data
+
+        // console.log("CandidateStore voterGuidesToFollowRetrieve");
+        voter_guides = action.res.voter_guides;
+        let is_empty = voter_guides.length === 0;
+        let search_term_exists = action.res.search_string !== "";
+        ballot_item_we_vote_id = action.res.ballot_item_we_vote_id || "";
+        let ballot_item_we_vote_id_exists = ballot_item_we_vote_id.length !== 0;
+
+        if (!ballot_item_we_vote_id_exists || !stringContains("cand", ballot_item_we_vote_id) || is_empty || search_term_exists) {
+          // Exit this routine
+          // console.log("exiting CandidateStore voterGuidesToFollowRetrieve");
+          return state;
+        }
+        all_cached_positions_about_candidates = state.all_cached_positions_about_candidates;
+        // positions_about_one_candidate = {}; // Dictionary with organization_we_vote_id as the key, and the position as value
+        voter_guides.forEach( one_voter_guide => {
+          // Make sure we have a position in the voter guide
+          if (one_voter_guide.is_support_or_positive_rating || one_voter_guide.is_oppose_or_negative_rating || one_voter_guide.is_information_only) {
+            if (!all_cached_positions_about_candidates[ballot_item_we_vote_id]) {
+              all_cached_positions_about_candidates[ballot_item_we_vote_id] = {};
+            }
+            if (!all_cached_positions_about_candidates[ballot_item_we_vote_id][one_voter_guide.organization_we_vote_id]) {
+              all_cached_positions_about_candidates[ballot_item_we_vote_id][one_voter_guide.organization_we_vote_id] = {};
+            }
+
+            // positions_about_one_candidate = all_cached_positions_about_candidates[ballot_item_we_vote_id][one_voter_guide.organization_we_vote_id];
+            one_position = {
+              position_we_vote_id: one_voter_guide.position_we_vote_id, // Currently empty
+              ballot_item_display_name: one_voter_guide.ballot_item_display_name,
+              ballot_item_image_url_https_large: one_voter_guide.ballot_item_image_url_https_large,
+              ballot_item_image_url_https_medium: one_voter_guide.ballot_item_image_url_https_medium,
+              ballot_item_image_url_https_tiny: one_voter_guide.ballot_item_image_url_https_tiny,
+              ballot_item_twitter_handle: one_voter_guide.ballot_item_twitter_handle,
+              ballot_item_political_party: one_voter_guide.ballot_item_political_party,
+              kind_of_ballot_item: "CANDIDATE",
+              // ballot_item_id: 0,
+              ballot_item_we_vote_id: ballot_item_we_vote_id,
+              // ballot_item_state_code: "",
+              // contest_office_id: 0,
+              // contest_office_we_vote_id: "",
+              // contest_office_name: "",
+              is_support: one_voter_guide.is_support,
+              is_positive_rating: one_voter_guide.is_positive_rating,
+              is_support_or_positive_rating: one_voter_guide.is_support_or_positive_rating,
+              is_oppose: one_voter_guide.is_oppose,
+              is_negative_rating: one_voter_guide.is_negative_rating,
+              is_oppose_or_negative_rating: one_voter_guide.is_oppose_or_negative_rating,
+              is_information_only: one_voter_guide.is_information_only,
+              is_public_position: one_voter_guide.is_public_position,
+              speaker_display_name: one_voter_guide.speaker_display_name,
+              vote_smart_rating: one_voter_guide.vote_smart_rating,
+              vote_smart_time_span: one_voter_guide.vote_smart_time_span,
+              google_civic_election_id: one_voter_guide.google_civic_election_id,
+              // state_code: "",
+              more_info_url: one_voter_guide.more_info_url,
+              statement_text: one_voter_guide.statement_text,
+              last_updated: one_voter_guide.last_updated
+            };
+            // console.log("CandidateStore one_position: ", one_position);
+            all_cached_positions_about_candidates[ballot_item_we_vote_id][one_voter_guide.organization_we_vote_id] = one_position;
+          }
+        });
+        // console.log("CandidateStore all_cached_positions_about_candidates:", all_cached_positions_about_candidates);
+        return {
+          ...state,
+          all_cached_positions_about_candidates: all_cached_positions_about_candidates,
+        };
 
       case "error-candidateRetrieve" || "error-positionListForBallotItem":
         console.log(action);

--- a/src/js/utils/textFormat.js
+++ b/src/js/utils/textFormat.js
@@ -33,7 +33,13 @@ export function arrayUnique (array) {
 }
 
 export function arrayContains (needle, array_haystack) {
-    return array_haystack.indexOf(needle) > -1;
+  // console.log("arrayContains, needle:", needle, ", haystack: ", array_haystack);
+  return array_haystack.indexOf(needle) > -1;
+}
+
+export function stringContains (needle, string_haystack) {
+  // console.log("stringContains, needle:", needle, ", haystack: ", string_haystack);
+  return string_haystack.indexOf(needle) !== -1;
 }
 
 export function capitalizeString (raw_string) {


### PR DESCRIPTION
Fixed (bad) issue with looping switch between two ballots. Added ability to unfollow an organization from ItemTinyPositionBreakdownList. Now caching positions so subsequent calls to voterGuidesToFollowRetrieve won't wipe out the position data.