### PR TITLE
Implemented left/right scrolling to ItemSupportOpposeRacoon

### DIFF
--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -274,8 +274,8 @@ export default class ItemSupportOpposeRaccoon extends Component {
     }
 
     let positions_exist = support_count || oppose_count || this.state.organizations_to_follow_support.length || this.state.organizations_to_follow_oppose.length;
-    let maximum_organizations_to_show_desktop = 12;
-    let maximum_organizations_to_show_mobile = 7;
+    let maximum_organizations_to_show_desktop = 50;
+    let maximum_organizations_to_show_mobile = 50;
 
     let organizations_to_follow_support_desktop = [];
     let organizations_to_follow_support_mobile = [];
@@ -355,7 +355,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
             </Button> an organization to add their position to the <strong>Score in Your Network</strong>.
       </Popover>;
 
-    const positionsLabel = positions_exist ?
+    const positionsLabel =
       <OverlayTrigger trigger="click"
                       ref="positions-overlay"
                       onExit={this.closePositionsPopover}
@@ -363,8 +363,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
                       placement="top"
                       overlay={positionsPopover}>
         <span className="network-positions-stacked__support-label u-cursor--pointer">Positions&nbsp;</span>
-      </OverlayTrigger> :
-      null;
+      </OverlayTrigger>;
 
     return <div className="network-positions-stacked">
       <div className="network-positions-stacked__support">
@@ -393,47 +392,74 @@ export default class ItemSupportOpposeRaccoon extends Component {
           <span className="sr-only">{total_score > 0 ? total_score + " Support" : null }{total_score < 0 ? total_score + " Oppose" : null }</span>
         </div>
       </div>
-      <div className="network-positions-stacked__support">
-        {/* Show a break-down of the current positions in your network */}
-        <span className="network-positions-stacked__support-list u-flex u-justify-between u-items-center u-inset__v--xs hidden-xs">
-          { positionsLabel }
-          <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                         ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                         position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                         showSupport
-                                         supportProps={this.state.supportProps}
-                                         visibility="desktop" />
-          <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                         ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                         position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                         showOppose
-                                         supportProps={this.state.supportProps}
-                                         visibility="desktop" />
-          {/* Show support positions the voter can follow Desktop */}
-          { organizations_to_follow_support_desktop.length ? organizations_to_follow_support_desktop : null }
-          {/* Show oppose positions the voter can follow Desktop */}
-          { organizations_to_follow_oppose_desktop.length ? organizations_to_follow_oppose_desktop : null }
-        </span>
-        <span className="network-positions-stacked__support-list u-flex u-justify-between u-items-center u-inset__v--xs visible-xs">
-          { positionsLabel }
-          <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                         ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                         position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                         showSupport
-                                         supportProps={this.state.supportProps}
-                                         visibility="mobile" />
-          <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                         ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                         position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                         showOppose
-                                         supportProps={this.state.supportProps}
-                                         visibility="mobile" />
-          {/* Show support positions the voter can follow Mobile */}
-          { organizations_to_follow_support_mobile.length ? organizations_to_follow_support_mobile : null }
-          {/* Show oppose positions the voter can follow Mobile */}
-          { organizations_to_follow_oppose_mobile.length ? organizations_to_follow_oppose_mobile : null }
-        </span>
-      </div>
+      { positions_exist ?
+        <div className="network-positions-stacked__support-list-container-wrap">
+          {/* Show a break-down of the current positions in your network */}
+          <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs hidden-xs">
+            <ul className="network-positions-stacked__support-list">
+              <li className="network-positions-stacked__support-list-item">
+                { positionsLabel }
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                               showSupport
+                                               supportProps={this.state.supportProps}
+                                               visibility="desktop" />
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                               showOppose
+                                               supportProps={this.state.supportProps}
+                                               visibility="desktop" />
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                {/* Show support positions the voter can follow Desktop */}
+                { organizations_to_follow_support_desktop.length ? organizations_to_follow_support_desktop : null }
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                {/* Show oppose positions the voter can follow Desktop */}
+                { organizations_to_follow_oppose_desktop.length ? organizations_to_follow_oppose_desktop : null }
+              </li>
+            </ul>
+          </span>
+          <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs visible-xs">
+            <ul className="network-positions-stacked__support-list">
+              <li className="network-positions-stacked__support-list-item">
+                { positionsLabel }
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                               showSupport
+                                               supportProps={this.state.supportProps}
+                                               visibility="mobile" />
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                               showOppose
+                                               supportProps={this.state.supportProps}
+                                               visibility="mobile" />
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                {/* Show support positions the voter can follow Mobile */}
+                { organizations_to_follow_support_mobile.length ? organizations_to_follow_support_mobile : null }
+              </li>
+              <li className="network-positions-stacked__support-list-item">
+                {/* Show oppose positions the voter can follow Mobile */}
+                { organizations_to_follow_oppose_mobile.length ? organizations_to_follow_oppose_mobile : null }
+              </li>
+            </ul>
+          </span>
+        </div> :
+        null
+      }
     </div>;
   }
 }

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -242,6 +242,21 @@ export default class ItemSupportOpposeRaccoon extends Component {
     this.refs["score-overlay"].hide();
   }
 
