### PR TITLE
Moved "Related Issues" on candidate page to bottom of page

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -191,7 +191,7 @@ export default class CandidateItem extends Component {
                                   organizationsToFollowSupport={organizationsToFollowSupport}
                                   organizationsToFollowOppose={organizationsToFollowOppose}
                                   popoverBottom
-                                  showIssueList
+                                  // showIssueList
                                   showPositionStatementActionBar={this.props.showPositionStatementActionBar}
                                   supportProps={candidateSupportStore}
                                   type="CANDIDATE"/>

--- a/src/js/components/Issues/IssueTinyDisplay.jsx
+++ b/src/js/components/Issues/IssueTinyDisplay.jsx
@@ -12,7 +12,7 @@ import VoterGuideStore from "../../stores/VoterGuideStore";
 import { removeTwitterNameFromDescription } from "../../utils/textFormat";
 import { renderLog } from "../../utils/logging";
 
-export default class OrganizationListUnderIssue extends Component {
+export default class IssueTinyDisplay extends Component {
   static propTypes = {
     ballotItemWeVoteId: PropTypes.string,
     currentBallotIdInUrl: PropTypes.string,
@@ -39,7 +39,7 @@ export default class OrganizationListUnderIssue extends Component {
     this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
     let voter_guides_for_this_issue = IssueStore.getVoterGuidesForOneIssue(this.props.issue_we_vote_id);
-    // console.log("OrganizationListUnderIssue, componentDidMount, voter_guides_for_this_issue: ", voter_guides_for_this_issue);
+    // console.log("IssueTinyDisplay, componentDidMount, voter_guides_for_this_issue: ", voter_guides_for_this_issue);
     this.setState({
       issue_we_vote_id: this.props.issue_we_vote_id,
       voter_guides_for_this_issue: voter_guides_for_this_issue,
@@ -53,7 +53,7 @@ export default class OrganizationListUnderIssue extends Component {
 
   onIssueStoreChange () {
     let voter_guides_for_this_issue = IssueStore.getVoterGuidesForOneIssue(this.state.issue_we_vote_id);
-    // console.log("OrganizationListUnderIssue, onIssueStoreChange, voter_guides_for_this_issue: ", voter_guides_for_this_issue);
+    // console.log("IssueTinyDisplay, onIssueStoreChange, voter_guides_for_this_issue: ", voter_guides_for_this_issue);
     this.setState({
       voter_guides_for_this_issue: voter_guides_for_this_issue,
     });
@@ -62,7 +62,7 @@ export default class OrganizationListUnderIssue extends Component {
   onVoterGuideStoreChange () {
     // We just want to trigger a re-render
     let voter_guides_for_this_issue = IssueStore.getVoterGuidesForOneIssue(this.state.issue_we_vote_id);
-    // console.log("OrganizationListUnderIssue, onVoterGuideStoreChange, voter_guides_for_this_issue: ", voter_guides_for_this_issue);
+    // console.log("IssueTinyDisplay, onVoterGuideStoreChange, voter_guides_for_this_issue: ", voter_guides_for_this_issue);
     this.setState({
       voter_guides_for_this_issue: voter_guides_for_this_issue,
     });
@@ -124,7 +124,7 @@ export default class OrganizationListUnderIssue extends Component {
 
   render () {
     renderLog(__filename);
-    // console.log("OrganizationListUnderIssue render, issue_we_vote_id: ", this.state.issue_we_vote_id, ", this.state.voter_guides_for_this_issue: ", this.state.voter_guides_for_this_issue);
+    // console.log("IssueTinyDisplay render, issue_we_vote_id: ", this.state.issue_we_vote_id, ", this.state.voter_guides_for_this_issue: ", this.state.voter_guides_for_this_issue);
     if (!this.state.voter_guides_for_this_issue || !this.state.voter_guides_for_this_issue.length){
       return null;
     }

--- a/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
+++ b/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
@@ -19,6 +19,7 @@ export default class IssuesDisplayListWithOrganizationPopovers extends Component
     issueListToDisplay: PropTypes.array,
     instantRefreshOn: PropTypes.bool,
     maximumIssuesToDisplay: PropTypes.number,
+    popoverBottom: PropTypes.bool,
     toFollow: PropTypes.bool,
     overlayTriggerOnClickOnly: PropTypes.bool,
     urlWithoutHash: PropTypes.string,
@@ -171,7 +172,7 @@ export default class IssuesDisplayListWithOrganizationPopovers extends Component
                                onExiting={() => this.onTriggerLeave(issueWeVoteId)}
                                trigger={this.props.overlayTriggerOnClickOnly ? "click" : ["focus", "hover", "click"]}
                                rootClose
-                               placement="bottom"
+                               placement={this.props.popoverBottom ? "bottom" : "top"}
                                overlay={issuePopover}
                 >
           <span className="">

--- a/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
+++ b/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import OrganizationListUnderIssue from "./OrganizationListUnderIssue";
+import IssueTinyDisplay from "./IssueTinyDisplay";
 import { renderLog } from "../../utils/logging";
 
 // We use this for IssuesFollowedDisplayList, to show a voter a horizontal list of all of their
@@ -82,7 +82,7 @@ export default class IssuesDisplayListWithOrganizationPopovers extends Component
 
       // Once we have more organizations than we want to show, put them into a drop-down
       if (localCounter <= this.state.maximum_issues_display) {
-        return <OrganizationListUnderIssue key={`trigger-${issueWeVoteId}`}
+        return <IssueTinyDisplay key={`trigger-${issueWeVoteId}`}
                                            ballotItemWeVoteId={this.state.ballotItemWeVoteId}
                                            currentBallotIdInUrl={this.props.currentBallotIdInUrl}
                                            issue={oneIssue}

--- a/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
+++ b/src/js/components/Issues/IssuesDisplayListWithOrganizationPopovers.jsx
@@ -1,10 +1,5 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { OverlayTrigger, Popover } from "react-bootstrap";
-import { isCordova } from "../../utils/cordovaUtils";
-import IssueCard from "./IssueCard";
-import IssueImageDisplay from "./IssueImageDisplay";
-import IssueStore from "../../stores/IssueStore";
 import OrganizationListUnderIssue from "./OrganizationListUnderIssue";
 import { renderLog } from "../../utils/logging";
 
@@ -29,7 +24,6 @@ export default class IssuesDisplayListWithOrganizationPopovers extends Component
   constructor (props) {
     super(props);
 
-    this.popover_state = {};
     this.mobile = "ontouchstart" in document.documentElement;
 
     this.state = {
@@ -69,60 +63,6 @@ export default class IssuesDisplayListWithOrganizationPopovers extends Component
     });
   }
 
-  onTriggerEnter (issueWeVoteId) {
-    if (this.refs[`issue-overlay-${issueWeVoteId}`]) {
-      this.refs[`issue-overlay-${issueWeVoteId}`].show();
-    }
-
-    if (!this.popover_state[issueWeVoteId]) {
-      // If it wasn't created, create it now
-      this.popover_state[issueWeVoteId] = { show: false, timer: null };
-    }
-
-    clearTimeout(this.popover_state[issueWeVoteId].timer);
-    if (!this.popover_state[issueWeVoteId]) {
-      // If it wasn't created, create it now
-      this.popover_state[issueWeVoteId] = { show: false, timer: null };
-    }
-
-    this.popover_state[issueWeVoteId].show = true;
-  }
-
-  onTriggerLeave (issueWeVoteId) {
-    if (!this.popover_state[issueWeVoteId]) {
-      // If it wasn't created, create it now
-      this.popover_state[issueWeVoteId] = { show: false, timer: null };
-    }
-
-    this.popover_state[issueWeVoteId].show = false;
-    clearTimeout(this.popover_state[issueWeVoteId].timer);
-    this.popover_state[issueWeVoteId].timer = setTimeout(() => {
-      if (!this.popover_state[issueWeVoteId].show) {
-        if (this.refs[`issue-overlay-${issueWeVoteId}`]) {
-          this.refs[`issue-overlay-${issueWeVoteId}`].hide();
-        }
-      }
-    }, 100);
-  }
-
-  onTriggerToggle (e, issueWeVoteId) {
-    if (this.mobile) {
-      e.preventDefault();
-      e.stopPropagation();
-
-      if (!this.popover_state[issueWeVoteId]) {
-        // If it wasn't created, create it now
-        this.popover_state[issueWeVoteId] = { show: false, timer: null };
-      }
-
-      if (this.popover_state[issueWeVoteId].show) {
-        this.onTriggerLeave(issueWeVoteId);
-      } else {
-        this.onTriggerEnter(issueWeVoteId);
-      }
-    }
-  }
-
   render () {
     renderLog(__filename);
     if (this.state.issues_to_display === undefined) {
@@ -142,46 +82,17 @@ export default class IssuesDisplayListWithOrganizationPopovers extends Component
 
       // Once we have more organizations than we want to show, put them into a drop-down
       if (localCounter <= this.state.maximum_issues_display) {
-        this.popover_state[issueWeVoteId] = { show: false, timer: null };
-
-        let issuePopover = <Popover id={`issue-popover-${issueWeVoteId}`}
-                                    onMouseOver={() => this.onTriggerEnter(issueWeVoteId)}
-                                    onMouseOut={() => this.onTriggerLeave(issueWeVoteId)}
-                                    className="card-popover" title={<span onClick={() => this.onTriggerLeave(issueWeVoteId)}> &nbsp;
-                                      <span className={`fa fa-times pull-right u-cursor--pointer ${isCordova() && "u-mobile-x"} `} aria-hidden="true" /> </span>}
-                                    >
-            <IssueCard ballotItemWeVoteId={this.state.ballotItemWeVoteId}
-                       currentBallotIdInUrl={this.props.currentBallotIdInUrl}
-                       followToggleOn={this.props.toFollow}
-                       issue={oneIssue}
-                       issueImageSize={"MEDIUM"}
-                       urlWithoutHash={this.props.urlWithoutHash}
-                       we_vote_id={this.props.we_vote_id}
-            />
-            <OrganizationListUnderIssue currentBallotIdInUrl={this.props.currentBallotIdInUrl}
-                                        issue_we_vote_id={issueWeVoteId}
-                                        urlWithoutHash={this.props.urlWithoutHash}
-                                        we_vote_id={this.props.we_vote_id} />
-          </Popover>;
-
-        // onClick={(e) => this.onTriggerToggle(e, issueWeVoteId)}
-        return <OverlayTrigger key={`trigger-${issueWeVoteId}`}
-                               ref={`issue-overlay-${issueWeVoteId}`}
-                               onMouseOver={() => this.onTriggerEnter(issueWeVoteId)}
-                               onMouseOut={() => this.onTriggerLeave(issueWeVoteId)}
-                               onExiting={() => this.onTriggerLeave(issueWeVoteId)}
-                               trigger={this.props.overlayTriggerOnClickOnly ? "click" : ["focus", "hover", "click"]}
-                               rootClose
-                               placement={this.props.popoverBottom ? "bottom" : "top"}
-                               overlay={issuePopover}
-                >
-          <span className="">
-            <IssueImageDisplay issue={oneIssue}
-                               issueImageSize={this.state.issueImageSize}
-                               showPlaceholderImage
-                               isVoterFollowingThisIssue={IssueStore.isVoterFollowingThisIssue(issueWeVoteId)}/>
-          </span>
-        </OverlayTrigger>;
+        return <OrganizationListUnderIssue key={`trigger-${issueWeVoteId}`}
+                                           ballotItemWeVoteId={this.state.ballotItemWeVoteId}
+                                           currentBallotIdInUrl={this.props.currentBallotIdInUrl}
+                                           issue={oneIssue}
+                                           issueImageSize={this.state.issueImageSize}
+                                           issue_we_vote_id={issueWeVoteId}
+                                           overlayTriggerOnClickOnly={this.props.overlayTriggerOnClickOnly}
+                                           popoverBottom={this.props.popoverBottom}
+                                           toFollow={this.props.toFollow}
+                                           urlWithoutHash={this.props.urlWithoutHash}
+                                           we_vote_id={this.props.we_vote_id} />;
       } else {
         return null;
       }

--- a/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
+++ b/src/js/components/Issues/IssuesFollowedByBallotItemDisplayList.jsx
@@ -210,6 +210,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
                                                            issueImageSize={"MEDIUM"}
                                                            issueListToDisplay={this.state.issues_under_this_ballot_item_voter_is_following}
                                                            overlayTriggerOnClickOnly={this.props.overlayTriggerOnClickOnly}
+                                                           popoverBottom={this.props.popoverBottom}
                                                            toFollow
                                                            urlWithoutHash={this.props.urlWithoutHash}
                                                            we_vote_id={this.props.we_vote_id} />
@@ -219,6 +220,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
                                                            issueImageSize={"MEDIUM"}
                                                            issueListToDisplay={this.state.issues_under_this_ballot_item_voter_not_following}
                                                            overlayTriggerOnClickOnly={this.props.overlayTriggerOnClickOnly}
+                                                           popoverBottom={this.props.popoverBottom}
                                                            toFollow
                                                            urlWithoutHash={this.props.urlWithoutHash}
                                                            we_vote_id={this.props.we_vote_id} />
@@ -236,6 +238,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
                                                            issueImageSize={"MEDIUM"}
                                                            issueListToDisplay={this.state.issues_under_this_ballot_item_voter_is_following}
                                                            overlayTriggerOnClickOnly
+                                                           popoverBottom={this.props.popoverBottom}
                                                            toFollow
                                                            urlWithoutHash={this.props.urlWithoutHash}
                                                            we_vote_id={this.props.we_vote_id} />
@@ -245,6 +248,7 @@ export default class IssuesFollowedByBallotItemDisplayList extends Component {
                                                            issueImageSize={"MEDIUM"}
                                                            issueListToDisplay={this.state.issues_under_this_ballot_item_voter_not_following}
                                                            overlayTriggerOnClickOnly
+                                                           popoverBottom={this.props.popoverBottom}
                                                            toFollow
                                                            urlWithoutHash={this.props.urlWithoutHash}
                                                            we_vote_id={this.props.we_vote_id} />

--- a/src/js/components/Issues/IssuesFollowedDisplayList.jsx
+++ b/src/js/components/Issues/IssuesFollowedDisplayList.jsx
@@ -57,11 +57,13 @@ export default class IssuesFollowedDisplayList extends Component {
       {/* We want to display the images of the issues in the list we pass in */}
       <span className="visible-xs">
         <IssuesDisplayListWithOrganizationPopovers issueImageSize={"LARGE"}
-                                                   issueListToDisplay={issues_voter_is_following_mobile} />
+                                                   issueListToDisplay={issues_voter_is_following_mobile}
+                                                   popoverBottom />
       </span>
       <span className="hidden-xs">
         <IssuesDisplayListWithOrganizationPopovers issueImageSize={"LARGE"}
-                                                   issueListToDisplay={issues_voter_is_following_desktop} />
+                                                   issueListToDisplay={issues_voter_is_following_desktop}
+                                                   popoverBottom />
       </span>
     </span>;
   }

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -9,6 +9,7 @@ import { capitalizeString } from "../../utils/textFormat";
 import GuideList from "../../components/VoterGuide/GuideList";
 import Helmet from "react-helmet";
 import IssueActions from "../../actions/IssueActions";
+import IssuesFollowedByBallotItemDisplayList from "../../components/Issues/IssuesFollowedByBallotItemDisplayList";
 import IssueStore from "../../stores/IssueStore";
 import LoadingWheel from "../../components/LoadingWheel";
 import { renderLog } from "../../utils/logging";
@@ -211,6 +212,11 @@ export default class Candidate extends Component {
                        ballotItemWeVoteId={this.state.candidate_we_vote_id}
                        organizationsToFollow={this.state.voter_guides_to_follow_for_this_ballot_item}/></div>
           }
+        </div>
+        <div className="card__additional u-inset__squish--md">
+          <IssuesFollowedByBallotItemDisplayList ballot_item_display_name={this.state.candidate.ballot_item_display_name}
+                                                 ballotItemWeVoteId={this.state.candidate_we_vote_id}
+                                                 overlayTriggerOnClickOnly />
         </div>
       </section>
       <OpenExternalWebSite url="https://api.wevoteusa.org/vg/create/"


### PR DESCRIPTION
Moved the "Related Issues" list out of the candidate entry on the candidate page to the bottom of the page (#1679). Changed the position of the issue list popovers to show up above the list rather than below. Attempted to fix an issue where the popovers are still not positioned correctly.