### PR TITLE
Fix for issue 1645: Increase clickable area for close modal button

### DIFF
--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -61,10 +61,13 @@ $slick-dot-character: '\2022' !default;
     position: absolute;
     top: $space-none;
     right: $space-none;
-    width: $space-md * 1.25;
+    width: $space-md * 3;
     z-index: 9999;
     @include breakpoints (max mid-small) {
       width: $space-md;
+    }
+    img {
+      padding: 0 $space-md $space-md $space-md;
     }
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Addresses issue #1645 

### Changes included this pull request?
Enlarge clickable area for modal close button. 