+  // TODO: implement organization list scrolling on click
+  // scrollLeft (visible_tag) {
+  //   console.log("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag);
+  //   document.getElementById("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag).animate({
+  //       scrollLeft: "-=153"
+  //   }, 1000, "easeOutQuad");
+  // }
+  //
+  // scrollRight (visible_tag) {
+  //   console.log("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag);
+  //   document.getElementById("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag).animate({
+  //       scrollLeft: "+=153"
+  //   }, 1000, "easeOutQuad");
+  // }
+
   render () {
     // console.log("ItemSupportOpposeRaccoon render");
     let candidateSupportStore = SupportStore.get(this.state.ballot_item_we_vote_id);
@@ -393,70 +408,79 @@ export default class ItemSupportOpposeRaccoon extends Component {
         </div>
       </div>
       { positions_exist ?
-        <div className="network-positions-stacked__support-list-container-wrap">
-          {/* Show a break-down of the current positions in your network */}
-          <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs hidden-xs">
-            <ul className="network-positions-stacked__support-list">
-              <li className="network-positions-stacked__support-list-item">
-                { positionsLabel }
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                               showSupport
-                                               supportProps={this.state.supportProps}
-                                               visibility="desktop" />
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                               showOppose
-                                               supportProps={this.state.supportProps}
-                                               visibility="desktop" />
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                {/* Show support positions the voter can follow Desktop */}
-                { organizations_to_follow_support_desktop.length ? organizations_to_follow_support_desktop : null }
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                {/* Show oppose positions the voter can follow Desktop */}
-                { organizations_to_follow_oppose_desktop.length ? organizations_to_follow_oppose_desktop : null }
-              </li>
-            </ul>
-          </span>
-          <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs visible-xs">
-            <ul className="network-positions-stacked__support-list">
-              <li className="network-positions-stacked__support-list-item">
-                { positionsLabel }
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                               showSupport
-                                               supportProps={this.state.supportProps}
-                                               visibility="mobile" />
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
-                                               ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
-                                               position_list={this.state.position_list_from_advisers_followed_by_voter}
-                                               showOppose
-                                               supportProps={this.state.supportProps}
-                                               visibility="mobile" />
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                {/* Show support positions the voter can follow Mobile */}
-                { organizations_to_follow_support_mobile.length ? organizations_to_follow_support_mobile : null }
-              </li>
-              <li className="network-positions-stacked__support-list-item">
-                {/* Show oppose positions the voter can follow Mobile */}
-                { organizations_to_follow_oppose_mobile.length ? organizations_to_follow_oppose_mobile : null }
-              </li>
-            </ul>
-          </span>
+        <div className="network-positions-stacked__support-list u-flex u-justify-between u-items-center">
+          <div className="network-positions-stacked__support-list-container-wrap">
+            {/* Show a break-down of the current positions in your network */}
+            <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs hidden-xs">
+              <ul id={this.state.ballot_item_we_vote_id + "-org-list-desktop"} className="network-positions-stacked__support-list-items">
+                <li className="network-positions-stacked__support-list-item">
+                  { positionsLabel }
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                                 ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                                 position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                                 showSupport
+                                                 supportProps={this.state.supportProps}
+                                                 visibility="desktop" />
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                                 ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                                 position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                                 showOppose
+                                                 supportProps={this.state.supportProps}
+                                                 visibility="desktop" />
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  {/* Show support positions the voter can follow Desktop */}
+                  { organizations_to_follow_support_desktop.length ? organizations_to_follow_support_desktop : null }
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  {/* Show oppose positions the voter can follow Desktop */}
+                  { organizations_to_follow_oppose_desktop.length ? organizations_to_follow_oppose_desktop : null }
+                </li>
+              </ul>
+            </span>
+            <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs visible-xs">
+              <ul id={this.state.ballot_item_we_vote_id + "-org-list-mobile"} className="network-positions-stacked__support-list-items">
+                <li className="network-positions-stacked__support-list-item">
+                  { positionsLabel }
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                                 ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                                 position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                                 showSupport
+                                                 supportProps={this.state.supportProps}
+                                                 visibility="mobile" />
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
+                                                 ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
+                                                 position_list={this.state.position_list_from_advisers_followed_by_voter}
+                                                 showOppose
+                                                 supportProps={this.state.supportProps}
+                                                 visibility="mobile" />
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  {/* Show support positions the voter can follow Mobile */}
+                  { organizations_to_follow_support_mobile.length ? organizations_to_follow_support_mobile : null }
+                </li>
+                <li className="network-positions-stacked__support-list-item">
+                  {/* Show oppose positions the voter can follow Mobile */}
+                  { organizations_to_follow_oppose_mobile.length ? organizations_to_follow_oppose_mobile : null }
+                </li>
+              </ul>
+            </span>
+          </div>
+          {/* TODO: make these scroll buttons work */}
+          {/* Click to scroll through list Desktop */}
+          {/* <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list-scroll-icon u-cursor--pointer hidden-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-left"} onClick={this.scrollLeft.bind(this, "desktop")} />
+          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list-scroll-icon u-cursor--pointer hidden-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-right"} onClick={this.scrollRight.bind(this, "desktop")} /> */}
+          {/* Click to scroll through list Mobile */}
+          {/* <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list-scroll-icon u-cursor--pointer visible-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-left"} onClick={this.scrollLeft.bind(this, "mobile")} />
+          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list-scroll-icon u-cursor--pointer visible-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-right"} onClick={this.scrollRight.bind(this, "mobile")} /> */}
         </div> :
         null
       }

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -355,6 +355,17 @@ export default class ItemSupportOpposeRaccoon extends Component {
             </Button> an organization to add their position to the <strong>Score in Your Network</strong>.
       </Popover>;
 
+    const positionsLabel = positions_exist ?
+      <OverlayTrigger trigger="click"
+                      ref="positions-overlay"
+                      onExit={this.closePositionsPopover}
+                      rootClose
+                      placement="top"
+                      overlay={positionsPopover}>
+        <span className="network-positions-stacked__support-label u-cursor--pointer">Positions&nbsp;</span>
+      </OverlayTrigger> :
+      null;
+
     return <div className="network-positions-stacked">
       <div className="network-positions-stacked__support">
         {/* Support toggle here */}
@@ -383,75 +394,45 @@ export default class ItemSupportOpposeRaccoon extends Component {
         </div>
       </div>
       <div className="network-positions-stacked__support">
-        { positions_exist ?
-          <OverlayTrigger trigger="click"
-                          ref="positions-overlay"
-                          onExit={this.closePositionsPopover}
-                          rootClose
-                          placement="top"
-                          overlay={positionsPopover}>
-            <span className="network-positions-stacked__support-label u-cursor--pointer">Positions&nbsp;</span>
-          </OverlayTrigger> :
-          null }
         {/* Show a break-down of the current positions in your network */}
-        <span className="u-flex u-justify-between u-inset__v--xs hidden-xs">
+        <span className="network-positions-stacked__support-list u-flex u-justify-between u-items-center u-inset__v--xs hidden-xs">
+          { positionsLabel }
           <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
                                          ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
                                          position_list={this.state.position_list_from_advisers_followed_by_voter}
                                          showSupport
                                          supportProps={this.state.supportProps}
                                          visibility="desktop" />
-        </span>
-        <span className="u-flex u-justify-between u-inset__v--xs hidden-xs">
           <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
                                          ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
                                          position_list={this.state.position_list_from_advisers_followed_by_voter}
                                          showOppose
                                          supportProps={this.state.supportProps}
                                          visibility="desktop" />
+          {/* Show support positions the voter can follow Desktop */}
+          { organizations_to_follow_support_desktop.length ? organizations_to_follow_support_desktop : null }
+          {/* Show oppose positions the voter can follow Desktop */}
+          { organizations_to_follow_oppose_desktop.length ? organizations_to_follow_oppose_desktop : null }
         </span>
-        <span className="u-flex u-justify-between u-inset__v--xs visible-xs">
+        <span className="network-positions-stacked__support-list u-flex u-justify-between u-items-center u-inset__v--xs visible-xs">
+          { positionsLabel }
           <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
                                          ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
                                          position_list={this.state.position_list_from_advisers_followed_by_voter}
                                          showSupport
                                          supportProps={this.state.supportProps}
                                          visibility="mobile" />
-        </span>
-        <span className="u-flex u-justify-between u-inset__v--xs visible-xs">
           <ItemTinyPositionBreakdownList ballot_item_display_name={this.state.ballot_item_display_name}
                                          ballotItemWeVoteId={this.state.ballot_item_we_vote_id}
                                          position_list={this.state.position_list_from_advisers_followed_by_voter}
                                          showOppose
                                          supportProps={this.state.supportProps}
                                          visibility="mobile" />
+          {/* Show support positions the voter can follow Mobile */}
+          { organizations_to_follow_support_mobile.length ? organizations_to_follow_support_mobile : null }
+          {/* Show oppose positions the voter can follow Mobile */}
+          { organizations_to_follow_oppose_mobile.length ? organizations_to_follow_oppose_mobile : null }
         </span>
-
-        {/* Show support positions the voter can follow Desktop */}
-        { organizations_to_follow_support_desktop.length ?
-          <span className="hidden-xs">
-            {organizations_to_follow_support_desktop}
-          </span> :
-          null }
-        {/* Show support positions the voter can follow Mobile */}
-        { organizations_to_follow_support_mobile.length ?
-          <span className="visible-xs">
-            {organizations_to_follow_support_mobile}
-          </span> :
-          null }
-        {/* Show oppose positions the voter can follow Desktop */}
-        { organizations_to_follow_oppose_desktop.length ?
-          <span className="hidden-xs">
-            {organizations_to_follow_oppose_desktop}
-          </span> :
-          null }
-
-        {/* Show oppose positions the voter can follow Mobile */}
-        { organizations_to_follow_oppose_mobile.length ?
-          <span className="visible-xs">
-            {organizations_to_follow_oppose_mobile}
-          </span> :
-          null }
       </div>
     </div>;
   }

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -146,37 +146,39 @@
 
   // Tiny Organization Position Breakdown List
 
-  $scrollbar-height: 21px;
-  $list-height: 60px;
-  $list-height-visible: $list-height - $scrollbar-height;
-  $scroll-icon-margin: 6px $space-none $space-none $space-sm;
+  &__support-list {
+    $scrollbar-height: 21px;
+    $list-height: 60px;
+    $list-height-visible: $list-height - $scrollbar-height;
+    $scroll-icon-margin: 6px $space-none $space-none $space-sm;
 
-  &__support-list-container-wrap {
-    box-sizing: content-box;
-    overflow: hidden;
-    height: $list-height-visible;
-  }
+    &-container-wrap {
+      box-sizing: content-box;
+      overflow: hidden;
+      height: $list-height-visible;
+    }
 
-  &__support-list-container {
-    white-space: nowrap;
-    overflow-x: scroll;
-    overflow-y: hidden;
-    height: $list-height;
-  }
+    &-container {
+      white-space: nowrap;
+      overflow-x: scroll;
+      overflow-y: hidden;
+      height: $list-height;
+    }
 
-  &__support-list-items {
-    padding: $space-none;
-    list-style: none;
-  }
+    &-items {
+      padding: $space-none;
+      list-style: none;
+    }
 
-  &__support-list-item {
-    position: relative;
-    display: inline-block;
-    float: none;
-  }
+    &-item {
+      position: relative;
+      display: inline-block;
+      float: none;
+    }
 
-  &__support-list-scroll-icon {
-    margin: $scroll-icon-margin;
+    &-scroll-icon {
+      margin: $scroll-icon-margin;
+    }
   }
 }
 

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -149,6 +149,7 @@
   $scrollbar-height: 21px;
   $list-height: 60px;
   $list-height-visible: $list-height - $scrollbar-height;
+  $scroll-icon-margin: 6px $space-none $space-none $space-sm;
 
   &__support-list-container-wrap {
     box-sizing: content-box;
@@ -163,8 +164,8 @@
     height: $list-height;
   }
 
-  &__support-list {
-    padding: 0;
+  &__support-list-items {
+    padding: $space-none;
     list-style: none;
   }
 
@@ -172,6 +173,10 @@
     position: relative;
     display: inline-block;
     float: none;
+  }
+
+  &__support-list-scroll-icon {
+    margin: $scroll-icon-margin;
   }
 }
 

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -143,6 +143,36 @@
       font-size: .675rem;
     }
   }
+
+  // Tiny Organization Position Breakdown List
+
+  $scrollbar-height: 21px;
+  $list-height: 60px;
+  $list-height-visible: $list-height - $scrollbar-height;
+
+  &__support-list-container-wrap {
+    box-sizing: content-box;
+    overflow: hidden;
+    height: $list-height-visible;
+  }
+
+  &__support-list-container {
+    white-space: nowrap;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    height: $list-height;
+  }
+
+  &__support-list {
+    padding: 0;
+    list-style: none;
+  }
+
+  &__support-list-item {
+    position: relative;
+    display: inline-block;
+    float: none;
+  }
 }
 
 .red-bar { background-color: $red; }


### PR DESCRIPTION
Implemented the first version of the new list of organization icons that is entirely contained on one line and supports left/right scrolling on mobile and desktop (#1249). Includes the first draft of an implementation for scrolling through the organizations list with button clicks.