### PR TITLE
fix autocomplete on the Ballot page

### DIFF
--- a/src/sass/components/_ballotModals.scss
+++ b/src/sass/components/_ballotModals.scss
@@ -17,6 +17,7 @@
     bottom: 0;
     left: 0;
     overflow: auto;
+    z-index: 1050;
 
     &-mobile {
       @include breakpoints(small mid-small) {
@@ -51,4 +52,8 @@
   &__modal {
     top: 0;
   }
+}
+
+.modal-backdrop {
+  z-index: 1000;
 }


### PR DESCRIPTION
The Google autocomplete to offer suggested addresses on the Ballot page is functional as in the other components `WebApp/src/js/components/Settings/SettingsAddress.jsx`. The issue is that `.pac-container` that contains the list of autocompletes has a lower z-index value than the modal's z-index. Therefore, in the `WebApp/src/sass/components/_ballotModals.scss` I gave the modal a lower z-index value than the `.pac-container` to display the autocompletes. 