### PR TITLE
Fixes bug that caused message not to appear when a user sent the emai…

### DIFF
--- a/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
+++ b/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
@@ -569,7 +569,7 @@ export default class FacebookBallotToFriendsModal extends Component {
                       {this.state.success_message}
                     </div> : this.props.success_message ?
                     <div className="alert alert-success">
-                      {this.state.success_message}
+                      {this.props.success_message}
                     </div> : null
                   }
 


### PR DESCRIPTION
This commit should fix the following issue: 
When the user sends his ballot to himself using facebook ballot modal the success message was not appearing. 
<img width="990" alt="screen shot 2018-04-02 at 12 02 26 pm" src="https://user-images.githubusercontent.com/6605268/38203600-c0067ea0-366d-11e8-8ff3-baaa95268aaf.png">