### PR TITLE
Updated organization logo behavior on ballot page

### DIFF
--- a/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
+++ b/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
@@ -206,7 +206,7 @@ export default class ItemTinyPositionBreakdownList extends Component {
               onMouseOver={() => this.onTriggerEnter(organization_we_vote_id)}
               onMouseOut={() => this.onTriggerLeave(organization_we_vote_id)}
               onExiting={() => this.onTriggerLeave(organization_we_vote_id)}
-              trigger={["focus", "hover"]}
+              trigger={["focus", "hover", "click"]}
               rootClose
               placement="bottom"
               overlay={organizationPopover}>

--- a/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
+++ b/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
@@ -16,14 +16,14 @@ export default class ItemTinyPositionBreakdownList extends Component {
     showInfoOnly: PropTypes.bool,
     showOppose: PropTypes.bool,
     showSupport: PropTypes.bool,
-    supportProps: PropTypes.object
+    supportProps: PropTypes.object,
   };
 
   constructor (props) {
     super(props);
     this.state = {
       position_list: this.props.position_list,
-      ballot_item_we_vote_id: ""
+      ballot_item_we_vote_id: "",
     };
     this.show_popover = false;
   }
@@ -32,14 +32,14 @@ export default class ItemTinyPositionBreakdownList extends Component {
     this.setState({
       ballot_item_we_vote_id: this.props.ballotItemWeVoteId,
       position_list: this.props.position_list,
-      voter: VoterStore.getVoter() // We only set this once since the info we need isn't dynamic
+      voter: VoterStore.getVoter(), // We only set this once since the info we need isn't dynamic
     });
   }
 
-  componentWillReceiveProps (nextProps){
+  componentWillReceiveProps (nextProps) {
     this.setState({
       position_list: nextProps.position_list,
-      ballot_item_we_vote_id: nextProps.ballotItemWeVoteId
+      ballot_item_we_vote_id: nextProps.ballotItemWeVoteId,
     });
   }
 
@@ -90,7 +90,7 @@ export default class ItemTinyPositionBreakdownList extends Component {
         // If here, we are showing an icon for the voter
         one_organization = {
           organization_we_vote_id: this.state.voter.we_vote_id,
-          voter_guide_display_name: this.state.voter.full_name
+          voter_guide_display_name: this.state.voter.full_name,
         };
         let voter_organization_tiny_display;
         voter_image_url_tiny = this.state.voter.voter_photo_url_tiny ? this.state.voter.voter_photo_url_tiny : "";

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -18,12 +18,12 @@ export default class FollowToggle extends Component {
     super(props);
     this.state = {
       voter: {
-        we_vote_id: ""
+        we_vote_id: "",
       }
     };
   }
 
-  componentDidMount (){
+  componentDidMount () {
     // console.log("componentDidMount, this.props: ", this.props);
     this._onOrganizationStoreChange();
     this._onVoterStoreChange();
@@ -34,25 +34,25 @@ export default class FollowToggle extends Component {
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
   }
 
-  componentWillUnmount (){
+  componentWillUnmount () {
     // console.log("componentWillUnmount, this.props.we_vote_id: ", this.props.we_vote_id);
     this.voterGuideStoreListener.remove();
     this.organizationStoreListener.remove();
     this.voterStoreListener.remove();
   }
 
-  onVoterGuideStoreChange (){
+  onVoterGuideStoreChange () {
     // console.log("FollowToggle, onVoterGuideStoreChange, organization_we_vote_id: ", this.props.we_vote_id);
-    this.setState({ is_following: OrganizationStore.isVoterFollowingThisOrganization(this.props.we_vote_id)});
+    this.setState({ is_following: OrganizationStore.isVoterFollowingThisOrganization(this.props.we_vote_id) });
   }
 
-  _onOrganizationStoreChange (){
+  _onOrganizationStoreChange () {
     // console.log("FollowToggle, _onOrganizationStoreChange, organization_we_vote_id: ", this.props.we_vote_id);
-    this.setState({ is_following: OrganizationStore.isVoterFollowingThisOrganization(this.props.we_vote_id)});
+    this.setState({ is_following: OrganizationStore.isVoterFollowingThisOrganization(this.props.we_vote_id) });
   }
 
-  _onVoterStoreChange (){
-    this.setState({ voter: VoterStore.getVoter()});
+  _onVoterStoreChange () {
+    this.setState({ voter: VoterStore.getVoter() });
   }
 
   toggleFollow () {
@@ -61,25 +61,20 @@ export default class FollowToggle extends Component {
 
   render () {
     if (!this.state) { return <div />; }
+
     let { we_vote_id, organization_for_display } = this.props;
+    let classNameOverride = this.props.classNameOverride || "";
     let { is_following } = this.state;
+
     let is_looking_at_self = this.state.voter.linked_organization_we_vote_id === we_vote_id;
     // You should not be able to follow yourself
     if (is_looking_at_self) { return <div />; }
-    let classNameOverride = this.props.classNameOverride || "";
 
     const followFunc = OrganizationActions.organizationFollow.bind(this, we_vote_id);
     const stopFollowingFunc = OrganizationActions.organizationStopFollowing.bind(this, we_vote_id);
 
-    var stopFollowingInstantly = function () {
-      is_following = false;
-      stopFollowingFunc();
-    };
-
-    var followInstantly = function () {
-      is_following = true;
-      followFunc();
-    };
+    var stopFollowingInstantly = () => { is_following = false; stopFollowingFunc(); };
+    var followInstantly = () => { is_following = true; followFunc(); };
 
     if (organization_for_display) {
       return <span onClick={followInstantly}>
@@ -88,19 +83,22 @@ export default class FollowToggle extends Component {
     }
 
     return is_following ?
-        <span>
-      { this.props.hide_stop_following_button ?
-        null :
-        <Button bsStyle="warning"
-                bsSize="small"
-                className={classNameOverride.length ? classNameOverride : "pull-right"}
-                onClick={stopFollowingInstantly}>
-                <span>Unfollow</span>
-        </Button> }
-        </span> :
-        <Button bsStyle="info"
-                bsSize="small"
-                className={classNameOverride.length ? classNameOverride : "pull-right"}
-                onClick={followInstantly}><span>Follow</span></Button>;
+      <span>
+        { this.props.hide_stop_following_button ?
+          null :
+          <Button bsStyle="warning"
+                  bsSize="small"
+                  className={classNameOverride.length ? classNameOverride : "pull-right"}
+                  onClick={stopFollowingInstantly}>
+            <span>Unfollow</span>
+          </Button>
+        }
+      </span> :
+      <Button bsStyle="info"
+              bsSize="small"
+              className={classNameOverride.length ? classNameOverride : "pull-right"}
+              onClick={followInstantly}>
+        <span>Follow</span>
+      </Button>;
   }
 }

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -3,6 +3,7 @@ import { Button } from "react-bootstrap";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationStore from "../../stores/OrganizationStore";
+import OrganizationTinyDisplay from "../VoterGuide/OrganizationTinyDisplay";
 import VoterStore from "../../stores/VoterStore";
 
 export default class FollowToggle extends Component {
@@ -10,6 +11,7 @@ export default class FollowToggle extends Component {
     we_vote_id: PropTypes.string.isRequired,
     hide_stop_following_button: PropTypes.bool,
     classNameOverride: PropTypes.string,
+    organization_for_display: PropTypes.object,
   };
 
   constructor (props) {
@@ -59,8 +61,8 @@ export default class FollowToggle extends Component {
 
   render () {
     if (!this.state) { return <div />; }
-    let we_vote_id = this.props.we_vote_id;
-    let is_following = this.state.is_following;
+    let { we_vote_id, organization_for_display } = this.props;
+    let { is_following } = this.state;
     let is_looking_at_self = this.state.voter.linked_organization_we_vote_id === we_vote_id;
     // You should not be able to follow yourself
     if (is_looking_at_self) { return <div />; }
@@ -78,6 +80,12 @@ export default class FollowToggle extends Component {
       is_following = true;
       followFunc();
     };
+
+    if (organization_for_display) {
+      return <span onClick={followInstantly}>
+        <OrganizationTinyDisplay {...organization_for_display} showPlaceholderImage />
+      </span>;
+    }
 
     return is_following ?
         <span>

--- a/src/js/components/Widgets/ItemSupportOpposeCheetah.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCheetah.jsx
@@ -3,10 +3,10 @@ import { OverlayTrigger, Popover } from "react-bootstrap";
 import { Link } from "react-router";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateStore from "../../stores/CandidateStore";
+import FollowToggle from "./FollowToggle";
 import ItemTinyPositionBreakdownList from "../Position/ItemTinyPositionBreakdownList";
 import OrganizationCard from "../VoterGuide/OrganizationCard";
 import OrganizationsNotShownList from "../VoterGuide/OrganizationsNotShownList";
-import OrganizationTinyDisplay from "../VoterGuide/OrganizationTinyDisplay";
 
 export default class ItemSupportOpposeCheetah extends Component {
   static propTypes = {
@@ -184,10 +184,6 @@ export default class ItemSupportOpposeCheetah extends Component {
 
         this.popover_state[org_id] = {show: false, timer: null};
 
-        let voterGuideLink = one_organization.organization_twitter_handle ?
-                                  "/" + one_organization.organization_twitter_handle :
-                                  "/voterguide/" + one_organization.organization_we_vote_id;
-
         let organizationPopover = <Popover
             id={`organization-popover-${org_id}-${visible_tag}`}
             onMouseOver={() => this.onTriggerEnter(org_id, visible_tag)}
@@ -209,9 +205,9 @@ export default class ItemSupportOpposeCheetah extends Component {
             placement="bottom"
             overlay={organizationPopover}>
           <span className="position-rating__source with-popover">
-            <Link key={`tiny-link-${org_id}-${visible_tag}`} to={voterGuideLink} onClick={(e) => this.onTriggerToggle(e, org_id, visible_tag)} className="u-no-underline">
-              <OrganizationTinyDisplay {...one_organization} showPlaceholderImage />
-            </Link>
+            <FollowToggle we_vote_id={one_organization.organization_we_vote_id}
+                          organization_for_display={one_organization}
+                          classNameOverride="pull-left" />
           </span>
         </OverlayTrigger>;
       }


### PR DESCRIPTION
Converted the organization logos so that they, when clicked, follow the organization for those not currently following or open/close the mini-modal for organizations already followed (#1176). Various ES6 and style fixes.