### PR TITLE
Added flex positioning to measure vote descriptions

### DIFF
--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -348,21 +348,21 @@ export default class ItemActionBar extends Component {
       <div className={(yesVoteDescriptionExists || noVoteDescriptionExists ? "" : "btn-group") + (!this.props.shareButtonHide ? " u-push--sm" : "")}>
 
         {/* Start of Support Button */}
-        <div className="hidden-xs">
+        <div className="hidden-xs item-actionbar__position-bar">
           <OverlayTrigger placement="top" overlay={supportButtonPopoverTooltip}>{supportButton}</OverlayTrigger>
           {yesVoteDescriptionExists ? <span className="item-actionbar__following-text">{yesVoteDescription}</span> : null}
         </div>
-        <div className="visible-xs">
+        <div className="visible-xs item-actionbar__position-bar item-actionbar__position-bar--mobile">
           {supportButton}
           {yesVoteDescriptionExists ? <span className="item-actionbar__following-text">{yesVoteDescription}</span> : null}
         </div>
 
         {/* Start of Oppose Button */}
-        <div className="hidden-xs">
+        <div className="hidden-xs item-actionbar__position-bar">
           <OverlayTrigger placement="top" overlay={opposeButtonPopoverTooltip}>{opposeButton}</OverlayTrigger>
           {noVoteDescriptionExists ? <span className="item-actionbar__following-text">{noVoteDescription}</span> : null}
         </div>
-        <div className="visible-xs">
+        <div className="visible-xs item-actionbar__position-bar item-actionbar__position-bar--mobile">
           {opposeButton}
           {noVoteDescriptionExists ? <span className="item-actionbar__following-text">{noVoteDescription}</span> : null}
         </div>

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -6,6 +6,18 @@
   margin: $space-md $space-none;
   padding-top: $space-sm;
 
+  &__position-bar {
+    display: flex;
+    align-items: center;
+    margin-bottom: $space-sm;
+
+    &--mobile {
+      @include breakpoints (max small-bootstrap) {
+        display: flex !important;
+      }
+    }
+  }
+
   &__position-btn-label {
     color: $gray-mid;
     @include breakpoints (max mid-small) {


### PR DESCRIPTION
Added some formatting to the measure yes/no vote descriptions by adding Flexbox to position the descriptions to the right of their yes/no buttons as well as vertically align the yes/no buttons (#1507).