### PR TITLE
Removed an unimportant error message from some Cordova specific code

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -61,12 +61,6 @@ export default class Application extends Component {
   initCordova () {
     console.log("Application initCordova ------------ " + __filename);
 
-    if (device) {
-      // eslint-disable-next-line no-undef
-      console.log("------------------ device.platform = " + device.platform);
-    } else {
-      console.log("------------------ initCordova, device not found");
-    }
     if (isCordova()) {
       window.handleOpenURL = function (url) {
         TwitterSignIn.handleTwitterOpenURL(url);


### PR DESCRIPTION
That was causing an exception in the WebApp
"Uncaught ReferenceError: device is not defined"
