### PR TITLE
removing a pair of unnecessary <p> tags that causes a warning

### DIFF
--- a/src/js/components/VoterGuide/OrganizationVoterGuideCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideCard.jsx
@@ -64,11 +64,9 @@ export default class OrganizationVoterGuideCard extends Component {
         <FollowToggle we_vote_id={organization_we_vote_id} />
       }
       { twitterDescriptionMinusName && !this.props.turn_off_description ?
-        <p className="card-main__description">
           <ParsedTwitterDescription
             twitter_description={twitterDescriptionMinusName}
-          />
-        </p> :
+          />:
         <p className="card-main__description" />
       }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

![p tag within p tag](https://user-images.githubusercontent.com/25993366/33693136-d86b19e8-daa5-11e7-9e76-7ebaaa4db277.JPG)


### Changes included this pull request?
Deleted \<p\> tags in \<OrganizationVoterGuideCard\> since  \<ParsedTwitterDescription\> already have them.  