### PR TITLE
Fix required parameter errors in WebApp and Cordova

### DIFF
--- a/src/js/components/Widgets/EditAddress.jsx
+++ b/src/js/components/Widgets/EditAddress.jsx
@@ -8,13 +8,13 @@ export default class EditAddress extends Component {
   static propTypes = {
     address: PropTypes.object.isRequired,
     toggleSelectAddressModal: PropTypes.func.isRequired,
-    ballot_location_chosen: PropTypes.bool.isRequired,
+    ballot_location_chosen: PropTypes.bool,
     ballot_location_display_name: PropTypes.string,
     election_day_text: PropTypes.string,
-    election_is_upcoming: PropTypes.bool.isRequired,
-    google_civic_data_exists: PropTypes.bool.isRequired,
-    voter_entered_address: PropTypes.bool.isRequired,
-    voter_specific_ballot_from_google_civic: PropTypes.bool.isRequired,
+    election_is_upcoming: PropTypes.bool,
+    google_civic_data_exists: PropTypes.bool,
+    voter_entered_address: PropTypes.bool,
+    voter_specific_ballot_from_google_civic: PropTypes.bool,
   };
 
   constructor (props, context) {
@@ -38,14 +38,15 @@ export default class EditAddress extends Component {
       ballot_location_chosen: this.props.ballot_location_chosen,
       ballot_location_display_name: this.props.ballot_location_display_name,
       election_day_text: this.props.election_day_text,
-      election_is_upcoming: this.props.election_is_upcoming,
+      election_is_upcoming: this.props.election_is_upcoming || false,
       google_civic_data_exists: this.props.google_civic_data_exists,
       show_ballot_status: true,
       text_for_map_search: this.props.address.text_for_map_search || "",
-      voter_entered_address: this.props.voter_entered_address,
+      voter_entered_address: this.props.voter_entered_address || false,
       voter_specific_ballot_from_google_civic: this.props.voter_specific_ballot_from_google_civic,
     });
   }
