### PR TITLE
Overlay does not stick with the position bar when scrolling

### DIFF
--- a/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
@@ -90,14 +90,14 @@ export default class ItemSupportOpposeCounts extends Component {
       </div>
       {is_empty ?
         <div className={background_bar_class_name}>
-          <OverlayTrigger placement="top" overlay={nonSupportOpposePopoverTooltip}>
+          <OverlayTrigger container={this} placement="top" overlay={nonSupportOpposePopoverTooltip}>
             <div className="network-positions__bar" style={ !is_empty ? bar_style : empty_bar_style } >
               <span className="sr-only">Empty position bar</span>
             </div>
           </OverlayTrigger>
         </div> :
         <div className={background_bar_class_name}>
-          <OverlayTrigger placement="top" overlay={supportOpposePopoverTooltip}>
+          <OverlayTrigger container={this} placement="top" overlay={supportOpposePopoverTooltip}>
             <div className={ is_majority_support ?
               "network-positions__bar network-positions__bar--majority network-positions__bar--support" :
               "network-positions__bar network-positions__bar--majority network-positions__bar--oppose" }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
The position bar overlay in ballot modal does not stick with the position bar when you are scrolling. I tested it in the chrome developer tools iphone emulator and on an iphone iOS 11 (chrome and safari).
![wevoteissue](https://user-images.githubusercontent.com/6605268/33142651-37d73564-cf85-11e7-8064-1f7191855a04.gif)

### Changes included this pull request?
I set the property container in OverlayTrigger to be set to the position bar. Source: https://www.bountysource.com/issues/6528760-popover-does-not-update-position-with-overlaytrigger-in-position-fixed-container

![wevotesolution](https://user-images.githubusercontent.com/6605268/33143758-e0371b5e-cf88-11e7-9331-485474f1f3bb.gif)



