### PR TITLE
Implemented click to scroll organizations list, hide support/oppose button tooltips on mobile

### DIFF
--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -183,36 +183,42 @@ export default class ItemActionBar extends Component {
     const supportButtonPopoverTooltip = <Tooltip id="supportButtonTooltip">{is_support ? supportButtonUnselectedPopOverText : supportButtonSelectedPopOverText }</Tooltip>;
     const opposeButtonPopoverTooltip = <Tooltip id="opposeButtonTooltip">{is_oppose ? opposeButtonUnselectedPopOverText : opposeButtonSelectedPopOverText}</Tooltip>;
 
+    const supportButton = <button className={"item-actionbar__btn item-actionbar__btn--support btn btn-default" + (is_support ? " support-at-state" : "")} onClick={this.supportItem.bind(this, is_support)}>
+      <span className="btn__icon">
+        <Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={support_icon_color} />
+      </span>
+      { is_support ?
+        <span
+          className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label item-actionbar__position-at-state" }>Support</span> :
+        <span
+          className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Support</span>
+      }
+    </button>;
+
+    const opposeButton = <button className={(this.props.opposeHideInMobile ? "hidden-xs " : "") + "item-actionbar__btn item-actionbar__btn--oppose btn btn-default" + (is_oppose ? " oppose-at-state" : "")} onClick={this.opposeItem.bind(this, is_oppose)}>
+      <span className="btn__icon">
+        <Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={oppose_icon_color} />
+      </span>
+      { is_oppose ?
+        <span
+          className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label item-actionbar__position-at-state" }>Oppose</span> :
+        <span
+          className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Oppose</span>
+      }
+    </button>;
+
     return <div className={ this.props.shareButtonHide ? "item-actionbar--inline hidden-print" : "item-actionbar hidden-print" }>
       <div className={"btn-group" + (!this.props.shareButtonHide ? " u-push--sm" : "")}>
         {/* Start of Support Button */}
-        <OverlayTrigger placement="top" overlay={supportButtonPopoverTooltip}>
-          <button className={"item-actionbar__btn item-actionbar__btn--support btn btn-default" + (is_support ? " support-at-state" : "")} onClick={this.supportItem.bind(this, is_support)}>
-                <span className="btn__icon">
-                  <Icon name="thumbs-up-icon" width={icon_size} height={icon_size} color={support_icon_color} />
-                </span>
-            { is_support ?
-              <span
-                className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label item-actionbar__position-at-state" }>Support</span> :
-              <span
-                className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Support</span>
-            }
-          </button>
-        </OverlayTrigger>
+        <div className="hidden-xs">
+          <OverlayTrigger placement="top" overlay={supportButtonPopoverTooltip}>{supportButton}</OverlayTrigger>
+        </div>
+        <div className="visible-xs">{supportButton}</div>
         {/* Start of Oppose Button */}
-        <OverlayTrigger placement="top" overlay={opposeButtonPopoverTooltip}>
-          <button className={(this.props.opposeHideInMobile ? "hidden-xs " : "") + "item-actionbar__btn item-actionbar__btn--oppose btn btn-default" + (is_oppose ? " oppose-at-state" : "")} onClick={this.opposeItem.bind(this, is_oppose)}>
-                <span className="btn__icon">
-                  <Icon name="thumbs-down-icon" width={icon_size} height={icon_size} color={oppose_icon_color} />
-                </span>
-            { is_oppose ?
-              <span
-                className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label item-actionbar__position-at-state" }>Oppose</span> :
-              <span
-                className={ this.props.shareButtonHide ? "item-actionbar--inline__position-btn-label" : "item-actionbar__position-btn-label" }>Oppose</span>
-            }
-          </button>
-        </OverlayTrigger>
+        <div className="hidden-xs">
+          <OverlayTrigger placement="top" overlay={opposeButtonPopoverTooltip}>{opposeButton}</OverlayTrigger>
+        </div>
+        <div className="visible-xs">{opposeButton}</div>
       </div>
       { this.props.commentButtonHide ?
         null :

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -1,5 +1,7 @@
 import React, { Component, PropTypes } from "react";
 import { Button, OverlayTrigger, Popover } from "react-bootstrap";
+import { findDOMNode } from "react-dom";
+import $ from "jquery";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateStore from "../../stores/CandidateStore";
 import ItemActionBar from "../Widgets/ItemActionBar";
@@ -246,20 +248,23 @@ export default class ItemSupportOpposeRaccoon extends Component {
     this.refs["score-overlay"].hide();
   }
 
-  // TODO: implement organization list scrolling on click
-  // scrollLeft (visible_tag) {
-  //   console.log("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag);
-  //   document.getElementById("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag).animate({
-  //       scrollLeft: "-=153"
-  //   }, 1000, "easeOutQuad");
-  // }
-  //
-  // scrollRight (visible_tag) {
-  //   console.log("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag);
-  //   document.getElementById("#" + this.state.ballot_item_we_vote_id + "-org-list-" + visible_tag).animate({
-  //       scrollLeft: "+=153"
-  //   }, 1000, "easeOutQuad");
-  // }
+  scrollLeft (visible_tag) {
+    const element = findDOMNode(this.refs[`${this.state.candidate.we_vote_id}-org-list-${visible_tag}`]);
+    let position = $(element).scrollLeft();
+    let width = $(element).width();
+    $(element).animate({
+      scrollLeft: position - width,
+    }, 350);
+  }
+
+  scrollRight (visible_tag) {
+    const element = findDOMNode(this.refs[`${this.state.candidate.we_vote_id}-org-list-${visible_tag}`]);
+    let position = $(element).scrollLeft();
+    let width = $(element).width();
+    $(element).animate({
+      scrollLeft: position + width,
+    }, 350);
+  }
 
   render () {
     // console.log("ItemSupportOpposeRaccoon render");
@@ -457,8 +462,8 @@ export default class ItemSupportOpposeRaccoon extends Component {
         <div className="network-positions-stacked__support-list u-flex u-justify-between u-items-center">
           <div className="network-positions-stacked__support-list-container-wrap">
             {/* Show a break-down of the current positions in your network */}
-            <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs hidden-xs">
-              <ul id={this.state.ballot_item_we_vote_id + "-org-list-desktop"} className="network-positions-stacked__support-list-items">
+            <span ref={`${this.state.candidate.we_vote_id}-org-list-desktop`} className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs hidden-xs">
+              <ul className="network-positions-stacked__support-list-items">
                 <li className="network-positions-stacked__support-list-item">
                   { positionsLabel }
                 </li>
@@ -488,8 +493,8 @@ export default class ItemSupportOpposeRaccoon extends Component {
                 </li>
               </ul>
             </span>
-            <span className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs visible-xs">
-              <ul id={this.state.ballot_item_we_vote_id + "-org-list-mobile"} className="network-positions-stacked__support-list-items">
+            <span ref={`${this.state.candidate.we_vote_id}-org-list-mobile`} className="network-positions-stacked__support-list-container u-flex u-justify-between u-items-center u-inset__v--xs visible-xs">
+              <ul className="network-positions-stacked__support-list-items">
                 <li className="network-positions-stacked__support-list-item">
                   { positionsLabel }
                 </li>
@@ -520,13 +525,12 @@ export default class ItemSupportOpposeRaccoon extends Component {
               </ul>
             </span>
           </div>
-          {/* TODO: make these scroll buttons work */}
           {/* Click to scroll through list Desktop */}
-          {/* <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list-scroll-icon u-cursor--pointer hidden-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-left"} onClick={this.scrollLeft.bind(this, "desktop")} />
-          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list-scroll-icon u-cursor--pointer hidden-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-right"} onClick={this.scrollRight.bind(this, "desktop")} /> */}
+          <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list-scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "desktop")} />
+          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list-scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "desktop")} />
           {/* Click to scroll through list Mobile */}
-          {/* <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list-scroll-icon u-cursor--pointer visible-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-left"} onClick={this.scrollLeft.bind(this, "mobile")} />
-          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list-scroll-icon u-cursor--pointer visible-xs" id={this.state.ballot_item_we_vote_id + "-org-list-scroll-right"} onClick={this.scrollRight.bind(this, "mobile")} /> */}
+          <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list-scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "mobile")} />
+          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list-scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "mobile")} />
         </div> :
         null
       }

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -181,6 +181,7 @@
     }
 
     &-scroll-icon {
+      color: $gray-mid;
       margin: $scroll-icon-margin;
     }
   }


### PR DESCRIPTION
Implemented the ability to scroll through the organizations lists for each candidate by clicking on the left/right arrows to the right of each list (#1249). The ability to hide these arrows if the list is not scrollable, or hide one at a time if the list cannot scroll further to the left or right, will be a separate issue.

In addition, the supportButtonPopoverTooltip and opposeButtonPopoverTooltip are no longer shown on mobile (step 1 of #1241).