### PR TITLE
Network Tabs in Mobile: Not tall enough #1252

### DIFF
--- a/src/js/routes/Network.jsx
+++ b/src/js/routes/Network.jsx
@@ -98,7 +98,7 @@ export default class Network extends Component {
     return <span>
       <Helmet title="Your Network - We Vote" />
       <BrowserPushMessage incomingProps={this.props} />
-      <section className="card">
+      <section className="card network__card">
         <div className="card-main">
           <h3 className="h3 text-center">Build Your We Vote Network</h3>
 

--- a/src/sass/components/_network.scss
+++ b/src/sass/components/_network.scss
@@ -3,7 +3,7 @@ $button-margin-horizontal: 10px;
 $description-margin-top: 10px;
 $social-left-padding-mobile: 40px;
 $social-right-padding-mobile: 9px;
-$network-card-margin: (-$space-md) (-$space-md) $space-none (-$space-md);
+$network-card-margin-mobile: (-$space-md) (-$space-md) $space-none (-$space-md);
 
 .buttons-container {
   display: flex;
@@ -100,6 +100,6 @@ $follow-card-title-color: #fff;
 
 .network__card {
   @include breakpoints (max mid-small) {
-    margin: $network-card-margin;
+    margin: $network-card-margin-mobile;
   }
 }

--- a/src/sass/components/_network.scss
+++ b/src/sass/components/_network.scss
@@ -3,6 +3,7 @@ $button-margin-horizontal: 10px;
 $description-margin-top: 10px;
 $social-left-padding-mobile: 40px;
 $social-right-padding-mobile: 9px;
+$network-card-margin: (-$space-md) (-$space-md) $space-none (-$space-md);
 
 .buttons-container {
   display: flex;
@@ -94,5 +95,11 @@ $follow-card-title-color: #fff;
       left: 8px;
       font-size: .6rem;
     }
+  }
+}
+
+.network__card {
+  @include breakpoints (max mid-small) {
+    margin: $network-card-margin;
   }
 }

--- a/src/sass/components/_tabs.scss
+++ b/src/sass/components/_tabs.scss
@@ -55,6 +55,7 @@ $tab-spacing-mobile: $space-md;
 $scrollbar-height: 20px;
 $tab-height: 47px;
 $tab-height-visible: $tab-height - $scrollbar-height;
+$tab-margin-mobile: (-$space-md);
 
 .tabs {
   &__tabs-container-wrap {
@@ -67,8 +68,8 @@ $tab-height-visible: $tab-height - $scrollbar-height;
     overflow: hidden;
     height: $tab-height-visible;
     @include breakpoints (small mid-small) {
-      margin-right: $space-none - $space-md;
-      margin-left: $space-none - $space-md;
+      margin-right: $tab-margin-mobile;
+      margin-left: $tab-margin-mobile;
     }
   }
 

--- a/src/sass/components/_tabs.scss
+++ b/src/sass/components/_tabs.scss
@@ -67,7 +67,8 @@ $tab-height-visible: $tab-height - $scrollbar-height;
     overflow: hidden;
     height: $tab-height-visible;
     @include breakpoints (small mid-small) {
-      margin: $space-none -$space-md;
+      margin-right: $space-none - $space-md;
+      margin-left: $space-none - $space-md;
     }
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
1252

### Changes included this pull request?
- Changed the left and right tab margin to -16px ($space-md) for mobile.
- Changed the network card top, left and right margins to -16px ($space-md) and bottom margin to 0px ($space-none).