### PR TITLE
Make goToBallotLink() static to avoid unbound function error in two classes.

### DIFF
--- a/src/js/components/Intro/IntroNetworkBallotIsNext.jsx
+++ b/src/js/components/Intro/IntroNetworkBallotIsNext.jsx
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
-import {browserHistory} from "react-router";
+import React, { Component } from "react";
 import cookies from "../../utils/cookies";
+import { historyPush, isCordova } from "../../utils/cordovaUtils";
 import Helmet from "react-helmet";
 
 export default class IntroNetworkBallotIsNext extends Component {
@@ -10,9 +10,9 @@ export default class IntroNetworkBallotIsNext extends Component {
     this.state = {};
   }
 
- goToBallotLink () {
-    var goToBallot = "/ballot";
-    browserHistory.push(goToBallot);
+  static goToBallotLink () {
+    const goToBallot = "/ballot";
+    historyPush(goToBallot);
   }
 
   componentWillMount () {
@@ -27,8 +27,8 @@ export default class IntroNetworkBallotIsNext extends Component {
   }
 
   render () {
-
-    return <div className="intro-story intro-story__background background--image3">
+    return <div className="intro-story intro-story__background background--image3"
+                style={isCordova() ? { backgroundImage: "url(./img/global/intro-story/slide3-historic-place-698x600.jpg)" } : null} >
       <Helmet title="See Your Ballot - We Vote" />
       <div className="intro-story__h1--alt">We Vote</div>
       <div ref="header2" className="intro-story__h2 intro-story__padding-top">
@@ -44,7 +44,7 @@ export default class IntroNetworkBallotIsNext extends Component {
       <div className="intro-story__padding">
         <button type="button"
                 className="btn btn-lg btn-success"
-                onClick={this.goToBallotLink}>Go to Your Ballot&nbsp;&nbsp;&gt;</button>
+                onClick={IntroNetworkBallotIsNext.goToBallotLink}>Go to Your Ballot&nbsp;&nbsp;&gt;</button>
       </div>
       <div className="intro-story__padding-top">{/* Stay tuned for the latest election data! */}</div>
     </div>;

--- a/src/js/components/Intro/IntroNetworkDefinition.jsx
+++ b/src/js/components/Intro/IntroNetworkDefinition.jsx
@@ -1,10 +1,11 @@
 import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
+import { cordovaDot, isCordova, isWebApp } from "../../utils/cordovaUtils";
 
 export default class IntroNetworkDefinition extends Component {
   static propTypes = {
     history: PropTypes.object,
-    next: React.PropTypes.func
+    next: React.PropTypes.func,
   };
 
   constructor (props) {
@@ -13,7 +14,8 @@ export default class IntroNetworkDefinition extends Component {
   }
 
   render () {
-    return <div className="intro-story__background background--image4">
+    return <div className="intro-story__background background--image4"
+                style={isCordova() ? { backgroundImage: "url(./img/global/intro-story/slide4-working-together-698x600.jpg)" } : null} >
       <div className="intro-story__h1">We Vote Together</div>
       <div className="intro-story__h2">Your friends, and the <br />
         organizations
@@ -24,11 +26,10 @@ export default class IntroNetworkDefinition extends Component {
             </Button> to, <br />
         are your <strong>We Vote</strong> network.</div>
         <div><br /></div>
-      <div><img className="center-block intro-story__img-height--extra" src={"/img/global/intro-story/slide4-connect-friends-300x370-min.png"}/></div>
+      <div><img className="center-block intro-story__img-height--extra" src={cordovaDot("/img/global/intro-story/slide4-connect-friends-300x370-min.png")}/></div>
       <div className="intro-story__padding-btn">
         <button type="button" className="btn btn-success" onClick={this.props.next}>Next&nbsp;&nbsp;&gt;</button>
       </div>
     </div>;
   }
 }
-

--- a/src/js/components/Intro/IntroNetworkSafety.jsx
+++ b/src/js/components/Intro/IntroNetworkSafety.jsx
@@ -1,9 +1,19 @@
 import React, { Component, PropTypes } from "react";
+import { cordovaDot, isCordova } from "../../utils/cordovaUtils";
+
+/*
+The problem with urls in css for Apache Cordova
+https://github.com/webpack-contrib/file-loader/issues/46
+... cordova ...
+"The core of the problem is that CSS loads assets relative to itself, and js loads
+assets relative to the HTML. So if the CSS isn't in the same place as the HTML
+then you can't use relative paths."
+*/
 
 export default class IntroNetworkSafety extends Component {
   static propTypes = {
     history: PropTypes.object,
-    next: React.PropTypes.func
+    next: React.PropTypes.func,
   };
 
   constructor (props) {
@@ -12,16 +22,19 @@ export default class IntroNetworkSafety extends Component {
   }
 
   render () {
-    return <div className="intro-story__background background--image2">
-      <div className="intro-story__h1">We Vote in Safety</div>
-      <div className="intro-story__h2">You control who is in<br />
-        your <strong>We Vote</strong> network.</div>
-      <div><br /></div>
-      <div><img className="center-block intro-story__img-height" src={"/img/global/intro-story/slide2-ignore-troll-282x282-min.png"}/></div>
-      <div className="intro-story__padding-btn">
-        <button type="button" className="btn btn-success" onClick={this.props.next}>Next&nbsp;&nbsp;&gt;</button>
-      </div>
-    </div>;
+    return <div className="intro-story__background background--image2"
+                style={isCordova() ? { backgroundImage: "url(./img/global/intro-story/slide2-lady-liberty-698x600.jpg)" } : null} >
+        <div className="intro-story__h1">We Vote in Safety</div>
+        <div className="intro-story__h2">You control who is in<br/>
+          your <strong>We Vote</strong> network.
+        </div>
+        <div><br/></div>
+        <div><img className="center-block intro-story__img-height"
+                  src={cordovaDot("/img/global/intro-story/slide2-ignore-troll-282x282-min.png")}/></div>
+        <div className="intro-story__padding-btn">
+          <button type="button" className="btn btn-success" onClick={this.props.next}>Next&nbsp;&nbsp;&gt;</button>
+        </div>
+      </div>;
   }
 }
 

--- a/src/js/components/Intro/IntroNetworkScore.jsx
+++ b/src/js/components/Intro/IntroNetworkScore.jsx
@@ -1,10 +1,11 @@
 import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
+import { isCordova } from "../../utils/cordovaUtils";
 
 export default class IntroNetworkScore extends Component {
   static propTypes = {
     history: PropTypes.object,
-    next: React.PropTypes.func
+    next: React.PropTypes.func,
   };
 
   constructor (props) {
@@ -13,7 +14,8 @@ export default class IntroNetworkScore extends Component {
   }
 
   render () {
-    return <div className="intro-story__background background--image5">
+    return <div className="intro-story__background background--image5"
+                style={isCordova() ? { backgroundImage: "url(./img/global/intro-story/slide5-flagpole-698x600.jpg)" } : null} >
       <div className="intro-story__h1">We Keep Score</div>
       <div className="intro-story__h2">
         <Button bsStyle="success" bsSize="xsmall" >

--- a/src/js/routes/Intro/IntroNetwork.jsx
+++ b/src/js/routes/Intro/IntroNetwork.jsx
@@ -1,11 +1,11 @@
 import React, { Component } from "react";
-import { browserHistory } from "react-router";
 import Helmet from "react-helmet";
+import Slider from "react-slick";
+import { cordovaDot, historyPush } from "../../utils/cordovaUtils";
 import IntroNetworkSafety from "../../components/Intro/IntroNetworkSafety";
 import IntroNetworkDefinition from "../../components/Intro/IntroNetworkDefinition";
 import IntroNetworkScore from "../../components/Intro/IntroNetworkScore";
 import IntroNetworkBallotIsNext from "../../components/Intro/IntroNetworkBallotIsNext";
-var Slider = require("react-slick");
 
 export default class IntroNetwork extends Component {
 
@@ -25,9 +25,9 @@ export default class IntroNetwork extends Component {
     this.refs.slider.slickPrev();
   }
 
-  goToBallotLink () {
-    var ballotLink = "/ballot";
-    browserHistory.push(ballotLink);
+  static goToBallotLink () {
+    const ballotLink = "/ballot";
+    historyPush(ballotLink);
   }
 
   componentWillMount () {
@@ -42,7 +42,7 @@ export default class IntroNetwork extends Component {
 
   render () {
     //These are settings for the react-slick slider
-    var settings = {
+    const settings = {
       dots: true,
       infinite: false,
       speed: 500,
@@ -50,16 +50,13 @@ export default class IntroNetwork extends Component {
       slidesToScroll: 1,
       swipe: true,
       accessibility: true,
-      //react-slick default left & right nav arrows
       arrows: true,
-      beforeChange: function () {
-      }
     };
 
     return <div>
       <Helmet title="Welcome to We Vote" />
       <div className="intro-story container-fluid well u-inset--md">
-        <img src={"/img/global/icons/x-close.png"} onClick={this.goToBallotLink} className="x-close" alt={"close"}/>
+        <img src={cordovaDot("/img/global/icons/x-close.png")} onClick={IntroNetwork.goToBallotLink} className="x-close" alt={"close"}/>
         <Slider ref="slider" {...settings}>
           <div key={1}><IntroNetworkSafety next={this.next}/></div>
           <div key={2}><IntroNetworkDefinition next={this.next}/></div>

--- a/src/js/routes/Welcome.jsx
+++ b/src/js/routes/Welcome.jsx
@@ -7,7 +7,7 @@ import AnalyticsActions from "../actions/AnalyticsActions";
 import { validateEmail } from "../utils/email-functions";
 import FacebookStore from "../stores/FacebookStore";
 import FacebookActions from "../actions/FacebookActions";
-import { cordovaDot, historyPush } from "../utils/cordovaUtils";
+import { cordovaDot, historyPush, isCordova } from "../utils/cordovaUtils";
 import VoterActions from "../actions/VoterActions";
 import VoterConstants from "../constants/VoterConstants";
 import VoterStore from "../stores/VoterStore";
@@ -207,10 +207,11 @@ export default class Intro extends Component {
       });
 
     // && this.state.is_verification_email_sent ?
+    // urls in css are problematic in cordova
     return <div className="welcome-page">
       <Helmet title="Welcome to We Vote" />
       <section className="hero__section__container">
-        <div className="hero__section">
+        <div className="hero__section" style={isCordova() ? { backgroundImage: "url(./img/welcome/header-image-desktop.png)" } : null} >
           <div className="container">
             <Row className="hero__section__row">
               <div className="col-md-12">

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -1,9 +1,16 @@
 import { browserHistory, hashHistory } from "react-router";
-const webAppConfig = require("../config");
+
+export function isWebApp() {
+  return window.cordova === undefined;
+}
+
+export function isCordova() {
+  return window.cordova !== undefined;
+}
 
 // see https://github.com/ReactTraining/react-router/blob/v3/docs/guides/Histories.md
 export function historyPush(route) {
-  if (webAppConfig.IS_CORDOVA) {
+  if (isCordova()) {
     hashHistory.push(route);
   } else {
     browserHistory.push(route);
@@ -11,7 +18,7 @@ export function historyPush(route) {
 }
 
 export function cordovaDot(path) {
-  if (webAppConfig.IS_CORDOVA) {
+  if (isCordova()) {
     return "." + path;
   } else {
     return path;


### PR DESCRIPTION
URLs in css/sass are problematic for Cordova, since CSS loads assets
relative its location and js loads assets relative to the HTML location.
So condtionally overrode the css image locations with style settings in
the IntroNetwork* classes and in Welcome.jsx
