### PR TITLE
WebApp changes for Cordova Android -- oAuth through Twitter now works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1751,7 +1751,7 @@
     "base64-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
-      "integrity": "sha1-qRlH2h9KUW6jjltOwOw3c2deCIY=",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
       "dev": true
     },
     "base64id": {
@@ -1842,7 +1842,7 @@
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-      "integrity": "sha1-LN4J617jQfSEdGuwMJsyU7GxRC8=",
+      "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
     "body-parser": {
@@ -1866,7 +1866,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -1930,7 +1930,7 @@
     "bootstrap": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
-      "integrity": "sha1-zrA4QsFF/MG5tOFdoqBWVrpoRpo=",
+      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA==",
       "dev": true
     },
     "bootstrap-sass": {
@@ -2597,7 +2597,7 @@
     "cipher-base": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
-      "integrity": "sha1-h2Dk7MJy9MNjUy+SbYdKriwTl94=",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -2613,7 +2613,7 @@
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
         "chalk": "1.1.3"
@@ -3032,7 +3032,7 @@
     "content-type": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
       "dev": true
     },
     "content-type-parser": {
@@ -3239,7 +3239,7 @@
     "css-in-js-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.0.tgz",
-      "integrity": "sha1-WvHdcPSwazMfSNIqPYbgeGwLlDU=",
+      "integrity": "sha512-yuWmPMD9FLi50Xf3k8W8oO3WM1eVnxEGCldCLyfusQ+CgivFk0s23yst4ooW6tfxMuSa03S6uUEga9UhX6GRrA==",
       "requires": {
         "hyphenate-style-name": "1.0.2"
       }
@@ -3583,6 +3583,11 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deepmerge": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.0.tgz",
+      "integrity": "sha512-Q89Z26KAfA3lpPGhbF6XMfYAm3jIV3avViy6KOJ2JLzFbeWHOvPQUu5aSJIWXap3gDZC2y1eF5HXEPI2wGqgvw=="
     },
     "defaults": {
       "version": "1.0.3",
@@ -4735,7 +4740,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4797,7 +4802,7 @@
         "mime": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY=",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
           "dev": true
         },
         "send": {
@@ -4836,7 +4841,7 @@
         "setprototypeof": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY=",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
         },
         "statuses": {
@@ -4960,11 +4965,6 @@
         "setimmediate": "1.0.5",
         "ua-parser-js": "0.7.14"
       }
-    },
-    "fetch-jsonp": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/fetch-jsonp/-/fetch-jsonp-1.1.1.tgz",
-      "integrity": "sha1-t7n9fTpPdNODifXqLy0PRsNFEOQ="
     },
     "figures": {
       "version": "1.7.0",
@@ -6151,7 +6151,7 @@
     "function.prototype.name": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
-      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+      "integrity": "sha1-AJmuVXLp3W8DyX0CP9krzF5jnqw=",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
@@ -6242,7 +6242,7 @@
     "glamor": {
       "version": "2.20.40",
       "resolved": "https://registry.npmjs.org/glamor/-/glamor-2.20.40.tgz",
-      "integrity": "sha1-9gZmA1e3zxjfrOcxrRos+pOBfwU=",
+      "integrity": "sha512-DNXCd+c14N9QF8aAKrfl4xakPk5FdcFwmH7sD0qnC0Pr7xoZ5W9yovhUrY/dJc3psfGGXC58vqQyRtuskyUJxA==",
       "requires": {
         "fbjs": "0.8.14",
         "inline-style-prefixer": "3.0.8",
@@ -7262,7 +7262,7 @@
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha1-NA3tvmKQGHFRweodd3o0SJNd+EY=",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -7460,7 +7460,7 @@
     "iframe-resizer": {
       "version": "3.5.16",
       "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-3.5.16.tgz",
-      "integrity": "sha1-oJrGr8/2Iz2WsYZeR8k759NZ3N8="
+      "integrity": "sha512-kCXP+PkbdaiflO5z8exoPioxZ/6Hp/5Fat7xGZbJc0Rkd/6nJWuvo9jPd/gZgfIe7vzjeoNN6jhcM5c800i8UA=="
     },
     "ignore": {
       "version": "3.3.3",
@@ -8082,7 +8082,7 @@
     "jquery": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha1-lYzinoHJeQ8xvneS311NlfxX+8o="
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "js-base64": {
       "version": "2.1.9",
@@ -9430,7 +9430,7 @@
     "mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha1-Ms2eXGRVO9WNGaVor0Uqz/BJgbE="
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
       "version": "1.29.0",
@@ -9460,7 +9460,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -9491,7 +9491,7 @@
     "mocha": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
-      "integrity": "sha1-HgSA/jbS2lhY0etqzDhBiybqog0=",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.0",
@@ -9721,7 +9721,7 @@
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
-      "integrity": "sha1-X5QmPUBPbkR2fXJpAf/wVHjWAN8=",
+      "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
       "dev": true,
       "requires": {
         "assert": "1.4.1",
@@ -9752,7 +9752,7 @@
         "browserify-zlib": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
-          "integrity": "sha1-KGlFnZqjviRf6P4sofRuLn9U1z8=",
+          "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
           "dev": true,
           "requires": {
             "pako": "1.0.6"
@@ -9773,13 +9773,13 @@
         "pako": {
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-          "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg=",
+          "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==",
           "dev": true
         },
         "timers-browserify": {
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
-          "integrity": "sha1-lspT9LeUpefA4b18yIo3Ipj6AeY=",
+          "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
           "dev": true,
           "requires": {
             "setimmediate": "1.0.5"
@@ -15108,7 +15108,7 @@
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha1-BktyYCsY+Q8pGSuLG8QY/9Hr078=",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
       "requires": {
         "asap": "2.0.6"
       }
@@ -15194,7 +15194,7 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "query-string": {
       "version": "4.3.4",
@@ -15328,7 +15328,7 @@
     "randombytes": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
-      "integrity": "sha1-3ACaJGuNCaF3tLegrne8Vw9LG3k=",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
       "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
@@ -15513,7 +15513,7 @@
     "react-iframe-resizer-super": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/react-iframe-resizer-super/-/react-iframe-resizer-super-0.2.0.tgz",
-      "integrity": "sha1-L+TIC2ZKiyfNMtjwBTOsW1FEiLE=",
+      "integrity": "sha512-pVi/wS5jgA9k4YSnGizL3X6fiTFRUKDbqnXcUh08KvOzGogQM5YgdwnCXlC9/vhq3ULC5nttxf/mCVpD1nACVw==",
       "requires": {
         "babel-runtime": "6.25.0"
       }
@@ -15542,7 +15542,7 @@
     "react-mixin": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/react-mixin/-/react-mixin-3.1.1.tgz",
-      "integrity": "sha1-aHSXVr/jJpnlYTcqSu7Lkm23K38=",
+      "integrity": "sha512-z9fZ0aCRDjlgxLdMeWkJ9TwhmVLhQ09r8RFpin/cEPA2T6jsb7YHNWcIe0Oii+hhJNyMymdy91CSya5mRkuCkg==",
       "dev": true,
       "requires": {
         "object-assign": "4.1.1",
@@ -15571,13 +15571,13 @@
       }
     },
     "react-player": {
-      "version": "0.14.3",
-      "resolved": "https://registry.npmjs.org/react-player/-/react-player-0.14.3.tgz",
-      "integrity": "sha1-S4Ngkr21J6wpJkYJBfTpU8ahJ84=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/react-player/-/react-player-1.3.1.tgz",
+      "integrity": "sha512-dIT0lxWsg1ms/fGFdByUD7BwCaqTOhE2zSeLBumqFIrOW/9fjhjFhF/Otsd13GpziF5VRKx91+7kJK1f2MejvA==",
       "requires": {
-        "fetch-jsonp": "1.1.1",
+        "deepmerge": "2.1.0",
         "load-script": "1.0.0",
-        "query-string": "4.3.4"
+        "prop-types": "15.6.1"
       }
     },
     "react-prop-types": {
@@ -15622,7 +15622,7 @@
     "react-router-scroll": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/react-router-scroll/-/react-router-scroll-0.4.4.tgz",
-      "integrity": "sha1-TXtxx1tF/yluStyh4CmobomKFV0=",
+      "integrity": "sha512-FR+kyNmRrNqhRbMHDFSgFPVrOy923AdJZE0Qqefub5u56+5d7EENLy4DOrCZVr2fTHsJjWJDE0X1vU063t4bOA==",
       "requires": {
         "prop-types": "15.6.0",
         "scroll-behavior": "0.9.5",
@@ -15847,7 +15847,7 @@
         "react-transition-group": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
-          "integrity": "sha1-6ftne3nmRV/TkbA4I6/oSEnfShA=",
+          "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
           "requires": {
             "chain-function": "1.0.0",
             "classnames": "2.2.5",
@@ -15862,7 +15862,7 @@
     "react-transition-group": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-1.2.1.tgz",
-      "integrity": "sha1-4R9yslf5IbITIpp3TfRmEjRsfKY=",
+      "integrity": "sha512-CWaL3laCmgAFdxdKbhhps+c0HRGF4c+hdM4H23+FI1QBNUyx/AMeIJGWorehPNSaKnQNOAxL7PQmqMu78CDj3Q==",
       "dev": true,
       "requires": {
         "chain-function": "1.0.0",
@@ -15975,7 +15975,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -16628,7 +16628,7 @@
     "scroll-behavior": {
       "version": "0.9.5",
       "resolved": "https://registry.npmjs.org/scroll-behavior/-/scroll-behavior-0.9.5.tgz",
-      "integrity": "sha1-QdowtVnaAE60hFD2z/YGjHaW/yM=",
+      "integrity": "sha512-/5CtMX6YHmCrcV6AICYqFpNqYgx5v6YOyDTeMgVFdLZpgU+T3JXmgV+9s4R+uApcyYwcc7o8Nwp7VTt/ue8y0Q==",
       "requires": {
         "dom-helpers": "3.2.1",
         "invariant": "2.2.2"
@@ -17489,7 +17489,7 @@
     "stream-http": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-      "integrity": "sha1-QKBQ7I3DtTsz2ZCUFcAsC/Gr+60=",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -17553,7 +17553,7 @@
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -18476,7 +18476,7 @@
     "superagent": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha1-5KEbnQR/fT7+s7vlNtnsACHRZAM=",
+      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^15.6.2",
     "react-helmet": "^3.3.0",
     "react-iframe-resizer-super": "^0.2.0",
-    "react-player": "^0.14.1",
+    "react-player": "^1.3.1",
     "react-router-scroll": "^0.4.4",
     "react-slick": "^0.14.5",
     "react-slide-out": "^0.1.4",

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -3,7 +3,8 @@ import PropTypes from "prop-types";
 import { ToastContainer } from "react-toastify";
 import BookmarkActions from "./actions/BookmarkActions";
 import cookies from "./utils/cookies";
-import { historyPush, isCordova, cordovaOpenSafariView, isWebApp } from "./utils/cordovaUtils";
+import { historyPush, cordovaOpenSafariView, isAndroid, isCordova, isIOS,
+  isWebApp } from "./utils/cordovaUtils";
 import ElectionActions from "./actions/ElectionActions";
 import FooterBarCordova from "./components/Navigation/FooterBarCordova";
 import FriendActions from "./actions/FriendActions";
@@ -59,9 +60,10 @@ export default class Application extends Component {
 
   initCordova () {
     console.log("Application initCordova ------------ " + __filename);
+    console.log("------------------ device.platform = " + device.platform);
     if (isCordova()) {
       window.handleOpenURL = function (url) {
-        console.log("Application handleOpenUrl: " + url);
+        console.log("---------------xxxxxx-------- Application handleOpenUrl: " + url);
         if (url.startsWith("wevotetwitterscheme://")) {
           console.log("window.handleOpenURL received wevotetwitterscheme: " + url);
           let search = url.replace(new RegExp("&amp;", "g"), "&");
@@ -388,8 +390,10 @@ export default class Application extends Component {
       "headroom-getting-started__margin" : isWebApp() ? "headroom-wrapper" : "headroom-wrapper__cordova";
 
     let pageHeaderStyle = this.state.we_vote_branding_off ? "page-header__container_branding_off headroom" : "page-header__container headroom";
-    if (isCordova()) {
-      pageHeaderStyle += " page-header-cordova";
+    if (isIOS()) {
+      pageHeaderStyle = "page-header__container headroom page-header-cordova-ios";   // Note March 2018: no headroom.js for Cordova
+    } else if (isAndroid()) {
+      pageHeaderStyle = "page-header__container headroom";
     }
 
     let footerStyle = this.state.showFooter ? "footroom-wrapper" : "footroom-wrapper__hide";
@@ -412,7 +416,7 @@ export default class Application extends Component {
 
       return <div className="app-base" id="app-base-id">
         <ToastContainer closeButton={false} />
-        { isCordova() && <div className={"ios7plus-spacer"} /> }
+        { isCordova() && isIOS() && <div className={"ios7plus-spacer"} /> }
         <div className={headRoomSize}>
           <div ref="pageHeader" className={pageHeaderStyle}>
             { showBackToHeader ?
@@ -440,7 +444,7 @@ export default class Application extends Component {
     } else if (settingsMode) {
       return <div className="app-base" id="app-base-id">
         <ToastContainer closeButton={false} />
-        { isCordova() && <div className={"ios7plus-spacer"} /> }
+        { isCordova() && isIOS() && <div className={"ios7plus-spacer"} /> }
         <div className={headRoomSize}>
           <div ref="pageHeader" className={pageHeaderStyle}>
             {/* March 2018: One of HeaderBackToBar OR HeaderBar is displayed, AND under some circumstances HeaderGettingStartedBar is
@@ -467,7 +471,7 @@ export default class Application extends Component {
     // This handles other pages, like Welcome and the Ballot display
     return <div className="app-base" id="app-base-id">
       <ToastContainer closeButton={false} />
-      { isCordova() && <div className={"ios7plus-spacer"} /> }
+      { isCordova() && isIOS() && <div className={"ios7plus-spacer"} /> }
       <div className={headRoomSize}>
         <div ref="pageHeader" className={pageHeaderStyle}>
           {/* March 2018: One of HeaderBackToBar OR HeaderBar is displayed, AND under some circumstances HeaderGettingStartedBar is

--- a/src/js/dispatcher/Dispatcher.js
+++ b/src/js/dispatcher/Dispatcher.js
@@ -1,3 +1,5 @@
+import { httpLog } from "../utils/logging";
+
 var Dispatcher = require("flux/lib/Dispatcher");
 
 Dispatcher.prototype.$ajax = require("../utils/service").$ajax;
@@ -10,7 +12,7 @@ Dispatcher.prototype.loadEndpoint = function (endpoint, data = {}) {
     endpoint,
     data: data,
     success: (res) => {
-      // console.log("Ajax response to endpoint: " + endpoint);
+      httpLog("AJAX Response to endpoint: " + endpoint);
       this.dispatch({ type: endpoint, res });
     },
 

--- a/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { Button } from "react-bootstrap";
 import AnalyticsActions from "../../actions/AnalyticsActions";
-import { historyPush, isWebApp } from "../../utils/cordovaUtils";
+import { historyPush, isIOS, isWebApp } from "../../utils/cordovaUtils";
 import FollowToggle from "../../components/Widgets/FollowToggle";
 import VoterGuideStore from "../../stores/VoterGuideStore";
 import HeaderBar from "../../components/Navigation/HeaderBar";
@@ -153,7 +153,12 @@ export default class OrganizationVoterGuide extends Component {
     let isVoterOwner = this.state.organization.organization_we_vote_id !== undefined &&
       this.state.organization.organization_we_vote_id === this.state.voter.linked_organization_we_vote_id;
 
-    let pageHeaderStyle = isWebApp() ? "page-header__container headroom" : "page-header__container headroom page-header-cordova";
+    let pageHeaderStyle = "page-header__container headroom";
+    if (isIOS()) {
+      pageHeaderStyle = "page-header__container page-header-cordova-ios";  // Note March 2018: no headroom.js for Cordova
+    } else if (isAndroid()) {
+      pageHeaderStyle = "page-header__container";
+    }
 
     if (!organizationId) {
       let floatRight = {

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -101,3 +101,12 @@ export function deviceTypeString () {
 
   return deviceString;
 }
+
+export function isIOS () {
+  return isCordova() && window.device && device.platform === "iOS";
+}
+
+export function isAndroid () {
+  return isCordova() && window.device && device.platform === "Android";
+}
+

--- a/src/js/utils/logging.js
+++ b/src/js/utils/logging.js
@@ -30,11 +30,22 @@ export function renderLog (filePath, suffix) {
 
 //  Log http requests and cookie CHANGES
 export function httpLog (text, res) {
-  if (webAppConfig.LOG_NATIVE_HTTP_REQUESTS) {
+  if (webAppConfig.LOG_HTTP_REQUESTS) {
     if (res) {
       console.log(text, res);
     } else {
       console.log(text);
+    }
+  }
+}
+
+//  Log oAuth steps
+export function oAuthLog (text, res) {
+  if (webAppConfig.LOG_SIGNIN_STEPS) {
+    if (res) {
+      console.log(">> oAuth >> ", text, res);
+    } else {
+      console.log(">> oAuth >> ", text);
     }
   }
 }

--- a/src/js/utils/service.js
+++ b/src/js/utils/service.js
@@ -2,6 +2,7 @@ import assign from "object-assign";
 import url from "url";
 import cookies from "./cookies";
 import webAppConfig from "../config";
+import { httpLog } from "../utils/logging";
 
 // import { isCordova } from "../utils/cordovaUtils";
 
@@ -40,40 +41,7 @@ export function $ajax (options) {
   options.error = options.error || defaults.error;
   options.url = url.resolve(defaults.baseUrl, options.endpoint) + "/";
 
-  // if (isCordova()) {
-  //   console.log("AJAX URL: " + options.url);
-  // }
+  httpLog("AJAX URL: " + options.url);
 
   return $.ajax(options);
 }
-
-// Commented out March 2018, feel free to delete in a few months.  This seems to be abandoned.
-//const DEBUG = false;
-// export function get (options) {
-//   var opts = assign(defaults, options);
-//
-//   opts.url = url.resolve(opts.baseUrl, opts.endpoint);
-//   // We add voter_device_id to all endpoint calls
-//   opts.query.voter_device_id = cookies.getItem("voter_device_id");
-//
-//   return new Promise( (resolve, reject) => new request.Request("GET", opts.url)
-//     .accept(opts.dataType)
-//     .query(opts.query)
-//     .withCredentials()
-//     .end((err, res) => {
-//       if (err) {
-//         if (opts.error instanceof Function === true)
-//           opts.error(err || res.body);
-//
-//         reject(err);
-//       } else {
-//         if (opts.success instanceof Function === true)
-//           opts.success(res.body);
-//         else if (DEBUG)
-//           console.warn(res.body);
-//
-//         resolve(res.body);
-//       }
-//     })
-//   );
-// }

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -34,7 +34,7 @@ $space-search-right: 10%;
   }
 }
 
-.page-header-cordova {
+.page-header-cordova-ios {
   margin: $space-header-height auto $space-none;
 }
 

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -383,8 +383,7 @@ $container-margin: -15px;
   }
 
   &__text {
-    font-weight: 200 !important;
-    font-size: 13pt !important;
-    color: $blue !important;
+    font-weight: 300;
+    font-size: 13pt;
   }
 }

--- a/www/index.html
+++ b/www/index.html
@@ -19,14 +19,20 @@
           * Enable inline JS: add 'unsafe-inline' to default-src
     Steve 1/18/18:  I was working on making all the correct policies, and decided to just make it wide open for now.
   Wide open security policy for Apache Cordova. TODO: We should close this down
+        default-src 'self' data: http: https: localhost: wevotetwitterscheme: gap://* https://ssl.gstatic.com ;
   -->
   <meta http-equiv="Content-Security-Policy" content="
-      default-src * gap: ;
+      default-src * data: content: gap: https://ssl.gstatic.com;
+
+      img-src *;
       style-src * 'unsafe-inline';
       script-src * 'unsafe-inline';
+      frame-src http://*.facebook.com https://*.facebook.com https://*.twitter.com gap: ;
+      child-src gap://* ;
+      font-src *;
       media-src *;
-      img-src * data:;
     " />
+  <!--img-src https: data: file: android-webview-video-poster: https://api.wevoteusa.org;-->
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">
   <meta name="viewport"
@@ -67,9 +73,9 @@
               font-size: 32px;
               font-weight: normal;
               color: #fff;
-              ">Loading We Vote...
+              ">Loading We Vote CORDOVA2...
     </h1>
-    <div class="u-loading-spinner u-loading-spinner--light">Loading We Vote...</div>
+    <div class="u-loading-spinner u-loading-spinner--light">Loading We Vote CORDOVA...</div>
   </div>
 </div>
 <!--<script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>-->


### PR DESCRIPTION
Added InAppBrowser support for the oAuth redirect scheme, this relies on
a PR that I made to Cordova to allow schemes
https://github.com/apache/cordova-plugin-inappbrowser/pull/263
which they are likely to approve, but if not we can work off of the fork.
Moved all the iOS twitter scheme processing out of Application.js and into
TwitterSignIn.jsx, and enhanced it for Android.  Some small styling changes
to remove the iOS
