### PR TITLE
Fixed candidate summary text on ballot and candidate pages

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -166,6 +166,13 @@ export default class CandidateItem extends Component {
     } else {
       candidate_photo_url_html = <i className="card-main__avatar icon-office-child icon-main icon-icon-person-placeholder-6-1" />;
     }
+
+    let twitter_description_text = twitter_description && twitter_description.length ? twitter_description + " " : "";
+    let ballotpedia_candidate_summary_text = ballotpedia_candidate_summary && ballotpedia_candidate_summary.length ? ballotpedia_candidate_summary : "";
+    // Strip away any HTML tags
+    ballotpedia_candidate_summary_text = ballotpedia_candidate_summary_text.split(/<[^<>]*>/).join("");
+    let candidate_text = twitter_description_text + ballotpedia_candidate_summary_text;
+
     // let positions_in_your_network = SupportStore.get(we_vote_id) && ( SupportStore.get(we_vote_id).oppose_count || SupportStore.get(we_vote_id).support_count);
 
     let one_candidate = CandidateStore.getCandidate(candidateWeVoteId);
@@ -232,14 +239,14 @@ export default class CandidateItem extends Component {
             null
           }
           </p>
-          { twitter_description || ballotpedia_candidate_summary ?
+          { candidate_text.length ?
             <div className={ "u-stack--sm" + (this.props.link_to_ballot_item_page ? " card-main__description-container--truncated" : " card-main__description-container")}>
               <div className="card-main__description">
                 <LearnMore
                   learn_more_text="Read more on Ballotpedia"
                   num_of_lines={3}
                   learn_more_link={ballotpedia_candidate_url}
-                  text_to_display={ twitter_description && ballotpedia_candidate_summary ? twitter_description + " " + ballotpedia_candidate_summary : twitter_description + ballotpedia_candidate_summary } />
+                  text_to_display={candidate_text} />
                 {/* <ParsedTwitterDescription twitter_description={twitter_description} />
                 <span className="card-main__description">
                   { ballotpedia_candidate_summary }

--- a/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
@@ -422,6 +422,8 @@ export default class OfficeItemCompressedRaccoon extends Component {
             let candidate_party_text = one_candidate.party && one_candidate.party.length ? one_candidate.party + ". " : "";
             let candidate_twitter_description_text = one_candidate.twitter_description && one_candidate.twitter_description.length ? one_candidate.twitter_description : "";
             let ballotpediaCandidateSummary = one_candidate.ballotpedia_candidate_summary && one_candidate.ballotpedia_candidate_summary.length ? " " + one_candidate.ballotpedia_candidate_summary : "";
+            // Strip away any HTML tags
+            ballotpediaCandidateSummary = ballotpediaCandidateSummary.split(/<[^<>]*>/).join("");
             let candidate_text = candidate_party_text + candidate_twitter_description_text + ballotpediaCandidateSummary;
 
             let positions_display_raccoon = <div>

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -70,15 +70,16 @@ export default class ItemPositionStatementActionBar extends Component {
     }
     if (this.state.showEditPositionStatementInput) {
       //we don't want to do anything
-    } else if (nextProps.supportProps.voter_statement_text) {
+    } else if (nextProps.supportProps && nextProps.supportProps.voter_statement_text) {
       this.setState({
         statement_text_to_be_saved: nextProps.supportProps.voter_statement_text,
         showEditPositionStatementInput: false,
         transitioning: false,
       });
     } else {
+      let voter_statement_text = nextProps.supportProps && nextProps.supportProps.voter_statement_text || "";
       this.setState({
-        statement_text_to_be_saved: nextProps.supportProps.voter_statement_text,
+        statement_text_to_be_saved: voter_statement_text,
         showEditPositionStatementInput: nextProps.comment_edit_mode_on,
         transitioning: false,
       });

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -37,7 +37,7 @@ export default class PositionPublicToggle extends Component {
   componentDidMount () {
     this._onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this._onVoterStoreChange.bind(this));
-    let { is_public_position: isPublicOpinion } = this.props.supportProps;
+    let isPublicOpinion = this.props.supportProps && this.props.supportProps.is_public_position;
     this.setState({
       showToThePublicOn: isPublicOpinion || false,
     });


### PR DESCRIPTION
Fixed the candidate summary text on the ballot and candidate pages when the Twitter description is empty or the Ballotpedia summary contains HTML tags (#1530). Removed some errors in the browser console where objects are sometimes "undefined".