### PR TITLE
Temporary remove choose friends via Facebook

### DIFF
--- a/src/js/routes/Network.jsx
+++ b/src/js/routes/Network.jsx
@@ -19,7 +19,7 @@ import ReadMore from "../components/Widgets/ReadMore";
 
 const twitterInfoText = "Signing into Twitter is the fastest way to find voter guides related to the issues you care about. When you sign into Twitter, We Vote will find the voter guides for everyone you are following.";
 
-const facebookInfoText = "By signing into Facebook here, you can choose which friends you want to talk politics with, and avoid the trolls (or that guy from work who rambles on)! You control who is in your We Vote network.";
+// const facebookInfoText = "By signing into Facebook here, you can choose which friends you want to talk politics with, and avoid the trolls (or that guy from work who rambles on)! You control who is in your We Vote network.";
 
 const EmailInfoText = "Send email invitations to your friends. Share your vision, and get help from your friends as you make decisions about how to vote.";
 
@@ -139,7 +139,8 @@ export default class Network extends Component {
                 />
               </div>
             }
-            <div className="network-btn">
+            {/* Commented out since choose Friends via Facebook is currently broken */}
+            {/* <div className="network-btn">
               <Link to="/facebook_invitable_friends" className="btn btn-social btn-lg btn-facebook text-center">
                 <i className="fa fa-facebook"/>Choose Friends
               </Link>
@@ -148,7 +149,7 @@ export default class Network extends Component {
                 text_to_display={facebookInfoText}
                 num_of_lines={2}
               />
-            </div>
+            </div> */}
             <div className="network-btn">
             <Link to="/friends/invitebyemail" className="btn btn-social btn-lg btn--email text-center">
               <i className="fa fa-envelope" />Invite Friends
@@ -169,11 +170,12 @@ export default class Network extends Component {
                 <TwitterSignIn buttonText="Find" className="btn btn-social btn-md btn-twitter" />
               </div>
             }
-            <div className="network-btn">
+            {/* Commented out since choose Friends via Facebook is currently broken */}
+            {/* <div className="network-btn">
               <Link to="/facebook_invitable_friends" className="btn btn-social btn-md btn-facebook">
                 <i className="fa fa-facebook"/>Choose
               </Link>
-            </div>
+            </div> */}
             <div className="network-btn">
               <Link to="/friends/invitebyemail" className="btn btn-social btn-md btn--email">
                 <i className="fa fa-envelope" />Invite


### PR DESCRIPTION
* This feature is currently broken and wevote is get it working in 2019 per
https://github.com/wevote/WebApp/issues/1632

![screen shot 2018-08-25 at 10 51 38 am](https://user-images.githubusercontent.com/8117421/44621125-8d3be780-a855-11e8-9e22-ec76a2dc9c82.png)
![screen shot 2018-08-25 at 10 52 03 am](https://user-images.githubusercontent.com/8117421/44621126-8f05ab00-a855-11e8-906f-93a8a75e015f.png)


### What github.com/wevote/WebApp/issues does this fix?
Fixes https://github.com/wevote/WebApp/issues/1632
### Changes included this pull request?
Comment out Choose Friends via Facebook button.
