### PR TITLE
Fixed "Organizations You Trust" page layout, loading of candidate photos, list of issues followed on network page

### DIFF
--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -118,7 +118,7 @@ export default class BallotIntroFollowAdvisers extends Component {
     }
 
     let organizations_shown_count = 0;
-    let maximum_number_of_organizations_to_show = 9;  // Please reset to 24 once we have this fixed: https://github.com/wevote/WebApp/issues/1636
+    let maximum_number_of_organizations_to_show = 24; // Only show the first 6 * 4 = 24 issues so as to not overwhelm voter
     const voter_guides_to_follow_by_issues_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) => {
       if (organizations_shown_count < maximum_number_of_organizations_to_show) {
         organizations_shown_count++;
@@ -179,29 +179,30 @@ export default class BallotIntroFollowAdvisers extends Component {
       });
 
     return <div className="intro-modal">
-      <div className="intro-modal__h1">Opinions You Trust?</div>
-        <div>
-          <div className="intro-modal__top-description">
-            { this.state.description_text ?
-              this.state.description_text :
-              <span>Click to see who they endorse on your ballot. Or skip ahead!</span>
+      <div className="intro-modal__h1">
+        Opinions You Trust?
+      </div>
+      <div className="intro-modal__top-description">
+        { this.state.description_text ?
+          this.state.description_text :
+          <span>Click to see who they endorse on your ballot. Or skip ahead!</span>
+        }
+      </div>
+      <div className="intro-modal-vertical-scroll-contain">
+        <div className="intro-modal-vertical-scroll card">
+          <div className="row intro-modal__grid">
+            { voter_guides_to_follow_by_issues_for_display.length ? voter_guides_to_follow_by_issues_for_display : null }
+            { voter_guides_to_follow_all_for_display.length ? voter_guides_to_follow_all_for_display : null }
+            { voter_guides_to_follow_by_issues_for_display.length || voter_guides_to_follow_all_for_display.length ?
+              null :
+              <h4 className="intro-modal__default-text">There are no more organizations to listen to!</h4>
             }
           </div>
-          <div className="intro-modal-vertical-scroll-contain">
-            <div className="intro-modal-vertical-scroll card">
-              <div className="row intro-modal__grid">
-                { voter_guides_to_follow_by_issues_for_display.length ? voter_guides_to_follow_by_issues_for_display : null }
-                { voter_guides_to_follow_all_for_display.length ? voter_guides_to_follow_all_for_display : null }
-                { voter_guides_to_follow_by_issues_for_display.length || voter_guides_to_follow_all_for_display.length ?
-                  null :
-                  <h4 className="intro-modal__default-text">There are no more organizations to listen to!</h4>
-                }
-              </div>
-            </div>
-          </div>
-          <div className="intro-modal-shadow" />
         </div>
-      <br/>
+      </div>
+      <div className="intro-modal-shadow-wrap">
+        <div className="intro-modal-shadow" />
+      </div>
       <div className="intro-modal__button-wrap">
         <Button type="submit" className="btn btn-success intro-modal__button" onClick={this.onNext}>
           <span>{this.state.next_button_text}</span>

--- a/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
+++ b/src/js/components/Ballot/BallotIntroFollowAdvisers.jsx
@@ -118,7 +118,7 @@ export default class BallotIntroFollowAdvisers extends Component {
     }
 
     let organizations_shown_count = 0;
-    let maximum_number_of_organizations_to_show = 24; // Only show the first 6 * 4 = 24 issues so as to not overwhelm voter
+    let maximum_number_of_organizations_to_show = 12; // Only show the first 6 * 2 = 12 issues so as to not overwhelm voter
     const voter_guides_to_follow_by_issues_for_display = voter_guides_to_follow_by_issues_followed.map((voter_guide) => {
       if (organizations_shown_count < maximum_number_of_organizations_to_show) {
         organizations_shown_count++;

--- a/src/js/components/Ballot/BallotIntroVerifyAddress.jsx
+++ b/src/js/components/Ballot/BallotIntroVerifyAddress.jsx
@@ -29,7 +29,7 @@ export default class BallotIntroVerifyAddress extends Component {
     return <div className="intro-modal">
       <div className="intro-modal__h1">Verify your Address</div>
       <div className="intro-modal__h3">Please enter your full address so we can look up your full ballot.</div>
-      <div className={ isWebApp() ? "u-padding-bottom--md" : "SettingsCardBottomCordova" } >
+      <div className={ isWebApp() ? "intro-modal__address-box u-padding-bottom--md" : "SettingsCardBottomCordova" } >
         <AddressBox {...this.props} saveUrl="/ballot" waitingMessage="Thank you! Click 'See Your Ballot' below." disableAutoFocus />
       </div>
 

--- a/src/js/components/Network/NetworkIssuesFollowed.jsx
+++ b/src/js/components/Network/NetworkIssuesFollowed.jsx
@@ -26,6 +26,7 @@ export default class NetworkIssuesFollowed extends Component {
     }
 
     this.issueStoreListener = IssueStore.addListener(this._onIssueStoreChange.bind(this));
+    this._onIssueStoreChange();
   }
 
   componentWillUnmount () {

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -68,11 +68,12 @@ $candidate-font-size: .875rem;
     }
 
     &__avatar-compressed {
-      max-width: 40px;
+      background-image: url('/img/global/svg-icons/avatar-generic.svg');
+      width: 40px;
       border-radius: $radius-xs;
       .card-main & {
         @include breakpoints(mid-small) {
-          max-width: 40px;
+          width: 40px;
         }
         border-radius: $radius-rounded;
       }

--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -383,6 +383,11 @@ $slick-dot-character: '\2022' !default;
       right: 8px;
     }
   }
+
+  &__address-box {
+    align-self: center;
+    width: 80%;
+  }
 }
 
 // Intro Modal shadow


### PR DESCRIPTION
Fixed a bug where the the list of issues the voter is following does not show up on the network page. Fixed the layout of the "Organizations You Trust" page of the ballot intro modal to be consistent with the "Issues to Follow" page (#1636). Reduced the maximum number of organizations to show from 24 to 12. Reduced the width of the address box in the ballot intro modal to be the same as the width of the Next button. Added a generic avatar for each candidate on the ballot page before their photo finishes loading to prevent component shifting.