### PR TITLE
Intermediate checkin on "slide in" footer profile menu for cordova

### DIFF
--- a/src/js/actions/FriendActions.js
+++ b/src/js/actions/FriendActions.js
@@ -19,18 +19,18 @@ module.exports = {
     Dispatcher.loadEndpoint("friendInviteResponse", {
       voter_we_vote_id: other_voter_we_vote_id,
       kind_of_invite_response: "DELETE_INVITATION_VOTER_SENT_BY_ME"
-    } );
+    });
   },
 
   deleteFriendInviteEmail: function (other_voter_email_address) {
     Dispatcher.loadEndpoint("friendInviteResponse", {
       recipient_voter_email: other_voter_email_address,
       kind_of_invite_response: "DELETE_INVITATION_EMAIL_SENT_BY_ME"
-    } );
+    });
   },
 
   emailBallotData: function ( email_address_array, first_name_array, last_name_array, email_addresses,
-                              invitation_message, ballot_link, sender_email_address, verification_email_sent) {
+                              invitation_message, ballot_link, sender_email_address, verification_email_sent, deviceType) {
     Dispatcher.loadEndpoint("emailBallotData",
       {
         email_address_array: email_address_array,
@@ -40,7 +40,8 @@ module.exports = {
         invitation_message: invitation_message,
         ballot_link: ballot_link,
         sender_email_address: sender_email_address,
-        verification_email_sent: verification_email_sent
+        verification_email_sent: verification_email_sent,
+        device_type: deviceType,
       });
   },
 
@@ -53,7 +54,7 @@ module.exports = {
         last_name_array: last_name_array,
         email_addresses_raw: email_addresses,
         invitation_message: invitation_message,
-        sender_email_address: sender_email_address
+        sender_email_address: sender_email_address,
       });
   },
 

--- a/src/js/components/Ballot/EmailBallotModal.jsx
+++ b/src/js/components/Ballot/EmailBallotModal.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
+import { deviceTypeString } from "../../utils/cordovaUtils";
 import EmailBallotToFriendsModal from "./EmailBallotToFriendsModal";
 import FriendActions from "../../actions/FriendActions";
 import FriendStore from "../../stores/FriendStore";
@@ -99,17 +100,18 @@ export default class EmailBallotModal extends Component {
   }
 
   ballotEmailSend () {
-    let success_message = "";
-    let verification_email_sent = false;
-    success_message = <span>Success! This ballot has been sent to the email address {this.state.sender_email_address} </span>;
+    let successMessage = "";
+    let verificationEmailSent = false;
+    successMessage = <span>Success! This ballot has been sent to the email address {this.state.sender_email_address} </span>;
 
     FriendActions.emailBallotData("", "", "", this.state.sender_email_address, this.state.email_ballot_message,
-      this.state.ballot_link, this.state.sender_email_address, this.state.verification_email_sent);
+      this.state.ballot_link, this.state.sender_email_address, this.state.verification_email_sent, deviceTypeString());
 
     if (!this.hasValidEmail()) {
-      verification_email_sent = true;
-      success_message = <span>Success! This ballot has been sent to the email address {this.state.sender_email_address}. Please check your email and verify your email address to send Ballot to your friends. </span>;
+      verificationEmailSent = true;
+      successMessage = <span>Success! This ballot has been sent to the email address {this.state.sender_email_address}. Please check your email and verify your email address to send Ballot to your friends. </span>;
     }
+
     // After calling the API, reset the form
     this.setState({
       loading: true,
@@ -117,8 +119,8 @@ export default class EmailBallotModal extends Component {
       on_enter_email_addresses_step: true,
       on_ballot_email_sent_step: true,
       showEmailToFriendsModal: false,
-      verification_email_sent: verification_email_sent,
-      success_message: success_message,
+      verification_email_sent: verificationEmailSent,
+      success_message: successMessage,
     });
   }
 

--- a/src/js/components/Ballot/EmailBallotToFriendsModal.jsx
+++ b/src/js/components/Ballot/EmailBallotToFriendsModal.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
+import { deviceTypeString } from "../../utils/cordovaUtils";
 import FriendActions from "../../actions/FriendActions";
 import FriendStore from "../../stores/FriendStore";
 import LoadingWheel from "../LoadingWheel";
