### PR TITLE
Moved election date to left of election name, manually focus address box in issues modal

### DIFF
--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -14,6 +14,7 @@ export default class AddressBox extends Component {
   static propTypes = {
     cancelEditAddress: PropTypes.func,
     disableAutoFocus: PropTypes.bool,
+    manualFocus: PropTypes.bool,
     toggleSelectAddressModal: PropTypes.func,
     saveUrl: PropTypes.string.isRequired,
     waitingMessage: PropTypes.string,
@@ -51,6 +52,19 @@ export default class AddressBox extends Component {
       this.googleAutocompleteListener.remove();
     } else {
       console.log("Google Maps Error: DeletedApiProjectMapError");
+    }
+  }
+
+  componentDidUpdate () {
+    // If we're in the slide with this component, autofocus the address box, otherwise defocus.
+    let { manualFocus } = this.props;
+    if (manualFocus !== undefined) {
+      let address_box = this.refs.autocomplete;
+      if (address_box && manualFocus) {
+        address_box.focus();
+      } else {
+        address_box.blur();
+      }
     }
   }
 

--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -13,6 +13,7 @@ import VoterStore from "../stores/VoterStore";
 export default class AddressBox extends Component {
   static propTypes = {
     cancelEditAddress: PropTypes.func,
+    disableAutoFocus: PropTypes.bool,
     toggleSelectAddressModal: PropTypes.func,
     saveUrl: PropTypes.string.isRequired,
     waitingMessage: PropTypes.string,
@@ -134,7 +135,7 @@ export default class AddressBox extends Component {
             className="form-control"
             ref="autocomplete"
             placeholder="Enter address where you are registered to vote"
-            autoFocus={!isCordova()}
+            autoFocus={!isCordova() && !this.props.disableAutoFocus}
           />
         </form>
         <div>

--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -171,10 +171,10 @@ export default class BallotElectionList extends Component {
                   <img src={cordovaDot("/img/global/icons/Circle-Arrow.png")}/></span>
               }
               {/* Desktop */}
-              <span className="hidden-xs">{item.election_description_text}&nbsp;<img
+              <span className="hidden-xs">{moment(item.election_day_text).format("MMMM Do, YYYY")} - {item.election_description_text}&nbsp;<img
                 src={cordovaDot("/img/global/icons/Circle-Arrow.png")}/></span>
 
-              <div className="ballot-election-list__h2">{moment(item.election_day_text).format("MMMM Do, YYYY")}</div>
+              <div className="visible-xs ballot-election-list__h2">{moment(item.election_day_text).format("MMMM Do, YYYY")}</div>
             </button>
           </dl>
         </div> :
@@ -202,10 +202,10 @@ export default class BallotElectionList extends Component {
                   <img src={cordovaDot("/img/global/icons/Circle-Arrow.png")}/></span>
               }
               {/* Desktop */}
-              <span className="hidden-xs">{item.election_description_text}&nbsp;<img
+              <span className="hidden-xs">{moment(item.election_day_text).format("MMMM Do, YYYY")} - {item.election_description_text}&nbsp;<img
                 src={cordovaDot("/img/global/icons/Circle-Arrow.png")}/></span>
 
-              <div className="ballot-election-list__h2">{moment(item.election_day_text).format("MMMM Do, YYYY")}</div>
+              <div className="visible-xs ballot-election-list__h2">{moment(item.election_day_text).format("MMMM Do, YYYY")}</div>
             </button>
           </dl>
         </div>;

--- a/src/js/components/Ballot/BallotIntroModal.jsx
+++ b/src/js/components/Ballot/BallotIntroModal.jsx
@@ -20,8 +20,11 @@ export default class BallotIntroModal extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {};
+    this.state = {
+      current_page_index: 0,
+    };
     this._nextSliderPage = this._nextSliderPage.bind(this);
+    this.afterChangeHandler = this.afterChangeHandler.bind(this);
   }
 
   // componentDidMount () {
@@ -30,6 +33,12 @@ export default class BallotIntroModal extends Component {
   _nextSliderPage () {
     VoterActions.voterUpdateRefresh();
     this.refs.slider.slickNext();
+  }
+
+  afterChangeHandler (index) {
+    this.setState({
+      current_page_index: index,
+    });
   }
 
   render () {
@@ -42,6 +51,7 @@ export default class BallotIntroModal extends Component {
       slidesToScroll: 1,
       swipe: true,
       accessibility: true,
+      afterChange: this.afterChangeHandler,
       //react-slick default left & right nav arrows
       arrows: false,
     };
@@ -58,9 +68,9 @@ export default class BallotIntroModal extends Component {
         <Slider dotsClass="slick-dots intro-modal__gray-dots"
                 className="calc-height intro-modal__height-full"
                 ref="slider" {...slider_settings}>
-          <div className="intro-modal__height-full" key={1}><BallotIntroFollowIssues next={this._nextSliderPage}/></div>
-          <div className="intro-modal__height-full" key={2}><BallotIntroFollowAdvisers next={this._nextSliderPage}/></div>
-          <div className="intro-modal__height-full" key={3}><BallotIntroVerifyAddress next={this.props.toggleFunction}/></div>
+          <div className="intro-modal__height-full" key={1}><BallotIntroFollowIssues next={this._nextSliderPage} /></div>
+          <div className="intro-modal__height-full" key={2}><BallotIntroFollowAdvisers next={this._nextSliderPage} /></div>
+          <div className="intro-modal__height-full" key={3}><BallotIntroVerifyAddress next={this.props.toggleFunction} manualFocus={this.state.current_page_index === 2} /></div>
         </Slider>
       </Modal.Body>
     </Modal>;

--- a/src/js/components/Ballot/BallotIntroVerifyAddress.jsx
+++ b/src/js/components/Ballot/BallotIntroVerifyAddress.jsx
@@ -6,6 +6,7 @@ import { renderLog } from "../../utils/logging";
 
 export default class BallotIntroVerifyAddress extends Component {
   static propTypes = {
+    manualFocus: PropTypes.bool,
     next: PropTypes.func.isRequired,
     toggleSelectAddressModal: PropTypes.func,
   };

--- a/src/js/components/Ballot/BallotIntroVerifyAddress.jsx
+++ b/src/js/components/Ballot/BallotIntroVerifyAddress.jsx
@@ -29,7 +29,7 @@ export default class BallotIntroVerifyAddress extends Component {
       <div className="intro-modal__h1">Verify your Address</div>
       <div className="intro-modal__h3">Please enter your full address so we can look up your full ballot.</div>
       <div className={ isWebApp() ? "u-padding-bottom--md" : "SettingsCardBottomCordova" } >
-        <AddressBox {...this.props} saveUrl="/ballot" waitingMessage="Thank you! Click 'See Your Ballot' below." />
+        <AddressBox {...this.props} saveUrl="/ballot" waitingMessage="Thank you! Click 'See Your Ballot' below." disableAutoFocus />
       </div>
 
       <div className="intro-modal__h2"><br /></div>

--- a/src/js/components/Navigation/HeaderSecondaryNavBar.jsx
+++ b/src/js/components/Navigation/HeaderSecondaryNavBar.jsx
@@ -36,6 +36,7 @@ export default class HeaderSecondaryNavBar extends Component {
     this._openFacebookModal = this._openFacebookModal.bind(this);
     this._openPollingLocatorModal = this._openPollingLocatorModal.bind(this);
     this._nextSliderPage = this._nextSliderPage.bind(this);
+    this.afterChangeHandler = this.afterChangeHandler.bind(this);
     this.ballotEmailWasSent = this.ballotEmailWasSent.bind(this);
     this.ballotFacebookEmailWasSent = this.ballotFacebookEmailWasSent.bind(this);
     this.state = {
@@ -45,6 +46,7 @@ export default class HeaderSecondaryNavBar extends Component {
       ballot_intro_friends_completed: VoterStore.getInterfaceFlagState(VoterConstants.BALLOT_INTRO_FRIENDS_COMPLETED),
       ballot_intro_share_completed: VoterStore.getInterfaceFlagState(VoterConstants.BALLOT_INTRO_SHARE_COMPLETED),
       ballot_intro_vote_completed: VoterStore.getInterfaceFlagState(VoterConstants.BALLOT_INTRO_VOTE_COMPLETED),
+      current_page_index: 0,
       showBallotIntroFollowIssues: false,
       showBallotIntroOrganizations: false,
       showEmailModal: false,
@@ -117,6 +119,12 @@ export default class HeaderSecondaryNavBar extends Component {
     this.refs.slider.slickNext();
   }
 
+  afterChangeHandler (index) {
+    this.setState({
+      current_page_index: index,
+    });
+  }
+
   /**
    * Method that passes data between EmailBallotModal to EmailBallotToFriendsModal
    */
@@ -155,6 +163,7 @@ export default class HeaderSecondaryNavBar extends Component {
       slidesToScroll: 1,
       swipe: true,
       accessibility: true,
+      afterChange: this.afterChangeHandler,
       arrows: false,
     };
     let sliderSettingsWithSwipe = { ...sliderSettings, swipe: true };
@@ -174,7 +183,7 @@ export default class HeaderSecondaryNavBar extends Component {
           <Slider dotsClass="slick-dots intro-modal__gray-dots" className="calc-height" ref="slider" {...sliderSettings}>
             <div key={1}><BallotIntroFollowIssues next={this._nextSliderPage}/></div>
             <div key={2}><BallotIntroFollowAdvisers next={this._nextSliderPage}/></div>
-            <div key={3}><BallotIntroVerifyAddress next={this._toggleBallotIntroFollowIssues} /></div>
+            <div key={3}><BallotIntroVerifyAddress next={this._toggleBallotIntroFollowIssues} manualFocus={this.state.current_page_index === 2} /></div>
           </Slider>
         </Modal.Body>
       </Modal>;


### PR DESCRIPTION
Moved the election date to the left of the election name in the ballot election list in desktop mode (#1618). Manually focus/blur the address box in the issues modal so that the keyboard for mobile devices opens/closes at the appropriate times (#1644).