### PR TITLE
Did a bulk search-and-replace to change the way we import PropTypes, so we do not import from the main React package any more:  import React\, \{ Component \} from \"react\"\;\nimport PropTypes from \"prop-types\"\;\n

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { ToastContainer } from "react-toastify";
 import BookmarkActions from "./actions/BookmarkActions";
 import cookies from "./utils/cookies";

--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -1,5 +1,6 @@
 /* global google */
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { historyPush } from "../utils/cordovaUtils";
 import LoadingWheel from "../components/LoadingWheel";

--- a/src/js/components/Animation/AnimationStory1.jsx
+++ b/src/js/components/Animation/AnimationStory1.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 
 export default class AnimationStory1 extends Component {

--- a/src/js/components/Animation/AnimationStory2.jsx
+++ b/src/js/components/Animation/AnimationStory2.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 
 export default class AnimationStory2 extends Component {

--- a/src/js/components/Animation/AnimationStory3.jsx
+++ b/src/js/components/Animation/AnimationStory3.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 
 export default class AnimationStory3 extends Component {

--- a/src/js/components/Animation/AnimationStory4.jsx
+++ b/src/js/components/Animation/AnimationStory4.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 
 export default class AnimationStory4 extends Component {

--- a/src/js/components/Animation/AnimationStory5.jsx
+++ b/src/js/components/Animation/AnimationStory5.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 
 export default class AnimationStory5 extends Component {

--- a/src/js/components/Animation/AnimationStory6.jsx
+++ b/src/js/components/Animation/AnimationStory6.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 
 export default class AnimationStory6 extends Component {

--- a/src/js/components/Animation/AnimationStory7.jsx
+++ b/src/js/components/Animation/AnimationStory7.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { historyPush } from "../../utils/cordovaUtils";
 import LoadingWheel from "../../components/LoadingWheel";
 import VoterStore from "../../stores/VoterStore";

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import BallotActions from "../../actions/BallotActions";
 import BallotStore from "../../stores/BallotStore";
 import { cordovaDot, historyPush } from "../../utils/cordovaUtils";

--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import VoterGuideActions from "../../actions/VoterGuideActions";
 import OrganizationFollowToggle from "./OrganizationFollowToggle";

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import IssueActions from "../../actions/IssueActions";
 import IssueFollowToggleSquare from "../Issues/IssueFollowToggleSquare";

--- a/src/js/components/Ballot/BallotIntroFriends.jsx
+++ b/src/js/components/Ballot/BallotIntroFriends.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class BallotIntroFriends extends Component {
   static propTypes = {

--- a/src/js/components/Ballot/BallotIntroIssuesSuccess.jsx
+++ b/src/js/components/Ballot/BallotIntroIssuesSuccess.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import IssuesFollowedDisplayList from "../Issues/IssuesFollowedDisplayList";
 

--- a/src/js/components/Ballot/BallotIntroMission.jsx
+++ b/src/js/components/Ballot/BallotIntroMission.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 
 export default class BallotIntroMission extends Component {

--- a/src/js/components/Ballot/BallotIntroModal.jsx
+++ b/src/js/components/Ballot/BallotIntroModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import Slider from "react-slick";
 // import BallotIntroMission from "./BallotIntroMission";

--- a/src/js/components/Ballot/BallotIntroOrganizations.jsx
+++ b/src/js/components/Ballot/BallotIntroOrganizations.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import VoterGuideActions from "../../actions/VoterGuideActions";
 import OrganizationFollowToggle from "./OrganizationFollowToggle";

--- a/src/js/components/Ballot/BallotIntroPositions.jsx
+++ b/src/js/components/Ballot/BallotIntroPositions.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class BallotIntroPositions extends Component {
   static propTypes = {

--- a/src/js/components/Ballot/BallotIntroShare.jsx
+++ b/src/js/components/Ballot/BallotIntroShare.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class BallotIntroShare extends Component {
   static propTypes = {

--- a/src/js/components/Ballot/BallotIntroVote.jsx
+++ b/src/js/components/Ballot/BallotIntroVote.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class BallotIntroVote extends Component {
   static propTypes = {

--- a/src/js/components/Ballot/BallotItem.jsx
+++ b/src/js/components/Ballot/BallotItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import CandidateList from "../Ballot/CandidateList";
 import MeasureItem from "../Ballot/MeasureItem";
 import BookmarkToggle from "../Bookmarks/BookmarkToggle";

--- a/src/js/components/Ballot/BallotItemCompressed.jsx
+++ b/src/js/components/Ballot/BallotItemCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import MeasureItemCompressed from "../../components/Ballot/MeasureItemCompressed";
 import OfficeItemCompressedRaccoon from "../../components/Ballot/OfficeItemCompressedRaccoon";
 

--- a/src/js/components/Ballot/BallotItemReadyToVote.jsx
+++ b/src/js/components/Ballot/BallotItemReadyToVote.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import MeasureItemReadyToVote from "../../components/Ballot/MeasureItemReadyToVote";
 import OfficeItemReadyToVote from "../../components/Ballot/OfficeItemReadyToVote";
 

--- a/src/js/components/Ballot/BallotStatusMessage.jsx
+++ b/src/js/components/Ballot/BallotStatusMessage.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import moment from "moment";
 import cookies from "../../utils/cookies";
 

--- a/src/js/components/Ballot/BallotSummaryModal.jsx
+++ b/src/js/components/Ballot/BallotSummaryModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import BallotSideBar from "../Navigation/BallotSideBar";
 

--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import BookmarkToggle from "../Bookmarks/BookmarkToggle";
 import CandidateStore from "../../stores/CandidateStore";

--- a/src/js/components/Ballot/CandidateList.jsx
+++ b/src/js/components/Ballot/CandidateList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import CandidateItem from "../../components/Ballot/CandidateItem";
 
 // This is related to components/VoterGuide/OrganizationVoterGuideCandidateList.jsx

--- a/src/js/components/Ballot/CandidateModal.jsx
+++ b/src/js/components/Ballot/CandidateModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateStore from "../../stores/CandidateStore";

--- a/src/js/components/Ballot/EmailBallotModal.jsx
+++ b/src/js/components/Ballot/EmailBallotModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { deviceTypeString } from "../../utils/cordovaUtils";
 import EmailBallotToFriendsModal from "./EmailBallotToFriendsModal";

--- a/src/js/components/Ballot/EmailBallotToFriendsModal.jsx
+++ b/src/js/components/Ballot/EmailBallotToFriendsModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { deviceTypeString } from "../../utils/cordovaUtils";
 import FriendActions from "../../actions/FriendActions";

--- a/src/js/components/Ballot/FacebookBallotModal.jsx
+++ b/src/js/components/Ballot/FacebookBallotModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { deviceTypeString, isWebApp } from "../../utils/cordovaUtils";
 import FacebookBallotToFriendsModal from "./FacebookBallotToFriendsModal";

--- a/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
+++ b/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { deviceTypeString } from "../../utils/cordovaUtils";
 import FacebookActions from "../../actions/FacebookActions";

--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { historyPush } from "../../utils/cordovaUtils";
 import ItemActionBar from "../Widgets/ItemActionBar";

--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { historyPush } from "../../utils/cordovaUtils";
 import VoterGuideStore from "../../stores/VoterGuideStore";

--- a/src/js/components/Ballot/MeasureItemReadyToVote.jsx
+++ b/src/js/components/Ballot/MeasureItemReadyToVote.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { cordovaDot } from "../../utils/cordovaUtils";
 import VoterGuideStore from "../../stores/VoterGuideStore";

--- a/src/js/components/Ballot/MeasureModal.jsx
+++ b/src/js/components/Ballot/MeasureModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import GuideList from "../VoterGuide/GuideList";
 import ItemActionBar from "../Widgets/ItemActionBar";

--- a/src/js/components/Ballot/OfficeItem.jsx
+++ b/src/js/components/Ballot/OfficeItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import BookmarkToggle from "../Bookmarks/BookmarkToggle";
 import { capitalizeString } from "../../utils/textFormat";

--- a/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import { Link } from "react-router";
 import TextTruncate from "react-text-truncate";

--- a/src/js/components/Ballot/OfficeItemReadyToVote.jsx
+++ b/src/js/components/Ballot/OfficeItemReadyToVote.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { cordovaDot, historyPush } from "../../utils/cordovaUtils";
 import VoterGuideStore from "../../stores/VoterGuideStore";

--- a/src/js/components/Ballot/OrganizationFollowToggle.jsx
+++ b/src/js/components/Ballot/OrganizationFollowToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Tooltip, OverlayTrigger } from "react-bootstrap";
 import OrganizationActions from "../../actions/OrganizationActions";
 import ImageHandler from "../ImageHandler";

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 // import EditPositionAboutCandidateModal from "../../components/VoterGuide/EditPositionAboutCandidateModal";

--- a/src/js/components/Ballot/PositionList.jsx
+++ b/src/js/components/Ballot/PositionList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import PositionItem from "./PositionItem";
 
 export default class PositionList extends Component {

--- a/src/js/components/Ballot/PositionsNotShownList.jsx
+++ b/src/js/components/Ballot/PositionsNotShownList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";

--- a/src/js/components/Ballot/SelectAddressModal.jsx
+++ b/src/js/components/Ballot/SelectAddressModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import AddressBox from "../../components/AddressBox";
 import { calculateBallotBaseUrl } from "../../utils/textFormat";

--- a/src/js/components/Ballot/SelectBallotModal.jsx
+++ b/src/js/components/Ballot/SelectBallotModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import BallotElectionList from "./BallotElectionList";
 import BallotLocationChoices from "../Navigation/BallotLocationChoices";

--- a/src/js/components/Bookmarks/BookmarkItem.jsx
+++ b/src/js/components/Bookmarks/BookmarkItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { historyPush } from "../../utils/cordovaUtils";
 import ItemSupportOpposeCounts from "../../components/Widgets/ItemSupportOpposeCounts";

--- a/src/js/components/Bookmarks/BookmarkToggle.jsx
+++ b/src/js/components/Bookmarks/BookmarkToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal, Tooltip, OverlayTrigger } from "react-bootstrap";
 import BookmarkStore from "../../stores/BookmarkStore";
 import BookmarkActions from "../../actions/BookmarkActions";

--- a/src/js/components/Connect/AddFacebookFriends.jsx
+++ b/src/js/components/Connect/AddFacebookFriends.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";
 import FacebookActions from "../../actions/FacebookActions";
 import FacebookStore from "../../stores/FacebookStore";

--- a/src/js/components/Connect/CheckBox.jsx
+++ b/src/js/components/Connect/CheckBox.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../../utils/cordovaUtils";
 import ImageHandler from "../ImageHandler";
 

--- a/src/js/components/Connect/CurrentFriendTinyDisplay.jsx
+++ b/src/js/components/Connect/CurrentFriendTinyDisplay.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ImageHandler from "../../components/ImageHandler";
 
 // CurrentFriendTinyDisplay is used by ItemTinyOpinionsToFollow for viewing the logos/icons for voter guides

--- a/src/js/components/Connect/CurrentFriends.jsx
+++ b/src/js/components/Connect/CurrentFriends.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import CurrentFriendTinyDisplay from "../../components/Connect/CurrentFriendTinyDisplay";

--- a/src/js/components/Connect/FacebookFriendCard.jsx
+++ b/src/js/components/Connect/FacebookFriendCard.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ImageHandler from "../../components/ImageHandler";
 
 export default class FacebookFriendCard extends Component {

--- a/src/js/components/Connect/FacebookFriendTinyDisplay.jsx
+++ b/src/js/components/Connect/FacebookFriendTinyDisplay.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ImageHandler from "../../components/ImageHandler";
 
 export default class FacebookFriendTinyDisplay extends Component {

--- a/src/js/components/Connect/FacebookFriendsDisplay.jsx
+++ b/src/js/components/Connect/FacebookFriendsDisplay.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import FacebookFriendTinyDisplay from "../../components/Connect/FacebookFriendTinyDisplay";

--- a/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
+++ b/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import FollowToggle from "../../components/Widgets/FollowToggle";

--- a/src/js/components/Donation/DonationCancelOrRefund.jsx
+++ b/src/js/components/Donation/DonationCancelOrRefund.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Table, Modal, Button } from "react-bootstrap";
 import DonateActions from "../../actions/DonateActions";
 import moment from "moment";

--- a/src/js/components/Donation/DonationError.jsx
+++ b/src/js/components/Donation/DonationError.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Label } from "react-bootstrap";
 
 export default class DonationError extends Component {

--- a/src/js/components/Donation/DonationForm.jsx
+++ b/src/js/components/Donation/DonationForm.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { cordovaDot, historyPush } from "../../utils/cordovaUtils";
 import DonateActions from "../../actions/DonateActions";

--- a/src/js/components/Donation/DonationList.jsx
+++ b/src/js/components/Donation/DonationList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import {Table, Panel} from "react-bootstrap";
 import moment from "moment";
 import VoterStore from "../../stores/VoterStore";

--- a/src/js/components/Facebook/FacebookDownloadPicture.jsx
+++ b/src/js/components/Facebook/FacebookDownloadPicture.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 
 import FacebookActions from "../../actions/FacebookActions";
 

--- a/src/js/components/Facebook/FacebookPicture.jsx
+++ b/src/js/components/Facebook/FacebookPicture.jsx
@@ -1,4 +1,5 @@
-import React, {PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 
 import FacebookConstants from "../../constants/FacebookConstants";
 

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { historyPush } from "../../utils/cordovaUtils";
 import LoadingWheel from "../LoadingWheel";

--- a/src/js/components/Friends/FriendDisplayForList.jsx
+++ b/src/js/components/Friends/FriendDisplayForList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import FriendToggle from "../Friends/FriendToggle";
 import ImageHandler from "../../components/ImageHandler";

--- a/src/js/components/Friends/FriendDisplayForListCompressed.jsx
+++ b/src/js/components/Friends/FriendDisplayForListCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 

--- a/src/js/components/Friends/FriendInvitationDisplayForList.jsx
+++ b/src/js/components/Friends/FriendInvitationDisplayForList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import FriendInvitationToggle from "../Friends/FriendInvitationToggle";
 import ImageHandler from "../../components/ImageHandler";

--- a/src/js/components/Friends/FriendInvitationEmailForList.jsx
+++ b/src/js/components/Friends/FriendInvitationEmailForList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import FriendActions from "../../actions/FriendActions";

--- a/src/js/components/Friends/FriendInvitationList.jsx
+++ b/src/js/components/Friends/FriendInvitationList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FriendInvitationDisplayForList from "./FriendInvitationDisplayForList";
 import FriendInvitationEmailForList from "./FriendInvitationEmailForList";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";

--- a/src/js/components/Friends/FriendInvitationProcessedDisplayForList.jsx
+++ b/src/js/components/Friends/FriendInvitationProcessedDisplayForList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 import { numberWithCommas, removeTwitterNameFromDescription } from "../../utils/textFormat";

--- a/src/js/components/Friends/FriendInvitationProcessedList.jsx
+++ b/src/js/components/Friends/FriendInvitationProcessedList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FriendInvitationProcessedDisplayForList from "./FriendInvitationProcessedDisplayForList";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 

--- a/src/js/components/Friends/FriendInvitationToggle.jsx
+++ b/src/js/components/Friends/FriendInvitationToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import FriendActions from "../../actions/FriendActions";
 import FriendStore from "../../stores/FriendStore";

--- a/src/js/components/Friends/FriendList.jsx
+++ b/src/js/components/Friends/FriendList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FriendDisplayForList from "./FriendDisplayForList";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 

--- a/src/js/components/Friends/FriendListCompressed.jsx
+++ b/src/js/components/Friends/FriendListCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FriendDisplayForListCompressed from "./FriendDisplayForListCompressed";
 
 export default class FriendListCompressed extends Component {

--- a/src/js/components/Friends/FriendToggle.jsx
+++ b/src/js/components/Friends/FriendToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import FriendActions from "../../actions/FriendActions";
 import FriendStore from "../../stores/FriendStore";

--- a/src/js/components/Friends/SuggestedFriendDisplayForList.jsx
+++ b/src/js/components/Friends/SuggestedFriendDisplayForList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import SuggestedFriendToggle from "../Friends/SuggestedFriendToggle";
 import ImageHandler from "../../components/ImageHandler";

--- a/src/js/components/Friends/SuggestedFriendList.jsx
+++ b/src/js/components/Friends/SuggestedFriendList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import SuggestedFriendDisplayForList from "./SuggestedFriendDisplayForList";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 

--- a/src/js/components/Friends/SuggestedFriendToggle.jsx
+++ b/src/js/components/Friends/SuggestedFriendToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import FriendActions from "../../actions/FriendActions";
 import FriendStore from "../../stores/FriendStore";

--- a/src/js/components/ImageHandler.jsx
+++ b/src/js/components/ImageHandler.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot } from "../utils/cordovaUtils";
 
 export default class ImageHandler extends Component {

--- a/src/js/components/InfoIconAction.jsx
+++ b/src/js/components/InfoIconAction.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class InfoIconAction extends Component {
   static propTypes = {

--- a/src/js/components/Intro/IntroNetworkDefinition.jsx
+++ b/src/js/components/Intro/IntroNetworkDefinition.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { cordovaDot, isCordova } from "../../utils/cordovaUtils";
 

--- a/src/js/components/Intro/IntroNetworkSafety.jsx
+++ b/src/js/components/Intro/IntroNetworkSafety.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { cordovaDot, isCordova } from "../../utils/cordovaUtils";
 
 /*

--- a/src/js/components/Intro/IntroNetworkScore.jsx
+++ b/src/js/components/Intro/IntroNetworkScore.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { isCordova } from "../../utils/cordovaUtils";
 

--- a/src/js/components/Issues/IssueCard.jsx
+++ b/src/js/components/Issues/IssueCard.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ImageHandler from "../../components/ImageHandler";
 import IssueFollowToggleButton from "../../components/Issues/IssueFollowToggleButton";
 import IssueStore from "../../stores/IssueStore";

--- a/src/js/components/Issues/IssueFollowToggle.jsx
+++ b/src/js/components/Issues/IssueFollowToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import IssueActions from "../../actions/IssueActions";
 import ImageHandler from "../ImageHandler";

--- a/src/js/components/Issues/IssueFollowToggleButton.jsx
+++ b/src/js/components/Issues/IssueFollowToggleButton.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import IssueActions from "../../actions/IssueActions";
 import IssueStore from "../../stores/IssueStore";

--- a/src/js/components/Issues/IssueImageDisplay.jsx
+++ b/src/js/components/Issues/IssueImageDisplay.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ImageHandler from "../../components/ImageHandler";
 
 // IssueImageDisplay is used by IssuesDisplayListWithOrganizationPopovers for viewing the icons for issues

--- a/src/js/components/Issues/IssueLinkToggle.jsx
+++ b/src/js/components/Issues/IssueLinkToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import {Button} from "react-bootstrap";
 import ImageHandler from "../ImageHandler";
 import IssueActions from "../../actions/IssueActions";

--- a/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
+++ b/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import IssueCard from "./IssueCard";
 import IssueImageDisplay from "./IssueImageDisplay";

--- a/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
+++ b/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import { findDOMNode } from "react-dom";
 import $ from "jquery";

--- a/src/js/components/Issues/OrganizationListUnderIssue.jsx
+++ b/src/js/components/Issues/OrganizationListUnderIssue.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FollowToggle from "../Widgets/FollowToggle";
 import ImageHandler from "../../components/ImageHandler";
 import IssueStore from "../../stores/IssueStore";

--- a/src/js/components/LanguageSwitchNavigation.jsx
+++ b/src/js/components/LanguageSwitchNavigation.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 
 export default class LanguageSwitchNavigation extends Component {

--- a/src/js/components/Navigation/AddFriendsFilter.jsx
+++ b/src/js/components/Navigation/AddFriendsFilter.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class AddFriendsFilter extends Component {
   static propTypes = {

--- a/src/js/components/Navigation/BallotFilter.jsx
+++ b/src/js/components/Navigation/BallotFilter.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import moment from "moment";
 

--- a/src/js/components/Navigation/BallotLocationButton.jsx
+++ b/src/js/components/Navigation/BallotLocationButton.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import BallotStore from "../../stores/BallotStore";
 import { shortenText } from "../../utils/textFormat";

--- a/src/js/components/Navigation/BallotLocationChoices.jsx
+++ b/src/js/components/Navigation/BallotLocationChoices.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import BallotActions from "../../actions/BallotActions";
 import BallotStore from "../../stores/BallotStore";
 import ElectionStore from "../../stores/ElectionStore";

--- a/src/js/components/Navigation/BallotSideBar.jsx
+++ b/src/js/components/Navigation/BallotSideBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import BallotStore from "../../stores/BallotStore";
 import BallotSideBarLink from "./BallotSideBarLink";

--- a/src/js/components/Navigation/BallotSideBarLink.jsx
+++ b/src/js/components/Navigation/BallotSideBarLink.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { capitalizeString, sentenceCaseString } from "../../utils/textFormat";
 
 

--- a/src/js/components/Navigation/BallotTabsRaccoon.jsx
+++ b/src/js/components/Navigation/BallotTabsRaccoon.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 
 export default class BallotTabsRaccoon extends Component {

--- a/src/js/components/Navigation/FollowingFilter.jsx
+++ b/src/js/components/Navigation/FollowingFilter.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 
 export default class FollowingFilter extends Component {

--- a/src/js/components/Navigation/FooterBarCordova.jsx
+++ b/src/js/components/Navigation/FooterBarCordova.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import BallotStore from "../../stores/BallotStore";
 import BookmarkStore from "../../stores/BookmarkStore";

--- a/src/js/components/Navigation/GettingStartedBarItem.jsx
+++ b/src/js/components/Navigation/GettingStartedBarItem.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { cordovaDot } from "../../utils/cordovaUtils";
 import OpenExternalWebSite from "../../utils/OpenExternalWebSite";

--- a/src/js/components/Navigation/HeaderBackToBar.jsx
+++ b/src/js/components/Navigation/HeaderBackToBar.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Icon from "react-svg-icons";
 import BallotStore from "../../stores/BallotStore";

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Icon from "react-svg-icons";
 import BallotStore from "../../stores/BallotStore";

--- a/src/js/components/Navigation/HeaderBarAboutMenu.jsx
+++ b/src/js/components/Navigation/HeaderBarAboutMenu.jsx
@@ -1,5 +1,7 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
+
 
 export default class HeaderBarAboutMenu extends Component {
   static propTypes = {

--- a/src/js/components/Navigation/HeaderBarProfilePopUp.jsx
+++ b/src/js/components/Navigation/HeaderBarProfilePopUp.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { isWebApp, enclosingRectangle, isCordova } from "../../utils/cordovaUtils";
 

--- a/src/js/components/Navigation/HeaderBarProfileSlideIn.jsx
+++ b/src/js/components/Navigation/HeaderBarProfileSlideIn.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Icon from "react-svg-icons";
 import { Table } from "react-bootstrap";

--- a/src/js/components/Navigation/HeaderGettingStartedBar.jsx
+++ b/src/js/components/Navigation/HeaderGettingStartedBar.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import BallotIntroFollowIssues from "../../components/Ballot/BallotIntroFollowIssues";

--- a/src/js/components/Navigation/SelectVoterGuidesSideBar.jsx
+++ b/src/js/components/Navigation/SelectVoterGuidesSideBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ElectionStore from "../../stores/ElectionStore";
 import SelectVoterGuidesSideBarLink from "./SelectVoterGuidesSideBarLink";
 import VoterGuideStore from "../../stores/VoterGuideStore";

--- a/src/js/components/Navigation/SelectVoterGuidesSideBarLink.jsx
+++ b/src/js/components/Navigation/SelectVoterGuidesSideBarLink.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { capitalizeString, sentenceCaseString } from "../../utils/textFormat";
 

--- a/src/js/components/Navigation/SettingsPersonalSideBar.jsx
+++ b/src/js/components/Navigation/SettingsPersonalSideBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 
 

--- a/src/js/components/Navigation/VoterGuideSettingsSideBar.jsx
+++ b/src/js/components/Navigation/VoterGuideSettingsSideBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ElectionStore from "../../stores/ElectionStore";
 

--- a/src/js/components/Network/NetworkFriends.jsx
+++ b/src/js/components/Network/NetworkFriends.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import FriendListCompressed from "../Friends/FriendListCompressed";
 import FriendActions from "../../actions/FriendActions";

--- a/src/js/components/Network/NetworkIssuesFollowed.jsx
+++ b/src/js/components/Network/NetworkIssuesFollowed.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import IssueActions from "../../actions/IssueActions";
 import IssueFollowToggleSquare from "../Issues/IssueFollowToggleSquare";

--- a/src/js/components/Network/NetworkIssuesToFollow.jsx
+++ b/src/js/components/Network/NetworkIssuesToFollow.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Helmet from "react-helmet";
 import IssueActions from "../../actions/IssueActions";

--- a/src/js/components/Network/NetworkOpinions.jsx
+++ b/src/js/components/Network/NetworkOpinions.jsx
@@ -3,7 +3,8 @@ import VoterGuideStore from "../../stores/VoterGuideStore";
 import SearchGuidesToFollowBox from "../Search/SearchGuidesToFollowBox";
 import GuideList from "../VoterGuide/GuideList";
 import { Link } from "react-router";
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 
 export default class NetworkOpinions extends Component {

--- a/src/js/components/Network/NetworkOpinionsFollowed.jsx
+++ b/src/js/components/Network/NetworkOpinionsFollowed.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import OrganizationStore from "../../stores/OrganizationStore";
 import OrganizationActions from "../../actions/OrganizationActions";

--- a/src/js/components/Organization/OpinionsFollowedList.jsx
+++ b/src/js/components/Organization/OpinionsFollowedList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FollowToggle from "../Widgets/FollowToggle";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationDisplayForList from "./OrganizationDisplayForList";

--- a/src/js/components/Organization/OpinionsFollowedListCompressed.jsx
+++ b/src/js/components/Organization/OpinionsFollowedListCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FollowToggle from "../Widgets/FollowToggle";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationDisplayForListCompressed from "./OrganizationDisplayForListCompressed";

--- a/src/js/components/Organization/OpinionsIgnoredList.jsx
+++ b/src/js/components/Organization/OpinionsIgnoredList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FollowToggle from "../Widgets/FollowToggle";
 import VoterGuideDisplayForList from "../VoterGuide/VoterGuideDisplayForList";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";

--- a/src/js/components/Organization/OrganizationDisplayForList.jsx
+++ b/src/js/components/Organization/OrganizationDisplayForList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 import { removeTwitterNameFromDescription } from "../../utils/textFormat";

--- a/src/js/components/Organization/OrganizationDisplayForListCompressed.jsx
+++ b/src/js/components/Organization/OrganizationDisplayForListCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../ImageHandler";
 

--- a/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
+++ b/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import OrganizationCard from "../VoterGuide/OrganizationCard";
 import OrganizationTinyDisplay from "../VoterGuide/OrganizationTinyDisplay";

--- a/src/js/components/Search/SearchBar.jsx
+++ b/src/js/components/Search/SearchBar.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class SearchBar extends Component {
   static propTypes = {

--- a/src/js/components/SearchAllBox.jsx
+++ b/src/js/components/SearchAllBox.jsx
@@ -1,5 +1,6 @@
 /* global $ */
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import BallotActions from "../actions/BallotActions";
 import classNames from "classnames";
 import { Link } from "react-router";

--- a/src/js/components/Settings/SettingsAddress.jsx
+++ b/src/js/components/Settings/SettingsAddress.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import AddressBox from "../../components/AddressBox";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";

--- a/src/js/components/Settings/SettingsElection.jsx
+++ b/src/js/components/Settings/SettingsElection.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";
 import BallotElectionList from "../../components/Ballot/BallotElectionList";

--- a/src/js/components/Settings/SettingsWidgetAccountType.jsx
+++ b/src/js/components/Settings/SettingsWidgetAccountType.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import LoadingWheel from "../../components/LoadingWheel";
 import OrganizationActions from "../../actions/OrganizationActions";

--- a/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
+++ b/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { isSpeakerTypeOrganization } from "../../utils/organization-functions";
 import LoadingWheel from "../../components/LoadingWheel";

--- a/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { isSpeakerTypeOrganization } from "../../utils/organization-functions";
 import LoadingWheel from "../../components/LoadingWheel";
 import OrganizationActions from "../../actions/OrganizationActions";

--- a/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { isSpeakerTypeOrganization } from "../../utils/organization-functions";
 import LoadingWheel from "../../components/LoadingWheel";
 import OrganizationActions from "../../actions/OrganizationActions";

--- a/src/js/components/Settings/VoterGuideSettingsGeneral.jsx
+++ b/src/js/components/Settings/VoterGuideSettingsGeneral.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";
 import LoadingWheel from "../../components/LoadingWheel";

--- a/src/js/components/Twitter/ParsedTwitterDescription.jsx
+++ b/src/js/components/Twitter/ParsedTwitterDescription.jsx
@@ -1,5 +1,5 @@
-import React, { PropTypes } from "react";
-//import PropTypes from "prop-types";
+import React from "react";
+import PropTypes from "prop-types";
 
 const ParsedTwitterDescription = (props) => {
   const parseTextForTwitterLinks = (text) => {

--- a/src/js/components/Twitter/TwitterAccountCard.jsx
+++ b/src/js/components/Twitter/TwitterAccountCard.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ParsedTwitterDescription from "../Twitter/ParsedTwitterDescription";
 import ImageHandler from "../../components/ImageHandler";
 import OpenExternalWebSite from "../../utils/OpenExternalWebSite";

--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { $ajax } from "../../utils/service";
 import cookies from "../../utils/cookies";

--- a/src/js/components/VoterEmailAddressEntry.jsx
+++ b/src/js/components/VoterEmailAddressEntry.jsx
@@ -120,7 +120,6 @@ export default class VoterEmailAddressEntry extends Component {
       return LoadingWheel;
     }
     //console.log("Entering VoterEmailAddressEntry.jsx");
-
     const email_address_status_html = <span>
       { this.state.email_address_status.email_address_already_owned_by_other_voter &&
         !this.state.email_address_status.link_to_sign_in_email_sent ?

--- a/src/js/components/VoterGuide/ChooseElectionForVoterGuide.jsx
+++ b/src/js/components/VoterGuide/ChooseElectionForVoterGuide.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import BallotStore from "../../stores/BallotStore";
 import { cordovaDot } from "../../utils/cordovaUtils";
 import ElectionActions from "../../actions/ElectionActions";

--- a/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
+++ b/src/js/components/VoterGuide/EditPositionAboutCandidateModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import CandidateStore from "../../stores/CandidateStore";
 import FollowToggle from "../../components/Widgets/FollowToggle";

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 import CandidateStore from "../../stores/CandidateStore";
 import FollowToggle from "../Widgets/FollowToggle";

--- a/src/js/components/VoterGuide/ItemTinyOpinionsToFollow.jsx
+++ b/src/js/components/VoterGuide/ItemTinyOpinionsToFollow.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import OrganizationCard from "./OrganizationCard";

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import FollowToggle from "../../components/Widgets/FollowToggle";
 import ImageHandler from "../../components/ImageHandler";

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../ImageHandler";
 import ItemActionBar from "../Widgets/ItemActionBar";

--- a/src/js/components/VoterGuide/OrganizationTinyDisplay.jsx
+++ b/src/js/components/VoterGuide/OrganizationTinyDisplay.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ImageHandler from "../../components/ImageHandler";
 
 // OrganizationTinyDisplay is used by ItemTinyOpinionsToFollow for viewing the logos/icons for voter guides

--- a/src/js/components/VoterGuide/OrganizationVoterGuideCandidateItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideCandidateItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import BookmarkToggle from "../Bookmarks/BookmarkToggle";
 import CandidateStore from "../../stores/CandidateStore";

--- a/src/js/components/VoterGuide/OrganizationVoterGuideCandidateList.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideCandidateList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import OrganizationVoterGuideCandidateItem from "../../components/VoterGuide/OrganizationVoterGuideCandidateItem";
 
 // This is related to components/Ballot/CandidateList.jsx

--- a/src/js/components/VoterGuide/OrganizationVoterGuideCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideCard.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import { historyPush } from "../../utils/cordovaUtils";

--- a/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import LoadingWheel from "../LoadingWheel";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationStore from "../../stores/OrganizationStore";

--- a/src/js/components/VoterGuide/OrganizationsNotShownList.jsx
+++ b/src/js/components/VoterGuide/OrganizationsNotShownList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 import LoadingWheel from "../../components/LoadingWheel";

--- a/src/js/components/VoterGuide/PledgeToSupportOrganizationButton.jsx
+++ b/src/js/components/VoterGuide/PledgeToSupportOrganizationButton.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { shortenText } from "../../utils/textFormat";
 import VoterGuideStore from "../../stores/VoterGuideStore";

--- a/src/js/components/VoterGuide/PledgeToSupportOrganizationStatusBar.jsx
+++ b/src/js/components/VoterGuide/PledgeToSupportOrganizationStatusBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { ProgressBar } from "react-bootstrap";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import VoterStore from "../../stores/VoterStore";

--- a/src/js/components/VoterGuide/PledgeToVoteButton.jsx
+++ b/src/js/components/VoterGuide/PledgeToVoteButton.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { shortenText } from "../../utils/textFormat";
 import VoterGuideStore from "../../stores/VoterGuideStore";

--- a/src/js/components/VoterGuide/PledgeToVoteStatusBar.jsx
+++ b/src/js/components/VoterGuide/PledgeToVoteStatusBar.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { ProgressBar } from "react-bootstrap";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import VoterStore from "../../stores/VoterStore";

--- a/src/js/components/VoterGuide/VoterGuideBallot.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallot.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { Link } from "react-router";
 import AddressBox from "../../components/AddressBox";

--- a/src/js/components/VoterGuide/VoterGuideBallotItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallotItemCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import MeasureItemCompressed from "../../components/Ballot/MeasureItemCompressed";
 import VoterGuideOfficeItemCompressed from "../../components/VoterGuide/VoterGuideOfficeItemCompressed";
 

--- a/src/js/components/VoterGuide/VoterGuideDisplayForList.jsx
+++ b/src/js/components/VoterGuide/VoterGuideDisplayForList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 import { removeTwitterNameFromDescription } from "../../utils/textFormat";

--- a/src/js/components/VoterGuide/VoterGuideEditActivityReports.jsx
+++ b/src/js/components/VoterGuide/VoterGuideEditActivityReports.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { historyPush } from "../../utils/cordovaUtils";
 

--- a/src/js/components/VoterGuide/VoterGuideEditAddPositions.jsx
+++ b/src/js/components/VoterGuide/VoterGuideEditAddPositions.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { historyPush } from "../../utils/cordovaUtils";
 

--- a/src/js/components/VoterGuide/VoterGuideEditIndex.jsx
+++ b/src/js/components/VoterGuide/VoterGuideEditIndex.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import { historyPush } from "../../utils/cordovaUtils";

--- a/src/js/components/VoterGuide/VoterGuideEditIssues.jsx
+++ b/src/js/components/VoterGuide/VoterGuideEditIssues.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import { historyPush } from "../../utils/cordovaUtils";

--- a/src/js/components/VoterGuide/VoterGuideEditName.jsx
+++ b/src/js/components/VoterGuide/VoterGuideEditName.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { historyPush } from "../../utils/cordovaUtils";
 

--- a/src/js/components/VoterGuide/VoterGuideFollowers.jsx
+++ b/src/js/components/VoterGuide/VoterGuideFollowers.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import GuideList from "./GuideList";

--- a/src/js/components/VoterGuide/VoterGuideFollowing.jsx
+++ b/src/js/components/VoterGuide/VoterGuideFollowing.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import { Button } from "react-bootstrap";
 import GuideList from "./GuideList";

--- a/src/js/components/VoterGuide/VoterGuideItem.jsx
+++ b/src/js/components/VoterGuide/VoterGuideItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import ImageHandler from "../../components/ImageHandler";
 import { numberWithCommas, removeTwitterNameFromDescription } from "../../utils/textFormat";

--- a/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { historyPush } from "../../utils/cordovaUtils";
 import TextTruncate from "react-text-truncate";

--- a/src/js/components/VoterGuide/VoterGuidePositions.jsx
+++ b/src/js/components/VoterGuide/VoterGuidePositions.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { capitalizeString } from "../../utils/textFormat";
 import Helmet from "react-helmet";
 import BallotStore from "../../stores/BallotStore";
@@ -152,7 +153,7 @@ export default class VoterGuidePositions extends Component {
             <h4 className="h4 card__additional-heading">
                <span className="u-push--sm">{ election_name ? election_name : "This Election"}</span>
               {/*{this.state.ballot_election_list.length > 1 ? <img src={cordovaDot("/img/global/icons/gear-icon.png")} className="hidden-print" role="button" onClick={this.toggleSelectBallotModal}
-                alt={'view your ballots' /> : null}*/}
+                alt='view your ballots' /> : null}*/}
             </h4>
           {/* </OverlayTrigger> */}
           { at_least_one_position_found_for_this_election ?

--- a/src/js/components/VoterGuide/VoterGuideRecommendationsFromOneOrganization.jsx
+++ b/src/js/components/VoterGuide/VoterGuideRecommendationsFromOneOrganization.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import GuideList from "./GuideList";
 

--- a/src/js/components/VoterGuide/VoterPositionItem.jsx
+++ b/src/js/components/VoterGuide/VoterPositionItem.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import BookmarkToggle from "../Bookmarks/BookmarkToggle";
 import ImageHandler from "../ImageHandler";

--- a/src/js/components/Widgets/BrowserPushMessage.jsx
+++ b/src/js/components/Widgets/BrowserPushMessage.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Alert } from "react-bootstrap";
 
 export default class BrowserPushMessage extends Component {

--- a/src/js/components/Widgets/CodeCopier.jsx
+++ b/src/js/components/Widgets/CodeCopier.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ImageHandler from "../ImageHandler";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationStore from "../../stores/OrganizationStore";

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 import CopyToClipboard from "react-copy-to-clipboard";
 

--- a/src/js/components/Widgets/EditAddress.jsx
+++ b/src/js/components/Widgets/EditAddress.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import EditAddressPopover from "./EditAddressPopover";
 import { shortenText } from "../../utils/textFormat";
 

--- a/src/js/components/Widgets/EditAddressInPlace.jsx
+++ b/src/js/components/Widgets/EditAddressInPlace.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import AddressBox from "../AddressBox";
 import { calculateBallotBaseUrl, shortenText } from "../../utils/textFormat";
 

--- a/src/js/components/Widgets/EditAddressPopover.jsx
+++ b/src/js/components/Widgets/EditAddressPopover.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import { shortenText } from "../../utils/textFormat";
 

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import OrganizationActions from "../../actions/OrganizationActions";

--- a/src/js/components/Widgets/FriendsOnlyIndicator.jsx
+++ b/src/js/components/Widgets/FriendsOnlyIndicator.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Tooltip, OverlayTrigger } from "react-bootstrap";
 const Icon = require("react-svg-icons");
 

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal, Tooltip, OverlayTrigger } from "react-bootstrap";
 import { showToastError, showToastSuccess } from "../../utils/showToast";
 import ShareButtonDropdown from "./ShareButtonDropdown";

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ReactPlayer from "react-player";
 import ReadMore from "../../components/Widgets/ReadMore";
 import Textarea from "react-textarea-autosize";

--- a/src/js/components/Widgets/ItemSupportOpposeCheetah.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCheetah.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import { Link } from "react-router";
 import CandidateActions from "../../actions/CandidateActions";

--- a/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeCounts.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Tooltip, OverlayTrigger } from "react-bootstrap";
 import { cordovaDot } from "../../utils/cordovaUtils";
 

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button, OverlayTrigger, Popover } from "react-bootstrap";
 import { findDOMNode } from "react-dom";
 import $ from "jquery";

--- a/src/js/components/Widgets/LearnMore.jsx
+++ b/src/js/components/Widgets/LearnMore.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import TextTruncate from "react-text-truncate";
 
 export default class ReadMore extends Component {

--- a/src/js/components/Widgets/OfficeNameText.jsx
+++ b/src/js/components/Widgets/OfficeNameText.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class OfficeNameText extends Component {
   static propTypes = {

--- a/src/js/components/Widgets/PositionDropdown.jsx
+++ b/src/js/components/Widgets/PositionDropdown.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class PositionDropdown extends Component {
   static propTypes = {

--- a/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
+++ b/src/js/components/Widgets/PositionInformationOnlySnippet.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ReactPlayer from "react-player";
 import OpenExternalWebSite from "../../utils/OpenExternalWebSite";
 import ReadMore from "../../components/Widgets/ReadMore";

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal, Tooltip, OverlayTrigger } from "react-bootstrap";
 import ReactBootstrapToggle from "react-bootstrap-toggle";
 import { showToastSuccess } from "../../utils/showToast";

--- a/src/js/components/Widgets/PositionRatingSnippet.jsx
+++ b/src/js/components/Widgets/PositionRatingSnippet.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import RatingPopover from "../../components/Widgets/RatingPopover";
 import { cordovaDot } from "../../utils/cordovaUtils";
 

--- a/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
+++ b/src/js/components/Widgets/PositionSupportOpposeSnippet.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ReactPlayer from "react-player";
 import { cordovaDot } from "../../utils/cordovaUtils";
 import OpenExternalWebSite from "../../utils/OpenExternalWebSite";

--- a/src/js/components/Widgets/RatingPopover.jsx
+++ b/src/js/components/Widgets/RatingPopover.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { OverlayTrigger, Popover } from "react-bootstrap";
 import { cordovaDot } from "../../utils/cordovaUtils";
 

--- a/src/js/components/Widgets/ReadMore.jsx
+++ b/src/js/components/Widgets/ReadMore.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import TextTruncate from "react-text-truncate";
 
 export default class ReadMore extends Component {

--- a/src/js/components/Widgets/ShareButtonDropdown.jsx
+++ b/src/js/components/Widgets/ShareButtonDropdown.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import CopyLinkModal from "../../components/Widgets/CopyLinkModal";
 
 export default class ShareButtonDropdown extends Component {

--- a/src/js/components/Widgets/ThisIsMeAction.jsx
+++ b/src/js/components/Widgets/ThisIsMeAction.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import VoterStore from "../../stores/VoterStore";
 

--- a/src/js/components/Widgets/ViewSourceModal.jsx
+++ b/src/js/components/Widgets/ViewSourceModal.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Modal } from "react-bootstrap";
 // import { $ajax } from "../../utils/service";
 import $ from "jquery";

--- a/src/js/components/WouldYouLikeToMergeAccounts.jsx
+++ b/src/js/components/WouldYouLikeToMergeAccounts.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Alert, Button } from "react-bootstrap";
 import { historyPush } from "../utils/cordovaUtils";
 

--- a/src/js/components/WouldYouLikeToMergeAccountsOld.jsx
+++ b/src/js/components/WouldYouLikeToMergeAccountsOld.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Alert, Button } from "react-bootstrap";
 import FacebookActions from "../actions/FacebookActions";
 import FacebookStore from "../stores/FacebookStore";

--- a/src/js/routes/Activity.jsx
+++ b/src/js/routes/Activity.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 
 export default class Activity extends Component {

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button, OverlayTrigger, Tooltip } from "react-bootstrap";
 import { Link } from "react-router";
 import AddressBox from "../../components/AddressBox";

--- a/src/js/routes/Ballot/BallotIndex.jsx
+++ b/src/js/routes/Ballot/BallotIndex.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 export default class BallotIndex extends Component {
   static propTypes = {

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateItem from "../../components/Ballot/CandidateItem";

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { capitalizeString } from "../../utils/textFormat";
 import GuideList from "../../components/VoterGuide/GuideList";
 import Helmet from "react-helmet";

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import CandidateList from "../../components/Ballot/CandidateList";
 import { capitalizeString } from "../../utils/textFormat";
 import Helmet from "react-helmet";

--- a/src/js/routes/FacebookInvitableFriends.jsx
+++ b/src/js/routes/FacebookInvitableFriends.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import AnalyticsActions from "../actions/AnalyticsActions";
 import CheckBox from "../components/Connect/CheckBox";

--- a/src/js/routes/Friends.jsx
+++ b/src/js/routes/Friends.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FriendList from "../components/Friends/FriendList";
 import FriendActions from "../actions/FriendActions";
 import FriendStore from "../stores/FriendStore";

--- a/src/js/routes/Intro/Intro.jsx
+++ b/src/js/routes/Intro/Intro.jsx
@@ -1,5 +1,6 @@
 "use strict";
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 const request = require("superagent");
 const web_app_config = require("../../config");

--- a/src/js/routes/Intro/IntroOpinions.jsx
+++ b/src/js/routes/Intro/IntroOpinions.jsx
@@ -1,10 +1,11 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Link } from "react-router";
 import { Button } from "react-bootstrap";
 import SearchGuidesToFollowBox from "../../components/Search/SearchGuidesToFollowBox";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import VoterStore from "../../stores/VoterStore";
 import GuideList from "../../components/VoterGuide/GuideList";
-import { Link } from "react-router";
-import React, {Component, PropTypes } from "react";
 
 export default class IntroOpinionsPage extends Component {
   static propTypes = {

--- a/src/js/routes/IssuesFollowed.jsx
+++ b/src/js/routes/IssuesFollowed.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Helmet from "react-helmet";
 import IssueActions from "../actions/IssueActions";

--- a/src/js/routes/IssuesToFollow.jsx
+++ b/src/js/routes/IssuesToFollow.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Helmet from "react-helmet";
 import IssueActions from "../actions/IssueActions";

--- a/src/js/routes/Network.jsx
+++ b/src/js/routes/Network.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import AnalyticsActions from "../actions/AnalyticsActions";
 import BrowserPushMessage from "../components/Widgets/BrowserPushMessage";

--- a/src/js/routes/Opinions.jsx
+++ b/src/js/routes/Opinions.jsx
@@ -1,9 +1,10 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Link } from "react-router";
 import VoterGuideStore from "../stores/VoterGuideStore";
 import Helmet from "react-helmet";
 import SearchGuidesToFollowBox from "../components/Search/SearchGuidesToFollowBox";
 import GuideList from "../components/VoterGuide/GuideList";
-import { Link } from "react-router";
-import React, {Component, PropTypes } from "react";
 
 /* VISUAL DESIGN HERE: https://invis.io/TR4A1NYAQ */
 

--- a/src/js/routes/OpinionsFollowed.jsx
+++ b/src/js/routes/OpinionsFollowed.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Helmet from "react-helmet";
 import OrganizationActions from "../actions/OrganizationActions";

--- a/src/js/routes/OpinionsIgnored.jsx
+++ b/src/js/routes/OpinionsIgnored.jsx
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Helmet from "react-helmet";
 import VoterGuideStore from "../stores/VoterGuideStore";

--- a/src/js/routes/Process/FacebookSignInProcess.jsx
+++ b/src/js/routes/Process/FacebookSignInProcess.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FacebookActions from "../../actions/FacebookActions";
 import FacebookStore from "../../stores/FacebookStore";
 import { historyPush } from "../../utils/cordovaUtils";

--- a/src/js/routes/Process/FriendInvitationByEmailVerifyProcess.jsx
+++ b/src/js/routes/Process/FriendInvitationByEmailVerifyProcess.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FriendActions from "../../actions/FriendActions";
 import FriendStore from "../../stores/FriendStore";
 import { historyPush } from "../../utils/cordovaUtils";

--- a/src/js/routes/Process/SignInEmailProcess.jsx
+++ b/src/js/routes/Process/SignInEmailProcess.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { historyPush } from "../../utils/cordovaUtils";
 import LoadingWheel from "../../components/LoadingWheel";
 import VoterActions from "../../actions/VoterActions";

--- a/src/js/routes/Process/SignInJumpProcess.jsx
+++ b/src/js/routes/Process/SignInJumpProcess.jsx
@@ -1,4 +1,5 @@
-import { Component, PropTypes } from "react";
+import { Component } from "react";
+import PropTypes from "prop-types";
 import { historyPush } from "../../utils/cordovaUtils";
 import LoadingWheel from "../../components/LoadingWheel";
 import VoterActions from "../../actions/VoterActions";

--- a/src/js/routes/Process/TwitterSignInProcess.jsx
+++ b/src/js/routes/Process/TwitterSignInProcess.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { historyPush } from "../../utils/cordovaUtils";
 import TwitterActions from "../../actions/TwitterActions";
 import TwitterStore from "../../stores/TwitterStore";

--- a/src/js/routes/Process/VerifyEmailProcess.jsx
+++ b/src/js/routes/Process/VerifyEmailProcess.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { historyPush } from "../../utils/cordovaUtils";
 import LoadingWheel from "../../components/LoadingWheel";
 import VoterActions from "../../actions/VoterActions";

--- a/src/js/routes/Settings/Location.jsx
+++ b/src/js/routes/Settings/Location.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import AddressBox from "../../components/AddressBox";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";

--- a/src/js/routes/Settings/SettingsDashboard.jsx
+++ b/src/js/routes/Settings/SettingsDashboard.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";

--- a/src/js/routes/Settings/SettingsMenuMobile.jsx
+++ b/src/js/routes/Settings/SettingsMenuMobile.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";

--- a/src/js/routes/Settings/VoterGuideSettingsMenuMobile.jsx
+++ b/src/js/routes/Settings/VoterGuideSettingsMenuMobile.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";

--- a/src/js/routes/Settings/VoterGuidesMenuMobile.jsx
+++ b/src/js/routes/Settings/VoterGuidesMenuMobile.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";

--- a/src/js/routes/VoterGuide/GuidePositionList.jsx
+++ b/src/js/routes/VoterGuide/GuidePositionList.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { Button } from "react-bootstrap";
 import { capitalizeString } from "../../utils/textFormat";

--- a/src/js/routes/VoterGuide/GuidePositionListForVoter.jsx
+++ b/src/js/routes/VoterGuide/GuidePositionListForVoter.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import LoadingWheel from "../../components/LoadingWheel";
 import VoterPositionItem from "../../components/VoterGuide/VoterPositionItem";

--- a/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { Button } from "react-bootstrap";
 import AnalyticsActions from "../../actions/AnalyticsActions";

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideCandidate.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideCandidate.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import CandidateActions from "../../actions/CandidateActions";
 import OrganizationVoterGuideCandidateItem from "../../components/VoterGuide/OrganizationVoterGuideCandidateItem";

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideOffice.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideOffice.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import OrganizationVoterGuideCandidateList from "../../components/VoterGuide/OrganizationVoterGuideCandidateList";
 import { capitalizeString } from "../../utils/textFormat";
 import Helmet from "react-helmet";

--- a/src/js/routes/VoterGuide/PositionListForFriends.jsx
+++ b/src/js/routes/VoterGuide/PositionListForFriends.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import FollowToggle from "../../components/Widgets/FollowToggle";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationCard from "../../components/VoterGuide/OrganizationCard";

--- a/src/js/routes/VoterGuide/UnknownTwitterAccount.jsx
+++ b/src/js/routes/VoterGuide/UnknownTwitterAccount.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import ThisIsMeAction from "../../components/Widgets/ThisIsMeAction";
 import TwitterAccountCard from "../../components/Twitter/TwitterAccountCard";
 

--- a/src/js/routes/VoterGuide/VerifyThisIsMe.jsx
+++ b/src/js/routes/VoterGuide/VerifyThisIsMe.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import CandidateItem from "../../components/Ballot/CandidateItem";

--- a/src/js/routes/VoterGuide/VoterGuideChooseElection.jsx
+++ b/src/js/routes/VoterGuide/VoterGuideChooseElection.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import { cordovaDot, historyPush } from "../../utils/cordovaUtils";

--- a/src/js/routes/Welcome.jsx
+++ b/src/js/routes/Welcome.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Helmet from "react-helmet";
 import { Link } from "react-router";
 import cookies from "../utils/cookies";

--- a/src/js/routes/YourPage.jsx
+++ b/src/js/routes/YourPage.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GuidePositionListForVoter from "./VoterGuide/GuidePositionListForVoter";
 import { historyPush } from "../utils/cordovaUtils";
 import LoadingWheel from "../components/LoadingWheel";


### PR DESCRIPTION
Did a bulk search-and-replace to change the way we import PropTypes, so we do not import from the main React package any more:  import React\, \{ Component \} from \"react\"\;\nimport PropTypes from \"prop-types\"\;\n