### PR TITLE
Fixed issues and opinions list scroll behavior

### DIFF
--- a/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
+++ b/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
@@ -21,6 +21,8 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
     this.state = {
       transitioning: false,
       showModal: false,
+      can_scroll_desktop: false,
+      can_scroll_mobile: false,
       can_scroll_left_desktop: false,
       can_scroll_left_mobile: false,
       can_scroll_right_desktop: true,
@@ -38,6 +40,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
     this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
     this.onVoterGuideStoreChange();
+    this.setScrollState();
     this.setState({
       ballotItemWeVoteId: this.props.ballotItemWeVoteId,
       ballot_item_display_name: this.props.ballot_item_display_name ? this.props.ballot_item_display_name : "this candidate",
@@ -49,6 +52,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
+    this.setScrollState();
     this.setState({
       ballotItemWeVoteId: nextProps.ballotItemWeVoteId,
       ballot_item_display_name: nextProps.ballot_item_display_name ? nextProps.ballot_item_display_name : "this candidate",
@@ -69,6 +73,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
   }
 
   onIssueStoreChange () {
+    this.setScrollState();
     this.setState({
       issues_under_this_ballot_item: IssueStore.getIssuesUnderThisBallotItem(this.state.ballotItemWeVoteId),
       issues_under_this_ballot_item_voter_is_following: IssueStore.getIssuesUnderThisBallotItemVoterIsFollowing(this.state.ballotItemWeVoteId),
@@ -127,6 +132,19 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
     });
   }
 
+  setScrollState () {
+    const desktop_list = findDOMNode(this.refs[`${this.props.ballotItemWeVoteId}-issue-list-desktop`]);
+    const mobile_list = findDOMNode(this.refs[`${this.props.ballotItemWeVoteId}-issue-list-mobile`]);
+    let desktop_list_visible_width = $(desktop_list).width();
+    let desktop_list_width = $(desktop_list).children().eq(0).children().eq(0).width();
+    let mobile_list_visible_width = $(mobile_list).width();
+    let mobile_list_width = $(mobile_list).children().eq(0).children().eq(0).width();
+    this.setState({
+      can_scroll_desktop: desktop_list_visible_width <= desktop_list_width,
+      can_scroll_mobile: mobile_list_visible_width <= mobile_list_width,
+    });
+  }
+
   render () {
     let issues_under_this_ballot_item_voter_is_following_found = this.state.issues_under_this_ballot_item_voter_is_following && this.state.issues_under_this_ballot_item_voter_is_following.length;
     let issues_under_this_ballot_item_voter_is_not_following = this.state.issues_under_this_ballot_item_voter_not_following && this.state.issues_under_this_ballot_item_voter_not_following.length;
@@ -136,7 +154,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
       return null;
     }
 
-    let issues_count = issues_under_this_ballot_item_voter_is_following_found + issues_under_this_ballot_item_voter_is_not_following;
+    // let issues_count = issues_under_this_ballot_item_voter_is_following_found + issues_under_this_ballot_item_voter_is_not_following;
     // console.log(issues_count);
 
     const issuesLabelPopover =
@@ -159,12 +177,12 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
     return (
       <div className="issues-list-stacked__support-list u-flex u-justify-between u-items-center">
         {/* Click to scroll left through list Desktop */}
-        { issues_count > 7 && this.state.can_scroll_left_desktop ?
+        { this.state.can_scroll_desktop && this.state.can_scroll_left_desktop ?
           <i className="fa fa-2x fa-chevron-left issues-list-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "desktop")} /> :
           <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
         }
         {/* Click to scroll left through list Mobile */}
-        { issues_count > 4 && this.state.can_scroll_left_mobile ?
+        { this.state.can_scroll_mobile && this.state.can_scroll_left_mobile ?
           <i className="fa fa-2x fa-chevron-left issues-list-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "mobile")} /> :
           <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
         }
@@ -212,12 +230,12 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
           </span>
         </div>
         {/* Click to scroll right through list Desktop */}
-        { issues_count > 7 && this.state.can_scroll_right_desktop ?
+        { this.state.can_scroll_desktop && this.state.can_scroll_right_desktop ?
           <i className="fa fa-2x fa-chevron-right issues-list-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "desktop")} /> :
           <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
         }
         {/* Click to scroll right through list Mobile */}
-        { issues_count > 4 && this.state.can_scroll_right_mobile ?
+        { this.state.can_scroll_mobile && this.state.can_scroll_right_mobile ?
           <i className="fa fa-2x fa-chevron-right issues-list-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "mobile")} /> :
           <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
         }

--- a/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
+++ b/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
@@ -161,12 +161,12 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
         {/* Click to scroll left through list Desktop */}
         { issues_count > 7 && this.state.can_scroll_left_desktop ?
           <i className="fa fa-2x fa-chevron-left issues-list-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "desktop")} /> :
-          null
+          <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
         }
         {/* Click to scroll left through list Mobile */}
         { issues_count > 4 && this.state.can_scroll_left_mobile ?
           <i className="fa fa-2x fa-chevron-left issues-list-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "mobile")} /> :
-          null
+          <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
         }
         <div className="issues-list-stacked__support-list__container-wrap">
           {/* Show a break-down of the current positions in your network */}
@@ -214,12 +214,12 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
         {/* Click to scroll right through list Desktop */}
         { issues_count > 7 && this.state.can_scroll_right_desktop ?
           <i className="fa fa-2x fa-chevron-right issues-list-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "desktop")} /> :
-          null
+          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
         }
         {/* Click to scroll right through list Mobile */}
         { issues_count > 4 && this.state.can_scroll_right_mobile ?
           <i className="fa fa-2x fa-chevron-right issues-list-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "mobile")} /> :
-          null
+          <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
         }
       </div>
     );

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -589,12 +589,12 @@ export default class ItemSupportOpposeRaccoon extends Component {
           {/* Click to scroll left through list Desktop */}
           { positions_count > 7 && this.state.can_scroll_left_desktop ?
             <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "desktop")} /> :
-            null
+            <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
           }
           {/* Click to scroll left through list Mobile */}
           { positions_count > 4 && this.state.can_scroll_left_mobile ?
             <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "mobile")} /> :
-            null
+            <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
           }
           <div className="network-positions-stacked__support-list__container-wrap">
             {/* Show a break-down of the current positions in your network */}
@@ -648,12 +648,12 @@ export default class ItemSupportOpposeRaccoon extends Component {
           {/* Click to scroll right through list Desktop */}
           { positions_count > 7 && this.state.can_scroll_right_desktop ?
             <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "desktop")} /> :
-            null
+            <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
           }
           {/* Click to scroll right through list Mobile */}
           { positions_count > 4 && this.state.can_scroll_right_mobile ?
             <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "mobile")} /> :
-            null
+            <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
           }
         </div> :
         null

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -38,6 +38,8 @@ export default class ItemSupportOpposeRaccoon extends Component {
     this.state = {
       ballot_item_display_name: "",
       ballot_item_we_vote_id: "",
+      can_scroll_desktop: false,
+      can_scroll_mobile: false,
       can_scroll_left_desktop: false,
       can_scroll_left_mobile: false,
       can_scroll_right_desktop: true,
@@ -59,6 +61,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
     this.candidateStoreListener = CandidateStore.addListener(this.onCandidateStoreChange.bind(this));
     this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
     CandidateActions.positionListForBallotItem(this.props.ballotItemWeVoteId);
+    this.setScrollState();
     this.setState({
       ballot_item_display_name: this.props.ballot_item_display_name,
       ballot_item_we_vote_id: this.props.ballotItemWeVoteId,
@@ -72,6 +75,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
+    this.setScrollState();
     this.setState({
       ballot_item_display_name: nextProps.ballot_item_display_name,
       ballot_item_we_vote_id: nextProps.ballotItemWeVoteId,
@@ -97,6 +101,7 @@ export default class ItemSupportOpposeRaccoon extends Component {
   }
 
   onCandidateStoreChange () {
+    this.setScrollState();
     this.setState({
       candidate: CandidateStore.getCandidate(this.state.ballot_item_we_vote_id),
       position_list_from_advisers_followed_by_voter: CandidateStore.getPositionList(this.state.ballot_item_we_vote_id),
@@ -258,6 +263,19 @@ export default class ItemSupportOpposeRaccoon extends Component {
           can_scroll_right_mobile: position + width === new_position,
         });
       }
+    });
+  }
+
+  setScrollState () {
+    const desktop_list = findDOMNode(this.refs[`${this.state.candidate.we_vote_id}-org-list-desktop`]);
+    const mobile_list = findDOMNode(this.refs[`${this.state.candidate.we_vote_id}-org-list-mobile`]);
+    let desktop_list_visible_width = $(desktop_list).width();
+    let desktop_list_width = $(desktop_list).children().eq(0).children().eq(0).width();
+    let mobile_list_visible_width = $(mobile_list).width();
+    let mobile_list_width = $(mobile_list).children().eq(0).children().eq(0).width();
+    this.setState({
+      can_scroll_desktop: desktop_list_visible_width <= desktop_list_width,
+      can_scroll_mobile: mobile_list_visible_width <= mobile_list_width,
     });
   }
 
@@ -587,12 +605,12 @@ export default class ItemSupportOpposeRaccoon extends Component {
       { positions_count ?
         <div className="network-positions-stacked__support-list u-flex u-justify-between u-items-center">
           {/* Click to scroll left through list Desktop */}
-          { positions_count > 7 && this.state.can_scroll_left_desktop ?
+          { this.state.can_scroll_desktop && this.state.can_scroll_left_desktop ?
             <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "desktop")} /> :
             <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
           }
           {/* Click to scroll left through list Mobile */}
-          { positions_count > 4 && this.state.can_scroll_left_mobile ?
+          { this.state.can_scroll_mobile && this.state.can_scroll_left_mobile ?
             <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollLeft.bind(this, "mobile")} /> :
             <i className="fa fa-2x fa-chevron-left network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
           }
@@ -646,12 +664,12 @@ export default class ItemSupportOpposeRaccoon extends Component {
             </span>
           </div>
           {/* Click to scroll right through list Desktop */}
-          { positions_count > 7 && this.state.can_scroll_right_desktop ?
+          { this.state.can_scroll_desktop && this.state.can_scroll_right_desktop ?
             <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon u-cursor--pointer hidden-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "desktop")} /> :
             <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled hidden-xs" aria-hidden="true" />
           }
           {/* Click to scroll right through list Mobile */}
-          { positions_count > 4 && this.state.can_scroll_right_mobile ?
+          { this.state.can_scroll_mobile && this.state.can_scroll_right_mobile ?
             <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon u-cursor--pointer visible-xs" aria-hidden="true" onClick={this.scrollRight.bind(this, "mobile")} /> :
             <i className="fa fa-2x fa-chevron-right network-positions-stacked__support-list__scroll-icon-disabled visible-xs" aria-hidden="true" />
           }

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -157,11 +157,14 @@
     $list-height: 76px;
     $list-height-visible: $list-height - $scrollbar-height;
     $scroll-icon-margin: $space-xxs $space-sm $space-none $space-sm;
+    margin-left: -36px;
+    margin-right: -16px;
 
     &__container-wrap {
       box-sizing: content-box;
       overflow: hidden;
       height: $list-height-visible;
+      flex-grow: 1;
     }
 
     &__container {
@@ -186,6 +189,11 @@
     &__scroll-icon {
       color: $gray-mid;
       margin: $scroll-icon-margin;
+
+      &-disabled {
+        color: transparent;
+        margin: $scroll-icon-margin;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixed the "jump" when scrolling through the issues and organizations lists by keeping the viewable width of each list constant and making the scroll buttons invisible when necessary rather than completely hiding them (#1363). Updated the algorithm for determining whether or not a list is scrollable at all.