### PR TITLE
Updates to ballot page modals, layout, and network page tabs

### DIFF
--- a/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
+++ b/src/js/components/Widgets/ItemSupportOpposeRaccoon.jsx
@@ -697,65 +697,6 @@ export default class ItemSupportOpposeRaccoon extends Component {
       </OverlayTrigger>;
 
     return <div className="network-positions-stacked">
-      <div className="network-positions-stacked__support">
-        {/* Support toggle here */}
-        {item_action_bar}
-
-        {/* Issue Score here */}
-        { showIssueScore ?
-          <OverlayTrigger trigger="click"
-                          ref="issue-score-overlay"
-                          onExit={this.closeIssueScorePopover}
-                          rootClose
-                          placement={issuesPopoverPlacement}
-                          overlay={scoreFromYourIssuesPopover}>
-            <span className={ showNetworkScore ?
-                              "network-positions-stacked__support-score u-cursor--pointer u-no-break hidden-xs" :
-                              "network-positions-stacked__support-score u-cursor--pointer u-no-break" }>
-              { voterIssuesScore === 0 ?
-                <span className="u-margin-left--md">{ voterIssuesScoreWithSign }&nbsp;</span> :
-                <span className="u-margin-left--xs">{ voterIssuesScoreWithSign }&nbsp;</span>
-              }
-              <span className="network-positions-stacked__support-score-label">
-                <span>Issue<br />Score</span>
-                <span>&nbsp;<i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" />&nbsp;</span>
-              </span>
-            </span>
-          </OverlayTrigger> :
-          null
-        }
-
-        {/* Network Score here */}
-        { showNetworkScore ?
-          <OverlayTrigger trigger="click"
-                          ref="network-score-overlay"
-                          onExit={this.closeNetworkScorePopover}
-                          rootClose
-                          placement={this.props.popoverBottom ? "bottom" : "top"}
-                          overlay={scoreInYourNetworkPopover}>
-            <span className="network-positions-stacked__support-score u-cursor--pointer u-no-break">
-              { total_network_score === 0 ?
-                <span className="u-margin-left--md">{ total_network_score_with_sign }&nbsp;</span> :
-                <span className="u-margin-left--xs">{ total_network_score_with_sign }&nbsp;</span>
-              }
-              <span className="network-positions-stacked__support-score-label">
-                <span className="visible-xs">Network<br />
-                  Score <i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" /></span>
-                <span className="hidden-xs">Score in<br />
-                  Your Network <i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" /></span>
-              </span>
-            </span>
-          </OverlayTrigger> :
-          null
-        }
-        <span className="sr-only">
-          {total_network_score > 0 ? total_network_score + " Support" : null }
-          {total_network_score < 0 ? total_network_score + " Oppose" : null }
-        </span>
-      </div>
-      { comment_display_raccoon_desktop }
-      { comment_display_raccoon_mobile }
-
       {/* Issues that have a score related to this ballot item */}
       <IssuesFollowedByBallotItemDisplayList ballot_item_display_name={this.state.ballot_item_display_name}
                                              ballotItemWeVoteId={this.props.ballotItemWeVoteId}
@@ -856,6 +797,65 @@ export default class ItemSupportOpposeRaccoon extends Component {
         </div> :
         null
       }
+
+      <div className="network-positions-stacked__support">
+        {/* Support toggle here */}
+        {item_action_bar}
+
+        {/* Issue Score here */}
+        { showIssueScore ?
+          <OverlayTrigger trigger="click"
+                          ref="issue-score-overlay"
+                          onExit={this.closeIssueScorePopover}
+                          rootClose
+                          placement={issuesPopoverPlacement}
+                          overlay={scoreFromYourIssuesPopover}>
+            <span className={ showNetworkScore ?
+                              "network-positions-stacked__support-score u-cursor--pointer u-no-break hidden-xs" :
+                              "network-positions-stacked__support-score u-cursor--pointer u-no-break" }>
+              { voterIssuesScore === 0 ?
+                <span className="u-margin-left--md">{ voterIssuesScoreWithSign }&nbsp;</span> :
+                <span className="u-margin-left--xs">{ voterIssuesScoreWithSign }&nbsp;</span>
+              }
+              <span className="network-positions-stacked__support-score-label">
+                <span>Issue<br />Score</span>
+                <span>&nbsp;<i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" />&nbsp;</span>
+              </span>
+            </span>
+          </OverlayTrigger> :
+          null
+        }
+
+        {/* Network Score here */}
+        { showNetworkScore ?
+          <OverlayTrigger trigger="click"
+                          ref="network-score-overlay"
+                          onExit={this.closeNetworkScorePopover}
+                          rootClose
+                          placement={this.props.popoverBottom ? "bottom" : "top"}
+                          overlay={scoreInYourNetworkPopover}>
+            <span className="network-positions-stacked__support-score u-cursor--pointer u-no-break">
+              { total_network_score === 0 ?
+                <span className="u-margin-left--md">{ total_network_score_with_sign }&nbsp;</span> :
+                <span className="u-margin-left--xs">{ total_network_score_with_sign }&nbsp;</span>
+              }
+              <span className="network-positions-stacked__support-score-label">
+                <span className="visible-xs">Network<br />
+                  Score <i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" /></span>
+                <span className="hidden-xs">Score in<br />
+                  Your Network <i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover hidden-print" aria-hidden="true" /></span>
+              </span>
+            </span>
+          </OverlayTrigger> :
+          null
+        }
+        <span className="sr-only">
+          {total_network_score > 0 ? total_network_score + " Support" : null }
+          {total_network_score < 0 ? total_network_score + " Oppose" : null }
+        </span>
+      </div>
+      { comment_display_raccoon_desktop }
+      { comment_display_raccoon_mobile }
     </div>;
   }
 }

