### PR TITLE
Changes for Cordova with iPad

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -59,9 +59,8 @@ export default class Application extends Component {
   }
 
   initCordova () {
-    console.log("Application initCordova ------------ " + __filename);
-
     if (isCordova()) {
+      console.log("Application initCordova ------------ " + __filename);
       window.handleOpenURL = function (url) {
         TwitterSignIn.handleTwitterOpenURL(url);
       };

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -202,7 +202,7 @@ export default class HeaderBar extends Component {
             </span>
           }
 
-          { showFullNavigation && !weVoteBrandingOff ? HeaderBar.donate(pathname === "/more/donate") : null }
+          { showFullNavigation && !weVoteBrandingOff && isWebApp() ? HeaderBar.donate(pathname === "/more/donate") : null }
 
           { !showFullNavigation && isWebApp() &&
             <button type="button" className="btn btn-sm btn-success"

--- a/src/js/components/Navigation/HeaderGettingStartedBar.jsx
+++ b/src/js/components/Navigation/HeaderGettingStartedBar.jsx
@@ -270,9 +270,12 @@ export default class HeaderGettingStartedBar extends Component {
                                      title="Issues"
                                      completed={this.state.ballot_intro_issues_completed} /> :
               null }
-            <GettingStartedBarItem show={this._openPrintModal}
-                                   title="Print"
-                                   printIcon/>
+            {/* Print disabled in Cordova */}
+            { isWebApp() &&
+              <GettingStartedBarItem show={this._openPrintModal}
+                                     title="Print"
+                                     printIcon/>
+            }
             <GettingStartedBarItem show={this._openEmailModal}
                                    title="Email"
                                    emailIcon/>

--- a/src/js/components/Navigation/SettingsPersonalSideBar.jsx
+++ b/src/js/components/Navigation/SettingsPersonalSideBar.jsx
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import { Link } from "react-router";
 import { renderLog } from "../../utils/logging";
 
-
 export default class SettingsPersonalSideBar extends Component {
   static propTypes = {
     editMode: PropTypes.string,
@@ -14,12 +13,6 @@ export default class SettingsPersonalSideBar extends Component {
   constructor (props) {
     super(props);
     this.state = {};
-  }
-
-  componentDidMount () {
-  }
-
-  componentWillUnmount () {
   }
 
   render () {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -37,6 +37,7 @@ function startApp () {
 if (isCordova()) {
   document.addEventListener("deviceready", (id) => {
     console.log("Received Cordova Event: ", id.type);
+    navigator.splashscreen.hide();
     startApp();
   }, false);
 } else {  // browser

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -18,7 +18,7 @@ import BrowserPushMessage from "../../components/Widgets/BrowserPushMessage";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateModal from "../../components/Ballot/CandidateModal";
 import cookies from "../../utils/cookies";
-import {cordovaDot, historyPush, isWebApp} from "../../utils/cordovaUtils";
+import { cordovaDot, historyPush, isCordova, isWebApp } from "../../utils/cordovaUtils";
 import ElectionActions from "../../actions/ElectionActions";
 import ElectionStore from "../../stores/ElectionStore";
 import Helmet from "react-helmet";
@@ -682,7 +682,7 @@ export default class Ballot extends Component {
               }
             </div>
 
-            { ballot_with_all_items.length === 0 ?
+            { ballot_with_all_items.length === 0 || isCordova() ?
               null :
               <div className="col-md-4 hidden-xs sidebar-menu">
                 <BallotSideBar displayTitle displaySubtitles />

--- a/src/js/routes/Settings/SettingsDashboard.jsx
+++ b/src/js/routes/Settings/SettingsDashboard.jsx
@@ -160,15 +160,17 @@ export default class SettingsDashboard extends Component {
     // console.log("this.state.organization.organization_banner_url:", this.state.organization.organization_banner_url);
     return <div className={ isWebApp() ? "settings-dashboard" : "settings-dashboard SettingsCardBottomCordova" } >
       {/* Header Spacing for Desktop */}
-      <div className="col-md-12 hidden-xs hidden-print">
-        <SettingsBannerAndOrganizationCard organization={this.state.organization} />
-      </div>
+      { isWebApp() &&
+        <div className={isWebApp() ? "col-md-12 hidden-xs hidden-print" : "col-md-12 hidden-print"}>
+          <SettingsBannerAndOrganizationCard organization={this.state.organization}/>
+        </div>
+      }
       {/* Header Spacing for Mobile */}
-      <div className="visible-xs hidden-print">
+      <div className={ isWebApp() ? "visible-xs hidden-print" : "hidden-print" } >
         <SettingsBannerAndOrganizationCard organization={this.state.organization} />
       </div>
 
-      <div className="visible-xs u-padding-top--md">
+      <div className={ isWebApp() ? "visible-xs u-padding-top--md" : "u-padding-top--md"}>
         <span className={"btn u-padding-left--sm u-padding-bottom--sm"}>
           <Button className={"btn btn-sm btn-default u-link-color"}
                 onClick={ () => historyPush(isWebApp() ? "/settings/menu" : "/more/hamburger") }>
@@ -177,36 +179,45 @@ export default class SettingsDashboard extends Component {
         </span>
       </div>
 
-      {/* Desktop left navigation + Settings content */}
-      <div className="hidden-xs">
-        <div className="container-fluid">
-          <div className="row">
-            {/* Desktop mode left navigation */}
-            <div className="col-4 sidebar-menu">
-              <SettingsPersonalSideBar editMode={this.state.editMode} isSignedIn={this.state.voter.is_signed_in} />
+      {/* Desktop left navigation + Settings content.
+          WebApp only, since the dashboard doesn't go well with the HamburgerMenu on iPad */}
+      { isWebApp() &&
+        <div className="hidden-xs">
+          <div className="container-fluid">
+            <div className="row">
+              {/* Desktop mode left navigation */}
+              <div className="col-4 sidebar-menu">
+                <SettingsPersonalSideBar editMode={this.state.editMode} isSignedIn={this.state.voter.is_signed_in}/>
 
-              <SelectVoterGuidesSideBar />
+                <SelectVoterGuidesSideBar/>
 
-              <h4 className="text-left" />
-              <div className="terms-and-privacy u-padding-top--md">
-                <Link to="/more/terms">Terms of Service</Link>&nbsp;&nbsp;&nbsp;<Link to="/more/privacy">Privacy Policy</Link>
+                <h4 className="text-left"/>
+                <div className="terms-and-privacy u-padding-top--md">
+                  <Link to="/more/terms">Terms of Service</Link>&nbsp;&nbsp;&nbsp;<Link to="/more/privacy">Privacy
+                  Policy</Link>
+                </div>
               </div>
-            </div>
-            {/* Desktop mode content */}
-            <div className="col-8">
-              {settingsComponentToDisplay}
+              {/* Desktop mode content */}
+              <div className="col-8">
+                {settingsComponentToDisplay}
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      }
 
       {/* Mobile Settings content */}
-      <div className="visible-xs">
-        {/* Mobile mode content */}
+      { isWebApp() ?
+        <div className="visible-xs">
+          {/* Mobile mode content */}
+          <div className="col-12">
+            {settingsComponentToDisplay}
+          </div>
+        </div> :
         <div className="col-12">
           {settingsComponentToDisplay}
         </div>
-      </div>
+      }
     </div>;
   }
 }

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -363,10 +363,12 @@ $container-margin: -15px;
   &__td-0 {
     padding-left: $space-md !important;
     vertical-align: middle !important;
+    max-width: 1em;
   }
   &__td-1 {
     font-size: 1.3rem;
     vertical-align: middle !important;
+    max-width: 1em;
   }
   &__td-2 {
     font-size: 1.3rem;


### PR DESCRIPTION
HeaderBar: suppress Donate button
HeaderGettingStartedBar:  suppress print ballot
SettingsPersonalSideBar: lint warning cleanup
Ballot: Don't show BallotSideBar if Cordova. Anchored hrefs with #, are
relative to a url, and don't work as is in Cordova.
SettingsDashboard: The new dashboard could fit on the iPad size display,
but does not fit well with the HamburgerMenu settings choice, so
suppressed it if Cordova.
Application: Cordova specific console.log was displaying in the webapp
_navigator.scss, fixed HamburgerMenu column width for iPad.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
