### PR TITLE
Type error voter guide ballot

### DIFF
--- a/src/js/components/Navigation/HeaderBarProfileSlideIn.jsx
+++ b/src/js/components/Navigation/HeaderBarProfileSlideIn.jsx
@@ -57,7 +57,7 @@ export default class HeaderBarProfileSlideIn extends Component {
   }
 
   render () {
-    console.log("STEVE STEVE HeaderBarProfileSlideIn render");
+    // console.log("STEVE STEVE HeaderBarProfileSlideIn render");
     let isSignedIn = this.props.voter.is_signed_in;
     let voter = this.props.voter;
     let voterPhotoUrlMedium = voter.voter_photo_url_medium;

--- a/src/js/components/VoterGuide/VoterGuideBallot.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallot.jsx
@@ -68,6 +68,8 @@ export default class VoterGuideBallot extends Component {
       showBallotSummaryModal: false,
       voter_ballot_list: [],
       waiting_for_new_ballot_items: false,
+
+      ballot_item_unfurled_tracker: {},
     };
 
     this.nullFunction = this.nullFunction.bind(this);
@@ -251,6 +253,9 @@ export default class VoterGuideBallot extends Component {
     this.supportStoreListener.remove();
     this.voterGuideStoreListener.remove();
     this.voterStoreListener.remove();
+
+    // save current open/close status to BallotStore
+    BallotActions.voterBallotItemOpenOrClosedSave(this.state.ballot_item_unfurled_tracker);
   }
 
   nullFunction () {
@@ -294,6 +299,20 @@ export default class VoterGuideBallot extends Component {
   toggleBallotSummaryModal () {
     this.setState({
       showBallotSummaryModal: !this.state.showBallotSummaryModal,
+    });
+  }
+
+  updateOfficeDisplayUnfurledTracker = (we_vote_id, status) => {
+    console.log('hi', we_vote_id, status)
+
+    // TODO: Add state prop above -DONE
+    // TODO: Add action function to VoterGuideActions???
+    // TODO: Add state var update in onBallotStoreChange ???
+    // TODO: add store update to componentWillUnmount ???
+
+    const new_ballot_item_unfurled_tracker = { ... this.state.ballot_item_unfurled_tracker, [we_vote_id]: status};
+    this.setState({
+      ballot_item_unfurled_tracker: new_ballot_item_unfurled_tracker
     });
   }
 
@@ -356,6 +375,13 @@ export default class VoterGuideBallot extends Component {
     this.setState({
       ballotElectionList: BallotStore.ballotElectionList(),
     });
+
+
+    if (Object.keys(this.state.ballot_item_unfurled_tracker).length === 0) {
+      this.setState({
+        ballot_item_unfurled_tracker: BallotStore.current_ballot_item_unfurled_tracker
+      });
+    }
   }
 
   onElectionStoreChange () {
@@ -673,6 +699,7 @@ export default class VoterGuideBallot extends Component {
                   {ballot_with_remaining_items.map( (item) => <BallotItemCompressed toggleCandidateModal={this.toggleCandidateModal}
                                                                toggleMeasureModal={this.toggleMeasureModal}
                                                                key={item.we_vote_id}
+                                                               updateOfficeDisplayUnfurledTracker={this.updateOfficeDisplayUnfurledTracker}
                                                                organization={this.props.organization}
                                                                organization_we_vote_id={this.props.organization.organization_we_vote_id}
                                                                {...item} />)}

--- a/src/js/components/VoterGuide/VoterGuideBallot.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallot.jsx
@@ -48,6 +48,7 @@ export default class VoterGuideBallot extends Component {
     super(props);
     this.state = {
       ballotElectionList: [],
+      ballot_item_unfurled_tracker: {},
       ballot_returned_we_vote_id: "",
       ballot_location_shortcut: "",
       candidate_for_modal: {
@@ -68,8 +69,6 @@ export default class VoterGuideBallot extends Component {
       showBallotSummaryModal: false,
       voter_ballot_list: [],
       waiting_for_new_ballot_items: false,
-
-      ballot_item_unfurled_tracker: {},
     };
 
     this.nullFunction = this.nullFunction.bind(this);
@@ -302,20 +301,6 @@ export default class VoterGuideBallot extends Component {
     });
   }
 
-  updateOfficeDisplayUnfurledTracker = (we_vote_id, status) => {
-    console.log('hi', we_vote_id, status)
-
-    // TODO: Add state prop above -DONE
-    // TODO: Add action function to VoterGuideActions???
-    // TODO: Add state var update in onBallotStoreChange ???
-    // TODO: add store update to componentWillUnmount ???
-
-    const new_ballot_item_unfurled_tracker = { ... this.state.ballot_item_unfurled_tracker, [we_vote_id]: status};
-    this.setState({
-      ballot_item_unfurled_tracker: new_ballot_item_unfurled_tracker
-    });
-  }
-
   onVoterStoreChange () {
     // console.log("VoterGuideBallot.jsx onVoterStoreChange");
     if (this.state.mounted) {
@@ -375,7 +360,6 @@ export default class VoterGuideBallot extends Component {
     this.setState({
       ballotElectionList: BallotStore.ballotElectionList(),
     });
-
 
     if (Object.keys(this.state.ballot_item_unfurled_tracker).length === 0) {
       this.setState({
@@ -498,6 +482,13 @@ export default class VoterGuideBallot extends Component {
   pledgeToVoteWithVoterGuide () {
     // console.log("VoterGuideBallot pledgeToVoteWithVoterGuide, this.state.voter_guide:", this.state.voter_guide);
     VoterGuideActions.pledgeToVoteWithVoterGuide(this.state.voter_guide.we_vote_id);
+  }
+
+  updateOfficeDisplayUnfurledTracker = (we_vote_id, status) => {
+    const new_ballot_item_unfurled_tracker = { ... this.state.ballot_item_unfurled_tracker, [we_vote_id]: status};
+    this.setState({
+      ballot_item_unfurled_tracker: new_ballot_item_unfurled_tracker
+    });
   }
 
   render () {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Addresses issue #1320 where a type error would show up in console

### Changes included this pull request?
This pr copies over the missing update function and state var from `Ballot` to the `VoterGuideBallot` component.
Opening/closing a ballot item in either view will now persist between views