### PR TITLE
Implemented show/hide elections by state in BallotElectionList

### DIFF
--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -222,7 +222,7 @@ export default class BallotElectionList extends Component {
 
     let currentDate = moment().format("YYYY-MM-DD");
 
-    let ballotElectionListUpcomingSorted = this.props.ballotElectionList;
+    let ballotElectionListUpcomingSorted = this.props.ballotElectionList.concat();
     // We want to sort ascending so the next upcoming election is first
     ballotElectionListUpcomingSorted.sort(function (a, b) {
       let election_day_text_A = a.election_day_text.toLowerCase();
@@ -234,7 +234,7 @@ export default class BallotElectionList extends Component {
       return 0; //default return value (no sorting)
     });
 
-    let ballotElectionListPastSorted = this.props.ballotElectionList;
+    let ballotElectionListPastSorted = this.props.ballotElectionList.concat();
     // We want to sort descending so the most recent election is first
     ballotElectionListPastSorted.sort(function (a, b) {
       let election_day_text_A = a.election_day_text.toLowerCase();

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -19,6 +19,7 @@ export default class BallotElectionList extends Component {
     ballotElectionList: PropTypes.array.isRequired,
     ballotBaseUrl: PropTypes.string,
     organization_we_vote_id: PropTypes.string, // If looking at voter guide, we pass in the parent organization_we_vote_id
+    showRelevantElections: PropTypes.bool,
     toggleFunction: PropTypes.func,
   };
 
@@ -34,6 +35,7 @@ export default class BallotElectionList extends Component {
     this.state = {
       loading_new_ballot_items: false,
       prior_election_id: prior_election_id,
+      state_code: VoterStore.getStateCodeFromIPAddress(),
       updated_election_id: ""
     };
 
@@ -115,6 +117,7 @@ export default class BallotElectionList extends Component {
         // console.log("onVoterStoreChange--------- loading_new_ballot_items:", this.state.loading_new_ballot_items);
         this.setState({
           loading_new_ballot_items: false,
+          state_code: VoterStore.getStateCodeFromIPAddress(),
           updated_election_id: VoterStore.election_id()
         });
         // console.log("onVoterStoreChange--------- this.props.toggleFunction()");
@@ -221,16 +224,31 @@ export default class BallotElectionList extends Component {
     });
     let priorElectionList = this.renderPriorElectionList(ballotElectionListPastSorted, currentDate);
 
-    return <div>
-      { upcomingElectionList && upcomingElectionList.length ?
-        <h4 className="h4">Upcoming Election(s)</h4> :
-        null }
-      {upcomingElectionList}
+    if (this.props.showRelevantElections) {
+      // TODO show filtered lists here
+      return <div>
+        { upcomingElectionList && upcomingElectionList.length ?
+          <h4 className="h4">Upcoming Election(s)</h4> :
+          null }
+        {upcomingElectionList}
 
-      { priorElectionList && priorElectionList.length ?
-        <h4 className="h4">Prior Election(s)</h4> :
-        null }
-      {priorElectionList}
-    </div>;
+        { priorElectionList && priorElectionList.length ?
+          <h4 className="h4">Prior Election(s)</h4> :
+          null }
+        {priorElectionList}
+      </div>;
+    } else {
+      return <div>
+        { upcomingElectionList && upcomingElectionList.length ?
+          <h4 className="h4">Upcoming Election(s)</h4> :
+          null }
+        {upcomingElectionList}
+
+        { priorElectionList && priorElectionList.length ?
+          <h4 className="h4">Prior Election(s)</h4> :
+          null }
+        {priorElectionList}
+      </div>;
+    }
   }
 }

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -123,36 +123,11 @@ export default class BallotElectionList extends Component {
     }
   }
 
-  render () {
-    renderLog(__filename);
-    if (this.state.loading_new_ballot_items) {
-      return <div>
-        <h1 className="h1">Switching ballot data now...</h1>
-        <br />
-        {LoadingWheel}
-      </div>;
-    }
-
-    let currentDate = moment().format("YYYY-MM-DD");
-    //console.log("currentDate: ", currentDate);
-    let electionDateTomorrow;
-    let electionDateTomorrowMoment;
-    let ballotElectionListUpcomingSorted = this.props.ballotElectionList;
-    // We want to sort ascending so the next upcoming election is first
-    ballotElectionListUpcomingSorted.sort(function (a, b) {
-      let election_day_text_A = a.election_day_text.toLowerCase();
-      let election_day_text_B = b.election_day_text.toLowerCase();
-      if (election_day_text_A < election_day_text_B) //sort string ascending
-        return -1;
-      if (election_day_text_A > election_day_text_B)
-        return 1;
-      return 0; //default return value (no sorting)
-    });
-    let upcomingElectionList = ballotElectionListUpcomingSorted.map((item, index) => {
-      electionDateTomorrowMoment = moment(item.election_day_text, "YYYY-MM-DD").add(1, "days");
-      electionDateTomorrow = electionDateTomorrowMoment.format("YYYY-MM-DD");
-      // console.log("electionDateTomorrow: ", electionDateTomorrow);
-      return electionDateTomorrow > currentDate ?
+  renderUpcomingElectionList (list, current_date) {
+    let rendered_list = list.map((item, index) => {
+      let electionDateTomorrowMoment = moment(item.election_day_text, "YYYY-MM-DD").add(1, "days");
+      let electionDateTomorrow = electionDateTomorrowMoment.format("YYYY-MM-DD");
+      return electionDateTomorrow > current_date ?
         <div key={index}>
           <dl className="list-unstyled text-center">
             <button type="button" className="btn btn-success ballot-election-list__button"
@@ -175,24 +150,14 @@ export default class BallotElectionList extends Component {
         </div> :
         null;
     });
-    upcomingElectionList = cleanArray(upcomingElectionList);
+    return cleanArray(rendered_list);
+  }
 
-    let ballotElectionListPastSorted = this.props.ballotElectionList;
-    // We want to sort descending so the most recent election is first
-    ballotElectionListPastSorted.sort(function (a, b) {
-      let election_day_text_A = a.election_day_text.toLowerCase();
-      let election_day_text_B = b.election_day_text.toLowerCase();
-      if (election_day_text_A < election_day_text_B) //sort string descending
-        return 1;
-      if (election_day_text_A > election_day_text_B)
-        return -1;
-      return 0; //default return value (no sorting)
-    });
-    let priorElectionList = ballotElectionListPastSorted.map((item, index) => {
-      // console.log("item.election_day_text: ", item.election_day_text);
-      electionDateTomorrowMoment = moment(item.election_day_text, "YYYY-MM-DD").add(1, "days");
-      electionDateTomorrow = electionDateTomorrowMoment.format("YYYY-MM-DD");
-      return electionDateTomorrow > currentDate ?
+  renderPriorElectionList (list, current_date) {
+    let rendered_list = list.map((item, index) => {
+      let electionDateTomorrowMoment = moment(item.election_day_text, "YYYY-MM-DD").add(1, "days");
+      let electionDateTomorrow = electionDateTomorrowMoment.format("YYYY-MM-DD");
+      return electionDateTomorrow > current_date ?
         null :
         <div key={index}>
           <dl className="list-unstyled text-center">
@@ -215,7 +180,46 @@ export default class BallotElectionList extends Component {
           </dl>
         </div>;
     });
-    priorElectionList = cleanArray(priorElectionList);
+    return cleanArray(rendered_list);
+  }
+
+  render () {
+    renderLog(__filename);
+    if (this.state.loading_new_ballot_items) {
+      return <div>
+        <h1 className="h1">Switching ballot data now...</h1>
+        <br />
+        {LoadingWheel}
+      </div>;
+    }
+
+    let currentDate = moment().format("YYYY-MM-DD");
+
+    let ballotElectionListUpcomingSorted = this.props.ballotElectionList;
+    // We want to sort ascending so the next upcoming election is first
+    ballotElectionListUpcomingSorted.sort(function (a, b) {
+      let election_day_text_A = a.election_day_text.toLowerCase();
+      let election_day_text_B = b.election_day_text.toLowerCase();
+      if (election_day_text_A < election_day_text_B) //sort string ascending
+        return -1;
+      if (election_day_text_A > election_day_text_B)
+        return 1;
+      return 0; //default return value (no sorting)
+    });
+    let upcomingElectionList = this.renderUpcomingElectionList(ballotElectionListUpcomingSorted, currentDate);
+
+    let ballotElectionListPastSorted = this.props.ballotElectionList;
+    // We want to sort descending so the most recent election is first
+    ballotElectionListPastSorted.sort(function (a, b) {
+      let election_day_text_A = a.election_day_text.toLowerCase();
+      let election_day_text_B = b.election_day_text.toLowerCase();
+      if (election_day_text_A < election_day_text_B) //sort string descending
+        return 1;
+      if (election_day_text_A > election_day_text_B)
+        return -1;
+      return 0; //default return value (no sorting)
+    });
+    let priorElectionList = this.renderPriorElectionList(ballotElectionListPastSorted, currentDate);
 
     return <div>
       { upcomingElectionList && upcomingElectionList.length ?

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -374,7 +374,7 @@ export default class BallotElectionList extends Component {
 
         <div className="ballot-election-list__prior">
           <h4 className="h4">
-            Upcoming Election
+            Prior Election
             { priorElectionList && priorElectionList.length !== 1 ? "s" : null }
           </h4>
           { priorElectionList && priorElectionList.length ?

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -276,15 +276,39 @@ export default class BallotElectionList extends Component {
 
       return <div>
         { upcomingElectionList && upcomingElectionList.length ?
-          <h4 className="h4">Upcoming Election(s)</h4> :
-          null }
+          <h4 className="h4">
+            Upcoming Election
+            { !this.state.show_more_upcoming_elections && upcomingElectionListInsideState.length !== 1 ||
+              this.state.show_more_upcoming_elections && upcomingElectionList.length !== 1 ?
+              "s" :
+              null
+            }
+            { !this.state.show_more_upcoming_elections && this.state.state_name.length ?
+              " in " + this.state.state_name :
+              null
+            }
+          </h4> :
+          null
+        }
         { upcomingElectionListInsideState }
         { this.state.show_more_upcoming_elections ? upcomingElectionListOutsideState : null }
         <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>Show { this.state.show_more_upcoming_elections ? "Fewer" : "All" } States</a>
 
         { priorElectionList && priorElectionList.length ?
-          <h4 className="h4">Prior Election(s)</h4> :
-          null }
+          <h4 className="h4">
+            Prior Election
+            { !this.state.show_more_prior_elections && priorElectionListInsideState.length !== 1 ||
+              this.state.show_more_prior_elections && priorElectionList.length !== 1 ?
+              "s" :
+              null
+            }
+            { !this.state.show_more_prior_elections && this.state.state_name.length ?
+              " in " + this.state.state_name :
+              null
+            }
+          </h4> :
+          null
+        }
         { priorElectionListInsideState }
         { this.state.show_more_prior_elections ? priorElectionListOutsideState : null }
         <a onClick={this.toggleShowMorePriorElections.bind(this)}>Show { this.state.show_more_prior_elections ? "Fewer" : "All" } States</a>

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -274,106 +274,114 @@ export default class BallotElectionList extends Component {
       let priorElectionListInsideState = this.renderPriorElectionList(priorBallotElectionListInsideState, currentDate);
       let priorElectionListOutsideState = this.renderPriorElectionList(priorBallotElectionListOutsideState, currentDate);
 
-      return <div>
-        <h4 className="h4">
-          Upcoming Election
-          { upcomingElectionListInsideState && upcomingElectionListInsideState.length !== 1 &&
-            !this.state.show_more_upcoming_elections ||
-            upcomingElectionList && upcomingElectionList.length !== 1 &&
+      return <div className="ballot-election-list__list">
+        <div className="ballot-election-list__upcoming">
+          <h4 className="h4">
+            Upcoming Election
+            { upcomingElectionListInsideState && upcomingElectionListInsideState.length !== 1 &&
+              !this.state.show_more_upcoming_elections ||
+              upcomingElectionList && upcomingElectionList.length !== 1 &&
+              this.state.show_more_upcoming_elections ?
+              "s" :
+              null
+            }
+            { this.state.state_name && this.state.state_name.length &&
+              !this.state.show_more_upcoming_elections ?
+              " in " + this.state.state_name :
+              null
+            }
+          </h4>
+          { upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
+            upcomingElectionListInsideState :
+            "There are no upcoming elections at this time."
+          }
+          { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length &&
             this.state.show_more_upcoming_elections ?
-            "s" :
+            upcomingElectionListOutsideState :
+            upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
+            null :
+            "There are no upcoming elections at this time."
+          }
+          { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length ?
+            this.state.show_more_upcoming_elections ?
+            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+              { this.state.state_name && this.state.state_name.length ?
+                "Only show elections in " + this.state.state_name :
+                "Hide state elections"
+              }
+            </a> :
+            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+              Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
+            </a> :
             null
           }
-          { this.state.state_name && this.state.state_name.length &&
-            !this.state.show_more_upcoming_elections ?
-            " in " + this.state.state_name :
-            null
-          }
-        </h4>
-        { upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
-          upcomingElectionListInsideState :
-          "There are no upcoming elections at this time."
-        }
-        { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length &&
-          this.state.show_more_upcoming_elections ?
-          upcomingElectionListOutsideState :
-          upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
-          null :
-          "There are no upcoming elections at this time."
-        }
-        { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length ?
-          this.state.show_more_upcoming_elections ?
-          <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
-            { this.state.state_name && this.state.state_name.length ?
-              "Only show elections in " + this.state.state_name :
-              "Hide state elections"
-            }
-          </a> :
-          <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
-            Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
-          </a> :
-          null
-        }
+        </div>
 
-        <h4 className="h4">
-          Prior Election
-          { priorElectionListInsideState && priorElectionListInsideState.length !== 1 &&
-            !this.state.show_more_prior_elections ||
-            priorElectionList && priorElectionList.length !== 1 &&
-            this.state.show_more_prior_elections ?
-            "s" :
-            null
-          }
-          { this.state.state_name && this.state.state_name.length &&
-            !this.state.show_more_prior_elections ?
-            " in " + this.state.state_name :
-            null
-          }
-        </h4>
-        { priorElectionListInsideState && priorElectionListInsideState.length ?
-          priorElectionListInsideState :
-          "There are no prior elections at this time."
-        }
-        { priorElectionListOutsideState && priorElectionListOutsideState.length &&
-          this.state.show_more_prior_elections ?
-          priorElectionListOutsideState :
-          priorElectionListInsideState && priorElectionListInsideState.length ?
-          null :
-          "There are no prior elections at this time."
-        }
-        { priorElectionListOutsideState && priorElectionListOutsideState.length ?
-          this.state.show_more_prior_elections ?
-          <a onClick={this.toggleShowMorePriorElections.bind(this)}>
-            { this.state.state_name && this.state.state_name.length ?
-              "Only show elections in " + this.state.state_name :
-              "Hide state elections"
+        <div className="ballot-election-list__prior">
+          <h4 className="h4">
+            Prior Election
+            { priorElectionListInsideState && priorElectionListInsideState.length !== 1 &&
+              !this.state.show_more_prior_elections ||
+              priorElectionList && priorElectionList.length !== 1 &&
+              this.state.show_more_prior_elections ?
+              "s" :
+              null
             }
-          </a> :
-          <a onClick={this.toggleShowMorePriorElections.bind(this)}>
-            Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
-          </a> :
-          null
-        }
+            { this.state.state_name && this.state.state_name.length &&
+              !this.state.show_more_prior_elections ?
+              " in " + this.state.state_name :
+              null
+            }
+          </h4>
+          { priorElectionListInsideState && priorElectionListInsideState.length ?
+            priorElectionListInsideState :
+            "There are no prior elections at this time."
+          }
+          { priorElectionListOutsideState && priorElectionListOutsideState.length &&
+            this.state.show_more_prior_elections ?
+            priorElectionListOutsideState :
+            priorElectionListInsideState && priorElectionListInsideState.length ?
+            null :
+            "There are no prior elections at this time."
+          }
+          { priorElectionListOutsideState && priorElectionListOutsideState.length ?
+            this.state.show_more_prior_elections ?
+            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+              { this.state.state_name && this.state.state_name.length ?
+                "Only show elections in " + this.state.state_name :
+                "Hide state elections"
+              }
+            </a> :
+            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+              Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
+            </a> :
+            null
+          }
+        </div>
       </div>;
     } else {
-      return <div>
-        <h4 className="h4">
-          Upcoming Election
-          { upcomingElectionList && upcomingElectionList.length !== 1 ? "s" : null }
-        </h4>
-        { upcomingElectionList && upcomingElectionList.length ?
-          upcomingElectionList :
-          "There are no upcoming elections at this time."
-        }
+      return <div className="ballot-election-list__list">
+        <div className="ballot-election-list__upcoming">
+          <h4 className="h4">
+            Upcoming Election
+            { upcomingElectionList && upcomingElectionList.length !== 1 ? "s" : null }
+          </h4>
+          { upcomingElectionList && upcomingElectionList.length ?
+            upcomingElectionList :
+            "There are no upcoming elections at this time."
+          }
+        </div>
 
-        <h4 className="h4">
-          Upcoming Election
-          { priorElectionList && priorElectionList.length !== 1 ? "s" : null }
-        </h4>
-        { priorElectionList && priorElectionList.length ?
-          priorElectionList :
-          "There are no prior elections at this time."
-        }
+        <div className="ballot-election-list__prior">
+          <h4 className="h4">
+            Upcoming Election
+            { priorElectionList && priorElectionList.length !== 1 ? "s" : null }
+          </h4>
+          { priorElectionList && priorElectionList.length ?
+            priorElectionList :
+            "There are no prior elections at this time."
+          }
+        </div>
       </div>;
     }
   }

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -301,7 +301,19 @@ export default class BallotElectionList extends Component {
             null :
             "There are no upcoming elections at this time."
         }
-        <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>Show { this.state.show_more_upcoming_elections ? "Fewer" : "All" } States</a>
+        { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length ?
+          this.state.show_more_upcoming_elections ?
+            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+              { this.state.state_name && this.state.state_name.length ?
+                "Only show elections in " + this.state.state_name :
+                "Hide state elections"
+              }
+            </a> :
+            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+              Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
+            </a> :
+          null
+        }
 
         <h4 className="h4">
           Prior Election
@@ -329,7 +341,19 @@ export default class BallotElectionList extends Component {
             null :
             "There are no prior elections at this time."
         }
-        <a onClick={this.toggleShowMorePriorElections.bind(this)}>Show { this.state.show_more_prior_elections ? "Fewer" : "All" } States</a>
+        { priorElectionListOutsideState && priorElectionListOutsideState.length ?
+          this.state.show_more_prior_elections ?
+            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+              { this.state.state_name && this.state.state_name.length ?
+                "Only show elections in " + this.state.state_name :
+                "Hide state elections"
+              }
+            </a> :
+            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+              Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
+            </a> :
+          null
+        }
       </div>;
     } else {
       return <div>

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -142,13 +142,14 @@ export default class BallotElectionList extends Component {
 
   isElectionInState (election) {
     let election_name = election.election_description_text;
-    if (this.state.state_name.length) {
-      return election_name.includes(this.state.state_name);
-    } else { // state not found, show national election(s)
-      return election_name.includes("U.S.") ||
-             election_name.includes("US") ||
-             election_name.includes("United States");
+    if (this.state.state_name.length && election_name.includes(this.state.state_name)) {
+      return true;
     }
+    // show all national elections regardless of state
+    // return election.is_national;
+    return election_name.includes("U.S.") ||
+           election_name.includes("US") ||
+           election_name.includes("United States");
   }
 
   renderUpcomingElectionList (list, current_date) {

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -275,55 +275,81 @@ export default class BallotElectionList extends Component {
       let priorElectionListOutsideState = this.renderPriorElectionList(priorBallotElectionListOutsideState, currentDate);
 
       return <div>
-        { upcomingElectionList && upcomingElectionList.length ?
-          <h4 className="h4">
-            Upcoming Election
-            { !this.state.show_more_upcoming_elections && upcomingElectionListInsideState.length !== 1 ||
-              this.state.show_more_upcoming_elections && upcomingElectionList.length !== 1 ?
-              "s" :
-              null
-            }
-            { !this.state.show_more_upcoming_elections && this.state.state_name.length ?
-              " in " + this.state.state_name :
-              null
-            }
-          </h4> :
-          null
+        <h4 className="h4">
+          Upcoming Election
+          { upcomingElectionListInsideState && upcomingElectionListInsideState.length !== 1 &&
+            !this.state.show_more_upcoming_elections ||
+            upcomingElectionList && upcomingElectionList.length !== 1 &&
+            this.state.show_more_upcoming_elections ?
+            "s" :
+            null
+          }
+          { this.state.state_name && this.state.state_name.length &&
+            !this.state.show_more_upcoming_elections ?
+            " in " + this.state.state_name :
+            null
+          }
+        </h4>
+        { upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
+          upcomingElectionListInsideState :
+          "There are no upcoming elections at this time."
         }
-        { upcomingElectionListInsideState }
-        { this.state.show_more_upcoming_elections ? upcomingElectionListOutsideState : null }
+        { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length &&
+          this.state.show_more_upcoming_elections ?
+          upcomingElectionListOutsideState :
+          upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
+            null :
+            "There are no upcoming elections at this time."
+        }
         <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>Show { this.state.show_more_upcoming_elections ? "Fewer" : "All" } States</a>
 
-        { priorElectionList && priorElectionList.length ?
-          <h4 className="h4">
-            Prior Election
-            { !this.state.show_more_prior_elections && priorElectionListInsideState.length !== 1 ||
-              this.state.show_more_prior_elections && priorElectionList.length !== 1 ?
-              "s" :
-              null
-            }
-            { !this.state.show_more_prior_elections && this.state.state_name.length ?
-              " in " + this.state.state_name :
-              null
-            }
-          </h4> :
-          null
+        <h4 className="h4">
+          Prior Election
+          { priorElectionListInsideState && priorElectionListInsideState.length !== 1 &&
+            !this.state.show_more_prior_elections ||
+            priorElectionList && priorElectionList.length !== 1 &&
+            this.state.show_more_prior_elections ?
+            "s" :
+            null
+          }
+          { this.state.state_name && this.state.state_name.length &&
+            !this.state.show_more_prior_elections ?
+            " in " + this.state.state_name :
+            null
+          }
+        </h4>
+        { priorElectionListInsideState && priorElectionListInsideState.length ?
+          priorElectionListInsideState :
+          "There are no prior elections at this time."
         }
-        { priorElectionListInsideState }
-        { this.state.show_more_prior_elections ? priorElectionListOutsideState : null }
+        { priorElectionListOutsideState && priorElectionListOutsideState.length &&
+          this.state.show_more_prior_elections ?
+          priorElectionListOutsideState :
+          priorElectionListInsideState && priorElectionListInsideState.length ?
+            null :
+            "There are no prior elections at this time."
+        }
         <a onClick={this.toggleShowMorePriorElections.bind(this)}>Show { this.state.show_more_prior_elections ? "Fewer" : "All" } States</a>
       </div>;
     } else {
       return <div>
+        <h4 className="h4">
+          Upcoming Election
+          { upcomingElectionList && upcomingElectionList.length !== 1 ? "s" : null }
+        </h4>
         { upcomingElectionList && upcomingElectionList.length ?
-          <h4 className="h4">Upcoming Election(s)</h4> :
-          null }
-        { upcomingElectionList }
+          upcomingElectionList :
+          "There are no upcoming elections at this time."
+        }
 
+        <h4 className="h4">
+          Upcoming Election
+          { priorElectionList && priorElectionList.length !== 1 ? "s" : null }
+        </h4>
         { priorElectionList && priorElectionList.length ?
-          <h4 className="h4">Prior Election(s)</h4> :
-          null }
-        { priorElectionList }
+          priorElectionList :
+          "There are no prior elections at this time."
+        }
       </div>;
     }
   }

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -311,13 +311,13 @@ export default class BallotElectionList extends Component {
           }
           { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length ?
             this.state.show_more_upcoming_elections ?
-            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+            <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
               { this.state.state_name && this.state.state_name.length ?
                 "Only show elections in " + this.state.state_name :
                 "Hide state elections"
               }
             </a> :
-            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+            <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
               Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
             </a> :
             null
@@ -354,19 +354,19 @@ export default class BallotElectionList extends Component {
             }
             { priorElectionListOutsideState && priorElectionListOutsideState.length ?
               this.state.show_more_prior_elections ?
-              <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+              <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMorePriorElections.bind(this)}>
                 { this.state.state_name && this.state.state_name.length ?
                   "Only show elections in " + this.state.state_name :
                   "Hide state elections"
                 }
               </a> :
-              <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+              <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMorePriorElections.bind(this)}>
                 Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
               </a> :
               null
             }
           </div> :
-          <a onClick={this.toggleShowPriorElectionsList.bind(this)}>
+          <a className="ballot-election-list__toggle-link" onClick={this.toggleShowPriorElectionsList.bind(this)}>
             Show prior elections
           </a>
         }

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -133,13 +133,13 @@ export default class BallotElectionList extends Component {
     }
   }
 
-  filterElectionsInsideState (election_list) {
+  filterElectionsInState (election_list) {
     return election_list.filter(election => this.isElectionInState(election));
   }
 
-  filterElectionsOutsideState (election_list) {
-    return election_list.filter(election => !this.isElectionInState(election));
-  }
+  // filterElectionsOutsideState (election_list) {
+  //   return election_list.filter(election => !this.isElectionInState(election));
+  // }
 
   isElectionInState (election) {
     let election_name = election.election_description_text;
@@ -271,21 +271,20 @@ export default class BallotElectionList extends Component {
     let priorElectionList = this.renderPriorElectionList(ballotElectionListPastSorted, currentDate);
 
     if (this.props.showRelevantElections) {
-      let upcomingBallotElectionListInsideState = this.filterElectionsInsideState(ballotElectionListUpcomingSorted);
-      let upcomingBallotElectionListOutsideState = this.filterElectionsOutsideState(ballotElectionListUpcomingSorted);
-      let priorBallotElectionListInsideState = this.filterElectionsInsideState(ballotElectionListPastSorted);
-      let priorBallotElectionListOutsideState = this.filterElectionsOutsideState(ballotElectionListPastSorted);
+      let upcomingBallotElectionListInState = this.filterElectionsInState(ballotElectionListUpcomingSorted);
+      let priorBallotElectionListInState = this.filterElectionsInState(ballotElectionListPastSorted);
 
-      let upcomingElectionListInsideState = this.renderUpcomingElectionList(upcomingBallotElectionListInsideState, currentDate);
-      let upcomingElectionListOutsideState = this.renderUpcomingElectionList(upcomingBallotElectionListOutsideState, currentDate);
-      let priorElectionListInsideState = this.renderPriorElectionList(priorBallotElectionListInsideState, currentDate);
-      let priorElectionListOutsideState = this.renderPriorElectionList(priorBallotElectionListOutsideState, currentDate);
+      let upcomingElectionListInState = this.renderUpcomingElectionList(upcomingBallotElectionListInState, currentDate);
+      let priorElectionListInState = this.renderPriorElectionList(priorBallotElectionListInState, currentDate);
+
+      let upcomingElectionListOutsideCount = upcomingElectionList.length - upcomingElectionListInState.length;
+      let priorElectionListOutsideCount = priorElectionList.length - priorElectionListInState.length;
 
       return <div className="ballot-election-list__list">
         <div className="ballot-election-list__upcoming">
           <h4 className="h4">
             Upcoming Election
-            { upcomingElectionListInsideState && upcomingElectionListInsideState.length !== 1 &&
+            { upcomingElectionListInState && upcomingElectionListInState.length !== 1 &&
               !this.state.show_more_upcoming_elections ||
               upcomingElectionList && upcomingElectionList.length !== 1 &&
               this.state.show_more_upcoming_elections ?
@@ -302,12 +301,11 @@ export default class BallotElectionList extends Component {
             upcomingElectionList && upcomingElectionList.length ?
             upcomingElectionList :
             "There are no upcoming elections at this time." :
-            upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
-            upcomingElectionListInsideState :
+            upcomingElectionListInState && upcomingElectionListInState.length ?
+            upcomingElectionListInState :
             "There are no upcoming elections at this time."
           }
-          { upcomingElectionList.length === upcomingElectionListInsideState.length ?
-            null :
+          { upcomingElectionListOutsideCount ?
             this.state.show_more_upcoming_elections ?
             <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
               { this.state.state_name && this.state.state_name.length ?
@@ -316,8 +314,9 @@ export default class BallotElectionList extends Component {
               }
             </a> :
             <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
-              Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
-            </a>
+              Show all states - { upcomingElectionListOutsideCount } more election{ upcomingElectionListOutsideCount !== 1 ? "s" : null }
+            </a> :
+            null
           }
         </div>
 
@@ -325,7 +324,7 @@ export default class BallotElectionList extends Component {
           <div className="ballot-election-list__prior">
             <h4 className="h4">
               Prior Election
-              { priorElectionListInsideState && priorElectionListInsideState.length !== 1 &&
+              { priorElectionListInState && priorElectionListInState.length !== 1 &&
                 !this.state.show_more_prior_elections ||
                 priorElectionList && priorElectionList.length !== 1 &&
                 this.state.show_more_prior_elections ?
@@ -342,12 +341,11 @@ export default class BallotElectionList extends Component {
               priorElectionList && priorElectionList.length ?
               priorElectionList :
               "There are no prior elections at this time." :
-              priorElectionListInsideState && priorElectionListInsideState.length ?
-              priorElectionListInsideState :
+              priorElectionListInState && priorElectionListInState.length ?
+              priorElectionListInState :
               "There are no prior elections at this time."
             }
-            { priorElectionList.length === priorElectionListInsideState.length ?
-              null :
+            { priorElectionListOutsideCount ?
               this.state.show_more_prior_elections ?
               <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMorePriorElections.bind(this)}>
                 { this.state.state_name && this.state.state_name.length ?
@@ -356,8 +354,9 @@ export default class BallotElectionList extends Component {
                 }
               </a> :
               <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMorePriorElections.bind(this)}>
-                Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
-              </a>
+                Show all states - { priorElectionListOutsideCount } more election{ priorElectionListOutsideCount !== 1 ? "s" : null }
+              </a> :
+              null
             }
           </div> :
           <a className="ballot-election-list__toggle-link" onClick={this.toggleShowPriorElectionsList.bind(this)}>

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -298,20 +298,20 @@ export default class BallotElectionList extends Component {
           this.state.show_more_upcoming_elections ?
           upcomingElectionListOutsideState :
           upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
-            null :
-            "There are no upcoming elections at this time."
+          null :
+          "There are no upcoming elections at this time."
         }
         { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length ?
           this.state.show_more_upcoming_elections ?
-            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
-              { this.state.state_name && this.state.state_name.length ?
-                "Only show elections in " + this.state.state_name :
-                "Hide state elections"
-              }
-            </a> :
-            <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
-              Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
-            </a> :
+          <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+            { this.state.state_name && this.state.state_name.length ?
+              "Only show elections in " + this.state.state_name :
+              "Hide state elections"
+            }
+          </a> :
+          <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
+            Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
+          </a> :
           null
         }
 
@@ -338,20 +338,20 @@ export default class BallotElectionList extends Component {
           this.state.show_more_prior_elections ?
           priorElectionListOutsideState :
           priorElectionListInsideState && priorElectionListInsideState.length ?
-            null :
-            "There are no prior elections at this time."
+          null :
+          "There are no prior elections at this time."
         }
         { priorElectionListOutsideState && priorElectionListOutsideState.length ?
           this.state.show_more_prior_elections ?
-            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
-              { this.state.state_name && this.state.state_name.length ?
-                "Only show elections in " + this.state.state_name :
-                "Hide state elections"
-              }
-            </a> :
-            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
-              Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
-            </a> :
+          <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+            { this.state.state_name && this.state.state_name.length ?
+              "Only show elections in " + this.state.state_name :
+              "Hide state elections"
+            }
+          </a> :
+          <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+            Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
+          </a> :
           null
         }
       </div>;

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -36,6 +36,8 @@ export default class BallotElectionList extends Component {
     this.state = {
       loading_new_ballot_items: false,
       prior_election_id: prior_election_id,
+      show_more_upcoming_elections: false,
+      show_more_prior_elections: false,
       state_code: state_code,
       state_name: convertStateCodeToStateText(state_code),
       updated_election_id: "",
@@ -209,6 +211,18 @@ export default class BallotElectionList extends Component {
     return cleanArray(rendered_list);
   }
 
+  toggleShowMoreUpcomingElections () {
+    this.setState({
+      show_more_upcoming_elections: !this.state.show_more_upcoming_elections,
+    });
+  }
+
+  toggleShowMorePriorElections () {
+    this.setState({
+      show_more_prior_elections: !this.state.show_more_prior_elections,
+    });
+  }
+
   render () {
     renderLog(__filename);
     if (this.state.loading_new_ballot_items) {
@@ -263,26 +277,28 @@ export default class BallotElectionList extends Component {
         { upcomingElectionList && upcomingElectionList.length ?
           <h4 className="h4">Upcoming Election(s)</h4> :
           null }
-        {upcomingElectionListInsideState}
-        {upcomingElectionListOutsideState}
+        { upcomingElectionListInsideState }
+        { this.state.show_more_upcoming_elections ? upcomingElectionListOutsideState : null }
+        <a onClick={this.toggleShowMoreUpcomingElections.bind(this)}>Show { this.state.show_more_upcoming_elections ? "Fewer" : "All" } States</a>
 
         { priorElectionList && priorElectionList.length ?
           <h4 className="h4">Prior Election(s)</h4> :
           null }
-        {priorElectionListInsideState}
-        {priorElectionListOutsideState}
+        { priorElectionListInsideState }
+        { this.state.show_more_prior_elections ? priorElectionListOutsideState : null }
+        <a onClick={this.toggleShowMorePriorElections.bind(this)}>Show { this.state.show_more_prior_elections ? "Fewer" : "All" } States</a>
       </div>;
     } else {
       return <div>
         { upcomingElectionList && upcomingElectionList.length ?
           <h4 className="h4">Upcoming Election(s)</h4> :
           null }
-        {upcomingElectionList}
+        { upcomingElectionList }
 
         { priorElectionList && priorElectionList.length ?
           <h4 className="h4">Prior Election(s)</h4> :
           null }
-        {priorElectionList}
+        { priorElectionList }
       </div>;
     }
   }

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -38,6 +38,7 @@ export default class BallotElectionList extends Component {
       prior_election_id: prior_election_id,
       show_more_upcoming_elections: false,
       show_more_prior_elections: false,
+      show_prior_elections_list: false,
       state_code: state_code,
       state_name: convertStateCodeToStateText(state_code),
       updated_election_id: "",
@@ -224,6 +225,12 @@ export default class BallotElectionList extends Component {
     });
   }
 
+  toggleShowPriorElectionsList () {
+    this.setState({
+      show_prior_elections_list: !this.state.show_prior_elections_list,
+    });
+  }
+
   render () {
     renderLog(__filename);
     if (this.state.loading_new_ballot_items) {
@@ -317,47 +324,52 @@ export default class BallotElectionList extends Component {
           }
         </div>
 
-        <div className="ballot-election-list__prior">
-          <h4 className="h4">
-            Prior Election
-            { priorElectionListInsideState && priorElectionListInsideState.length !== 1 &&
-              !this.state.show_more_prior_elections ||
-              priorElectionList && priorElectionList.length !== 1 &&
-              this.state.show_more_prior_elections ?
-              "s" :
-              null
-            }
-            { this.state.state_name && this.state.state_name.length &&
-              !this.state.show_more_prior_elections ?
-              " in " + this.state.state_name :
-              null
-            }
-          </h4>
-          { priorElectionListInsideState && priorElectionListInsideState.length ?
-            priorElectionListInsideState :
-            "There are no prior elections at this time."
-          }
-          { priorElectionListOutsideState && priorElectionListOutsideState.length &&
-            this.state.show_more_prior_elections ?
-            priorElectionListOutsideState :
-            priorElectionListInsideState && priorElectionListInsideState.length ?
-            null :
-            "There are no prior elections at this time."
-          }
-          { priorElectionListOutsideState && priorElectionListOutsideState.length ?
-            this.state.show_more_prior_elections ?
-            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
-              { this.state.state_name && this.state.state_name.length ?
-                "Only show elections in " + this.state.state_name :
-                "Hide state elections"
+        { this.state.show_prior_elections_list ?
+          <div className="ballot-election-list__prior">
+            <h4 className="h4">
+              Prior Election
+              { priorElectionListInsideState && priorElectionListInsideState.length !== 1 &&
+                !this.state.show_more_prior_elections ||
+                priorElectionList && priorElectionList.length !== 1 &&
+                this.state.show_more_prior_elections ?
+                "s" :
+                null
               }
-            </a> :
-            <a onClick={this.toggleShowMorePriorElections.bind(this)}>
-              Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
-            </a> :
-            null
-          }
-        </div>
+              { this.state.state_name && this.state.state_name.length &&
+                !this.state.show_more_prior_elections ?
+                " in " + this.state.state_name :
+                null
+              }
+            </h4>
+            { priorElectionListInsideState && priorElectionListInsideState.length ?
+              priorElectionListInsideState :
+              "There are no prior elections at this time."
+            }
+            { priorElectionListOutsideState && priorElectionListOutsideState.length &&
+              this.state.show_more_prior_elections ?
+              priorElectionListOutsideState :
+              priorElectionListInsideState && priorElectionListInsideState.length ?
+              null :
+              "There are no prior elections at this time."
+            }
+            { priorElectionListOutsideState && priorElectionListOutsideState.length ?
+              this.state.show_more_prior_elections ?
+              <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+                { this.state.state_name && this.state.state_name.length ?
+                  "Only show elections in " + this.state.state_name :
+                  "Hide state elections"
+                }
+              </a> :
+              <a onClick={this.toggleShowMorePriorElections.bind(this)}>
+                Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
+              </a> :
+              null
+            }
+          </div> :
+          <a onClick={this.toggleShowPriorElectionsList.bind(this)}>
+            Show prior elections
+          </a>
+        }
       </div>;
     } else {
       return <div className="ballot-election-list__list">

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -15,7 +15,6 @@ import { convertStateCodeToStateText } from "../../utils/address-functions";
 const MAXIMUM_NUMBER_OF_CHARACTERS_TO_SHOW = 36;
 
 export default class BallotElectionList extends Component {
-
   static propTypes = {
     ballotElectionList: PropTypes.array.isRequired,
     ballotBaseUrl: PropTypes.string,
@@ -39,7 +38,7 @@ export default class BallotElectionList extends Component {
       prior_election_id: prior_election_id,
       state_code: state_code,
       state_name: convertStateCodeToStateText(state_code),
-      updated_election_id: ""
+      updated_election_id: "",
     };
 
     this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
@@ -123,7 +122,7 @@ export default class BallotElectionList extends Component {
           loading_new_ballot_items: false,
           state_code: state_code,
           state_name: convertStateCodeToStateText(state_code),
-          updated_election_id: VoterStore.election_id()
+          updated_election_id: VoterStore.election_id(),
         });
         // console.log("onVoterStoreChange--------- this.props.toggleFunction()");
         this.props.toggleFunction(this.state.destinationUrlForHistoryPush);
@@ -224,7 +223,7 @@ export default class BallotElectionList extends Component {
 
     let ballotElectionListUpcomingSorted = this.props.ballotElectionList.concat();
     // We want to sort ascending so the next upcoming election is first
-    ballotElectionListUpcomingSorted.sort(function (a, b) {
+    ballotElectionListUpcomingSorted.sort((a, b) => {
       let election_day_text_A = a.election_day_text.toLowerCase();
       let election_day_text_B = b.election_day_text.toLowerCase();
       if (election_day_text_A < election_day_text_B) //sort string ascending
@@ -236,7 +235,7 @@ export default class BallotElectionList extends Component {
 
     let ballotElectionListPastSorted = this.props.ballotElectionList.concat();
     // We want to sort descending so the most recent election is first
-    ballotElectionListPastSorted.sort(function (a, b) {
+    ballotElectionListPastSorted.sort((a, b) => {
       let election_day_text_A = a.election_day_text.toLowerCase();
       let election_day_text_B = b.election_day_text.toLowerCase();
       if (election_day_text_A < election_day_text_B) //sort string descending

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -298,18 +298,16 @@ export default class BallotElectionList extends Component {
               null
             }
           </h4>
-          { upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
+          { this.state.show_more_upcoming_elections ?
+            upcomingElectionList && upcomingElectionList.length ?
+            upcomingElectionList :
+            "There are no upcoming elections at this time." :
+            upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
             upcomingElectionListInsideState :
             "There are no upcoming elections at this time."
           }
-          { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length &&
-            this.state.show_more_upcoming_elections ?
-            upcomingElectionListOutsideState :
-            upcomingElectionListInsideState && upcomingElectionListInsideState.length ?
+          { upcomingElectionList.length === upcomingElectionListInsideState.length ?
             null :
-            "There are no upcoming elections at this time."
-          }
-          { upcomingElectionListOutsideState && upcomingElectionListOutsideState.length ?
             this.state.show_more_upcoming_elections ?
             <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
               { this.state.state_name && this.state.state_name.length ?
@@ -319,8 +317,7 @@ export default class BallotElectionList extends Component {
             </a> :
             <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMoreUpcomingElections.bind(this)}>
               Show all states - { upcomingElectionListOutsideState.length } more election{ upcomingElectionListOutsideState.length !== 1 ? "s" : null }
-            </a> :
-            null
+            </a>
           }
         </div>
 
@@ -341,18 +338,16 @@ export default class BallotElectionList extends Component {
                 null
               }
             </h4>
-            { priorElectionListInsideState && priorElectionListInsideState.length ?
+            { this.state.show_more_prior_elections ?
+              priorElectionList && priorElectionList.length ?
+              priorElectionList :
+              "There are no prior elections at this time." :
+              priorElectionListInsideState && priorElectionListInsideState.length ?
               priorElectionListInsideState :
               "There are no prior elections at this time."
             }
-            { priorElectionListOutsideState && priorElectionListOutsideState.length &&
-              this.state.show_more_prior_elections ?
-              priorElectionListOutsideState :
-              priorElectionListInsideState && priorElectionListInsideState.length ?
+            { priorElectionList.length === priorElectionListInsideState.length ?
               null :
-              "There are no prior elections at this time."
-            }
-            { priorElectionListOutsideState && priorElectionListOutsideState.length ?
               this.state.show_more_prior_elections ?
               <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMorePriorElections.bind(this)}>
                 { this.state.state_name && this.state.state_name.length ?
@@ -362,8 +357,7 @@ export default class BallotElectionList extends Component {
               </a> :
               <a className="ballot-election-list__toggle-link" onClick={this.toggleShowMorePriorElections.bind(this)}>
                 Show all states - { priorElectionListOutsideState.length } more election{ priorElectionListOutsideState.length !== 1 ? "s" : null }
-              </a> :
-              null
+              </a>
             }
           </div> :
           <a className="ballot-election-list__toggle-link" onClick={this.toggleShowPriorElectionsList.bind(this)}>

--- a/src/js/components/Ballot/SelectBallotModal.jsx
+++ b/src/js/components/Ballot/SelectBallotModal.jsx
@@ -77,6 +77,7 @@ export default class SelectBallotModal extends Component {
         <BallotElectionList ballotBaseUrl={ballotBaseUrl}
                             ballotElectionList={ballotElectionList}
                             organization_we_vote_id={this.props.organization_we_vote_id}
+                            showRelevantElections
                             toggleFunction={this.props.toggleFunction}
                              />
       </Modal.Body>

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button } from "react-bootstrap";
+// import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import AddressBox from "../../components/AddressBox";
 import AnalyticsActions from "../../actions/AnalyticsActions";

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -587,7 +587,9 @@ export default class Ballot extends Component {
             If your ballot does not appear momentarily, please <Link to="/settings/location">change your address</Link>.
           </p>
         </div>
-        <BallotElectionList ballotElectionList={this.state.voter_ballot_list} ballotBaseUrl="/ballot" />
+        <BallotElectionList ballotElectionList={this.state.voter_ballot_list}
+                            ballotBaseUrl="/ballot"
+                            showRelevantElections />
       </div>;
     }
 

--- a/src/js/utils/address-functions.js
+++ b/src/js/utils/address-functions.js
@@ -1,1 +1,70 @@
 // For functions related to addresses
+
+let state_code_map = {
+  "AK": "Alaska",
+  "AL": "Alabama",
+  "AR": "Arkansas",
+  "AS": "American Samoa",
+  "AZ": "Arizona",
+  "CA": "California",
+  "CO": "Colorado",
+  "CT": "Connecticut",
+  "DC": "District of Columbia",
+  "DE": "Delaware",
+  "FL": "Florida",
+  "GA": "Georgia",
+  "GU": "Guam",
+  "HI": "Hawaii",
+  "IA": "Iowa",
+  "ID": "Idaho",
+  "IL": "Illinois",
+  "IN": "Indiana",
+  "KS": "Kansas",
+  "KY": "Kentucky",
+  "LA": "Louisiana",
+  "MA": "Massachusetts",
+  "MD": "Maryland",
+  "ME": "Maine",
+  "MI": "Michigan",
+  "MN": "Minnesota",
+  "MO": "Missouri",
+  "MP": "Northern Mariana Islands",
+  "MS": "Mississippi",
+  "MT": "Montana",
+  "NA": "National",
+  "NC": "North Carolina",
+  "ND": "North Dakota",
+  "NE": "Nebraska",
+  "NH": "New Hampshire",
+  "NJ": "New Jersey",
+  "NM": "New Mexico",
+  "NV": "Nevada",
+  "NY": "New York",
+  "OH": "Ohio",
+  "OK": "Oklahoma",
+  "OR": "Oregon",
+  "PA": "Pennsylvania",
+  "PR": "Puerto Rico",
+  "RI": "Rhode Island",
+  "SC": "South Carolina",
+  "SD": "South Dakota",
+  "TN": "Tennessee",
+  "TX": "Texas",
+  "UT": "Utah",
+  "VA": "Virginia",
+  "VI": "Virgin Islands",
+  "VT": "Vermont",
+  "WA": "Washington",
+  "WI": "Wisconsin",
+  "WV": "West Virginia",
+  "WY": "Wyoming",
+};
+
+export function convertStateCodeToStateText (state_code) {
+  for (let key in state_code_map) {
+    if (key === state_code) {
+      return state_code_map[key];
+    }
+  }
+  return "";
+}

--- a/src/sass/components/_ballotModals.scss
+++ b/src/sass/components/_ballotModals.scss
@@ -52,6 +52,14 @@
   &__modal {
     top: 0;
   }
+
+  &__toggle-link {
+    $toggle-link-margin: -$space-xs $space-none $space-sm $space-none;
+
+    display: block;
+    font-size: 14px;
+    margin: $toggle-link-margin;
+  }
 }
 
 .modal-backdrop {

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -66,9 +66,11 @@ $slick-dot-character: '\2022' !default;
     @include breakpoints (max mid-small) {
       width: $space-md;
     }
+    /* stylelint-disable selector-max-type */
     img {
-      padding: 0 $space-md $space-md $space-md;
+      padding: $space-none $space-md $space-md $space-md;
     }
+    /* stylelint-enable */
   }
 
   &__small {
@@ -258,7 +260,7 @@ $slick-dot-character: '\2022' !default;
 
   // Modifies slick default selector type dot styles
   // We need to disable stylelint type selector rule because we need to override existing slick package styles.
-  /* stylelint-disable selector-max-type  */
+  /* stylelint-disable selector-max-type */
   &__gray-dots li button::before {
     color: $gray-pale;
     font-size: 12px;


### PR DESCRIPTION
Implemented hiding elections outside the user's state (currently based on IP address) in the lists of upcoming and prior elections on the ballot page. Changed the text on the election list headers as appropriate. Completely hidden the prior elections list until toggled on (#1627).