### PR TITLE
Increased close modal button clickable area in mobile

### DIFF
--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -64,10 +64,13 @@ $slick-dot-character: '\2022' !default;
     width: $space-md * 3;
     z-index: 9999;
     @include breakpoints (max mid-small) {
-      width: $space-md;
+      width: $space-md * 1.75;
     }
     img {
-      padding: 0 $space-md $space-md $space-md;
+      padding: 0 0 $space-md $space-md * 1.7;
+      @include breakpoints (max mid-small) {
+        padding: 0 0 $space-md * .5 $space-md * .75;
+      }
     }
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fix for #1645 
### Changes included this pull request?
Added styles to support mobile screen sizes.

<img width="377" alt="screen shot 2018-08-23 at 10 57 51 pm" src="https://user-images.githubusercontent.com/9255547/44564340-089f7b00-a728-11e8-8928-a81929058441.png">

