### PR TITLE
added a little space above and below the search box

### DIFF
--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -26,7 +26,7 @@ $space-search-right: 10%;
   }
 
   &__search {
-    margin: $space-none;
+    margin: $space-sm;
     position: relative;
     width: 100%;
   }


### PR DESCRIPTION
### Changes included this pull request?
I changed the margin size from $space-none to $space-sm in the `page-header__search`. The HeaderBar's height on pages that use the "Back to Ballot"  button did not have any margins, so I gave it a margin to show the dark blue background.