### PR TITLE
Fix for ballot modal not closing

### DIFF
--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -57,7 +57,7 @@ export default class AddressBox extends Component {
 
   componentDidUpdate () {
     // If we're in the slide with this component, autofocus the address box, otherwise defocus.
-    if (this.props.manualFocus !== undefined) {
+    if (this.props.manualFocus !== undefined && !this.state.loading) {
       let address_box = this.refs.autocomplete;
       if (address_box) {
         if (this.props.manualFocus) {


### PR DESCRIPTION
address_box was null because when the component is loading it doesn’t render the address_box input. This was throwing an error and blocking the modal close

Resolves #1670 