### PR TITLE
Performance fixes for WebApp and Cordova (issuesRetrieve)

### DIFF
--- a/src/js/actions/IssueActions.js
+++ b/src/js/actions/IssueActions.js
@@ -13,6 +13,8 @@ export default {
     });
   },
 
+  // June 15, 2018:  There is no functional difference in the JSON retured with this API, than with issuesRetrieve, and before today's change, we called the two API's 11 times
+  // in 3 seconds when navigating between Ballot and Candidate (and each time receiving the exact same return)
   issuesRetrieveForElection: function (google_civic_election_id, ballot_location_shortcut = "", ballot_returned_we_vote_id = "") {
     Dispatcher.loadEndpoint("issuesRetrieve", {
       ballot_location_shortcut: ballot_location_shortcut,

--- a/src/js/components/Ballot/BallotIntroFollowIssues.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowIssues.jsx
@@ -32,8 +32,9 @@ export default class BallotIntroFollowIssues extends Component {
   }
 
   componentWillMount () {
-    IssueActions.issuesRetrieve();
-    // IssueActions.retrieveIssuesToFollow();
+    if (IssueStore.getPreviousGoogleCivicElectionId() < 1) {
+      IssueActions.issuesRetrieve();
+    }
   }
 
   componentDidMount () {

--- a/src/js/components/Network/NetworkIssuesFollowed.jsx
+++ b/src/js/components/Network/NetworkIssuesFollowed.jsx
@@ -6,23 +6,25 @@ import IssueFollowToggleSquare from "../Issues/IssueFollowToggleSquare";
 import IssueStore from "../../stores/IssueStore";
 import { renderLog } from "../../utils/logging";
 
-
 export default class NetworkIssuesFollowed extends Component {
   static propTypes = {
     children: PropTypes.object,
-    history: PropTypes.object
+    history: PropTypes.object,
   };
 
   constructor (props) {
     super(props);
     this.state = {
       edit_mode: false,
-      issues_followed: []
+      issues_followed: [],
     };
   }
 
   componentDidMount () {
-    IssueActions.issuesRetrieve();
+    if (IssueStore.getPreviousGoogleCivicElectionId() < 1) {
+      IssueActions.issuesRetrieve();
+    }
+
     this.issueStoreListener = IssueStore.addListener(this._onIssueStoreChange.bind(this));
   }
 
@@ -37,36 +39,34 @@ export default class NetworkIssuesFollowed extends Component {
   }
 
   getCurrentRoute () {
-    var current_route = "/issues_followed";
-    return current_route;
+    return "/issues_followed";
   }
 
   toggleEditMode () {
-    this.setState({edit_mode: !this.state.edit_mode});
+    this.setState({ edit_mode: !this.state.edit_mode });
   }
 
   onKeyDownEditMode (event) {
     let enterAndSpaceKeyCodes = [13, 32];
-    let scope = this;
     if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
-      scope.setState({edit_mode: !this.state.edit_mode});
+      this.setState({ edit_mode: !this.state.edit_mode });
     }
   }
 
   render () {
     renderLog(__filename);
-    let issue_list = [];
+    let issueList = [];
     if (this.state.issues_followed) {
-      issue_list = this.state.issues_followed;
+      issueList = this.state.issues_followed;
     }
 
     const ISSUES_TO_SHOW = 6;
 
-    let is_following = true;
-    let issue_count = 0;
-    const issue_list_for_display = issue_list.map((issue) => {
-      issue_count++;
-      if (issue_count > ISSUES_TO_SHOW) {
+    let isFollowing = true;
+    let issueCount = 0;
+    const issueListForDisplay = issueList.map((issue) => {
+      issueCount++;
+      if (issueCount > ISSUES_TO_SHOW) {
         return null;
       } else {
         return <IssueFollowToggleSquare
@@ -76,7 +76,7 @@ export default class NetworkIssuesFollowed extends Component {
           issue_description={issue.issue_description}
           issue_image_url={issue.issue_image_url}
           edit_mode={this.state.edit_mode}
-          is_following={is_following}
+          is_following={isFollowing}
           grid="col-sm-6"
           read_only />;
       }
@@ -88,7 +88,7 @@ export default class NetworkIssuesFollowed extends Component {
           <h1 className="h4">Issues You Are Following</h1>
           <div className="network-issues-list voter-guide-list card">
             <div className="card-child__list-group clearfix">
-              { issue_list_for_display }
+              { issueListForDisplay }
             </div>
             <div>
             {

--- a/src/js/components/Network/NetworkIssuesToFollow.jsx
+++ b/src/js/components/Network/NetworkIssuesToFollow.jsx
@@ -30,7 +30,10 @@ export default class NetworkIssuesToFollow extends Component {
 
   componentDidMount () {
     IssueActions.retrieveIssuesToFollow();
-    IssueActions.issuesRetrieve();
+    if (IssueStore.getPreviousGoogleCivicElectionId() < 1) {
+      IssueActions.issuesRetrieve();
+    }
+
     this.issueStoreListener = IssueStore.addListener(this._onIssueStoreChange.bind(this));
   }
 
@@ -84,8 +87,8 @@ export default class NetworkIssuesToFollow extends Component {
         grid="col-4 col-sm-3"
       />;
     });
-    var floatRight = {
-        float: "right"
+    let floatRight = {
+      float: "right",
     };
 
     return <div className="opinions-followed__container">

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -41,15 +41,14 @@ import VoterGuideStore from "../../stores/VoterGuideStore";
 import VoterStore from "../../stores/VoterStore";
 import webAppConfig from "../../config";
 
-
 // Related to WebApp/src/js/components/VoterGuide/VoterGuideBallot.jsx
 export default class Ballot extends Component {
   static propTypes = {
     location: PropTypes.object,
-    params: PropTypes.object
+    params: PropTypes.object,
   };
 
-  constructor (props){
+  constructor (props) {
     super(props);
     this.state = {
       ballotElectionList: [],
@@ -58,14 +57,14 @@ export default class Ballot extends Component {
       ballot_location_shortcut: "",
       candidate_for_modal: {
         voter_guides_to_follow_for_latest_ballot_item: [],
-        position_list: []
+        position_list: [],
       },
       hide_intro_modal_from_url: 0,
       hide_intro_modal_from_cookie: 0,
       lastHashUsedInLinkScroll: "",
       measure_for_modal: {
         voter_guides_to_follow_for_latest_ballot_item: [],
-        position_list: []
+        position_list: [],
       },
       mounted: false,
       showBallotIntroModal: false,
@@ -93,15 +92,15 @@ export default class Ballot extends Component {
     let wait_until_voter_sign_in_completes = this.props.location.query ? this.props.location.query.wait_until_voter_sign_in_completes : 0;
     let issues_voter_can_follow = IssueStore.getIssuesVoterCanFollow(); // Check to see if the issues have been retrieved yet
 
-    if ( wait_until_voter_sign_in_completes !== undefined || hide_intro_modal_from_cookie || hide_intro_modal_from_url || !issues_voter_can_follow ) {
+    if (wait_until_voter_sign_in_completes !== undefined || hide_intro_modal_from_cookie || hide_intro_modal_from_url || !issues_voter_can_follow) {
       this.setState({
         mounted: true,
-        showBallotIntroModal: false
+        showBallotIntroModal: false,
       });
     } else {
       this.setState({
         mounted: true,
-        showBallotIntroModal: !VoterStore.getInterfaceFlagState(VoterConstants.BALLOT_INTRO_MODAL_SHOWN)
+        showBallotIntroModal: !VoterStore.getInterfaceFlagState(VoterConstants.BALLOT_INTRO_MODAL_SHOWN),
       });
     }
 
@@ -111,22 +110,26 @@ export default class Ballot extends Component {
       // console.log("ballotWithAllItemsByFilterType !== undefined");
       this.setState({
         ballotWithAllItemsByFilterType: ballotWithAllItemsByFilterType,
-        filter_type: filter_type
+        filter_type: filter_type,
       });
     }
 
     let google_civic_election_id_from_url = this.props.params.google_civic_election_id || 0;
+
     // console.log("google_civic_election_id_from_url: ", google_civic_election_id_from_url);
     let ballot_returned_we_vote_id = this.props.params.ballot_returned_we_vote_id || "";
     ballot_returned_we_vote_id = ballot_returned_we_vote_id === "none" ? "" : ballot_returned_we_vote_id;
+
     // console.log("this.props.params.ballot_returned_we_vote_id: ", this.props.params.ballot_returned_we_vote_id);
     let ballot_location_shortcut = this.props.params.ballot_location_shortcut || "";
     ballot_location_shortcut = ballot_location_shortcut.trim();
     ballot_location_shortcut = ballot_location_shortcut === "none" ? "" : ballot_location_shortcut;
     let google_civic_election_id = 0;
+
     // console.log("componentDidMount, BallotStore.ballot_properties: ", BallotStore.ballot_properties);
     if (google_civic_election_id_from_url !== 0) {
       google_civic_election_id_from_url = parseInt(google_civic_election_id_from_url, 10);
+
       // google_civic_election_id = google_civic_election_id_from_url;
     } else if (BallotStore.ballot_properties && BallotStore.ballot_properties.google_civic_election_id) {
       google_civic_election_id = BallotStore.ballot_properties.google_civic_election_id;
@@ -135,22 +138,29 @@ export default class Ballot extends Component {
     // console.log("ballot_returned_we_vote_id: ", ballot_returned_we_vote_id, ", ballot_location_shortcut:", ballot_location_shortcut, ", google_civic_election_id_from_url: ", google_civic_election_id_from_url);
     if (ballot_returned_we_vote_id || ballot_location_shortcut || google_civic_election_id_from_url) {
       if (ballot_location_shortcut !== "") {
+
         // Change the ballot on load to make sure we are getting what we expect from the url
         BallotActions.voterBallotItemsRetrieve(0, "", ballot_location_shortcut);
+
         // Change the URL to match
         historyPush("/ballot/" + ballot_location_shortcut);
       } else if (ballot_returned_we_vote_id !== "") {
+
         // Change the ballot on load to make sure we are getting what we expect from the url
         BallotActions.voterBallotItemsRetrieve(0, ballot_returned_we_vote_id, "");
+
         // Change the URL to match
         historyPush("/ballot/id/" + ballot_returned_we_vote_id);
       } else if (google_civic_election_id_from_url !== 0) {
+
         // Change the ballot on load to make sure we are getting what we expect from the url
         if (google_civic_election_id !== google_civic_election_id_from_url) {
           BallotActions.voterBallotItemsRetrieve(google_civic_election_id_from_url, "", "");
+
           // Change the URL to match
           historyPush("/ballot/election/" + google_civic_election_id_from_url);
         }
+
         // No change to the URL needed
         // Now set google_civic_election_id
         google_civic_election_id = google_civic_election_id_from_url;
@@ -163,6 +173,7 @@ export default class Ballot extends Component {
       // console.log("if (BallotStore.ballot_properties && BallotStore.ballot_properties.ballot_found === false");
       historyPush("/settings/location");
     } else if (ballotWithAllItemsByFilterType === undefined) {
+
       // console.log("WebApp doesn't know the election or have ballot data, so ask the API server to return best guess");
       BallotActions.voterBallotItemsRetrieve(0, "", "");
     }
@@ -171,7 +182,11 @@ export default class Ballot extends Component {
     // console.log("VoterStore.election_id: ", VoterStore.election_id());
     if (google_civic_election_id || ballot_location_shortcut || ballot_returned_we_vote_id) {
       // console.log("CALLING IssueActions.issuesRetrieveForElection");
-      IssueActions.issuesRetrieveForElection(google_civic_election_id, ballot_location_shortcut, ballot_returned_we_vote_id);
+
+      if (IssueStore.getPreviousGoogleCivicElectionId() < 1) {
+        IssueActions.issuesRetrieveForElection(google_civic_election_id, ballot_location_shortcut, ballot_returned_we_vote_id);
+      }
+
       this.setState({
         issues_retrieved_from_google_civic_election_id: google_civic_election_id,
         issues_retrieved_from_ballot_returned_we_vote_id: ballot_returned_we_vote_id,
@@ -183,12 +198,18 @@ export default class Ballot extends Component {
     // NOTE: voterAllPositionsRetrieve and positionsCountForAllBallotItems are also called in SupportStore when voterAddressRetrieve is received,
     // so we get duplicate calls when you come straight to the Ballot page. There is no easy way around this currently.
     SupportActions.voterAllPositionsRetrieve();
-    SupportActions.positionsCountForAllBallotItems(google_civic_election_id);
+
+    // June 2018: Avoid hitting this same api multiple times, if we already have the data
+    if (!SupportStore.isSupportAlreadyInCache()) {
+      SupportActions.positionsCountForAllBallotItems(google_civic_election_id);
+    }
+
     BallotActions.voterBallotListRetrieve(); // Retrieve a list of ballots for the voter from other elections
     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
     this.supportStoreListener = SupportStore.addListener(this.onBallotStoreChange.bind(this));
     this.onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
+
     // Once a voter hits the ballot, they have gone through orientation
     cookies.setItem("show_full_navigation", "1", Infinity, "/");
 
@@ -214,13 +235,13 @@ export default class Ballot extends Component {
       wait_until_voter_sign_in_completes: wait_until_voter_sign_in_completes,
     });
 
-    if (this.props.location && this.props.location.hash){
+    if (this.props.location && this.props.location.hash) {
       // this.hashLinkScroll();
-      this.setState({lastHashUsedInLinkScroll: this.props.location.hash});
+      this.setState({ lastHashUsedInLinkScroll: this.props.location.hash });
     }
   }
 
-  componentWillReceiveProps (nextProps){
+  componentWillReceiveProps (nextProps) {
     // console.log('Ballot componentWillReceiveProps()');
     // console.log("Ballot componentWillReceiveProps, nextProps: ", nextProps);
     // console.log("Ballot this.state: ", this.state);
@@ -251,27 +272,29 @@ export default class Ballot extends Component {
         AnalyticsActions.saveActionBallotVisit(VoterStore.election_id());
       }
     }
-    if (nextProps.location && nextProps.location.hash){
+
+    if (nextProps.location && nextProps.location.hash) {
       // this.hashLinkScroll();
-      this.setState({lastHashUsedInLinkScroll: nextProps.location.hash});
+      this.setState({ lastHashUsedInLinkScroll: nextProps.location.hash });
     }
   }
 
   componentDidUpdate (prevProps, prevState) {
     // console.log('Ballot componentDidUpdate()', 'prevState.lastHashUsedInLinkScroll:', prevState.lastHashUsedInLinkScroll,'this.state.lastHashUsedInLinkScroll:', this.state.lastHashUsedInLinkScroll);
-    if (this.state.lastHashUsedInLinkScroll && this.state.lastHashUsedInLinkScroll !== prevState.lastHashUsedInLinkScroll){
+    if (this.state.lastHashUsedInLinkScroll && this.state.lastHashUsedInLinkScroll !== prevState.lastHashUsedInLinkScroll) {
       this.hashLinkScroll();
       // this.setState({lastHashUsedInLinkScroll: this.state.location.hash});
     }
   }
 
-  componentWillUnmount (){
+  componentWillUnmount () {
     // console.log("Ballot componentWillUnmount");
 
     //this.setState({mounted: false});
-    if (BallotStore.ballot_properties && BallotStore.ballot_properties.ballot_found === false){
+    if (BallotStore.ballot_properties && BallotStore.ballot_properties.ballot_found === false) {
       // No ballot found
     }
+
     this.ballotStoreListener.remove();
     this.electionListListener.remove();
     this.supportStoreListener.remove();
@@ -289,7 +312,7 @@ export default class Ballot extends Component {
 
     this.setState({
       candidate_for_modal: candidate_for_modal,
-      showCandidateModal: !this.state.showCandidateModal
+      showCandidateModal: !this.state.showCandidateModal,
     });
   }
 
@@ -301,6 +324,7 @@ export default class Ballot extends Component {
       // Clear out any # from anchors in the URL
       historyPush(this.state.pathname);
     }
+
     this.setState({ showBallotIntroModal: !this.state.showBallotIntroModal });
   }
 
@@ -311,9 +335,10 @@ export default class Ballot extends Component {
       measure_for_modal.voter_guides_to_follow_for_latest_ballot_item = VoterGuideStore.getVoterGuidesToFollowForBallotItemId(measure_for_modal.we_vote_id);
       MeasureActions.positionListForBallotItem(measure_for_modal.we_vote_id);
     }
+
     this.setState({
       measure_for_modal: measure_for_modal,
-      showMeasureModal: !this.state.showMeasureModal
+      showMeasureModal: !this.state.showMeasureModal,
     });
   }
 
@@ -326,14 +351,15 @@ export default class Ballot extends Component {
     } else {
       BallotActions.voterBallotListRetrieve(); // Retrieve a list of ballots for the voter from other elections
     }
+
     this.setState({
-      showSelectBallotModal: !this.state.showSelectBallotModal
+      showSelectBallotModal: !this.state.showSelectBallotModal,
     });
   }
 
   toggleBallotSummaryModal () {
     this.setState({
-      showBallotSummaryModal: !this.state.showBallotSummaryModal
+      showBallotSummaryModal: !this.state.showBallotSummaryModal,
     });
   }
 
@@ -341,9 +367,9 @@ export default class Ballot extends Component {
     // console.log("Ballot.jsx onVoterStoreChange");
     if (this.state.mounted) {
       let consider_opening_ballot_intro_modal = true;
-      if ( this.state.wait_until_voter_sign_in_completes ) {
+      if (this.state.wait_until_voter_sign_in_completes) {
         consider_opening_ballot_intro_modal = false;
-        if ( this.state.voter && this.state.voter.is_signed_in ) {
+        if (this.state.voter && this.state.voter.is_signed_in) {
           consider_opening_ballot_intro_modal = true;
           this.setState({ wait_until_voter_sign_in_completes: undefined });
           // console.log("onVoterStoreChange, about tohistoryPush(this.state.pathname):", this.state.pathname);
@@ -351,11 +377,12 @@ export default class Ballot extends Component {
         }
       }
 
-      if ( this.state.hide_intro_modal_from_cookie || this.state.hide_intro_modal_from_url ) {
+      if (this.state.hide_intro_modal_from_cookie || this.state.hide_intro_modal_from_url) {
         consider_opening_ballot_intro_modal = false;
       }
+
       // console.log("Ballot.jsx onVoterStoreChange VoterStore.getVoter: ", VoterStore.getVoter());
-      if ( consider_opening_ballot_intro_modal ) {
+      if (consider_opening_ballot_intro_modal) {
         this.setState({
           voter: VoterStore.getVoter(),
           showBallotIntroModal: !VoterStore.getInterfaceFlagState(VoterConstants.BALLOT_INTRO_MODAL_SHOWN),
@@ -370,7 +397,7 @@ export default class Ballot extends Component {
     }
   }
 
-  onBallotStoreChange (){
+  onBallotStoreChange () {
     // console.log("Ballot.jsx onBallotStoreChange, BallotStore.ballot_properties: ", BallotStore.ballot_properties);
     if (this.state.mounted) {
       if (BallotStore.ballot_properties && BallotStore.ballot_properties.ballot_found && BallotStore.ballot && BallotStore.ballot.length === 0) {
@@ -385,13 +412,18 @@ export default class Ballot extends Component {
         });
       }
     }
+
     if (BallotStore.ballot_properties) {
       // If the incoming google_civic_election_id, ballot_returned_we_vote_id, or ballot_location_shortcut are different, call issuesRetrieveForElection
       if (parseInt(BallotStore.ballot_properties.google_civic_election_id, 10) !== this.state.issues_retrieved_from_google_civic_election_id ||
           BallotStore.ballot_properties.ballot_returned_we_vote_id !== this.state.issues_retrieved_from_ballot_returned_we_vote_id ||
           BallotStore.ballot_properties.ballot_location_shortcut !== this.state.issues_retrieved_from_ballot_location_shortcut) {
         // console.log("onBallotStoreChange, Calling issuesRetrieveForElection");
-        IssueActions.issuesRetrieveForElection(BallotStore.ballot_properties.google_civic_election_id, BallotStore.ballot_properties.ballot_location_shortcut, BallotStore.ballot_properties.ballot_returned_we_vote_id);
+
+        if (IssueStore.getPreviousGoogleCivicElectionId() < 1) {
+          IssueActions.issuesRetrieveForElection(BallotStore.ballot_properties.google_civic_election_id, BallotStore.ballot_properties.ballot_location_shortcut, BallotStore.ballot_properties.ballot_returned_we_vote_id);
+        }
+
         this.setState({
           issues_retrieved_from_google_civic_election_id: parseInt(BallotStore.ballot_properties.google_civic_election_id, 10),
           issues_retrieved_from_ballot_returned_we_vote_id: BallotStore.ballot_properties.ballot_returned_we_vote_id,
@@ -402,15 +434,17 @@ export default class Ballot extends Component {
       this.setState({
         ballot_returned_we_vote_id: BallotStore.ballot_properties.ballot_returned_we_vote_id || "",
         ballot_location_shortcut: BallotStore.ballot_properties.ballot_location_shortcut || "",
-        google_civic_election_id: parseInt(BallotStore.ballot_properties.google_civic_election_id, 10)
+        google_civic_election_id: parseInt(BallotStore.ballot_properties.google_civic_election_id, 10),
       });
+
     }
-    this.setState({ballotElectionList: BallotStore.ballotElectionList()});
+
+    this.setState({ ballotElectionList: BallotStore.ballotElectionList() });
 
     if (Object.keys(this.state.ballot_item_unfurled_tracker).length === 0) {
       // console.log("current tracker in Ballotstore", BallotStore.current_ballot_item_unfurled_tracker)
       this.setState({
-        ballot_item_unfurled_tracker: BallotStore.current_ballot_item_unfurled_tracker
+        ballot_item_unfurled_tracker: BallotStore.current_ballot_item_unfurled_tracker,
       });
     }
   }
@@ -425,8 +459,8 @@ export default class Ballot extends Component {
     let ballot_location_shortcut;
     let ballot_returned_we_vote_id;
 
-    for (var i = 0; i < elections_list.length; i++) {
-      var election = elections_list[i];
+    for (let i = 0; i < elections_list.length; i++) {
+      let election = elections_list[i];
       elections_locations_list.push(election);
       ballot_returned_we_vote_id = "";
       ballot_location_shortcut = "";
@@ -438,6 +472,7 @@ export default class Ballot extends Component {
         ballot_returned_we_vote_id = one_ballot_location.ballot_returned_we_vote_id || "";
         ballot_returned_we_vote_id = ballot_returned_we_vote_id.trim();
       }
+
       voter_ballot = {
         google_civic_election_id: election.google_civic_election_id,
         election_description_text: election.election_name,
@@ -455,22 +490,22 @@ export default class Ballot extends Component {
     });
   }
 
-  onVoterGuideStoreChange (){
+  onVoterGuideStoreChange () {
     // console.log("Ballot onVoterGuideStoreChange");
     // Update the data for the modal to include the position of the organization related to this ballot item
     if (this.state.candidate_for_modal) {
       this.setState({
         candidate_for_modal: {
           ...this.state.candidate_for_modal,
-          voter_guides_to_follow_for_latest_ballot_item: VoterGuideStore.getVoterGuidesToFollowForLatestBallotItem()
-        }
+          voter_guides_to_follow_for_latest_ballot_item: VoterGuideStore.getVoterGuidesToFollowForLatestBallotItem(),
+        },
       });
     } else if (this.state.measure_for_modal) {
       this.setState({
         measure_for_modal: {
           ...this.state.measure_for_modal,
-          voter_guides_to_follow_for_latest_ballot_item: VoterGuideStore.getVoterGuidesToFollowForLatestBallotItem()
-        }
+          voter_guides_to_follow_for_latest_ballot_item: VoterGuideStore.getVoterGuidesToFollowForLatestBallotItem(),
+        },
       });
     }
   }
@@ -488,7 +523,7 @@ export default class Ballot extends Component {
 
         if (element) {
           let positionY = element.offsetTop;
-          if (isMobile() ){
+          if (isMobile()) {
             window.scrollTo(0, positionY + 250);
           } else {
             window.scrollTo(0, positionY + 196);
@@ -510,16 +545,16 @@ export default class Ballot extends Component {
   }
 
   updateOfficeDisplayUnfurledTracker (we_vote_id, status) {
-    const new_ballot_item_unfurled_tracker = { ... this.state.ballot_item_unfurled_tracker, [we_vote_id]: status};
+    const new_ballot_item_unfurled_tracker = { ... this.state.ballot_item_unfurled_tracker, [we_vote_id]: status };
     BallotActions.voterBallotItemOpenOrClosedSave(new_ballot_item_unfurled_tracker);
     this.setState({
-      ballot_item_unfurled_tracker: new_ballot_item_unfurled_tracker
+      ballot_item_unfurled_tracker: new_ballot_item_unfurled_tracker,
     });
   }
 
   render () {
     renderLog(__filename);
-    // console.log("Ballot render");
+
     let text_for_map_search = VoterStore.getTextForMapSearch();
     let issues_voter_can_follow = IssueStore.getIssuesVoterCanFollow(); // Don't auto-open intro until Issues are loaded
 
@@ -538,6 +573,7 @@ export default class Ballot extends Component {
     }
 
     const missing_address = this.state.location === null;
+
     // const ballot_caveat = BallotStore.ballot_properties.ballot_caveat; // ballot_properties might be undefined
     const election_name = BallotStore.currentBallotElectionName;
     const election_day_text = BallotStore.currentBallotElectionDate;
@@ -583,12 +619,15 @@ export default class Ballot extends Component {
     if (voter_ballot_location && voter_ballot_location.voter_entered_address) {
       voter_entered_address = true;
     }
+
     if (voter_ballot_location && voter_ballot_location.voter_specific_ballot_from_google_civic) {
       voter_specific_ballot_from_google_civic = true;
     }
+
     if (BallotStore.ballot_properties && BallotStore.ballot_properties.ballot_location_display_name) {
       ballot_location_display_name = BallotStore.ballot_properties.ballot_location_display_name;
     } else if (voter_ballot_location && voter_ballot_location.ballot_location_display_name) {
+
       // Get the location name from the VoterStore address object
       ballot_location_display_name = voter_ballot_location.ballot_location_display_name;
     }
@@ -596,6 +635,7 @@ export default class Ballot extends Component {
     if (this.state.ballotWithAllItemsByFilterType.length === 0 && in_remaining_decisions_mode) {
       historyPush(this.state.pathname);
     }
+
     // console.log("Ballot.jsx, this.state.google_civic_election_id: ", this.state.google_civic_election_id);
 
     return <div className="ballot">

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -5,6 +5,7 @@ import { capitalizeString } from "../../utils/textFormat";
 import Helmet from "react-helmet";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import IssueActions from "../../actions/IssueActions";
+import IssueStore from "../../stores/IssueStore";
 import LoadingWheel from "../../components/LoadingWheel";
 import { renderLog } from "../../utils/logging";
 import OfficeActions from "../../actions/OfficeActions";
@@ -16,7 +17,7 @@ import VoterStore from "../../stores/VoterStore";
 // This is related to routes/VoterGuide/OrganizationVoterGuideOffice
 export default class Office extends Component {
   static propTypes = {
-    params: PropTypes.object.isRequired
+    params: PropTypes.object.isRequired,
   };
 
   constructor (props) {
@@ -27,16 +28,20 @@ export default class Office extends Component {
     };
   }
 
-  componentDidMount (){
-    IssueActions.issuesRetrieveForElection(VoterStore.election_id());
+  componentDidMount () {
+    if (IssueStore.getPreviousGoogleCivicElectionId() < 1) {
+      IssueActions.issuesRetrieveForElection(VoterStore.election_id());
+    }
 
     this.officeStoreListener = OfficeStore.addListener(this._onOfficeStoreChange.bind(this));
     let office = OfficeStore.getOffice(this.props.params.office_we_vote_id);
-		if ( !office || !office.ballot_item_display_name ) {
+
+    if (!office || !office.ballot_item_display_name) {
       OfficeActions.officeRetrieve(this.props.params.office_we_vote_id);
     } else {
-      this.setState({office: office});
+      this.setState({ office: office });
     }
+
     this.setState({
       office_we_vote_id: this.props.params.office_we_vote_id,
     });
@@ -48,11 +53,12 @@ export default class Office extends Component {
   componentWillReceiveProps (nextProps) {
     // When a new office is passed in, update this component to show the new data
     let office = OfficeStore.getOffice(nextProps.params.office_we_vote_id);
-		if ( !office || !office.ballot_item_display_name ) {
-      this.setState({office_we_vote_id: nextProps.params.office_we_vote_id});
+
+    if (!office || !office.ballot_item_display_name) {
+      this.setState({ office_we_vote_id: nextProps.params.office_we_vote_id });
       OfficeActions.officeRetrieve(nextProps.params.office_we_vote_id);
     } else {
-      this.setState({office: office, office_we_vote_id: nextProps.params.office_we_vote_id});
+      this.setState({ office: office, office_we_vote_id: nextProps.params.office_we_vote_id });
     }
 
     // Display the office name in the search box
@@ -65,8 +71,8 @@ export default class Office extends Component {
     this.officeStoreListener.remove();
   }
 
-  _onOfficeStoreChange (){
-    var office = OfficeStore.getOffice(this.state.office_we_vote_id);
+  _onOfficeStoreChange () {
+    let office = OfficeStore.getOffice(this.state.office_we_vote_id);
     this.setState({ office: office });
   }
 
@@ -81,13 +87,14 @@ export default class Office extends Component {
           <br />
         </div>;
     }
-    let office_name = capitalizeString(office.ballot_item_display_name);
-    let title_text = office_name + " - We Vote";
-    let description_text = "Choose who you support for " + office_name + "in the November Election";
+
+    let officeName = capitalizeString(office.ballot_item_display_name);
+    let titleText = officeName + " - We Vote";
+    let descriptionText = "Choose who you support for " + officeName + "in the November Election";
 
     return <div>
-      <Helmet title={title_text}
-              meta={[{"name": "description", "content": description_text}]}
+      <Helmet title={titleText}
+              meta={[{ "name": "description", "content": descriptionText }]}
               />
       <OfficeItem we_vote_id={office.we_vote_id}
                   kind_of_ballot_item="OFFICE"

--- a/src/js/routes/IssuesFollowed.jsx
+++ b/src/js/routes/IssuesFollowed.jsx
@@ -28,7 +28,10 @@ export default class IssuesFollowed extends Component {
   }
 
   componentDidMount () {
-    IssueActions.issuesRetrieve();
+    if (IssueStore.getPreviousGoogleCivicElectionId() < 1) {
+      IssueActions.issuesRetrieve();
+    }
+
     this.issueStoreListener = IssueStore.addListener(this._onIssueStoreChange.bind(this));
   }
 
@@ -43,19 +46,17 @@ export default class IssuesFollowed extends Component {
   }
 
   getCurrentRoute () {
-    var current_route = "/issues_followed";
-    return current_route;
+    return "/issues_followed";
   }
 
   toggleEditMode () {
-    this.setState({edit_mode: !this.state.edit_mode});
+    this.setState({ edit_mode: !this.state.edit_mode });
   }
 
   onKeyDownEditMode (event) {
     let enterAndSpaceKeyCodes = [13, 32];
-    let scope = this;
     if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
-      scope.setState({edit_mode: !this.state.edit_mode});
+      this.setState({ edit_mode: !this.state.edit_mode });
     }
   }
 
@@ -69,7 +70,7 @@ export default class IssuesFollowed extends Component {
 
   render () {
     renderLog(__filename);
-    var issue_list = [];
+    let issue_list = [];
     if (this.state.issues_followed) {
       issue_list = this.state.issues_followed;
     }

--- a/src/js/stores/IssueStore.js
+++ b/src/js/stores/IssueStore.js
@@ -26,6 +26,7 @@ class IssueStore extends ReduceStore {
       issue_we_vote_ids_under_each_ballot_item: {}, // Dictionary with key: candidate or measure we_vote_id, list: issue_we_vote_id. An org with that issue has a position in this election
       organization_we_vote_ids_linked_to_issue_dict: {}, // Dictionary with key: issue_we_vote_id, list: organization_we_vote_id that is linked to this issue
       all_cached_issues: {}, // Dictionary with key: issue_we_vote_id, and value: complete issue object
+      googleCivicElectionId: 0,
     };
   }
 
@@ -49,6 +50,7 @@ class IssueStore extends ReduceStore {
       // LEAVE DATA: issue_we_vote_ids_under_each_ballot_item: {}, // Dictionary with key: candidate or measure we_vote_id, list: issue_we_vote_id. An org with that issue has a position in this election
       // LEAVE DATA: organization_we_vote_ids_linked_to_issue_dict: {}, // Dictionary with key: issue_we_vote_id, list: organization_we_vote_id that is linked to this issue
       // LEAVE DATA: all_cached_issues: {}, // Dictionary with key: issue_we_vote_id, and value: complete issue object
+      googleCivicElectionId: 0,
     };
   }
 
@@ -305,6 +307,10 @@ class IssueStore extends ReduceStore {
     }
   }
 
+  getPreviousGoogleCivicElectionId () {
+    return this.getState().googleCivicElectionId;
+  }
+
   reduce (state, action) {
     let all_cached_issues;
     let ballot_item_we_vote_id;
@@ -330,6 +336,7 @@ class IssueStore extends ReduceStore {
     let revisedState;
     let voterElectionId;
     let voter_guides;
+    let googleCivicElectionId;
 
     // Exit if we don't have a successful response (since we expect certain variables in a successful response below)
     if (!action.res || !action.res.success)
@@ -374,6 +381,8 @@ class IssueStore extends ReduceStore {
         organization_name_support_list_for_each_ballot_item = state.organization_name_support_list_for_each_ballot_item;
         organization_name_oppose_list_for_each_ballot_item = state.organization_name_oppose_list_for_each_ballot_item;
         issue_score_for_each_ballot_item = state.issue_score_for_each_ballot_item;
+        googleCivicElectionId = action.res.google_civic_election_id === false ? state.googleCivicElectionId : action.res.google_civic_election_id;
+
         if (action.res.issue_score_list) {
           issue_score_list = action.res.issue_score_list;
           if (issue_score_list.length) {
@@ -434,7 +443,8 @@ class IssueStore extends ReduceStore {
           organization_we_vote_id_oppose_list_for_each_ballot_item: organization_we_vote_id_oppose_list_for_each_ballot_item,
           organization_name_support_list_for_each_ballot_item: organization_name_support_list_for_each_ballot_item,
           organization_name_oppose_list_for_each_ballot_item: organization_name_oppose_list_for_each_ballot_item,
-          issue_score_for_each_ballot_item: issue_score_for_each_ballot_item
+          issue_score_for_each_ballot_item: issue_score_for_each_ballot_item,
+          googleCivicElectionId: googleCivicElectionId,
         });
 
         // console.log("action.res.voter_issues_only:", action.res.voter_issues_only);


### PR DESCRIPTION
This was the next biggest performance killer on the Cordova side, and
also was tested on the WebApp side.
issuesRetrieve was being called 11 times in 3 seconds, when navigating
between Ballot and Candidate, and returning identical data.  Now only
does this once or twice (twice if the first two queries are simultaneous).

