### PR TITLE
Updated ballot issues modal layout and swipe behavior

### DIFF
--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -175,7 +175,7 @@ export default class BallotIntroFollowAdvisers extends Component {
               <span>Great work! Next, click to listen to any of these organizations to see their opinions on your ballot.</span>
             }
           </div>
-          <div className="intro-modal-vertical-scroll-contain intro-modal-vertical-scroll-contain__advisers">
+          <div className="intro-modal-vertical-scroll-contain">
             <div className="intro-modal-vertical-scroll card">
               <div className="row intro-modal__grid">
                 { voter_guides_to_follow_by_issues_for_display.length ? voter_guides_to_follow_by_issues_for_display : null }

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -187,7 +187,6 @@ export default class BallotIntroFollowIssues extends Component {
           <span>{this.state.next_button_text}</span>
         </Button>
       </div>
-      <br/>
     </div>
     );
   }

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -7,7 +7,7 @@ import IssueStore from "../../stores/IssueStore";
 
 const NEXT_BUTTON_TEXT = "Next >";
 const SKIP_BUTTON_TEXT = "Skip >";
-const NEXT_SCREEN_PROMPT_TEXT = "On the next screen, we'll help you find organizations that share your values.";
+// const NEXT_SCREEN_PROMPT_TEXT = "On the next screen, we'll help you find organizations that share your values.";
 
 export default class BallotIntroFollowIssues extends Component {
   static propTypes = {
@@ -18,7 +18,7 @@ export default class BallotIntroFollowIssues extends Component {
   constructor (props) {
     super(props);
     this.state = {
-      description_text: null,
+      // description_text: null,
       followed_issues: [],
       issues: [],
       next_button_text: NEXT_BUTTON_TEXT,
@@ -74,17 +74,17 @@ export default class BallotIntroFollowIssues extends Component {
 
   onIssueFollow (issue_we_vote_id) {
     let index = this.state.followed_issues.indexOf(issue_we_vote_id);
-    let description_text;
+    // let description_text;
     if (index === -1) {
       var new_followed_issues = this.state.followed_issues;
       new_followed_issues.push(issue_we_vote_id);
-      if (this.state.followed_issues.length >= this.state.number_of_required_issues) {
-        description_text = NEXT_SCREEN_PROMPT_TEXT;
-      } else {
-        description_text = null;
-      }
+      // if (this.state.followed_issues.length >= this.state.number_of_required_issues) {
+      //   description_text = NEXT_SCREEN_PROMPT_TEXT;
+      // } else {
+      //   description_text = null;
+      // }
       this.setState({
-        description_text: description_text,
+        // description_text: description_text,
         followed_issues: new_followed_issues,
         next_button_text: NEXT_BUTTON_TEXT
       });
@@ -95,22 +95,22 @@ export default class BallotIntroFollowIssues extends Component {
 
   onIssueStopFollowing (issue_we_vote_id) {
     let index = this.state.followed_issues.indexOf(issue_we_vote_id);
-    let description_text;
+    // let description_text;
     if (index > -1) {
       var new_followed_issues = this.state.followed_issues;
       new_followed_issues.splice(index, 1);
-      if (this.state.followed_issues.length >= this.state.number_of_required_issues) {
-        description_text = NEXT_SCREEN_PROMPT_TEXT;
-      } else {
-        description_text = null;
-      }
+      // if (this.state.followed_issues.length >= this.state.number_of_required_issues) {
+      //   description_text = NEXT_SCREEN_PROMPT_TEXT;
+      // } else {
+      //   description_text = null;
+      // }
       if (new_followed_issues.length) {
         this.setState({
           followed_issues: new_followed_issues,
         });
       } else {
         this.setState({
-          description_text: description_text,
+          // description_text: description_text,
           followed_issues: new_followed_issues,
           next_button_text: NEXT_BUTTON_TEXT,
         });
@@ -173,13 +173,14 @@ export default class BallotIntroFollowIssues extends Component {
           </div>
         </div>
       </div>
-      <div className="intro-modal-shadow" />
-      {this.state.description_text ?
+      <div className="intro-modal-shadow-wrap">
+        <div className="intro-modal-shadow" />
+      </div>
+      {/* {this.state.description_text ?
         <div className="intro-modal__description-text">
           {this.state.description_text}
         </div> :
-        null }
-      <br/>
+        null } */}
       <div className="intro-modal__button-wrap">
         <Button type="submit"
           className={ this.remainingIssues() ? "btn intro-modal__button intro-modal__button-disabled disabled btn-secondary btn-block" : "btn btn-success intro-modal__button intro-modal__button-follow"}

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -183,7 +183,7 @@ export default class BallotIntroFollowIssues extends Component {
         null } */}
       <div className="intro-modal__button-wrap">
         <Button type="submit"
-          className={ this.remainingIssues() ? "btn intro-modal__button intro-modal__button-disabled disabled btn-secondary btn-block" : "btn btn-success intro-modal__button intro-modal__button-follow"}
+          className={ this.remainingIssues() ? "btn intro-modal__button disabled btn-secondary" : "btn btn-success intro-modal__button"}
           onClick={this.onNext}>
           <span>{this.state.next_button_text}</span>
         </Button>

--- a/src/js/components/Ballot/BallotIntroIssuesSuccess.jsx
+++ b/src/js/components/Ballot/BallotIntroIssuesSuccess.jsx
@@ -18,7 +18,6 @@ export default class BallotIntroIssuesSuccess extends Component {
       <div className="intro-modal__h1">Nice job!</div>
       <div className="intro-modal__h2">Watch for your issues under each candidate or measure.</div>
       <span className=""><IssuesFollowedDisplayList /></span>
-      <div className="intro-modal__h2"><br /></div>
       <div className="intro-modal__h2">By clicking on an issue image,<br />
         you will find advisers<br />
         related to that issue<br />
@@ -27,6 +26,7 @@ export default class BallotIntroIssuesSuccess extends Component {
                             >
                       <span>Listen</span>
                     </Button> to.</div>
+      <div className="intro-modal__h2"><br /></div>
       <div className="intro-modal__button-wrap">
         <button type="button" className="btn btn-success intro-modal__button" onClick={this.props.next}>See Your Ballot&nbsp;&gt;</button>
       </div>

--- a/src/js/components/Navigation/HeaderGettingStartedBar.jsx
+++ b/src/js/components/Navigation/HeaderGettingStartedBar.jsx
@@ -167,7 +167,7 @@ export default class HeaderGettingStartedBar extends Component {
       speed: 500,
       slidesToShow: 1,
       slidesToScroll: 1,
-      swipe: true,
+      swipe: false,
       accessibility: true,
       arrows: false,
     };

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -1,10 +1,13 @@
 .intro-modal {
   padding: $space-none;
-  min-height: 480px;
+  // min-height: 480px;
   height: 100%;
   width: 100%;
   color: $white;
   text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 
   &__h1 {
     font-weight: 700;
@@ -113,19 +116,13 @@
   }
 
   &__button {
-    position: absolute;
-    bottom: 36px;
-    width: 19%;
-  }
-
-  &__button-follow,
-  &__button-disabled {
-    width: 19%;
+    // position: absolute;
+    margin-bottom: 32px;
+    width: 80%;
   }
 
   &__button-wrap {
-    display: flex;
-    justify-content: space-around;
+    width: 100%;
   }
 
   &__span {
@@ -377,6 +374,10 @@
 }
 
 // Intro Modal shadow
+.intro-modal-shadow-wrap {
+  flex-basis: 0;
+}
+
 .intro-modal-shadow {
   position: relative;
   top: -25px;
@@ -428,26 +429,16 @@
   overflow-x: hidden;
 }
 
+.intro-modal-vertical-scroll-contain-wrap {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+}
+
 .intro-modal-vertical-scroll-contain {
-  height: calc(100vh - 336px);
-  max-height: 654px; // Scroll area in modal: 990 - 336 = 654px We set this so that when We Vote is in a frame, the modal isn't too long.
   overflow-y: auto;
   -webkit-overflow-scrolling: auto;
   overflow-x: hidden;
-
-  &__advisers {
-    height: calc(100vh - 345px);
-  }
-
-  @include breakpoints (max mid-small) {
-    height: calc(100vh - 256px);
-    max-height: 344px; // Scroll area in modal: 600 - 256 = 344px We set this so that when We Vote is in a frame, the modal isn't too long.
-  }
-
-  @include breakpoints (mid-small medium) {
-    height: calc(100vh - 312px);
-    max-height: 288px; // Scroll area in modal: 600 - 312 = 654px We set this so that when We Vote is in a frame, the modal isn't too long.
-  }
 }
 
 // TODO Move to separate file if global, otherwise, rename to be scoped to this component '.intro-story__close-btn'
@@ -531,26 +522,8 @@
   @include breakpoints (small) {
     height: inherit;
 
-    .intro-modal__button-disabled,
-    .intro-modal__button {
-      width: 20%;
-      bottom: 65px;
-    }
-
     .intro-modal__button-wrap {
       justify-content: auto;
-    }
-
-    .intro-modal__gray-dots {
-      bottom: 25px;
-    }
-
-    .intro-modal-vertical-scroll-contain {
-      height: calc(100vh - 375px);
-      max-height: 640px; // Scroll area in modal: 990 - 350 = 640px We set this so that when We Vote is in a frame, the modal isn't too long.
-      &__advisers {
-        height: calc(100vh - 345px);
-      }
     }
 
     .calc-height {
@@ -561,12 +534,6 @@
     .intro-modal-vertical-scroll-contain_without_slider {
       height: calc(100vh - 100px);
       max-height: 540px; // Scroll area in modal: 990 - 350 = 640px We set this so that when We Vote is in a frame, the modal isn't too long.
-    }
-  }
-
-  @include breakpoints (mid-small medium) {
-    .intro-modal-vertical-scroll-contain {
-      height: calc(100vh - 400px); // slight bug with new shadow that needs this
     }
   }
 }

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -117,7 +117,7 @@
 
   &__button {
     // position: absolute;
-    margin-bottom: 32px;
+    margin-bottom: $space-lg;
     width: 80%;
   }
 


### PR DESCRIPTION
 Fixed the responsive layout of the issues modal on the ballot page by using flexbox over calculated heights. Fixed the choppy scroll behavior of the issues list by disabling the ability to swipe left/right in the modal (#1366). Removed the text in issues modal suggesting that the next screen leads to the organizations modal.