### PR TITLE
Improve readability of Issues Modal

### DIFF
--- a/src/sass/components/_intro-modal.scss
+++ b/src/sass/components/_intro-modal.scss
@@ -1,5 +1,7 @@
 // April 2018: Something in our sass processing chain is messing up the utf-8 char in slick-theme.css within Cordova, so force it here.
 $slick-dot-character: '\2022' !default;
+$description-padding: 10px;
+$backdrop-border-radius: 0 0 8px 8px;
 
 .intro-modal {
   padding: $space-none;
@@ -330,12 +332,14 @@ $slick-dot-character: '\2022' !default;
 
   &__square-name {
     position: absolute;
-    right: 10px;
-    bottom: 10px;
-    left: 10px;
+    bottom: 2px;
     font-size: 1rem;
     word-wrap: break-word;
     text-shadow: 1px 1px 2px rgba($black, .6);
+    background: rgba(0, 0, 0, .5);
+    padding: $description-padding;
+    width: calc(100% - 4px);
+    border-radius: $backdrop-border-radius;
 
     @include breakpoints (xsmall-bootstrap small-bootstrap) {
       right: 8px;

--- a/src/sass/components/_network.scss
+++ b/src/sass/components/_network.scss
@@ -4,6 +4,8 @@ $description-margin-top: 10px;
 $social-left-padding-mobile: 40px;
 $social-right-padding-mobile: 9px;
 $network-card-margin-mobile: (-$space-md) (-$space-md) $space-none (-$space-md);
+$description-padding: 10px;
+$backdrop-border-radius: 0 0 8px 8px;
 
 .buttons-container {
   display: flex;
@@ -59,13 +61,14 @@ $network-card-margin-mobile: (-$space-md) (-$space-md) $space-none (-$space-md);
 
   .intro-modal__square-name {
     position: absolute;
-    right: 10px;
-    bottom: 10px;
-    left: 10px;
     font-size: 1rem;
     word-wrap: break-word;
     color: $white;
     text-shadow: 1px 1px 2px rgba($black, .6);
+    background: rgba(0, 0, 0, .5);
+    padding: $description-padding;
+    width: calc(100% - 4px);
+    border-radius: $backdrop-border-radius;
 
     @include breakpoints (xsmall-bootstrap medium-bootstrap) {
       right: 8px;


### PR DESCRIPTION
### In reference to Issue #1677 

Added a backdrop behind the text in the starter issue modal. There are a few other places in other files (friends, network) with the same class name, though. Should they be fixed as well?
