### PR TITLE
changed to track the array outside of state due to async nature

### DIFF
--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -187,7 +187,7 @@ export default class AddFriendsByEmail extends Component {
           email_addresses_error: true,
         });
       }
-      if (this.state.email_address_array.length === 0 ) {
+      if (this.email_address_array.length === 0 ) {
         // console.log("AddFriendsByEmailStepsManager: this.state.email_add is ", this.state.email_address_array);
         email_addresses_error = true;
         error_message += "Please enter at least one email address.";


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

Error message shows up even though user entered a correct email in "AddFriendsByEmail"

### Changes included this pull request?

Changed component to check a storage array instead of a state array due to async nature of setState.