### PR TITLE
Condensed support label text on ballot page

### DIFF
--- a/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
+++ b/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
@@ -175,7 +175,10 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
                       rootClose
                       placement={this.props.popoverBottom ? "bottom" : "top"}
                       overlay={issuesLabelPopover}>
-        <span className="issues-list-stacked__support-label u-cursor--pointer u-no-break">Related Issues&nbsp;<i className="fa fa-info-circle fa-md issues-list-stacked__info-icon-for-popover hidden-print" aria-hidden="true" />&nbsp;</span>
+        <span className="issues-list-stacked__support-label u-cursor--pointer u-no-break">
+          <span>Related<br />Issues</span>
+          <span>&nbsp;<i className="fa fa-info-circle fa-md issues-list-stacked__info-icon-for-popover hidden-print" aria-hidden="true" />&nbsp;</span>
+        </span>
       </OverlayTrigger>;
 
     return (

--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -540,7 +540,10 @@ export default class ItemSupportOpposeRaccoon extends Component {
                       rootClose
                       placement={this.props.popoverBottom ? "bottom" : "top"}
                       overlay={positionsPopover}>
-        <span className="network-positions-stacked__support-label u-cursor--pointer u-no-break">Opinions{this.state.ballot_item_display_name ? " about " + returnFirstXWords(this.state.ballot_item_display_name, 1) : ""}&nbsp;<i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" />&nbsp;</span>
+        <span className="network-positions-stacked__support-label u-cursor--pointer u-no-break">
+          <span>Opinions{this.state.ballot_item_display_name ? <br /> : null}{this.state.ballot_item_display_name ? "about " + returnFirstXWords(this.state.ballot_item_display_name, 1) : ""}</span>
+          <span>&nbsp;<i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" />&nbsp;</span>
+        </span>
       </OverlayTrigger>;
 
     return <div className="network-positions-stacked">

--- a/src/sass/components/_network-positions.scss
+++ b/src/sass/components/_network-positions.scss
@@ -144,7 +144,12 @@
     color: $gray-dark;
     font-size: .875rem;
     font-weight: 200;
+    line-height: 1.2;
     vertical-align: middle;
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+
     @include breakpoints (small mid-small) {
       font-size: .875rem;
     }


### PR DESCRIPTION
Modified the issues and opinions support label on the ballot page by separating it into two lines (on both desktop and mobile) (#1361).