+
   componentWillReceiveProps (nextProps) {
     // console.log("BallotStatusMessage componentWillReceiveProps");
     this.setState({
@@ -63,13 +64,13 @@ export default class EditAddress extends Component {
 
   render () {
     renderLog(__filename);
-    let no_address_message = "- no address entered -";
-    let edit_address_popover_on = true;
-    let maximum_address_display_length = 30;
+    let noAddressMessage = "- no address entered -";
+    let editAddressPopoverOn = true;
+    let maximumAddressDisplayLength = 30;
 
     return (
       <span className="ballot__date_location">
-        { edit_address_popover_on ?
+        { editAddressPopoverOn ?
           <EditAddressPopover text_for_map_search={this.state.text_for_map_search}
                               placement={"bottom"}
                               onEnterAddressClick={this.props.toggleSelectAddressModal}
@@ -77,11 +78,11 @@ export default class EditAddress extends Component {
                               ballot_location_display_name={this.state.ballot_location_display_name}
                               election_day_text={this.state.election_day_text}
                               election_is_upcoming={this.state.election_is_upcoming}
-                              maxAddressDisplayLength={maximum_address_display_length}
+                              maxAddressDisplayLength={maximumAddressDisplayLength}
                               voter_entered_address={this.state.voter_entered_address}
                               google_civic_data_exists={this.state.google_civic_data_exists}
                               voter_specific_ballot_from_google_civic={this.state.voter_specific_ballot_from_google_civic} /> :
-          <span>{ this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximum_address_display_length) : no_address_message }</span>
+          <span>{ this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximumAddressDisplayLength) : noAddressMessage }</span>
         }
         <span className="hidden-print">(<a onClick={this.props.toggleSelectAddressModal}>Edit</a>)</span>
       </span>

--- a/src/js/components/Widgets/EditAddressPopover.jsx
+++ b/src/js/components/Widgets/EditAddressPopover.jsx
@@ -6,17 +6,17 @@ import { shortenText } from "../../utils/textFormat";
 
 export default class EditAddressPopover extends Component {
   static propTypes = {
-    ballot_location_chosen: PropTypes.bool.isRequired,
+    ballot_location_chosen: PropTypes.bool,
     ballot_location_display_name: PropTypes.string,
     election_day_text: PropTypes.string,
-    election_is_upcoming: PropTypes.bool.isRequired,
-    google_civic_data_exists: PropTypes.bool.isRequired,
+    election_is_upcoming: PropTypes.bool,
+    google_civic_data_exists: PropTypes.bool,
     maxAddressDisplayLength: PropTypes.number,
     onEnterAddressClick: PropTypes.func.isRequired,
     placement: PropTypes.string.isRequired,
     text_for_map_search: PropTypes.string.isRequired,
-    voter_entered_address: PropTypes.bool.isRequired,
-    voter_specific_ballot_from_google_civic: PropTypes.bool.isRequired,
+    voter_entered_address: PropTypes.bool,
+    voter_specific_ballot_from_google_civic: PropTypes.bool,
   };
 
   constructor (props, context) {
@@ -51,6 +51,7 @@ export default class EditAddressPopover extends Component {
       voter_specific_ballot_from_google_civic: this.props.voter_specific_ballot_from_google_civic,
     });
   }
+
   componentWillReceiveProps (nextProps) {
     // console.log("EditAddressPopover componentWillReceiveProps");
     this.setState({
@@ -73,62 +74,57 @@ export default class EditAddressPopover extends Component {
 
   render () {
     renderLog(__filename);
+
+    // TODO STEVE March 2018:  As we use EditAddress today, the next 30 lines do nothing.  Same for their associated props here, and in EditAddress
     // let exclamation_circle_red = "#fc0d1b"; // I tried to replace literal string below with this variable. Didn't work.
-    let message_title = "This is our best guess";
-    let message_string = "";
-    let address_popover_on = true;
-    let address_popover_enter_address_on = true;
+    let messageTitle = "This is our best guess";
+    let messageString = "";
+    let addressPopoverOn = true;
+    let addressPopoverEnterAddressOn = true;
 
     // TODO DALE: Deal with the situation where you are in one state (ex "NC") and you link to a NY ballot
     // The EditAddressPopover message should update
     if (this.state.election_is_upcoming) {
       if (this.state.voter_specific_ballot_from_google_civic) {
-        // message_string += ""; // No additional text
-        address_popover_on = false;
-        address_popover_enter_address_on = false;
-        // return null;
-      } else if (this.state.voter_entered_address) {
-        // message_title = "";
-        // message_string += "We are showing you the closest match to your official ballot.";
-        //address_popover_enter_address_on = false;
-        // return null;
+        // messageString += ""; // No additional text
+        addressPopoverOn = false;
+        addressPopoverEnterAddressOn = false;
       } else if (this.state.google_civic_data_exists) {
-        message_string += "Want to make sure these are your ballot items? Enter the full address where you are registered to vote.";
-        address_popover_enter_address_on = true;
+        messageString += "Want to make sure these are your ballot items? Enter the full address where you are registered to vote.";
+        addressPopoverEnterAddressOn = true;
       } else {
-        message_string += "We are showing you the closest match to your official ballot.";
+        messageString += "We are showing you the closest match to your official ballot.";
       }
     } else if (this.state.voter_entered_address) {
-      message_string += "We are showing you the closest match to your official ballot.";
-      address_popover_enter_address_on = false;
+      messageString += "We are showing you the closest match to your official ballot.";
+      addressPopoverEnterAddressOn = false;
     } else if (this.state.google_civic_data_exists) {
-      message_string += "This election is in the past. We are showing you the closest match to your official ballot.";
-      address_popover_enter_address_on = false;
+      messageString += "This election is in the past. We are showing you the closest match to your official ballot.";
+      addressPopoverEnterAddressOn = false;
     } else {
-      message_string += "This election is in the past. We are showing you the closest match to your official ballot.";
-      address_popover_enter_address_on = false;
+      messageString += "This election is in the past. We are showing you the closest match to your official ballot.";
+      addressPopoverEnterAddressOn = false;
     }
 
-
     const AddressPopover = <Popover id="popover-trigger-click-root-close" onClick={this.closePopover}>
-      <div style={{textAlign: "center"}}>
+      <div style={{ textAlign: "center" }}>
         <p>
-          <span style={{color: "#ef1e26"}}>{message_title}</span>
+          <span style={{ color: "#ef1e26" }}>{messageTitle}</span>
           {/* This is the "x" to close the popover */}
           <i className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" />
         </p>
-        <p>{message_string}</p>
-        { address_popover_enter_address_on ?
+        <p>{messageString}</p>
+        { addressPopoverEnterAddressOn ?
           <button className="btn btn-success" onClick={this.props.onEnterAddressClick}>Enter Address &gt;&gt;</button> :
           null
         }
       </div>
     </Popover>;
 
-    let no_address_message = "- no address entered -";
-    let maximum_address_display_length = this.state.max_address_display_length !== 0 ? this.state.max_address_display_length : 30;
+    let noAddressMessage = "- no address entered -";
+    let maximumAddressDisplayLength = this.state.max_address_display_length !== 0 ? this.state.max_address_display_length : 30;
 
-    return <span>{ address_popover_on ?
+    return <span>{ addressPopoverOn ?
         <OverlayTrigger
           trigger="click"
           ref="overlay"
@@ -137,13 +133,13 @@ export default class EditAddressPopover extends Component {
           placement={this.props.placement}
           overlay={AddressPopover}>
             <span className="u-cursor--pointer">
-              { this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximum_address_display_length) : no_address_message }
+              { this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximumAddressDisplayLength) : noAddressMessage }
               <span className="position-rating__source with-popover">&nbsp;&nbsp;
-              <i className="fa fa-exclamation-circle" aria-hidden="true" style={{color: "#fc0d1b"}} />&nbsp;&nbsp;</span>
+              <i className="fa fa-exclamation-circle" aria-hidden="true" style={{ color: "#fc0d1b" }} />&nbsp;&nbsp;</span>
             </span>
         </OverlayTrigger> :
         <span onClick={this.props.onEnterAddressClick} className="u-cursor--pointer">
-          { this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximum_address_display_length) : no_address_message }
+          { this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximumAddressDisplayLength) : noAddressMessage }
           <span className="position-rating__source with-popover">&nbsp;&nbsp;</span>
         </span> }
     </span>;

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,7 +1,7 @@
 // Note that we import these values where needed as "webAppConfig"
 module.exports = {
-  WE_VOTE_URL_PROTOCOL: "https://",  // "http://" for local dev or "https://" for live server
-  WE_VOTE_HOSTNAME: "wevote.us",  // This should be without "http...". This is "WeVote.US" on live server.
+  WE_VOTE_URL_PROTOCOL: "http://",  // "http://" for local dev or "https://" for live server
+  WE_VOTE_HOSTNAME: "localhost:3000",  // This should be without "http...". This is "WeVote.US" on live server.
 
   WE_VOTE_SERVER_ROOT_URL: "https://api.wevoteusa.org/",
   WE_VOTE_SERVER_ADMIN_ROOT_URL: "https://api.wevoteusa.org/admin/",
@@ -24,7 +24,7 @@ module.exports = {
     text_for_map_search: "",
   },
 
-  FACEBOOK_APP_ID: "1097389196952441",
+  FACEBOOK_APP_ID: "",
 
-  STRIPE_API_KEY: "pk_live_zpl7eSkLnySR2i4vtJQ1lJmi",
+  STRIPE_API_KEY: "",
 };

--- a/src/js/config.js
+++ b/src/js/config.js
@@ -1,7 +1,7 @@
 // Note that we import these values where needed as "webAppConfig"
 module.exports = {
-  WE_VOTE_URL_PROTOCOL: "http://",  // "http://" for local dev or "https://" for live server
-  WE_VOTE_HOSTNAME: "localhost:3000",  // This should be without "http...". This is "WeVote.US" on live server.
+  WE_VOTE_URL_PROTOCOL: "https://",  // "http://" for local dev or "https://" for live server
+  WE_VOTE_HOSTNAME: "wevote.us",  // This should be without "http...". This is "WeVote.US" on live server.
 
   WE_VOTE_SERVER_ROOT_URL: "https://api.wevoteusa.org/",
   WE_VOTE_SERVER_ADMIN_ROOT_URL: "https://api.wevoteusa.org/admin/",
@@ -24,7 +24,7 @@ module.exports = {
     text_for_map_search: "",
   },
 
-  FACEBOOK_APP_ID: "",
+  FACEBOOK_APP_ID: "1097389196952441",
 
-  STRIPE_API_KEY: "",
+  STRIPE_API_KEY: "pk_live_zpl7eSkLnySR2i4vtJQ1lJmi",
 };


### PR DESCRIPTION
Marked 5 parameters as not required.
As we use EditAddress today, half of the parameters are not used,
and not needed in EditAddress or EditAddressPopover.  Same with dozens
of lines of code that process the parameters that we don't pass.
Added a TODO indicating the abandoned code, which can be removed if we
have permanently gone a different direction.