### PR TITLE
Added buttons that link to "Capture Voter Guide", opposed measures now show up under "Items Decided"

### DIFF
--- a/src/js/components/Navigation/BallotTabsRaccoon.jsx
+++ b/src/js/components/Navigation/BallotTabsRaccoon.jsx
@@ -46,8 +46,8 @@ export default class BallotTabsRaccoon extends Component {
 
       { show_decisions_made ?
         <li className="tab__item">
-          <Link to={{ pathname: pathname, query: { type: "filterSupport" } }}
-                className={this.props.ballot_type === "WHAT_I_SUPPORT" ? "tab tab--active" : "tab tab--default"}>
+          <Link to={{ pathname: pathname, query: { type: "filterDecided" } }}
+                className={this.props.ballot_type === "ITEMS_DECIDED" ? "tab tab--active" : "tab tab--default"}>
             {/* Desktop */}
             <span className="hidden-xs">Items Decided ({items_decided_count})</span>
             {/* Mobile */}

--- a/src/js/components/Network/NetworkOpinionsFollowed.jsx
+++ b/src/js/components/Network/NetworkOpinionsFollowed.jsx
@@ -1,9 +1,11 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Button } from "react-bootstrap";
 import { Link } from "react-router";
 import { renderLog } from "../../utils/logging";
 import OrganizationStore from "../../stores/OrganizationStore";
 import OrganizationActions from "../../actions/OrganizationActions";
+import OpenExternalWebSite from "../../utils/OpenExternalWebSite";
 import OpinionsFollowedListCompressed from "../Organization/OpinionsFollowedListCompressed";
 
 export default class NetworkOpinionsFollowed extends Component {
@@ -88,6 +90,15 @@ export default class NetworkOpinionsFollowed extends Component {
                   <span>You are not listening to any organizations yet.</span>
               }
             </div>
+          </div>
+          <OpenExternalWebSite url="https://api.wevoteusa.org/vg/create/"
+                               className="opinions-followed__missing-org-link"
+                               target="_blank"
+                               title="Suggest Organization"
+                               body={<Button className="u-stack--xs" bsStyle="primary">Suggest Organization</Button>}
+          />
+          <div className="opinions-followed__missing-org-text u-no-break">
+            Don’t see your favorite organization?
           </div>
           <br />
         </div>

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -1,9 +1,11 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Button } from "react-bootstrap";
 import ReactCSSTransitionGroup from "react-addons-css-transition-group";
 import CandidateStore from "../../stores/CandidateStore";
 import FollowToggle from "../Widgets/FollowToggle";
 import MeasureStore from "../../stores/MeasureStore";
+import OpenExternalWebSite from "../../utils/OpenExternalWebSite";
 import OrganizationActions from "../../actions/OrganizationActions";
 import VoterGuideDisplayForList from "./VoterGuideDisplayForList";
 import { showToastSuccess } from "../../utils/showToast";
@@ -99,7 +101,23 @@ export default class GuideList extends Component {
 
     return <div className="guidelist card-child__list-group">
         <ReactCSSTransitionGroup transitionName="org-ignore" transitionEnterTimeout={500} transitionLeaveTimeout={300}>
-          {organization_list}
+          { organization_list.length ?
+            organization_list :
+            <div className="u-flex u-flex-column u-items-center">
+              <div className="u-margin-top--sm u-stack--sm u-no-break">
+                No results found.
+              </div>
+              <OpenExternalWebSite url="https://api.wevoteusa.org/vg/create/"
+                                   className="opinions-followed__missing-org-link"
+                                   target="_blank"
+                                   title="Organization Missing?"
+                                   body={<Button className="u-stack--xs" bsStyle="primary">Organization Missing?</Button>}
+              />
+              <div className="opinions-followed__missing-org-text u-stack--sm u-no-break">
+                Don’t see an organization you want to Listen to?
+              </div>
+            </div>
+          }
         </ReactCSSTransitionGroup>
       </div>;
   }

--- a/src/js/components/VoterGuide/VoterGuideBallot.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallot.jsx
@@ -505,7 +505,7 @@ export default class VoterGuideBallot extends Component {
     switch (filter_type) {
       case "filterRemaining":
         return "You already chose a candidate or position for each ballot item";
-      case "filterSupport":
+      case "filterDecided":
         return "You haven't supported any candidates or measures yet.";
       default:
         return "";

--- a/src/js/components/VoterGuide/VoterGuidePositions.jsx
+++ b/src/js/components/VoterGuide/VoterGuidePositions.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Button } from "react-bootstrap";
 import { calculateBallotBaseUrl, capitalizeString } from "../../utils/textFormat";
 import Helmet from "react-helmet";
 import BallotActions from "../../actions/BallotActions";
@@ -8,6 +9,7 @@ import BallotStore from "../../stores/BallotStore";
 import FooterDoneBar from "../Navigation/FooterDoneBar";
 import { historyPush } from "../../utils/cordovaUtils";
 import { renderLog } from "../../utils/logging";
+import OpenExternalWebSite from "../../utils/OpenExternalWebSite";
 import OrganizationActions from "../../actions/OrganizationActions";
 import OrganizationStore from "../../stores/OrganizationStore";
 import OrganizationPositionItem from "../../components/VoterGuide/OrganizationPositionItem";
@@ -338,6 +340,15 @@ export default class VoterGuidePositions extends Component {
         </span> :
         null
       }
+      <OpenExternalWebSite url="https://api.wevoteusa.org/vg/create/"
+                           className="opinions-followed__missing-org-link"
+                           target="_blank"
+                           title="Endorsements Missing?"
+                           body={<Button className="u-stack--xs" bsStyle="primary">Endorsements Missing?</Button>}
+      />
+      <div className="opinions-followed__missing-org-text u-stack--lg u-no-break">
+        Are there endorsements from {organization_name} that you expected to see?
+      </div>
     </div>;
   }
 }

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -553,9 +553,9 @@ export default class Ballot extends Component {
   getEmptyMessageByFilterType (filter_type) {
     switch (filter_type) {
       case "filterRemaining":
-        return "You already chose a candidate or position for each ballot item";
+        return "You have chosen a candidate for every office and decided on all measures.";
       case "filterDecided":
-        return "You haven't supported any candidates or measures yet.";
+        return "You haven't supported any candidates or decided on any measures yet.";
       default:
         return "";
     }

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -554,7 +554,7 @@ export default class Ballot extends Component {
     switch (filter_type) {
       case "filterRemaining":
         return "You already chose a candidate or position for each ballot item";
-      case "filterSupport":
+      case "filterDecided":
         return "You haven't supported any candidates or measures yet.";
       default:
         return "";

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import { Button } from "react-bootstrap";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import CandidateActions from "../../actions/CandidateActions";
 import CandidateItem from "../../components/Ballot/CandidateItem";
@@ -200,6 +201,15 @@ export default class Candidate extends Component {
           }
         </div>
       </section>
+      <OpenExternalWebSite url="https://api.wevoteusa.org/vg/create/"
+                           className="opinions-followed__missing-org-link"
+                           target="_blank"
+                           title="Endorsements Missing?"
+                           body={<Button className="u-margin-top--sm u-stack--xs" bsStyle="primary">Endorsements Missing?</Button>}
+      />
+      <div className="opinions-followed__missing-org-text u-no-break">
+        Are there endorsements for {candidateName} that you expected to see?
+      </div>
       <br />
       <ThisIsMeAction twitter_handle_being_viewed={this.state.candidate.twitter_handle}
                     name_being_viewed={this.state.candidate.ballot_item_display_name}

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -136,7 +136,7 @@ class BallotStore extends ReduceStore {
     return ballot_remaining_choices.length || 0;
   }
 
-  get ballot_supported () {
+  get ballot_decided () {
     if (!this.isLoaded()){ return undefined; }
 
     return this.ballot_filtered_unsupported_candidates().filter( ballot_item => {
@@ -188,8 +188,8 @@ class BallotStore extends ReduceStore {
     switch (filter_type) {
       case "filterRemaining":
         return this.ballot_remaining_choices;
-      case "filterSupport":
-        return this.ballot_supported;
+      case "filterDecided":
+        return this.ballot_decided;
       case "filterReadyToVote":
         return this.ballot;
       default :
@@ -201,8 +201,8 @@ class BallotStore extends ReduceStore {
     switch (filter_type) {
       case "filterRemaining":
         return "CHOICES_REMAINING";
-      case "filterSupport":
-        return "WHAT_I_SUPPORT";
+      case "filterDecided":
+        return "ITEMS_DECIDED";
       case "filterReadyToVote":
         return "READY_TO_VOTE";
       default :

--- a/src/js/stores/BallotStore.js
+++ b/src/js/stores/BallotStore.js
@@ -143,7 +143,7 @@ class BallotStore extends ReduceStore {
       if (ballot_item.kind_of_ballot_item === "OFFICE"){ //Offices
         return ballot_item.candidate_list.length > 0;
       } else { //MEASURES
-        return SupportStore.supportList[ballot_item.we_vote_id];
+        return SupportStore.supportList[ballot_item.we_vote_id] || SupportStore.opposeList[ballot_item.we_vote_id];
       }
     });
   }

--- a/src/sass/components/_network.scss
+++ b/src/sass/components/_network.scss
@@ -103,3 +103,9 @@ $network-card-margin-mobile: (-$space-md) (-$space-md) $space-none (-$space-md);
     margin: $network-card-margin-mobile;
   }
 }
+
+.opinions-followed {
+  &__missing-org-text {
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
Added buttons to the network, candidate, and organization pages that open the "Capture Voter Guide" page in a new tab and allow the user to suggest missing organizations or endorsements (#1634).

Append: Fixed an issue where opposed measures do not show up under "Items Decided" (#1552). Renamed related filter types and functions as appropriate.