@@ -138,7 +139,7 @@ export default class EmailBallotToFriendsModal extends Component {
 
     FriendActions.emailBallotData(this.email_address_array, this.first_name_array,
       this.last_name_array, "", this.state.email_ballot_message, this.props.ballot_link,
-      sender_email_address, this.props.verification_email_sent);
+      sender_email_address, this.props.verification_email_sent, deviceTypeString());
 
     // After calling the API, reset the form
     this.setState({
@@ -292,11 +293,11 @@ export default class EmailBallotToFriendsModal extends Component {
   }
 
   prepareApiArraysFromForm () {
-    var _state = this.state;
-    var result;
-    var tmpEmailArray = _state.email_address_array.slice();
-    var tmpFirstNameArray = _state.first_name_array.slice();
-    var tmpLastNameArray = _state.last_name_array.slice();
+    let _state = this.state;
+    let result;
+    let tmpEmailArray = _state.email_address_array.slice();
+    let tmpFirstNameArray = _state.first_name_array.slice();
+    let tmpLastNameArray = _state.last_name_array.slice();
 
     if (_state.friend1_email_address) {
       result = validateEmail(_state.friend1_email_address);
@@ -403,7 +404,7 @@ export default class EmailBallotToFriendsModal extends Component {
   }
 
   addAnotherInvitation () {
-    var _state = this.state;
+    let _state = this.state;
     if (!_state.row2_open)
       this.setState({ row2_open: true});
     else if (!_state.row3_open)

--- a/src/js/components/Ballot/FacebookBallotModal.jsx
+++ b/src/js/components/Ballot/FacebookBallotModal.jsx
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
-import { isWebApp } from "../../utils/cordovaUtils";
+import { deviceTypeString, isWebApp } from "../../utils/cordovaUtils";
 import FacebookBallotToFriendsModal from "./FacebookBallotToFriendsModal";
 import FacebookActions from "../../actions/FacebookActions";
 import FacebookStore from "../../stores/FacebookStore";
@@ -133,7 +133,7 @@ export default class FacebookBallotModal extends Component {
     }
 
     FriendActions.emailBallotData("", "", "", this.state.sender_email_address, this.state.email_ballot_message,
-      this.state.ballot_link, this.state.sender_email_address, this.state.verification_email_sent);
+      this.state.ballot_link, this.state.sender_email_address, this.state.verification_email_sent, deviceTypeString());
 
     if (!this.hasValidEmail()) {
       verification_email_sent = true;

--- a/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
+++ b/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from "react";
 import { Button } from "react-bootstrap";
+import { deviceTypeString } from "../../utils/cordovaUtils";
 import FacebookActions from "../../actions/FacebookActions";
 import FacebookStore from "../../stores/FacebookStore";
 import FriendActions from "../../actions/FriendActions";
@@ -160,7 +161,7 @@ export default class FacebookBallotToFriendsModal extends Component {
 
     FriendActions.emailBallotData(this.email_address_array, this.first_name_array,
       this.last_name_array, "", this.state.email_ballot_message, this.props.ballot_link,
-      sender_email_address, this.props.verification_email_sent);
+      sender_email_address, this.props.verification_email_sent, deviceTypeString());
 
     // After calling the API, reset the form
     this.setState({
@@ -314,11 +315,11 @@ export default class FacebookBallotToFriendsModal extends Component {
   }
 
   prepareApiArraysFromForm () {
-    var _state = this.state;
-    var result;
-    var tmpEmailArray = _state.email_address_array.slice();
-    var tmpFirstNameArray = _state.first_name_array.slice();
-    var tmpLastNameArray = _state.last_name_array.slice();
+    let _state = this.state;
+    let result;
+    let tmpEmailArray = _state.email_address_array.slice();
+    let tmpFirstNameArray = _state.first_name_array.slice();
+    let tmpLastNameArray = _state.last_name_array.slice();
 
     if (_state.friend1_email_address) {
       result = validateEmail(_state.friend1_email_address);
@@ -425,15 +426,15 @@ export default class FacebookBallotToFriendsModal extends Component {
   }
 
   addAnotherInvitation () {
-    var _state = this.state;
+    let _state = this.state;
     if (!_state.row2_open)
-      this.setState({ row2_open: true});
+      this.setState({ row2_open: true });
     else if (!_state.row3_open)
-      this.setState({ row3_open: true});
+      this.setState({ row3_open: true });
     else if (!_state.row4_open)
-      this.setState({ row4_open: true});
+      this.setState({ row4_open: true });
     else if (!_state.row5_open)
-      this.setState({ row5_open: true});
+      this.setState({ row5_open: true });
   }
 
   allRowsOpen () {
@@ -527,7 +528,7 @@ export default class FacebookBallotToFriendsModal extends Component {
       }
     } else {
       FacebookActions.login();
-      this.setState({on_mobile: true});
+      this.setState({ on_mobile: true });
     }
   }
 

--- a/src/js/components/Navigation/HeaderBarProfileSlideIn.jsx
+++ b/src/js/components/Navigation/HeaderBarProfileSlideIn.jsx
@@ -1,11 +1,9 @@
 import React, { Component, PropTypes } from "react";
 import { Link } from "react-router";
 import Icon from "react-svg-icons";
-import { Panel, Table } from "react-bootstrap";
+import { Table } from "react-bootstrap";
 import { isWebApp, enclosingRectangle, isCordova } from "../../utils/cordovaUtils";
-import { isSpeakerTypeOrganization } from "../../utils/organization-functions";
-// import Slider from "react-slide-out";
-
+import HeaderBarProfileSlideInRow from "./HeaderBarProfileSlideInRow";
 
 export default class HeaderBarProfileSlideIn extends Component {
   static propTypes = {
@@ -33,15 +31,24 @@ export default class HeaderBarProfileSlideIn extends Component {
     enclosingRectangle("HeaderBarProfileSlideIn, ", this.instance);
   }
 
-  imagePlaceholder (speakerType) {
-    let imagePlaceholderString = "";
-    if (isSpeakerTypeOrganization(speakerType)) {
-      imagePlaceholderString = <div id= "anonIcon" className="header-nav__avatar"><Icon name="avatar-generic" width={34} height={34} /></div>;
-    } else {
-      imagePlaceholderString = <div id= "anonIcon" className="header-nav__avatar"><Icon name="avatar-generic" width={34} height={34} /></div>;
-    }
-
-    return imagePlaceholderString;
+  yourAccountIcon (voterPhotoUrlMedium) {
+    return (
+      <span className="header-nav__avatar-wrapper u-cursor--pointer u-flex-none"
+            onClick={this.toggleProfilePopUp} >
+        {voterPhotoUrlMedium ?
+          <div id="js-header-avatar" className="header-nav__avatar-container">
+            <img className="header-nav__avatar"
+                 src={voterPhotoUrlMedium}
+                 height={34}
+                 width={34}
+            />
+          </div> :
+          <div id= "anonIcon" className="header-nav__avatar">
+            <Icon name="avatar-generic" width={34} height={34} />
+          </div>
+        }
+      </span>
+    );
   }
 
   render () {
@@ -56,7 +63,6 @@ export default class HeaderBarProfileSlideIn extends Component {
     let twitterScreenName = this.props.voter.twitter_screen_name;
     let showYourPageFromTwitter = signedInTwitter && twitterScreenName;
     let showYourPageFromFacebook = signedInFacebook && linkedOrganizationWeVoteId && !showYourPageFromTwitter;
-    let speakerType = "V";  // TODO DALE make this dynamic
     let yourVoterGuideTo = null;
     if (showYourPageFromTwitter) {
       yourVoterGuideTo = "/" + twitterScreenName;
@@ -68,133 +74,81 @@ export default class HeaderBarProfileSlideIn extends Component {
 
     /* eslint-disable no-extra-parens */
     let profilePopUpOpen = this.props.profilePopUpOpen ? (isWebApp() ? "profile-menu--open" : "profile-foot-menu--open") : "";
+    let signInColor = isSignedIn ? { fontSize: 28, color: "red" } : { fontSize: 28, color: "green" };
 
     return (
       <div className={profilePopUpOpen}>
-        {/*<div className="page-overlay" onClick={this.hideProfilePopUp} />*/}
-        {/*<td className={isWebApp() ? "profile-menu" : "profile-foot-menu"} ref={ (el) => (this.instance = el) }*/}
-            {/*style={{ marginBottom: 113, maxWidth: 1000, padding: 0, width: "100%" }}>*/}
-          {/*/!* https://www.npmjs.com/package/react-slide-out *!/*/}
-          {/*<Slider*/}
-            {/*verticalOffset={{ bottom: 170, top: 0 }}*/}
-            {/*isOpen*/}
-            {/*onOutsideClick={this.hideProfilePopUp}*/}
-            {/*ref={ (el) => (this.instance = el) }>*/}
-            {/*<Panel className={"just-outside-table"} style={{ backgroundColor: "white", height: "500px", overflowY: "auto", color: "black" }} >*/}
+        <div className={"profile-foot-menu"} ref={ (el) => (this.instance = el)} onClick={this.hideProfilePopUp}>
+          <Table striped bordered condensed hover responsive style={{ borderTop: 40, borderTopColor: "white" }}>
+            <tr className={"slide-in-tr"}>
+              <td colSpan={3} style={{ padding: 15, color: "DarkGrey" }}>
+                <span className="we-vote-promise" style={{ fontSize: 15 }}>Our Promise: We'll never sell your email.</span>
+              </td>
+            </tr>
 
-            <div className={"profile-foot-menu"} ref={ (el) => (this.instance = el)} onClick={this.hideProfilePopUp}>
+            {yourVoterGuideTo &&
+              <HeaderBarProfileSlideInRow onClickAction={this.transitionToYourVoterGuide}
+                                          to={yourVoterGuideTo}
+                                          icon={"fa fa-list"}
+                                          iconStyle={{ fontSize: 20, color: "#1c2f4b" }}
+                                          linkText={"Your Voter Guide"} />
+            }
 
-            <Table striped bordered condensed hover responsive style={{ borderTop: 40, borderTopColor: "white" }}>
+            {this.props.voter && isSignedIn &&
+              <HeaderBarProfileSlideInRow onClickAction={this.hideProfilePopUp}
+                                          to={"/more/sign_in"}
+                                          fullIcon={this.yourAccountIcon(voterPhotoUrlMedium)}
+                                          linkText={"Your Account"} />
+            }
 
-              <tr className={"slide-in-tr"}>
-                <td colSpan={3} style={{ padding: 15, color: "DarkGrey" }}>
-                  <span className="we-vote-promise" style={{ fontSize: 15 }}>Our Promise: We'll never sell your email.</span>
-                </td>
-              </tr>
+            {this.props.voter &&
+              <HeaderBarProfileSlideInRow onClickAction={this.signOutAndHideProfilePopUp}
+                                          to={"/more/sign_in"}
+                                          icon={isSignedIn ? "fa fa-sign-out" : "fa fa-sign-in"}
+                                          iconStyle={signInColor}
+                                          linkText={isSignedIn ? "Sign Out" : "Sign In"} />
+            }
 
-              {yourVoterGuideTo &&
-              <tr className={"slide-in-tr"}>
-                <td className={"slide-in-td-left"}>
-                  <span className="fa fa-list" style={{ fontSize: 20, color: "#1c2f4b" }}/>
-                </td>
-                <td style={{ padding: 15, width: "75%", fontSize: 20 }}>
-                  <Link onClick={this.transitionToYourVoterGuide} to={yourVoterGuideTo}>
-                    <span className="header-slide-out-menu-text-left">Your Voter Guide</span>
-                  </Link>
-                </td>
-              </tr>
-              }
+            { this.props.bookmarks && this.props.bookmarks.length ?
+              <HeaderBarProfileSlideInRow onClickAction={this.hideProfilePopUp}
+                                          to={"/bookmarks"}
+                                          icon={"fa fa-arrow-circle-right"}
+                                          iconStyle={{ fontSize: 28, color: "green" }}
+                                          linkText={"Your Bookmarked Items"} /> : null
+            }
 
-              {this.props.voter && isSignedIn &&
-              <tr className={"slide-in-tr"}>
-                <td className={"slide-in-td-left"}>
-                  <span className="header-nav__avatar-wrapper u-cursor--pointer u-flex-none"
-                        onClick={this.toggleProfilePopUp}>
-                    {voterPhotoUrlMedium ?
-                      <div id="js-header-avatar" className="header-nav__avatar-container">
-                        <img className="header-nav__avatar"
-                             src={voterPhotoUrlMedium}
-                             height={34}
-                             width={34}
-                        />
-                      </div> : this.imagePlaceholder(speakerType)
-                    }
-                  </span>
-                </td>
-                <td className={"slide-in-td-mid"}>
-                  <Link onClick={this.hideProfilePopUp} to="/more/sign_in">Your Account</Link>
-                </td>
-              </tr>
-              }
+            <HeaderBarProfileSlideInRow onClickAction={this.signOutAndHideProfilePopUp}
+                                        to={"/more/howtouse"}
+                                        icon={"fa fa-arrow-circle-right"}
+                                        iconStyle={{ fontSize: 28, color: "green" }}
+                                        linkText={"Getting Started"} />
 
-              {this.props.voter &&
-              <tr className={"slide-in-tr"}>
-                <td className={"slide-in-td-left"}>
-                  <span className={isSignedIn ? "fa fa-sign-out" : "fa fa-sign-in"} style={isSignedIn ? { fontSize: 28, color: "red" } : { fontSize: 28, color: "#ff4921" } }/>
-                </td>
-                <td className={"slide-in-td-mid"}>
-                  <Link onClick={this.signOutAndHideProfilePopUp} to="/more/sign_in">{isSignedIn ? "Sign Out" : "Sign In"}</Link>
-                </td>
-              </tr>
-              }
+            <HeaderBarProfileSlideInRow onClickAction={this.hideProfilePopUp}
+                                        to={"/more/about"}
+                                        icon={"fa fa-users"}
+                                        iconStyle={{ fontSize: 20, color: "#1c2f4b" }}
+                                        linkText={"About We Vote"} />
 
-              {this.props.bookmarks && this.props.bookmarks.length ?
-                <tr className={"slide-in-tr"}>
-                  <td className={"slide-in-td-left"}>
-                    <span className="fa fa-arrow-circle-right" style={{ fontSize: 28, color: "green" }}/>
-                  </td>
-                  <td className={"slide-in-td-mid"}>
-                    <Link onClick={this.signOutAndHideProfilePopUp} to="/bookmarks">Your Bookmarked Items</Link>
-                  </td>
-                </tr> :
-                null
-              }
+            {this.props.weVoteBrandingOff || isCordova() ? null :
+              <HeaderBarProfileSlideInRow onClickAction={this.hideProfilePopUp}
+                                          to={"/more/donate"}
+                                          icon={"fa fa-money"}
+                                          iconStyle={{ fontSize: 20, color: "green" }}
+                                          linkText={"Donate"} />
+            }
 
-              <tr className={"slide-in-tr"}>
-                <td className={"slide-in-td-left"}>
-                  <span className="fa fa-arrow-circle-right" style={{ fontSize: 28, color: "green" }}/>
-                </td>
-                <td className={"slide-in-td-mid"}>
-                  <Link onClick={this.signOutAndHideProfilePopUp} to="/more/howtouse">Getting Started</Link>
-                </td>
-                {/*<td style={{ padding: 15, width: "10%" }}> > </td>*/}
-              </tr>
-
-              <tr className={"slide-in-tr"}>
-                <td className={"slide-in-td-left"}>
-                  <span className="fa fa-users" style={{ fontSize: 20, color: "#1c2f4b" }}/>
-                </td>
-                <td className={"slide-in-td-mid"}>
-                  <Link onClick={this.signOutAndHideProfilePopUp} to="/more/about">About We Vote</Link>
-                </td>
-              </tr>
-
-              {this.props.weVoteBrandingOff || isCordova() ? null :
-                <tr className={"slide-in-tr"}>
-                  <td className={"slide-in-td-left"}>
-                    <span className="fa fa-money" style={{ fontSize: 20, color: "green" }}/>
-                  </td>
-                  <td className={"slide-in-td-mid"}>
-                    <Link onClick={this.signOutAndHideProfilePopUp} to="/more/donate">Donate</Link>
-                  </td>
-                </tr>
-              }
-
-              <tr style={{ height: 50 }}>
-                <td colSpan={3} style={{ padding: 15, paddingBottom: 7, paddingTop: 23 }}>
-                <span className="terms-and-privacy-slide" style={{ fontWeight: 400, fontSize: 14, color: "blue" }}>
-                  <Link onClick={this.hideProfilePopUp} to="/more/terms">Terms of Service</Link>
-                  <span style={{ paddingLeft: 20 }} />
-                  <Link onClick={this.hideProfilePopUp} to="/more/privacy">Privacy Policy</Link>
-                </span>
-                </td>
-              </tr>
-            </Table>
-          {/*</Panel>*/}
-        {/*</Slider>*/}
+            <tr style={{ height: 50 }}>
+              <td colSpan={3} style={{ padding: 15, paddingBottom: 7, paddingTop: 23 }}>
+              <span className="terms-and-privacy-slide" style={{ fontWeight: 400, fontSize: 14, color: "blue" }}>
+                <Link onClick={this.hideProfilePopUp} to="/more/terms">Terms of Service</Link>
+                <span style={{ paddingLeft: 20 }} />
+                <Link onClick={this.hideProfilePopUp} to="/more/privacy">Privacy Policy</Link>
+              </span>
+              </td>
+            </tr>
+          </Table>
         </div>
       </div>
-
     );
   }
 }

--- a/src/js/components/Navigation/HeaderBarProfileSlideInRow.jsx
+++ b/src/js/components/Navigation/HeaderBarProfileSlideInRow.jsx
@@ -1,0 +1,35 @@
+import React, { Component, PropTypes } from "react";
+import { Link } from "react-router";
+
+export default class HeaderBarProfileSlideInRow extends Component {
+  static propTypes = {
+    onClickAction: PropTypes.func.required,
+    icon: PropTypes.string,
+    iconStyle: PropTypes.array,
+    fullIcon: PropTypes.object,
+    linkText: PropTypes.string.required,
+    to: PropTypes.string,
+  };
+
+  constructor (props) {
+    super(props);
+  }
+
+  render () {
+    return (
+      <tr className={"slide-in-tr"}>
+        <td className={"slide-in-td-left"}>
+          <Link onClick={this.props.onClickAction} to={this.props.to}>
+            {this.props.fullIcon ? this.props.fullIcon :
+              <span className={this.props.icon} style={this.props.iconStyle}/>
+            }
+          </Link>
+        </td>
+        <td className={"slide-in-td-mid"}>
+          <Link onClick={this.props.onClickAction} to={this.props.to}>{this.props.linkText}</Link>
+        </td>
+      </tr>
+    );
+  }
+}
+

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -88,3 +88,13 @@ export function enclosingRectangle (objectNameString, instance) {
     ", width " + rect.width +
     ", height " + rect.height);
 }
+
+// webapp, webapp:iOS, webapp:Android
+export function deviceTypeString() {
+  let deviceString = isWebApp() ? "webapp" : "cordova";
+  if (isCordova() && window.device) {
+    deviceString += ":" + device.platform;
+  }
+
+  return deviceString;
+}

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -48,7 +48,7 @@ $space-search-right: 10%;
   top: $space-none;
   position: fixed;
   height: $space-header-height;
-  background: $link-color;
+  background: $gray-light;
   width: 100%;
   opacity: 1;
   z-index: 3;


### PR DESCRIPTION
emailBallotData endpoint now sends a deviceType string so that we can
make the emails have the correct url format for iOS and Android.
HeaderBarProfileSlideIn was refactored to eliminate tons of repetitive
code, now calls the new HeaderBarProfileSlideInRow.
In cordovaUtils, added a new deviceTypeString() that enumerates if
cordova and if ios/andoroid in a string that can be sent to the server.
