### PR TITLE
Removed extra padding in network issues pages

### DIFF
--- a/src/js/routes/IssuesFollowed.jsx
+++ b/src/js/routes/IssuesFollowed.jsx
@@ -119,13 +119,10 @@ export default class IssuesFollowed extends Component {
                      searchUpdateDelayTime={0} />
           <br />
           <div className="network-issues-list voter-guide-list card">
-            <div className="card-child__list-group">
-              {
-                issue_list.length ?
-                  issue_list_for_display :
-                  <h4 className="intro-modal__default-text">You are not following any issues yet.</h4>
-              }
-            </div>
+            { issue_list.length ?
+              issue_list_for_display :
+              <h4 className="intro-modal__default-text">You are not following any issues yet.</h4>
+            }
           </div>
           <Link className="pull-left" to="/issues_to_follow">Find Issues to follow</Link>
           <br />

--- a/src/js/routes/IssuesToFollow.jsx
+++ b/src/js/routes/IssuesToFollow.jsx
@@ -96,13 +96,10 @@ export default class IssuesToFollow extends Component {
                      searchUpdateDelayTime={0} />
           <br />
           <div className="network-issues-list voter-guide-list card">
-            <div className="card-child__list-group">
-              {
-                this.state.issues_to_follow && this.state.issues_to_follow.length ?
-                  issue_list_for_display :
-                  null
-              }
-            </div>
+            { this.state.issues_to_follow && this.state.issues_to_follow.length ?
+              issue_list_for_display :
+              null
+            }
           </div>
           <Link className="pull-left" to="/issues_followed">Issues you are following</Link>
           <br />


### PR DESCRIPTION
In mobile view, removed the excess left/right padding to the issues lists in the Issues Followed and Issues To Follow pages by removing the surrounding `card-child__list-group` div elements (#1354).