### PR TITLE
It fixes the github issue: #1158 (Video positions in CandidateModal need to be resized)

### DIFF
--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -122,8 +122,8 @@ export default class PositionInformationOnlySnippet extends Component {
           <span>
             <span>{statement_text_html}</span>
             {/* if there's an external source for the explicit position/endorsement, show it */}
-            {video_url ?
-              <ReactPlayer url={`${video_url}`} width="300px" height="231px"/> :
+            { video_url ?
+              <ReactPlayer className="explicit-position__media-player" url={`${video_url}`} width="100%" height="100%"/>:
               null }
             {more_info_url ?
               <div className="hidden-xs">

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -122,8 +122,8 @@ export default class PositionSupportOpposeSnippet extends Component {
             <span>
               <span>{statement_text_html}</span>
               {/* if there's an external source for the explicit position/endorsement, show it */}
-              {video_url ?
-                <ReactPlayer url={`${video_url}`} width="300px" height="231px"/> :
+              { video_url ?
+                <ReactPlayer className="explicit-position__media-player" url={`${video_url}`} width="100%" height="100%"/>:
                 null }
               {more_info_url ?
                 <div className="hidden-xs">

--- a/src/sass/components/_position.scss
+++ b/src/sass/components/_position.scss
@@ -4,7 +4,7 @@
 // Explicit Positions
 
 @include media-object('.explicit-position', '.explicit-position__icon', '.explicit-position__text', $margin: 5px);
-s
+
 .explicit-position__icon {
   margin-top: $space-xxs;
 }

--- a/src/sass/components/_position.scss
+++ b/src/sass/components/_position.scss
@@ -4,7 +4,7 @@
 // Explicit Positions
 
 @include media-object('.explicit-position', '.explicit-position__icon', '.explicit-position__text', $margin: 5px);
-
+s
 .explicit-position__icon {
   margin-top: $space-xxs;
 }
@@ -20,6 +20,11 @@
 
 .explicit-position__source {
   color: $gray-mid;
+}
+
+.explicit-position__media-player {
+  max-width: 300px;
+  max-height: 231px;
 }
 
 // Position Ratings


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
It fixes the github issue: #1158 (Video positions in CandidateModal need to be resized)
### Changes included this pull request?
I created a css class called explicit-position__media-player in the _position.scss file. The css class sets the ReactPlayer to have a maximum height of 231px and maximum width of 300px.
I set the ReactPlayer to use that css class, and changed the ReactPlayer width and height to 100%.