### PR TITLE
Changed comment area layout on ballot page

### DIFF
--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -145,25 +145,25 @@ export default class ItemPositionStatementActionBar extends Component {
       statement_placeholder_text = "Your thoughts…";
     }
 
-    var user_position_text;
-    var user_position_icon;
-    var user_position_subject_name = this.props.ballot_item_display_name ?
-      " " + this.props.ballot_item_display_name :
-      null;
-    if (is_support) {
-      user_position_icon = "thumbs-up-color-icon";
-      user_position_text = <span><strong>You support</strong>{user_position_subject_name}</span>;
-    } else if (is_oppose) {
-      user_position_icon = "thumbs-down-color-icon";
-      user_position_text = <span><strong>You oppose</strong>{user_position_subject_name}</span>;
-    } else {
-      user_position_icon = "no-position-icon";
-      if (this.props.ballot_item_display_name) {
-        user_position_text = <em className="u-gray-mid">No position on {user_position_subject_name}</em>;
-      } else {
-        user_position_text = <em className="u-gray-mid">No position</em>;
-      }
-    }
+    // var user_position_text;
+    // var user_position_icon;
+    // var user_position_subject_name = this.props.ballot_item_display_name ?
+    //   " " + this.props.ballot_item_display_name :
+    //   null;
+    // if (is_support) {
+    //   user_position_icon = "thumbs-up-color-icon";
+    //   user_position_text = <span><strong>You support</strong>{user_position_subject_name}</span>;
+    // } else if (is_oppose) {
+    //   user_position_icon = "thumbs-down-color-icon";
+    //   user_position_text = <span><strong>You oppose</strong>{user_position_subject_name}</span>;
+    // } else {
+    //   user_position_icon = "no-position-icon";
+    //   if (this.props.ballot_item_display_name) {
+    //     user_position_text = <em className="u-gray-mid">No position on {user_position_subject_name}</em>;
+    //   } else {
+    //     user_position_text = <em className="u-gray-mid">No position</em>;
+    //   }
+    // }
 
     // Currently this "Post" text is the same given we display the visibility setting, but we may want to change this
     //  here if the near by visibility setting text changes
@@ -218,16 +218,17 @@ export default class ItemPositionStatementActionBar extends Component {
     }
 
     return <div className={ this.props.shown_in_list ? "position-statement__container__in-list" : "position-statement__container"}>
