### PR TITLE
Rearrange args sent to facebook login method; Check auth response fro…

### DIFF
--- a/src/js/actions/FacebookActions.js
+++ b/src/js/actions/FacebookActions.js
@@ -169,18 +169,20 @@ export default {
           } else {
             let api = isWebApp() ? window.FB : window.facebookConnectPlugin;  // eslint-disable-line no-undef
             api.login(
-              ["public_profile", "email", "user_friends"],
               (res) => {
+                // Check if res.authResponse is null indicating cancelled login attempt
+                if (! res.authResponse) {
+                  oAuthLog("FacebookActions loginFailure error response: ", res);
+                  return;
+                }
+
                 oAuthLog("FacebookActions loginSuccess userData: ", res);
                 Dispatcher.dispatch({
                   type: FacebookConstants.FACEBOOK_LOGGED_IN,
                   data: res,
                 });
               },
-
-              function (error) {
-                oAuthLog("FacebookActions loginFailure error response: ", error);
-              }
+              {scope: "public_profile,email,user_friends"}
             );
           }
         }


### PR DESCRIPTION
…m login attempt, cancel login flow if null

### What github.com/wevote/WebApp/issues does this fix?
Addresses issue #1484 

### Changes included this pull request?
Refactor arguments sent to facebook login method.
Check the response value sent from facebook login request. If null (indicating cancelled/rejected login attempt), return from the function back to the signin page.