### PR TITLE
Fixed a bug that prevented measure descriptions from displaying on ballot page, hide filter buttons not in use

### DIFF
--- a/src/js/components/Navigation/BallotSideBar.jsx
+++ b/src/js/components/Navigation/BallotSideBar.jsx
@@ -136,32 +136,47 @@ export default class BallotSideBar extends Component {
     this.formCloseTimer = setTimeout(this.onNPSDismissed, 3000);
   }
 
-  filteredBallotToRender (ballot, ballotWithAllItemIdsByFilterType, type) {
-    return ballot.filter(item => {
+  filteredBallotToRender (ballot, ballotWithAllItemIdsByFilterType, type, key) {
+    let filteredBallot = ballot.filter(item => {
       if (item.kind_of_ballot_item === "MEASURE") {
         return type === "Measure";
       } else {
         return type === item.race_office_level;
       }
-    }).map((item, key) => {
+    });
+
+    if (!filteredBallot.length) {
+      return null;
+    }
+
+    let filteredBallotListItems = filteredBallot.map((item, itemKey) => {
       if (
         item.kind_of_ballot_item === "OFFICE" ||
         item.kind_of_ballot_item === "MEASURE"
       ) {
         return (
-          <li className="BallotItem__summary__list-item" key={key}>
+          <li className="BallotItem__summary__list-item" key={itemKey}>
             <BallotSideBarLink url={this.renderUrl(item.we_vote_id, ballotWithAllItemIdsByFilterType)}
-                                      ballotItemLinkHasBeenClicked={this.props.ballotItemLinkHasBeenClicked}
-                                      label={item.ballot_item_display_name}
-                                      subtitle={item.measure_subtitle}
-                                      displaySubtitles={this.props.displaySubtitles}
-                                      onClick={this.handleClick} />
+                               ballotItemLinkHasBeenClicked={this.props.ballotItemLinkHasBeenClicked}
+                               label={item.ballot_item_display_name}
+                               subtitle={item.measure_subtitle}
+                               displaySubtitles={this.props.displaySubtitles}
+                               onClick={this.handleClick} />
           </li>
         );
       } else {
         return <span />;
       }
     });
+
+    return <div className="BallotItem__summary__group" key={key}>
+      <div className="BallotItem__summary__group-title">
+        {type === "Measure" ? "Ballot Measures" : type}
+      </div>
+      <ul className="BallotItem__summary__list">
+        {filteredBallotListItems}
+      </ul>
+    </div>;
   }
 
   render () {
@@ -186,14 +201,7 @@ export default class BallotSideBar extends Component {
             null
           }
           { BALLOT_ITEM_FILTER_TYPES.map((type, key) =>
-            <div className="BallotItem__summary__group" key={key}>
-              <div className="BallotItem__summary__group-title">
-                {type === "Measure" ? "Ballot Measures" : type}
-              </div>
-              <ul className="BallotItem__summary__list">
-                {this.filteredBallotToRender(ballot, ballotWithAllItemIdsByFilterType, type)}
-              </ul>
-            </div>
+            this.filteredBallotToRender(ballot, ballotWithAllItemIdsByFilterType, type, key)
           )}
           <h4 className="text-left" />
           <span className="terms-and-privacy">

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -83,8 +83,7 @@ export default class ItemActionBar extends Component {
       isSupportAPIState: isSupportAPIState,
       supportCount: supportCount,
       opposeCount: opposeCount,
-    });
-    this.onMeasureStoreChange();
+    }, this.onMeasureStoreChange);
   }
 
   componentWillReceiveProps (nextProps) {
@@ -93,7 +92,7 @@ export default class ItemActionBar extends Component {
       // console.log("itemActionBar, ballotItemWeVoteId setState");
       this.setState({
         ballotItemWeVoteId: nextProps.ballot_item_we_vote_id,
-      });
+      }, this.onMeasureStoreChange);
     }
     // Only proceed if we have valid supportProps
     if (nextProps.supportProps !== undefined && nextProps.supportProps) {
@@ -226,14 +225,6 @@ export default class ItemActionBar extends Component {
       // console.log("shouldComponentUpdate: itemActionBar, showSupportOrOpposeHelpModal different");
       return true;
     }
-    if (this.state.yesVoteDescription !== nextState.yesVoteDescription) {
-      // console.log("shouldComponentUpdate: itemActionBar, yesVoteDescription different");
-      return true;
-    }
-    if (this.state.noVoteDescription !== nextState.noVoteDescription) {
-      // console.log("shouldComponentUpdate: itemActionBar, noVoteDescription different");
-      return true;
-    }
     if (this.state.yesVoteDescriptionExists !== nextState.yesVoteDescriptionExists) {
       // console.log("shouldComponentUpdate: itemActionBar, yesVoteDescriptionExists different");
       return true;
@@ -253,9 +244,12 @@ export default class ItemActionBar extends Component {
     if (this.isMeasure()) {
       this.setState({
         yesVoteDescription: MeasureStore.getYesVoteDescription(this.state.ballotItemWeVoteId),
-        yesVoteDescriptionExists: this.state.yesVoteDescription && this.state.yesVoteDescription.length,
         noVoteDescription: MeasureStore.getNoVoteDescription(this.state.ballotItemWeVoteId),
-        noVoteDescriptionExists: this.state.noVoteDescription && this.state.noVoteDescription.length,
+      }, () => {
+        this.setState({
+          yesVoteDescriptionExists: this.state.yesVoteDescription && this.state.yesVoteDescription.length,
+          noVoteDescriptionExists: this.state.noVoteDescription && this.state.noVoteDescription.length,
+        });
       });
     }
   }

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -52,6 +52,7 @@ export default class Ballot extends Component {
     super(props);
     this.state = {
       ballotElectionList: [],
+      ballotWithAllItems: [],
       ballotWithAllItemsByFilterType: [],
       ballot_item_filter_type: "",
       ballot_returned_we_vote_id: "",
@@ -113,10 +114,20 @@ export default class Ballot extends Component {
     let ballotWithAllItemsByFilterType = BallotStore.getBallotByFilterType(filter_type);
     if (ballotWithAllItemsByFilterType !== undefined) {
       // console.log("ballotWithAllItemsByFilterType !== undefined");
-      this.setState({
-        ballotWithAllItemsByFilterType: ballotWithAllItemsByFilterType,
-        filter_type: filter_type,
-      });
+      if (filter_type === "all") {
+        this.setState({
+          ballotWithAllItems: ballotWithAllItemsByFilterType,
+          ballotWithAllItemsByFilterType: ballotWithAllItemsByFilterType,
+          filter_type: filter_type,
+        });
+      } else {
+        let ballotWithAllItems = BallotStore.getBallotByFilterType("all");
+        this.setState({
+          ballotWithAllItems: ballotWithAllItems,
+          ballotWithAllItemsByFilterType: ballotWithAllItemsByFilterType,
+          filter_type: filter_type,
+        });
+      }
     }
 
     let google_civic_election_id_from_url = this.props.params.google_civic_election_id || 0;
@@ -264,6 +275,7 @@ export default class Ballot extends Component {
     // Were there any actual changes?
     if (ballot_returned_we_vote_id !== this.state.ballot_returned_we_vote_id || ballot_location_shortcut !== this.state.ballot_location_shortcut || google_civic_election_id !== this.state.google_civic_election_id || filter_type !== this.state.filter_type) {
       this.setState({
+        ballotWithAllItems: BallotStore.getBallotByFilterType("all"),
         ballotWithAllItemsByFilterType: BallotStore.getBallotByFilterType(filter_type),
         ballot_returned_we_vote_id: ballot_returned_we_vote_id,
         ballot_location_shortcut: ballot_location_shortcut,
@@ -418,6 +430,7 @@ export default class Ballot extends Component {
         let prior_filter_type = this.state.filter_type || "all";
         let new_filter_type = this.state.location && this.state.location.query && this.state.location.query.type !== "" ? this.state.location.query.type : prior_filter_type;
         this.setState({
+          ballotWithAllItems: BallotStore.getBallotByFilterType("all"),
           ballotWithAllItemsByFilterType: BallotStore.getBallotByFilterType(new_filter_type),
           filter_type: new_filter_type,
         });
@@ -797,20 +810,30 @@ export default class Ballot extends Component {
                   { this.state.ballotWithAllItemsByFilterType && this.state.ballotWithAllItemsByFilterType.length ?
                     <div className="row ballot__item-filter-tabs">
                       { BALLOT_ITEM_FILTER_TYPES.map(one_type => {
-                          let ballotItemsByFilterType = this.state.ballotWithAllItemsByFilterType.filter(item => {
+                          let allBallotItemsByFilterType = this.state.ballotWithAllItems.filter(item => {
                             if (one_type === "Measure") {
                               return item.kind_of_ballot_item === "MEASURE";
                             } else {
                               return one_type === item.race_office_level;
                             }
                           });
-                          let ballotItemsByFilterTypeLength = ballotItemsByFilterType.length;
-                          return <div className="col-6 col-sm-3 u-stack--md u-inset__h--xs" key={one_type}>
-                            <Button block active={one_type === this.state.ballot_item_filter_type}
-                                    onClick={() => this.setBallotItemFilterType(one_type)}>
-                              {one_type}&nbsp;({ballotItemsByFilterTypeLength})
-                            </Button>
-                          </div>;
+                          if (allBallotItemsByFilterType.length) {
+                            let ballotItemsByFilterType = this.state.ballotWithAllItemsByFilterType.filter(item => {
+                              if (one_type === "Measure") {
+                                return item.kind_of_ballot_item === "MEASURE";
+                              } else {
+                                return one_type === item.race_office_level;
+                              }
+                            });
+                            return <div className="col-6 col-sm-3 u-stack--md u-inset__h--xs" key={one_type}>
+                              <Button block active={one_type === this.state.ballot_item_filter_type}
+                                      onClick={() => this.setBallotItemFilterType(one_type)}>
+                                {one_type}&nbsp;({ballotItemsByFilterType.length})
+                              </Button>
+                            </div>;
+                          } else {
+                            return null;
+                          }
                         })
                       }
                     </div> :

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -825,7 +825,7 @@ export default class Ballot extends Component {
                                 return one_type === item.race_office_level;
                               }
                             });
-                            return <div className="col-6 col-sm-3 u-stack--md u-inset__h--xs" key={one_type}>
+                            return <div className="col-6 col-sm-3 u-stack--md u-inset__h--sm" key={one_type}>
                               <Button block active={one_type === this.state.ballot_item_filter_type}
                                       onClick={() => this.setBallotItemFilterType(one_type)}>
                                 {one_type}&nbsp;({ballotItemsByFilterType.length})

--- a/src/sass/components/_ballot.scss
+++ b/src/sass/components/_ballot.scss
@@ -10,7 +10,7 @@ $minus-header-extension-top-voter-guide: -1%;
 $scrollbar-height: 20px;
 $tab-height: 47px;
 $tab-height-visible: $tab-height - $scrollbar-height;
-$neg-space-xs: -$space-xs;
+$neg-space-sm: -$space-sm;
 $neg-space-lg: -$space-lg;
 $bottom-spacing-cordova: 50px;
 
@@ -120,12 +120,12 @@ $bottom-spacing-cordova: 50px;
   // ===========================================
 
   &__body {
-    margin-top: $space-lg;
+    margin-top: $space-md;
   }
 
   &__item-filter-tabs {
-    margin-left: $neg-space-xs;
-    margin-right: $neg-space-xs;
+    margin-left: $neg-space-sm;
+    margin-right: $neg-space-sm;
   }
 
   &__edit-address-preview {


### PR DESCRIPTION
Fixed a bug that prevented ballot measure descriptions from displaying on the ballot page after the "Measure" filter is selected more than once and the list of ballot items is reconstructed. Used setState's callback function argument to correctly calculate the values of the measure state variables.

Implemented the hiding of each filter button if a ballot contains zero items of each filter type (#1684). Adjusted the space around the filter buttons to be equal on all sides.