### PR TITLE
Possible solution for the popover not working on mobile

### DIFF
--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -387,6 +387,6 @@ $candidate-font-size: .875rem;
 .card-popover {
   max-width: 350px;
   &__width--minimum {
-    width: 350px;
+    width: 90vw;
   }
 }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1263

### Changes included this pull request?
Instead of using a fixed pixel value for the popover size I am using the viewport width.