### PR TITLE
Return opposed items when displaying "Items Decided" on Ballot

### DIFF
--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -143,7 +143,7 @@ class BallotStore extends ReduceStore {
       if (ballot_item.kind_of_ballot_item === "OFFICE"){ //Offices
         return ballot_item.candidate_list.length > 0;
       } else { //MEASURES
-        return SupportStore.supportList[ballot_item.we_vote_id];
+        return SupportStore.supportList[ballot_item.we_vote_id] || SupportStore.opposeList[ballot_item.we_vote_id];
       }
     });
   }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Addresses Issue #1552 

### Changes included this pull request?
Have Ballot store getter return opposed items along with supported items for "Items Decided" filter.