--- a/src/js/routes/Network.jsx
+++ b/src/js/routes/Network.jsx
@@ -11,7 +11,6 @@ import { renderLog } from "../utils/logging";
 import NetworkFriendRequests from "../components/Network/NetworkFriendRequests";
 import NetworkFriends from "../components/Network/NetworkFriends";
 import NetworkIssuesFollowed from "../components/Network/NetworkIssuesFollowed";
-import NetworkIssuesToFollow from "../components/Network/NetworkIssuesToFollow";
 import NetworkOpinions from "../components/Network/NetworkOpinions";
 import NetworkOpinionsFollowed from "../components/Network/NetworkOpinionsFollowed";
 import TwitterSignIn from "../components/Twitter/TwitterSignIn";
@@ -68,8 +67,6 @@ export default class Network extends Component {
       } else {
         this.setState({ edit_mode: nextProps.params.edit_mode });
       }
-    } else if (nextProps.location.pathname === "/more/network" || !nextProps.params.edit_mode) {
-      this.setState({ edit_mode: "issues" });
     } else {
       this.setState({ edit_mode: nextProps.params.edit_mode });
     }
@@ -94,10 +91,8 @@ export default class Network extends Component {
       } else {
         newState.edit_mode = this.props.params.edit_mode || "friends";
       }
-    } else if (this.state.pathname === "/more/network") {  //no invitations
-      newState.edit_mode = "issues";
     } else {
-      newState.edit_mode = this.props.params.edit_mode || "issues";
+      newState.edit_mode = this.props.params.edit_mode || "organizations";
     }
 
     this.setState(newState);
@@ -121,9 +116,6 @@ export default class Network extends Component {
         break;
       case "friends":
         networkComponentToDisplay = <NetworkFriendRequests />;
-        break;
-      case "issues":
-        networkComponentToDisplay = <NetworkIssuesToFollow />;
         break;
     }
 
@@ -199,13 +191,6 @@ export default class Network extends Component {
                   <Link to={{ pathname: "/more/network/friends" }} className={this.state.edit_mode === "friends" ? "tab tab-active" : "tab tab-default"}>
                     <span className="visible-xs">Requests</span>
                     <span className="hidden-xs">Friend Requests</span>
-                  </Link>
-                </li>
-
-                <li className="tab-item">
-                  <Link to={{ pathname: "/more/network/issues" }} className={this.state.edit_mode === "issues" ? "tab tab-active" : "tab tab-default"}>
-                    <span className="visible-xs">Issues</span>
-                    <span className="hidden-xs">Issues to Follow</span>
                   </Link>
                 </li>
 

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -512,7 +512,18 @@ $slick-dot-character: '\2022' !default;
 .modal-dialog {
   position: relative;
   // top: 20%;
-  transform: translateY(-50%);
+  // transform: translateY(-50%);
+
+  -moz-transition: none !important;
+  -o-transition: none !important;
+  -webkit-transition: none !important;
+  transition: none !important;
+
+  -moz-transform: none !important;
+  -ms-transform: none !important;
+  -o-transform: none !important;
+  -webkit-transform: none !important;
+  transform: none !important;
 
   @include breakpoints(medium large) {
     width: 750px;


### PR DESCRIPTION
Turned off the slide down animation when opening modals (#1638). Moved the row containing the network actions for each candidate to the bottom of the candidate card (#1639). Removed the "Issues to Follow" tab from the Network page (#1628).