### PR TITLE
Added NPS widget, show measure descriptions on load in ballot page

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "react-dom": "^15.6.2",
     "react-helmet": "^3.3.0",
     "react-iframe-resizer-super": "^0.2.0",
+    "react-nps-input": "^0.3.0",
     "react-player": "^1.5.0",
     "react-router-scroll": "^0.4.4",
     "react-slick": "^0.14.5",

--- a/src/js/components/Navigation/BallotSideBar.jsx
+++ b/src/js/components/Navigation/BallotSideBar.jsx
@@ -108,6 +108,7 @@ export default class BallotSideBar extends Component {
   }
 
   onNPSDismissed () {
+    clearTimeout(this.formCloseTimer);
     this.setState({
       showNPSInput: false,
       formSubmitted: false,
@@ -132,6 +133,7 @@ export default class BallotSideBar extends Component {
     this.setState({
       formSubmitted: true,
     });
+    this.formCloseTimer = setTimeout(this.onNPSDismissed, 3000);
   }
 
   render () {

--- a/src/js/components/Navigation/BallotSideBar.jsx
+++ b/src/js/components/Navigation/BallotSideBar.jsx
@@ -138,6 +138,8 @@ export default class BallotSideBar extends Component {
 
   render () {
     renderLog(__filename);
+    let turnedOnNPSInput = false;
+
     let click = this.handleClick;
     let ballot = this.state.ballot;
     let { ballotWithAllItemsByFilterType, displaySubtitles } = this.props;
@@ -181,12 +183,17 @@ export default class BallotSideBar extends Component {
             <Link to="/more/privacy">
               Privacy Policy
             </Link>
-            &nbsp;&nbsp;&nbsp;
-            <a onClick={this.showNPSInput}>
-              Send Feedback
-            </a>
+            { turnedOnNPSInput ?
+              <span>
+                &nbsp;&nbsp;&nbsp;
+                <a onClick={this.showNPSInput}>
+                  Send Feedback
+                </a>
+              </span> :
+              null
+            }
           </span>
-          { this.state.showNPSInput ?
+          { turnedOnNPSInput && this.state.showNPSInput ?
             <NPSInput onSubmit={this.onNPSSubmit}
                       onDismissed={this.onNPSDismissed}>
               {({ score }) => {

--- a/src/js/components/Navigation/BallotSideBar.jsx
+++ b/src/js/components/Navigation/BallotSideBar.jsx
@@ -1,6 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Link } from "react-router";
+import NPSInput from "react-nps-input";
+import Textarea from "react-textarea-autosize";
 import BallotStore from "../../stores/BallotStore";
 import BallotSideBarLink from "./BallotSideBarLink";
 import { renderLog } from "../../utils/logging";
@@ -23,8 +25,16 @@ export default class BallotSideBar extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {};
+    this.state = {
+      feedbackScore: undefined,
+      feedbackText: "",
+      formSubmitted: false,
+      showNPSInput: false,
+    };
     this.handleClick = this.handleClick.bind(this);
+    this.onNPSDismissed = this.onNPSDismissed.bind(this);
+    this.onNPSSubmit = this.onNPSSubmit.bind(this);
+    this.showNPSInput = this.showNPSInput.bind(this);
   }
 
   componentDidMount () {
@@ -90,6 +100,40 @@ export default class BallotSideBar extends Component {
     }
     return `${this.props.pathname}#${ballotItemWeVoteId}`;
   }
+
+  showNPSInput () {
+    this.setState({
+      showNPSInput: true,
+    });
+  }
+
+  onNPSDismissed () {
+    this.setState({
+      showNPSInput: false,
+      formSubmitted: false,
+    });
+  }
+
+  updateFeedbackText (e) {
+    this.setState({
+      feedbackText: e.target.value,
+    });
+  }
+
+  onNPSSubmit ({ score }) {
+    this.setState({
+      feedbackScore: score,
+    });
+    this.feedbackTextArea.focus();
+  }
+
+  onFormSubmit () {
+    // TODO send feedback entered to database
+    this.setState({
+      formSubmitted: true,
+    });
+  }
+
   render () {
     renderLog(__filename);
     let click = this.handleClick;
@@ -133,8 +177,33 @@ export default class BallotSideBar extends Component {
               Terms of Service
             </Link>&nbsp;&nbsp;&nbsp;<Link to="/more/privacy">
               Privacy Policy
-            </Link>
+            </Link>&nbsp;&nbsp;&nbsp;<a onClick={this.showNPSInput}>
+              Send Feedback
+            </a>
           </span>
+          { this.state.showNPSInput ?
+            <NPSInput onSubmit={this.onNPSSubmit} onDismissed={this.onNPSDismissed}>
+              {({ score }) => {
+                if (this.state.formSubmitted) {
+                  return <p>Thank you! Your feedback has been submitted.</p>;
+                } else {
+                  return <form onSubmit={this.onFormSubmit.bind(this)}>
+                    <p>Thank you for your rating! You just gave us a {score}.</p>
+                    <p>Any additional comments you would like to provide? (optional)</p>
+                    <Textarea onChange={this.updateFeedbackText.bind(this)}
+                      name="feedback_text"
+                      className="u-stack--sm form-control"
+                      minRows={3}
+                      placeholder={"Enter your comments here."}
+                      defaultValue={""}
+                      inputRef={tag => {this.feedbackTextArea = tag;}} />
+                    <button className="position-statement__post-button btn btn-default btn-sm" type="submit">Submit</button>
+                  </form>;
+                }
+              }}
+            </NPSInput> :
+            null
+          }
         </div>
       );
     } else {

--- a/src/js/components/Navigation/BallotSideBar.jsx
+++ b/src/js/components/Navigation/BallotSideBar.jsx
@@ -16,7 +16,7 @@ export default class BallotSideBar extends Component {
     displaySubtitles: PropTypes.bool,
     onClick: PropTypes.func,
     pathname: PropTypes.string,
-    rawUrlVariablesString: PropTypes.string
+    rawUrlVariablesString: PropTypes.string,
   };
 
   static defaultProps = {
@@ -39,9 +39,7 @@ export default class BallotSideBar extends Component {
 
   componentDidMount () {
     this.onBallotStoreChange();
-    this.ballotStoreListener = BallotStore.addListener(
-      this.onBallotStoreChange.bind(this)
-    );
+    this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
   }
 
   componentWillUnmount () {
@@ -50,7 +48,9 @@ export default class BallotSideBar extends Component {
 
   onBallotStoreChange () {
     let unsorted = BallotStore.ballot;
-    this.setState({ ballot: this._sortBallots(unsorted) });
+    this.setState({
+      ballot: this._sortBallots(unsorted),
+    });
   }
 
   _sortBallots (unsorted) {
@@ -141,7 +141,7 @@ export default class BallotSideBar extends Component {
     let { ballotWithAllItemsByFilterType, displaySubtitles } = this.props;
     if (ballot && ballot.length) {
       let ballotWithAllItemIdsByFilterType = [];
-      ballotWithAllItemsByFilterType.forEach((itemByFilterType)=>{
+      ballotWithAllItemsByFilterType.forEach(itemByFilterType => {
           ballotWithAllItemIdsByFilterType.push(itemByFilterType.we_vote_id);
       });
       return (
@@ -162,8 +162,7 @@ export default class BallotSideBar extends Component {
                                      label={item.ballot_item_display_name}
                                      subtitle={item.measure_subtitle}
                                      displaySubtitles={displaySubtitles}
-                                     onClick={click}
-                  />
+                                     onClick={click} />
                 </div>
               );
             } else {
@@ -175,14 +174,19 @@ export default class BallotSideBar extends Component {
             <br />
             <Link to="/more/terms">
               Terms of Service
-            </Link>&nbsp;&nbsp;&nbsp;<Link to="/more/privacy">
+            </Link>
+            &nbsp;&nbsp;&nbsp;
+            <Link to="/more/privacy">
               Privacy Policy
-            </Link>&nbsp;&nbsp;&nbsp;<a onClick={this.showNPSInput}>
+            </Link>
+            &nbsp;&nbsp;&nbsp;
+            <a onClick={this.showNPSInput}>
               Send Feedback
             </a>
           </span>
           { this.state.showNPSInput ?
-            <NPSInput onSubmit={this.onNPSSubmit} onDismissed={this.onNPSDismissed}>
+            <NPSInput onSubmit={this.onNPSSubmit}
+                      onDismissed={this.onNPSDismissed}>
               {({ score }) => {
                 if (this.state.formSubmitted) {
                   return <p>Thank you! Your feedback has been submitted.</p>;

--- a/src/js/components/Navigation/BallotSideBar.jsx
+++ b/src/js/components/Navigation/BallotSideBar.jsx
@@ -201,7 +201,7 @@ export default class BallotSideBar extends Component {
                   return <p>Thank you! Your feedback has been submitted.</p>;
                 } else {
                   return <form onSubmit={this.onFormSubmit.bind(this)}>
-                    <p>Thank you for your rating! You just gave us a {score}.</p>
+                    <p>Thank you for your rating! You just gave us a{score === 8 ? "n" : null} {score}.</p>
                     <p>Any additional comments you would like to provide? (optional)</p>
                     <Textarea onChange={this.updateFeedbackText.bind(this)}
                       name="feedback_text"

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -35,7 +35,7 @@ export default class ItemActionBar extends Component {
   constructor (props) {
     super(props);
     this.state = {
-      ballotItemWeVoteId: "",
+      ballotItemWeVoteId: this.props.ballot_item_we_vote_id,
       componentDidMountFinished: false,
       isOpposeAPIState: undefined,
       isOpposeLocalState: undefined,
@@ -45,6 +45,10 @@ export default class ItemActionBar extends Component {
       showSupportOrOpposeHelpModal: false,
       supportCount: 0,
       opposeCount: 0,
+      yesVoteDescription: "",
+      yesVoteDescriptionExists: false,
+      noVoteDescription: "",
+      noVoteDescriptionExists: false,
       // supportProps: this.props.supportProps,
       transitioning: false,
     };
@@ -56,6 +60,8 @@ export default class ItemActionBar extends Component {
   }
 
   componentDidMount () {
+    this.measureStoreListener = MeasureStore.addListener(this.onMeasureStoreChange.bind(this));
+    this.onMeasureStoreChange();
     // console.log("itemActionBar, NEW componentDidMount");
     let isOpposeAPIState = false;
     let isPublicPosition = false;
@@ -71,7 +77,6 @@ export default class ItemActionBar extends Component {
     }
 
     this.setState({
-      ballotItemWeVoteId: this.props.ballot_item_we_vote_id,
       componentDidMountFinished: true,
       isOpposeAPIState: isOpposeAPIState,
       isPublicPosition: isPublicPosition,
@@ -220,7 +225,38 @@ export default class ItemActionBar extends Component {
       // console.log("shouldComponentUpdate: itemActionBar, showSupportOrOpposeHelpModal different");
       return true;
     }
+    if (this.state.yesVoteDescription !== nextState.yesVoteDescription) {
+      // console.log("shouldComponentUpdate: itemActionBar, yesVoteDescription different");
+      return true;
+    }
+    if (this.state.noVoteDescription !== nextState.noVoteDescription) {
+      // console.log("shouldComponentUpdate: itemActionBar, noVoteDescription different");
+      return true;
+    }
+    if (this.state.yesVoteDescriptionExists !== nextState.yesVoteDescriptionExists) {
+      // console.log("shouldComponentUpdate: itemActionBar, yesVoteDescriptionExists different");
+      return true;
+    }
+    if (this.state.noVoteDescriptionExists !== nextState.noVoteDescriptionExists) {
+      // console.log("shouldComponentUpdate: itemActionBar, noVoteDescriptionExists different");
+      return true;
+    }
     return false;
+  }
+
+  componentWillUnmount () {
+    this.measureStoreListener.remove();
+  }
+
+  onMeasureStoreChange () {
+    if (this.isMeasure()) {
+      this.setState({
+        yesVoteDescription: MeasureStore.getYesVoteDescription(this.state.ballotItemWeVoteId),
+        yesVoteDescriptionExists: this.state.yesVoteDescription && this.state.yesVoteDescription.length,
+        noVoteDescription: MeasureStore.getNoVoteDescription(this.state.ballotItemWeVoteId),
+        noVoteDescriptionExists: this.state.noVoteDescription && this.state.noVoteDescription.length,
+      });
+    }
   }
 
   isMeasure () {
@@ -468,24 +504,6 @@ export default class ItemActionBar extends Component {
     const supportButtonPopoverTooltip = <Tooltip id="supportButtonTooltip">{this.isSupportCalculated() ? supportButtonUnselectedPopOverText : supportButtonSelectedPopOverText }</Tooltip>;
     const opposeButtonPopoverTooltip = <Tooltip id="opposeButtonTooltip">{this.isOpposeCalculated() ? opposeButtonUnselectedPopOverText : opposeButtonSelectedPopOverText}</Tooltip>;
 
-    let yesVoteDescriptionExists = false;
-    let yesVoteDescription = "";
-    if (this.isMeasure()) {
-      yesVoteDescription = MeasureStore.getYesVoteDescription(this.state.ballotItemWeVoteId);
-      if (yesVoteDescription && yesVoteDescription.length) {
-        yesVoteDescriptionExists = true;
-      }
-    }
-
-    let noVoteDescriptionExists = false;
-    let noVoteDescription = "";
-    if (this.isMeasure()) {
-      noVoteDescription = MeasureStore.getNoVoteDescription(this.state.ballotItemWeVoteId);
-      if (noVoteDescription && noVoteDescription.length) {
-        noVoteDescriptionExists = true;
-      }
-    }
-
     const supportButton = <button className={"item-actionbar__btn item-actionbar__btn--support btn btn-default" + (this.isSupportCalculated() ? " support-at-state" : "")} onClick={() => this.supportItem()}>
       <span className="btn__icon">
         <Icon name="thumbs-up-icon" width={iconSize} height={iconSize} color={supportIconColor} />
@@ -511,26 +529,26 @@ export default class ItemActionBar extends Component {
     </button>;
 
     return <div className={ this.props.shareButtonHide ? "item-actionbar--inline hidden-print" : "item-actionbar hidden-print" }>
-      <div className={(yesVoteDescriptionExists || noVoteDescriptionExists ? "" : "btn-group") + (!this.props.shareButtonHide ? " u-push--sm" : "")}>
+      <div className={(this.state.yesVoteDescriptionExists || this.state.noVoteDescriptionExists ? "" : "btn-group") + (!this.props.shareButtonHide ? " u-push--sm" : "")}>
 
         {/* Start of Support Button */}
         <div className="hidden-xs item-actionbar__position-bar">
           <OverlayTrigger placement="top" overlay={supportButtonPopoverTooltip}>{supportButton}</OverlayTrigger>
-          {yesVoteDescriptionExists ? <span className="item-actionbar__following-text">{yesVoteDescription}</span> : null}
+          {this.state.yesVoteDescriptionExists ? <span className="item-actionbar__following-text">{this.state.yesVoteDescription}</span> : null}
         </div>
         <div className="visible-xs item-actionbar__position-bar item-actionbar__position-bar--mobile">
           {supportButton}
-          {yesVoteDescriptionExists ? <span className="item-actionbar__following-text">{yesVoteDescription}</span> : null}
+          {this.state.yesVoteDescriptionExists ? <span className="item-actionbar__following-text">{this.state.yesVoteDescription}</span> : null}
         </div>
 
         {/* Start of Oppose Button */}
         <div className="hidden-xs item-actionbar__position-bar">
           <OverlayTrigger placement="top" overlay={opposeButtonPopoverTooltip}>{opposeButton}</OverlayTrigger>
-          {noVoteDescriptionExists ? <span className="item-actionbar__following-text">{noVoteDescription}</span> : null}
+          {this.state.noVoteDescriptionExists ? <span className="item-actionbar__following-text">{this.state.noVoteDescription}</span> : null}
         </div>
         <div className="visible-xs item-actionbar__position-bar item-actionbar__position-bar--mobile">
           {opposeButton}
-          {noVoteDescriptionExists ? <span className="item-actionbar__following-text">{noVoteDescription}</span> : null}
+          {this.state.noVoteDescriptionExists ? <span className="item-actionbar__following-text">{this.state.noVoteDescription}</span> : null}
         </div>
       { this.props.commentButtonHide ?
         null :

--- a/src/sass/components/_nps-input.scss
+++ b/src/sass/components/_nps-input.scss
@@ -1,0 +1,126 @@
+// copied from https://github.com/SamyPesse/react-nps-input/blob/master/stylesheets/main.less
+
+$NPSInput-Value-color:       #f2f5fd;
+$NPSInput-Value-hover-color: #3884ff;
+$NPSInput-Value-size:        32px;
+$NPSInput-Value-padding:     3px;
+$NPSInput-Value-width:       ($NPSInput-Value-size + 2 * $NPSInput-Value-padding) * 11;
+
+.NPSInput {
+  position: fixed;
+  bottom: 0px;
+  left: 0px;
+  right: 0px;
+  border-top: 1px solid #e5e5e5;
+  background: #fff;
+  box-shadow: 0px -10px 10px rgba(200, 200, 200, 0.08);
+
+  &.animated {
+    animation-duration: 0.7s;
+    animation-name: NPSInput-slidein;
+  }
+
+  .NPSInput-Close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: transparent;
+    outline: none;
+    display: inline-block;
+    zoom: 1;
+    line-height: normal;
+    white-space: nowrap;
+    vertical-align: baseline;
+    text-align: center;
+    cursor: pointer;
+    user-select: none;
+    font-family: inherit;
+    font-size: 100%;
+    padding: 0.5em 1em;
+    text-decoration: none;
+    border: 0;
+    opacity: 0.4;
+    font-size: 16px;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+
+  .NPSInput-Inner {
+    width: 100%;
+    max-width: 1000px;
+    margin: 20px auto;
+    text-align: center;
+  }
+
+  .NPSScale {
+    width: $NPSInput-Value-width;
+    margin: 0px auto;
+
+    .NPSScale-Values {
+      .NPSScale-Value {
+        padding: 0px 3px;
+        display: inline-block;
+
+        div {
+          background: $NPSInput-Value-color;
+          width: $NPSInput-Value-size;
+          height: $NPSInput-Value-size;
+          line-height: $NPSInput-Value-size;
+          border-radius: $NPSInput-Value-size;
+          cursor: pointer;
+          transition: 0.15s ease all;
+          color: #999;
+        }
+
+        &.selected {
+          div {
+            background: $NPSInput-Value-hover-color;
+            color: #fff;
+          }
+        }
+
+        &:hover {
+          div {
+            transform: scale(1.25);
+          }
+        }
+      }
+    }
+
+    .NPSScale-Legend {
+      display: flex;
+      margin-top: 12px;
+
+      .NPSScale-Label {
+        flex: 1;
+        color: #999;
+        font-size: 12px;
+
+        &.left {
+          text-align: left;
+        }
+        &.right {
+          text-align: right;
+        }
+      }
+    }
+  }
+
+  .NPSInput-Message {
+    margin: 0px;
+    margin-bottom: 15px;
+    font-size: 16px;
+  }
+}
+
+@keyframes NPSInput-slidein {
+  from {
+    bottom: -100%;
+  }
+
+  to {
+    bottom: 0px;
+  }
+}

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -55,6 +55,7 @@
 
 @import 'components/buttons';
 @import 'components/loading-spinner';
+@import 'components/nps-input';
 @import 'components/twitter-followers';
 
 // -------------------------------


### PR DESCRIPTION
Added the `react-nps-input` package and `NPSInput` component to the ballot page for users to send feedback, currently temporarily disabled since the database doesn't support it yet (#1631). Fixed a bug where the measure descriptions for each measure item on the ballot page are not shown when the page loads.