### PR TITLE
Image preloading

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -14,6 +14,8 @@ import SearchAllActions from "./actions/SearchAllActions";
 import VoterStore from "./stores/VoterStore";
 const web_app_config = require("./config");
 import { stringContains } from "./utils/textFormat";
+import IssueActions from "./actions/IssueActions";
+import IssueStore from "././stores/IssueStore";
 
 var loadingScreenStyles = {
   position: "fixed",
@@ -46,6 +48,7 @@ export default class Application extends Component {
     };
     this.loadedHeader = false;
     this.initFacebook();
+    this.preloadIssueImages = this.preloadIssueImages.bind(this);
   }
 
   initFacebook (){
@@ -79,6 +82,9 @@ export default class Application extends Component {
     ElectionActions.electionsRetrieve();
 
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
+   //preload images
+    IssueActions.retrieveIssuesToFollow();
+    this.issueStoreListener = IssueStore.addListener(this.preloadIssueImages);
   }
 
   componentWillUnmount () {
@@ -190,6 +196,15 @@ export default class Application extends Component {
 
   hideSearchContainer () {
     SearchAllActions.exitSearch();
+  }
+
+  preloadIssueImages () {
+    // console.log("preloadIssueImages func")
+    IssueStore.getIssuesVoterCanFollow().forEach(issue => {
+      document.createElement("img").src = issue.issue_image_url;
+    });
+    //only need to preload once
+    this.issueStoreListener.remove();
   }
 
   render () {

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -23,16 +23,28 @@ export default class BallotIntroFollowIssues extends Component {
       next_button_text: NEXT_BUTTON_TEXT,
       number_of_required_issues: 5,
     };
-  }
-
-  componentDidMount () {
-    IssueActions.retrieveIssuesForVoter();
-    IssueActions.retrieveIssuesToFollow();
-    this._onIssueStoreChange();
     this.onIssueFollow = this.onIssueFollow.bind(this);
     this.onIssueStopFollowing = this.onIssueStopFollowing.bind(this);
     this.onNext = this.onNext.bind(this);
-    this.issueStoreListener = IssueStore.addListener(this._onIssueStoreChange.bind(this));
+    this._onIssueStoreChange = this._onIssueStoreChange.bind(this);
+  }
+
+  componentDidUpdate (prevProps, prevState) {
+    if (prevState.issues[0] !== this.state.issues[0]) {
+      console.log("issues array loaded at" + Date.now() + "num of issues = " + this.state.issues.length);
+    }
+  }
+
+  componentWillMount () {
+    IssueActions.retrieveIssuesForVoter();
+    IssueActions.retrieveIssuesToFollow();
+    console.log("CWM: " + Date.now());
+  }
+
+  componentDidMount () {
+    this._onIssueStoreChange();
+    console.log("CDM: " + Date.now())
+    this.issueStoreListener = IssueStore.addListener(this._onIssueStoreChange);
   }
 
   componentWillUnmount () {
@@ -127,7 +139,7 @@ export default class BallotIntroFollowIssues extends Component {
   }
 
   render () {
-    let issue_list = this.state.issues || [];
+    let issue_list = this.state.issues;
     let remaining_issues = this.remainingIssues();
 
     let edit_mode = true;

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -29,21 +29,13 @@ export default class BallotIntroFollowIssues extends Component {
     this._onIssueStoreChange = this._onIssueStoreChange.bind(this);
   }
 
-  componentDidUpdate (prevProps, prevState) {
-    if (prevState.issues[0] !== this.state.issues[0]) {
-      console.log("issues array loaded at" + Date.now() + "num of issues = " + this.state.issues.length);
-    }
-  }
-
   componentWillMount () {
     IssueActions.retrieveIssuesForVoter();
-    IssueActions.retrieveIssuesToFollow();
-    console.log("CWM: " + Date.now());
+    // IssueActions.retrieveIssuesToFollow();
   }
 
   componentDidMount () {
     this._onIssueStoreChange();
-    console.log("CDM: " + Date.now())
     this.issueStoreListener = IssueStore.addListener(this._onIssueStoreChange);
   }
 

--- a/src/js/components/Ballot/BallotIntroModal.jsx
+++ b/src/js/components/Ballot/BallotIntroModal.jsx
@@ -19,11 +19,11 @@ export default class BallotIntroModal extends Component {
   constructor (props) {
     super(props);
     this.state = {};
-  }
-
-  componentDidMount () {
     this._nextSliderPage = this._nextSliderPage.bind(this);
   }
+
+  // componentDidMount () {
+  // }
 
   _nextSliderPage () {
     VoterActions.voterUpdateRefresh();


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Pre-load Issue Images so they are in browser cache #1240

### Changes included this pull request?
1) I moved "IssueActions.retrieveIssuesToFollow()" to from "BallotIntroFollowIssues.jsx" after mount to "Application.js" after mount and attached a "preloadIssueImage" callback to preload all the issue images
2) I moved "IssueActions.retrieveIssuesForVoter();" in "BallotIntroFollowIssues.jsx" from after mount to before mount; this is a minor speed improvement;
3) moved several lines of method binding into <constructor> from <componentDidMount> per standard convention