-      { this.props.stance_display_off ?
+      {/* { this.props.stance_display_off ?
         null :
         <div className="position-statement__overview u-flex items-center u-stack--sm">
-        { is_support || is_oppose ? <Icon className="u-push--xs" name={user_position_icon} width={24} height={24} /> : null }
-        { user_position_text }
+          { is_support || is_oppose ? <Icon className="u-push--xs" name={user_position_icon} width={24} height={24} /> : null }
+          { user_position_text }
           <PositionPublicToggle ballot_item_we_vote_id={this.props.ballot_item_we_vote_id}
                                 type={this.props.type}
                                 supportProps={this.props.supportProps}
                                 className="u-flex-auto u-tr hidden-print" />
-        </div> }
+        </div>
+      } */}
 
       { // Show the edit box (Viewing self)
         edit_mode ?
@@ -235,18 +236,24 @@ export default class ItemPositionStatementActionBar extends Component {
             <div className="position-statement hidden-print">
               { speaker_image_url_https ?
                 <img className="position-statement__avatar"
-                      src={speaker_image_url_https}
-                      width="34px"
-                /> :
-              image_placeholder }
+                     src={speaker_image_url_https}
+                     width="34px" /> :
+                image_placeholder
+              }
               <span className="position-statement__input-group u-flex u-items-start">
                 <Textarea onChange={this.updateStatementTextToBeSaved.bind(this)}
                   name="statement_text_to_be_saved"
                   className="position-statement__input u-push--sm form-control"
+                  minRows={2}
                   placeholder={statement_placeholder_text}
-                  defaultValue={statement_text_to_be_saved}
-                  />
-                <button className="btn btn-default btn-sm" type="submit">{post_button_text}</button>
+                  defaultValue={statement_text_to_be_saved} />
+              <div className="u-flex u-flex-column u-justify-between u-items-end">
+                <PositionPublicToggle ballot_item_we_vote_id={this.props.ballot_item_we_vote_id}
+                                      type={this.props.type}
+                                      supportProps={this.props.supportProps}
+                                      className="u-flex-auto u-tr hidden-print" />
+                <button className="position-statement__post-button btn btn-default btn-sm" type="submit">{post_button_text}</button>
+              </div>
               </span>
             </div>
           </form> :

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -339,9 +339,9 @@ export default class ItemSupportOpposeRaccoon extends Component {
 
     let comment_display_raccoon_desktop = this.props.showPositionStatementActionBar || is_support || is_oppose || voter_statement_text ?
       <div className="hidden-xs o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
-        <div
+        {/* <div
           className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm">&nbsp;
-        </div>
+        </div> */}
         <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
           <ItemPositionStatementActionBar ballot_item_we_vote_id={this.state.ballot_item_we_vote_id}
                                           ballot_item_display_name={this.state.ballot_item_display_name}
@@ -355,9 +355,9 @@ export default class ItemSupportOpposeRaccoon extends Component {
 
     let comment_display_raccoon_mobile = this.props.showPositionStatementActionBar || is_support || is_oppose || voter_statement_text ?
       <div className="visible-xs o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
-        <div
+        {/* <div
           className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm">&nbsp;
-        </div>
+        </div> */}
         <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
           <ItemPositionStatementActionBar ballot_item_we_vote_id={this.state.ballot_item_we_vote_id}
                                           ballot_item_display_name={this.state.ballot_item_display_name}

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -163,7 +163,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
     //   orgs_not_shown_count = organizations_to_follow.length - maximum_organization_display;
     //   orgs_not_shown_list = organizations_to_follow.slice(maximum_organization_display);
     // }
-    return organizations_to_follow.map( (one_organization) => {
+    return organizations_to_follow.map( one_organization => {
       local_counter++;
       let org_id = one_organization.organization_we_vote_id;
 
@@ -303,13 +303,13 @@ export default class ItemSupportOpposeRaccoon extends Component {
     let candidateSupportStore = SupportStore.get(this.state.ballot_item_we_vote_id);
     // Removed from ItemActionBar opposeHideInMobile
     let candidate_support_action_raccoon = <span>
-      <ItemActionBar ballot_item_display_name={this.state.ballot_item_display_name}
-                     ballot_item_we_vote_id={this.state.ballot_item_we_vote_id}
-                     commentButtonHide
-                     shareButtonHide
-                     supportProps={candidateSupportStore}
-                     transitioning={this.state.transitioning}
-                     type="CANDIDATE"/>
+        <ItemActionBar ballot_item_display_name={this.state.ballot_item_display_name}
+                       ballot_item_we_vote_id={this.state.ballot_item_we_vote_id}
+                       commentButtonHide
+                       shareButtonHide
+                       supportProps={candidateSupportStore}
+                       transitioning={this.state.transitioning}
+                       type="CANDIDATE" />
       </span>;
 
     let support_count = 0;
@@ -348,7 +348,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
                                           supportProps={candidateSupportStore}
                                           transitioning={this.state.transitioning}
                                           type="CANDIDATE"
-                                          shown_in_list/>
+                                          shown_in_list />
         </div>
       </div> :
       null;
@@ -364,7 +364,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
                                           supportProps={candidateSupportStore}
                                           transitioning={this.state.transitioning}
                                           type="CANDIDATE"
-                                          shown_in_list/>
+                                          shown_in_list />
         </div>
       </div> :
       null;
@@ -384,7 +384,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
       let support_positions_list_count = 0;
       let oppose_positions_list_count = 0;
       // let info_only_positions_list_count = 0;
-      this.state.position_list_from_advisers_followed_by_voter.map((one_position) => {
+      this.state.position_list_from_advisers_followed_by_voter.map( one_position => {
         // console.log("one_position: ", one_position);
         // Filter out the positions that we don't want to display
         if (one_position.is_support_or_positive_rating) {
@@ -430,8 +430,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
         Each one that <span className="u-no-break"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")}
                                                width="20" height="20" /> opposes</span> subtracts
         1 from this <strong>Score</strong>. <Button bsStyle="success"
-                                                    bsSize="xsmall"
-                                                    >
+                                                    bsSize="xsmall">
                                               <span>Listen</span>
                                             </Button> to an
         organization to add their opinion to the <strong>Score in Your Network</strong>.
@@ -447,8 +446,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
                                                width="20" height="20" /> oppose</span> {this.state.ballot_item_display_name}.
         Click on the logo
         and <Button bsStyle="success"
-                    bsSize="xsmall"
-                    >
+                    bsSize="xsmall">
               <span>Listen</span>
             </Button> to an organization to add their opinion to the <strong>Score in Your Network</strong>.
       </Popover>;
@@ -490,8 +488,8 @@ export default class ItemSupportOpposeRaccoon extends Component {
           <span className="sr-only">{total_score > 0 ? total_score + " Support" : null }{total_score < 0 ? total_score + " Oppose" : null }</span>
         </div>
       </div>
-      {comment_display_raccoon_desktop}
-      {comment_display_raccoon_mobile}
+      { comment_display_raccoon_desktop }
+      { comment_display_raccoon_mobile }
       { positions_count ?
         <div className="network-positions-stacked__support-list u-flex u-justify-between u-items-center">
           {/* Click to scroll left through list Desktop */}

--- a/src/sass/base/_variables.scss
+++ b/src/sass/base/_variables.scss
@@ -85,9 +85,9 @@ $radius-rounded: 100rem;
 
 // Misc spacing
 $gutter-width: 30px; // from Bootstrap
-$half-gutter-width: $gutter-width/2; // from Bootstrap
-$gutter-offset: -$gutter-width/2;
-$space-position-comment: 37px;
+$half-gutter-width: $gutter-width / 2; // from Bootstrap
+$gutter-offset: -$gutter-width / 2;
+// $space-position-comment: 37px;
 
 // ===========================================
 // Colors

--- a/src/sass/components/_itemPositionStatementActionBar.scss
+++ b/src/sass/components/_itemPositionStatementActionBar.scss
@@ -1,5 +1,8 @@
 @include media-object('.position-statement', '.position-statement__avatar', '.position-statement__input-group');
 
+$post-button-margin: 6px $space-none $space-none $space-none;
+$post-button-padding: 3px 7px;
+
 .position-statement {
   display: flex;
   flex: 1 1 100%;
@@ -28,6 +31,11 @@
     &__in-list {
       // margin-left: $space-position-comment;
     }
+  }
+
+  &__post-button {
+    margin: $post-button-margin;
+    padding: $post-button-padding;
   }
 
   &--truncated {

--- a/src/sass/components/_itemPositionStatementActionBar.scss
+++ b/src/sass/components/_itemPositionStatementActionBar.scss
@@ -1,4 +1,3 @@
-
 @include media-object('.position-statement', '.position-statement__avatar', '.position-statement__input-group');
 
 .position-statement {
@@ -25,8 +24,9 @@
     background-color: $gray-pale;
     padding: $space-sm $space-md;
     margin: $space-none (-$space-md) (-$space-sm);
+
     &__in-list {
-      margin-left: $space-position-comment;
+      // margin-left: $space-position-comment;
     }
   }
 


### PR DESCRIPTION
Removed the extra space to the left of the comment area (#1305). Changed the comment area layout by removing the support/oppose text, moving the public position toggle and post button to the right of the comment area, and changed the size of the post button to align with the toggle.