### PR TITLE
Fix to dropdown size, from the SearchAllBox in Cordova, and more

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -4,4 +4,5 @@
     "excludeFiles": ["build/**", "node_modules"],
     "maximumLineLength": null,
     "maxErrors": 200,
+    "disallowSpacesInFunctionDeclaration": null
 }

--- a/src/js/components/SearchAllBox.jsx
+++ b/src/js/components/SearchAllBox.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import BallotActions from "../actions/BallotActions";
 import classNames from "classnames";
 import { Link } from "react-router";
-import { historyPush, isWebApp } from "../utils/cordovaUtils";
+import { historyPush, isCordova, isWebApp } from "../utils/cordovaUtils";
 import SearchAllActions from "../actions/SearchAllActions";
 import SearchAllStore from "../stores/SearchAllStore";
 import { makeSearchLink } from "../utils/search-functions";
@@ -284,6 +284,7 @@ export default class SearchAllBox extends Component {
     let searchContainerClasses = classNames({
       "search-container__hidden": !this.state.open,
       "search-container": true,
+      "search-container--cordova": isCordova(),
     });
     let clearButtonClasses = classNames({
       "site-search__clear": true,

--- a/src/js/components/VoterGuide/VoterGuideBallot.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallot.jsx
@@ -13,7 +13,7 @@ import BallotSummaryModal from "../../components/Ballot/BallotSummaryModal";
 import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateModal from "../../components/Ballot/CandidateModal";
-import { cordovaDot, historyPush } from "../../utils/cordovaUtils";
+import {cordovaDot, historyPush, isWebApp} from "../../utils/cordovaUtils";
 import cookies from "../../utils/cookies";
 import EditAddressInPlace from "../../components/Widgets/EditAddressInPlace";
 import ElectionActions from "../../actions/ElectionActions";
@@ -683,7 +683,7 @@ export default class VoterGuideBallot extends Component {
             <div className="col-xs-12 col-md-12">
               {/* The ballot items the organization wants to promote */}
               <div>
-                <div className="BallotList">
+                <div className={isWebApp() ? "BallotList" : "BallotList__cordova"}>
                   {ballot_with_organization_items.map( (item) => <VoterGuideBallotItemCompressed toggleCandidateModal={this.toggleCandidateModal}
                                                                toggleMeasureModal={this.toggleMeasureModal}
                                                                key={item.we_vote_id}
@@ -698,7 +698,7 @@ export default class VoterGuideBallot extends Component {
                 null }
               {/* The rest of the ballot items */}
               <div>
-                <div className="BallotList">
+                <div className={isWebApp() ? "BallotList" : "BallotList__cordova"}>
                   {ballot_with_remaining_items.map( (item) => <BallotItemCompressed toggleCandidateModal={this.toggleCandidateModal}
                                                                toggleMeasureModal={this.toggleMeasureModal}
                                                                key={item.we_vote_id}

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -19,16 +19,15 @@ function startApp () {
 
     window.$ = require("jquery");
 
-  // March 22, 2018, maybe not needed anymore after today's Cordova install refresh?
-  //   // prevent keyboard scrolling our view, https://www.npmjs.com/package/cordova-plugin-keyboard
-  //   if (window.Keyboard) {
-  //     console.log("Cordova startupApp keyboard plugin found");
-  //     Keyboard.shrinkView(true);
-  //
-  //     window.addEventListener("keyboardDidShow", function () {
-  //       document.activeElement.scrollIntoView();
-  //     });
-  //   } else console.log("ERROR: Cordova index.js startApp keyboard plugin WAS NOT found");
+    // prevent keyboard scrolling our view, https://www.npmjs.com/package/cordova-plugin-keyboard
+    if (window.Keyboard) {
+      console.log("Cordova startupApp keyboard plugin found");
+      Keyboard.shrinkView(true);                      // eslint-disable-line no-undef
+
+      window.addEventListener("keyboardDidShow", function () {
+        document.activeElement.scrollIntoView();
+      });
+    } else console.log("ERROR: Cordova index.js startApp keyboard plugin WAS NOT found");
   }
 
   render(<Router history={isCordova() ? hashHistory : browserHistory}
@@ -40,7 +39,7 @@ function startApp () {
 // If Apache Cordova is available, wait for it to be ready, otherwise start the WebApp
 if (isCordova()) {
   document.addEventListener("deviceready", (id) => {
-    console.log('Received Cordova Event: ', id.type);
+    console.log("Received Cordova Event: ", id.type);
     startApp();
   }, false);
 } else {  // browser

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -18,7 +18,7 @@ import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateModal from "../../components/Ballot/CandidateModal";
 import cookies from "../../utils/cookies";
-import { cordovaDot, historyPush } from "../../utils/cordovaUtils";
+import {cordovaDot, historyPush, isWebApp} from "../../utils/cordovaUtils";
 import ElectionActions from "../../actions/ElectionActions";
 import ElectionStore from "../../stores/ElectionStore";
 import Helmet from "react-helmet";
@@ -645,12 +645,12 @@ export default class Ballot extends Component {
                                          target="_blank"
                                          body={"See more information about casting your official vote."} />
                   </div>
-                  <div className="BallotList">
+                  <div className={isWebApp() ? "BallotList" : "BallotList__cordova"}>
                     {ballot_with_all_items.map( (item) => <BallotItemReadyToVote key={item.we_vote_id} {...item} />)}
                   </div>
                 </div> :
                 <div>
-                  <div className="BallotList">
+                  <div className={isWebApp() ? "BallotList" : "BallotList__cordova"}>
                     {ballot_with_all_items.map( (item) => <BallotItemCompressed toggleCandidateModal={this.toggleCandidateModal}
                                                                  toggleMeasureModal={this.toggleMeasureModal}
                                                                  key={item.we_vote_id}

--- a/src/sass/components/_ballotList.scss
+++ b/src/sass/components/_ballotList.scss
@@ -2,6 +2,10 @@
   @include print {
     column-count: 1;
   }
+
+  &__cordova {
+    margin-bottom: $space-xl;
+  }
 }
 
 .BallotItem {

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -204,6 +204,11 @@ $space-search-right: 10%;
     font-size: 14px;
     color: $gray-mid;
   }
+
+  &--cordova {
+    left: 0;
+    width: auto;
+  }
 }
 
 .search-image {


### PR DESCRIPTION
Fixes the most recent problem in wevote/WeVoteCordova#32

Dale's suggestion to add "margin-bottom" of $space-xl to the
"BallotList" class (VoterGuideBallot, Ballot, and _ballotList.scss) resolves wevote/WeVoteCordova#26

In .jscrcs, added `"disallowSpacesInFunctionDeclaration": null`
to remove lint error indicator, for example, where
`function startApp () {` had been flagged for the space between "startApp" and "()".  This change
will take effect for all `*.js` files, but was not an issue in `*.jsx` files.
