### PR TITLE
#1183 Removed the space that appears at the top of the printed page

### DIFF
--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -66,6 +66,9 @@ $header-height-getting-started: 104px;
 }
 
 .headroom-getting-started__margin {
+  @include print {
+    margin-top: 0;
+  }
   margin-top: $header-height-getting-started;
 }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1183 

### Changes included this pull request?
Used the print mixin to remove the top space when printing the ballot.