### PR TITLE
Fixed the issue where the organizational icons are cut off #1289

### DIFF
--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -1,4 +1,5 @@
 // Network Positions bar (ItemSupportOpposeCounts)
+$support_list_items_margin_bottom: 25px;
 
 .network-positions {
   $bar-height: 10px;
@@ -171,6 +172,7 @@
 
     &-items {
       padding: $space-none;
+      margin-bottom: $support_list_items_margin_bottom;
       list-style: none;
     }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1289 

### Changes included this pull request?
 - Increased the bottom margin of the support list items.

<img width="594" alt="screen shot 2018-01-25 at 4 07 26 pm" src="https://user-images.githubusercontent.com/6605268/35418902-e6a77c70-01e9-11e8-9281-9b6c2ec1afbc.png">
