### PR TITLE
Remove candidate description in Ballot page

### DIFF
--- a/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
@@ -419,11 +419,6 @@ export default class OfficeItemCompressedRaccoon extends Component {
             let organizationsToFollowSupport = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdSupports(candidate_we_vote_id);
             let organizationsToFollowOppose = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdOpposes(candidate_we_vote_id);
             let candidate_party_text = one_candidate.party && one_candidate.party.length ? one_candidate.party + ". " : "";
-            let candidate_twitter_description_text = one_candidate.twitter_description && one_candidate.twitter_description.length ? one_candidate.twitter_description : "";
-            let ballotpediaCandidateSummary = one_candidate.ballotpedia_candidate_summary && one_candidate.ballotpedia_candidate_summary.length ? " " + one_candidate.ballotpedia_candidate_summary : "";
-            // Strip away any HTML tags
-            ballotpediaCandidateSummary = ballotpediaCandidateSummary.split(/<[^<>]*>/).join("");
-            let candidate_text = candidate_party_text + candidate_twitter_description_text + ballotpediaCandidateSummary;
 
             let positions_display_raccoon = <div>
               <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
@@ -471,7 +466,9 @@ export default class OfficeItemCompressedRaccoon extends Component {
                   {/* Description under candidate name */}
                   <LearnMore on_click={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null}
                              num_of_lines={3}
-                             text_to_display={candidate_text}
+                             text_to_display={candidate_party_text}
+                             always_show_external_link
+                             learn_more_text={"Learn more"}
                              />
                   {/* DESKTOP: If voter has taken position, offer the comment bar */}
                   {/* comment_display_raccoon_desktop */}

--- a/src/js/components/Widgets/LearnMore.jsx
+++ b/src/js/components/Widgets/LearnMore.jsx
@@ -12,6 +12,7 @@ export default class LearnMore extends Component {
     learn_more_text: PropTypes.node,
     num_of_lines: PropTypes.number,
     on_click: PropTypes.func,
+    always_show_external_link: PropTypes.bool
   };
 
   constructor (props) {
@@ -42,7 +43,8 @@ export default class LearnMore extends Component {
 
   render () {
     renderLog(__filename);
-    let { text_to_display: textToDisplay, show_more_text: showMoreText, num_of_lines: numOfLines, learn_more_link: learnMoreLink, learn_more_text: learnMoreText, on_click: onClick } = this.props;
+    let { text_to_display: textToDisplay, show_more_text: showMoreText, num_of_lines: numOfLines,
+      learn_more_link: learnMoreLink, learn_more_text: learnMoreText, on_click: onClick, always_show_external_link: alwaysShowExternalLink} = this.props;
 
     // default prop values
     if (numOfLines === undefined) {
@@ -103,8 +105,21 @@ export default class LearnMore extends Component {
       }
     });
 
+    const externalLink = learnMoreLink ?
+    <OpenExternalWebSite url={learnMoreLink}
+                         target="_blank"
+                         body={<span>{learnMoreText}&nbsp;<i className="fa fa-external-link" /></span>} /> :
+    <a tabIndex="0"
+      onClick={onClick}
+      onKeyDown={this.onKeyDown.bind(this)}>
+      {learnMoreText}
+    </a>;
+
     if (notEnoughTextToTruncate) {
-      return <span>{expandedTextToDisplay}</span>;
+      return <span>{expandedTextToDisplay}{
+        alwaysShowExternalLink &&
+        externalLink
+      }</span>;
     }
 
     if (this.state.readMore) {
@@ -123,15 +138,8 @@ export default class LearnMore extends Component {
        </span>;
     } else {
       return <span tabIndex="0"> {expandedTextToDisplay}&nbsp;&nbsp;
-        { learnMoreLink ?
-          <OpenExternalWebSite url={learnMoreLink}
-                               target="_blank"
-                               body={<span>{learnMoreText}&nbsp;<i className="fa fa-external-link" /></span>} /> :
-          <a tabIndex="0"
-            onClick={onClick}
-            onKeyDown={this.onKeyDown.bind(this)}>
-            {learnMoreText}
-          </a>
+        {
+          externalLink
         }
       </span>;
     }


### PR DESCRIPTION
### Issue #1678 

When the description is shortened, the Learn More link does not show up (notEnoughTextToTruncate), so I tried to specify a property that will show it, regardless of length.