### PR TITLE
Fix for #1231: fix up setter for email_address_array

### DIFF
--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -278,15 +278,19 @@ export default class AddFriendsByEmail extends Component {
   }
 
   setEmailAddressArray (value) {
+    // do we need both this.email... and this.state.email...?
     this.email_address_array = value;
+    this.state.email_address_array = value;
   }
 
   setFirstNameArray (value) {
     this.first_name_array = value;
+    this.state.first_name_array = value;
   }
 
   setLastNameArray (value) {
     this.last_name_array = value;
+    this.state.last_name_array = value;
   }
 
   prepareApiArraysFromForm () {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Issue #1231 

### Changes included this pull request?
Prior to this fix, the app sets this.email_address_array, but then checks for the value in this.state.email_address_array.  Setting them both in the setEmailAddressArray setter works around the problem, but it's possible that this.email_address_array also needs to go away altogether.