### PR TITLE
Progress on styling for React 16 and Bootstrap 4

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -4,5 +4,6 @@
     "excludeFiles": ["build/**", "node_modules"],
     "maximumLineLength": null,
     "maxErrors": 200,
-    "disallowSpacesInFunctionDeclaration": null
+    "disallowSpacesInFunctionDeclaration": null,
+    "requirePaddingNewLinesBeforeLineComments": null
 }

--- a/src/js/components/Ballot/BallotItemSearchResult.jsx
+++ b/src/js/components/Ballot/BallotItemSearchResult.jsx
@@ -1,40 +1,40 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { renderLog } from "../../utils/logging";
-import MeasureItemCompressed from "../../components/Ballot/MeasureItemCompressed";
-import CandidateItemCompressed from "../../components/Ballot/CandidateItemCompressed";
-
-const TYPES = require("keymirror")({
-  OFFICE: null,
-  MEASURE: null,
-});
-
-export default class BallotItemSearchResult extends Component {
-  static propTypes = {
-    allBallotItemsCount: PropTypes.number,
-    ballot_item_display_name: PropTypes.string.isRequired,
-    candidate_list: PropTypes.array,
-    kind_of_ballot_item: PropTypes.string.isRequired,
-    organization: PropTypes.object,
-    organization_we_vote_id: PropTypes.string,
-    toggleCandidateModal: PropTypes.func,
-    toggleMeasureModal: PropTypes.func,
-    we_vote_id: PropTypes.string.isRequired,
-    updateOfficeDisplayUnfurledTracker: PropTypes.func,
-  };
-
-  isMeasure () {
-    return this.props.kind_of_ballot_item === TYPES.MEASURE;
-  }
-
-  render () {
-    renderLog(__filename);
-    return <div className="BallotItem card" id={this.props.we_vote_id}>
-        { this.isMeasure() ?
-          <MeasureItemCompressed {...this.props}
-                   link_to_ballot_item_page /> :
-          <CandidateItemCompressed oneCandidate={this.props} />
-        }
-      </div>;
-  }
-}
+// import React, { Component } from "react";
+// import PropTypes from "prop-types";
+// import { renderLog } from "../../utils/logging";
+// import MeasureItemCompressed from "../../components/Ballot/MeasureItemCompressed";
+// import CandidateItemCompressed from "../../components/Ballot/CandidateItemCompressed";
+//
+// const TYPES = require("keymirror")({
+//   OFFICE: null,
+//   MEASURE: null,
+// });
+//
+// export default class BallotItemSearchResult extends Component {
+//   static propTypes = {
+//     allBallotItemsCount: PropTypes.number,
+//     ballot_item_display_name: PropTypes.string.isRequired,
+//     candidate_list: PropTypes.array,
+//     kind_of_ballot_item: PropTypes.string.isRequired,
+//     organization: PropTypes.object,
+//     organization_we_vote_id: PropTypes.string,
+//     toggleCandidateModal: PropTypes.func,
+//     toggleMeasureModal: PropTypes.func,
+//     we_vote_id: PropTypes.string.isRequired,
+//     updateOfficeDisplayUnfurledTracker: PropTypes.func,
+//   };
+//
+//   isMeasure () {
+//     return this.props.kind_of_ballot_item === TYPES.MEASURE;
+//   }
+//
+//   render () {
+//     renderLog(__filename);
+//     return <div className="BallotItem card" id={this.props.we_vote_id}>
+//         { this.isMeasure() ?
+//           <MeasureItemCompressed {...this.props}
+//                    link_to_ballot_item_page /> :
+//           <CandidateItemCompressed oneCandidate={this.props} />
+//         }
+//       </div>;
+//   }
+// }

--- a/src/js/components/Ballot/CandidateItemCompressed.jsx
+++ b/src/js/components/Ballot/CandidateItemCompressed.jsx
@@ -1,199 +1,199 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import TextTruncate from "react-text-truncate";
-import { historyPush } from "../../utils/cordovaUtils";
-import ImageHandler from "../ImageHandler";
-import ItemSupportOpposeRaccoon from "../Widgets/ItemSupportOpposeRaccoon";
-import LearnMore from "../Widgets/LearnMore";
-import { renderLog } from "../../utils/logging";
-import OrganizationStore from "../../stores/OrganizationStore";
-import SupportStore from "../../stores/SupportStore";
-import VoterGuideStore from "../../stores/VoterGuideStore";
-
-export default class CandidateItemCompressed extends Component {
-  static propTypes = {
-    link_to_ballot_item_page: PropTypes.bool,
-    organization: PropTypes.object,
-    oneCandidate: PropTypes.object,
-    showPositionStatementActionBar: PropTypes.bool,
-  };
-
-  constructor (props) {
-    super(props);
-    this.state = {
-      display_all_candidates_flag: false,
-      display_office_unfurled: false,
-      editMode: false,
-      maximum_organization_display: 4,
-      organization: {},
-      show_position_statement: true,
-      transitioning: false,
-    };
-
-    this.closeYourNetworkIsUndecidedPopover = this.closeYourNetworkIsUndecidedPopover.bind(this);
-    this.closeYourNetworkSupportsPopover = this.closeYourNetworkSupportsPopover.bind(this);
-    this.closeHighestIssueScorePopover = this.closeHighestIssueScorePopover.bind(this);
-    this.getCandidateLink = this.getCandidateLink.bind(this);
-    this.goToCandidateLink = this.goToCandidateLink.bind(this);
-  }
-
-  componentDidMount () {
-    this.organizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
-    this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
-    this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
-    this.onVoterGuideStoreChange();
-
-    // console.log("this.props.candidate_list: ", this.props.candidate_list);
-    if (this.props.oneCandidate && this.props.oneCandidate.we_vote_id) {
-      this.setState({
-        oneCandidate: this.props.oneCandidate,
-      });
-    }
-    if (this.props.organization && this.props.organization.organization_we_vote_id) {
-      this.setState({
-        organization: this.props.organization,
-      });
-    }
-  }
-
-  componentWillReceiveProps (nextProps){
-    // console.log("officeItem nextProps", nextProps);
-    if (nextProps.organization && nextProps.organization.organization_we_vote_id) {
-      this.setState({
-        organization: OrganizationStore.getOrganizationByWeVoteId(nextProps.organization.organization_we_vote_id),
-      });
-    }
-  }
-
-  componentWillUnmount () {
-    this.organizationStoreListener.remove();
-    this.supportStoreListener.remove();
-    this.voterGuideStoreListener.remove();
-  }
-
-  onVoterGuideStoreChange () {
-    this.setState({
-      transitioning: false,
-    });
-  }
-
-  onOrganizationStoreChange () {
-    // console.log("VoterGuideOfficeItemCompressed onOrganizationStoreChange, org_we_vote_id: ", this.state.organization.organization_we_vote_id);
-    this.setState({
-      organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
-    });
-  }
-
-  onSupportStoreChange () {
-    // Whenever positions change, we want to make sure to get the latest organization, because it has
-    //  position_list_for_one_election and position_list_for_all_except_one_election attached to it
-    this.setState({
-      organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
-      transitioning: false,
-    });
-  }
-
-  getCandidateLink (oneCandidateWeVoteId) {
-    if (this.state.organization && this.state.organization.organization_we_vote_id) {
-      // If there is an organization_we_vote_id, signal that we want to link back to voter_guide for that organization
-      return "/candidate/" + oneCandidateWeVoteId + "/btvg/" + this.state.organization.organization_we_vote_id;
-    } else {
-      // If no organization_we_vote_id, signal that we want to link back to default ballot
-      return "/candidate/" + oneCandidateWeVoteId + "/b/btdb/";
-    }
-  }
-
-  goToCandidateLink (oneCandidateWeVoteId) {
-    let candidate_link = this.getCandidateLink(oneCandidateWeVoteId);
-    historyPush(candidate_link);
-  }
-
-  closeYourNetworkSupportsPopover () {
-    this.refs["supports-overlay"].hide();
-  }
-
-  closeHighestIssueScorePopover () {
-    this.refs["highest-issue-score-overlay"].hide();
-  }
-
-  closeYourNetworkIsUndecidedPopover () {
-    this.refs["undecided-overlay"].hide();
-  }
-
-  render () {
-    renderLog(__filename);
-    if (!this.state.oneCandidate || !this.state.oneCandidate.we_vote_id) {
-      return null;
-    }
-
-    let oneCandidateWeVoteId = this.state.oneCandidate.we_vote_id;
-    let candidateSupportStore = SupportStore.get(oneCandidateWeVoteId);
-    let organizationsToFollowSupport = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdSupports(oneCandidateWeVoteId);
-    let organizationsToFollowOppose = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdOpposes(oneCandidateWeVoteId);
-    // console.log("OfficeItemCompressedRaccoon, just retrieved getVoterGuidesToFollowForBallotItemIdSupports");
-    let candidate_party_text = this.state.oneCandidate.party && this.state.oneCandidate.party.length ? this.state.oneCandidate.party + ". " : "";
-    let candidate_description_text = this.state.oneCandidate.twitter_description && this.state.oneCandidate.twitter_description.length ? this.state.oneCandidate.twitter_description : "";
-    let candidate_text = candidate_party_text + candidate_description_text;
-
-    let candidate_photo_raccoon = <div onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(this.state.oneCandidate.we_vote_id) : null}>
-        <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
-                      sizeClassName="icon-candidate-small u-push--sm "
-                      imageUrl={this.state.oneCandidate.candidate_photo_url_large}
-                      alt="candidate-photo"
-                      kind_of_ballot_item="CANDIDATE" />
-      </div>;
-
-    let candidate_name_raccoon = <h4 className="card-main__candidate-name u-f5">
-      {this.props.link_to_ballot_item_page ?
-        <a onClick={() => this.goToCandidateLink(this.state.oneCandidate.we_vote_id)}>
-          <TextTruncate line={1}
-                        truncateText="…"
-                        text={this.state.oneCandidate.ballot_item_display_name}
-                        textTruncateChild={null}/>
-        </a> :
-        <TextTruncate line={1}
-                      truncateText="…"
-                      text={this.state.oneCandidate.ballot_item_display_name}
-                      textTruncateChild={null}/>
-      }
-
-    </h4>;
-
-    let positions_display_raccoon = <div>
-      <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
-        {/* Positions in Your Network and Possible Voter Guides to Follow */}
-        <ItemSupportOpposeRaccoon ballotItemWeVoteId={oneCandidateWeVoteId}
-                                  ballot_item_display_name={this.state.oneCandidate.ballot_item_display_name}
-                                  display_raccoon_details_flag
-                                  goToCandidate={() => this.goToCandidateLink(this.state.oneCandidate.we_vote_id)}
-                                  maximumOrganizationDisplay={this.state.maximum_organization_display}
-                                  organizationsToFollowSupport={organizationsToFollowSupport}
-                                  organizationsToFollowOppose={organizationsToFollowOppose}
-                                  showPositionStatementActionBar={this.props.showPositionStatementActionBar}
-                                  supportProps={candidateSupportStore}
-                                  type="CANDIDATE"/>
-      </div>
-    </div>;
-
-    return <div key={oneCandidateWeVoteId} className="u-stack--md">
-      <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
-        {/* Candidate Photo, only shown in Desktop */}
-        {candidate_photo_raccoon}
-        <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
-          {/* Candidate Name */}
-          {candidate_name_raccoon}
-          {/* Description under candidate name */}
-          <LearnMore text_to_display={candidate_text}
-                     on_click={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(this.state.oneCandidate.we_vote_id) : null}
-                     num_of_lines={3} />
-          {/* DESKTOP: If voter has taken position, offer the comment bar */}
-          {/* comment_display_raccoon_desktop */}
-          {/* Organization's Followed AND to Follow Items */}
-          {positions_display_raccoon}
-        </div>
-        {/* MOBILE: If voter has taken position, offer the comment bar */}
-        {/* comment_display_raccoon_mobile */}
-      </div>
-    </div>;
-  }
-}
+// import React, { Component } from "react";
+// import PropTypes from "prop-types";
+// import TextTruncate from "react-text-truncate";
+// import { historyPush } from "../../utils/cordovaUtils";
+// import ImageHandler from "../ImageHandler";
+// import ItemSupportOpposeRaccoon from "../Widgets/ItemSupportOpposeRaccoon";
+// import LearnMore from "../Widgets/LearnMore";
+// import { renderLog } from "../../utils/logging";
+// import OrganizationStore from "../../stores/OrganizationStore";
+// import SupportStore from "../../stores/SupportStore";
+// import VoterGuideStore from "../../stores/VoterGuideStore";
+//
+// export default class CandidateItemCompressed extends Component {
+//   static propTypes = {
+//     link_to_ballot_item_page: PropTypes.bool,
+//     organization: PropTypes.object,
+//     oneCandidate: PropTypes.object,
+//     showPositionStatementActionBar: PropTypes.bool,
+//   };
+//
+//   constructor (props) {
+//     super(props);
+//     this.state = {
+//       display_all_candidates_flag: false,
+//       display_office_unfurled: false,
+//       editMode: false,
+//       maximum_organization_display: 4,
+//       organization: {},
+//       show_position_statement: true,
+//       transitioning: false,
+//     };
+//
+//     this.closeYourNetworkIsUndecidedPopover = this.closeYourNetworkIsUndecidedPopover.bind(this);
+//     this.closeYourNetworkSupportsPopover = this.closeYourNetworkSupportsPopover.bind(this);
+//     this.closeHighestIssueScorePopover = this.closeHighestIssueScorePopover.bind(this);
+//     this.getCandidateLink = this.getCandidateLink.bind(this);
+//     this.goToCandidateLink = this.goToCandidateLink.bind(this);
+//   }
+//
+//   componentDidMount () {
+//     this.organizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
+//     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
+//     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
+//     this.onVoterGuideStoreChange();
+//
+//     // console.log("this.props.candidate_list: ", this.props.candidate_list);
+//     if (this.props.oneCandidate && this.props.oneCandidate.we_vote_id) {
+//       this.setState({
+//         oneCandidate: this.props.oneCandidate,
+//       });
+//     }
+//     if (this.props.organization && this.props.organization.organization_we_vote_id) {
+//       this.setState({
+//         organization: this.props.organization,
+//       });
+//     }
+//   }
+//
+//   componentWillReceiveProps (nextProps){
+//     // console.log("officeItem nextProps", nextProps);
+//     if (nextProps.organization && nextProps.organization.organization_we_vote_id) {
+//       this.setState({
+//         organization: OrganizationStore.getOrganizationByWeVoteId(nextProps.organization.organization_we_vote_id),
+//       });
+//     }
+//   }
+//
+//   componentWillUnmount () {
+//     this.organizationStoreListener.remove();
+//     this.supportStoreListener.remove();
+//     this.voterGuideStoreListener.remove();
+//   }
+//
+//   onVoterGuideStoreChange () {
+//     this.setState({
+//       transitioning: false,
+//     });
+//   }
+//
+//   onOrganizationStoreChange () {
+//     // console.log("VoterGuideOfficeItemCompressed onOrganizationStoreChange, org_we_vote_id: ", this.state.organization.organization_we_vote_id);
+//     this.setState({
+//       organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
+//     });
+//   }
+//
+//   onSupportStoreChange () {
+//     // Whenever positions change, we want to make sure to get the latest organization, because it has
+//     //  position_list_for_one_election and position_list_for_all_except_one_election attached to it
+//     this.setState({
+//       organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
+//       transitioning: false,
+//     });
+//   }
+//
+//   getCandidateLink (oneCandidateWeVoteId) {
+//     if (this.state.organization && this.state.organization.organization_we_vote_id) {
+//       // If there is an organization_we_vote_id, signal that we want to link back to voter_guide for that organization
+//       return "/candidate/" + oneCandidateWeVoteId + "/btvg/" + this.state.organization.organization_we_vote_id;
+//     } else {
+//       // If no organization_we_vote_id, signal that we want to link back to default ballot
+//       return "/candidate/" + oneCandidateWeVoteId + "/b/btdb/";
+//     }
+//   }
+//
+//   goToCandidateLink (oneCandidateWeVoteId) {
+//     let candidate_link = this.getCandidateLink(oneCandidateWeVoteId);
+//     historyPush(candidate_link);
+//   }
+//
+//   closeYourNetworkSupportsPopover () {
+//     this.refs["supports-overlay"].hide();
+//   }
+//
+//   closeHighestIssueScorePopover () {
+//     this.refs["highest-issue-score-overlay"].hide();
+//   }
+//
+//   closeYourNetworkIsUndecidedPopover () {
+//     this.refs["undecided-overlay"].hide();
+//   }
+//
+//   render () {
+//     renderLog(__filename);
+//     if (!this.state.oneCandidate || !this.state.oneCandidate.we_vote_id) {
+//       return null;
+//     }
+//
+//     let oneCandidateWeVoteId = this.state.oneCandidate.we_vote_id;
+//     let candidateSupportStore = SupportStore.get(oneCandidateWeVoteId);
+//     let organizationsToFollowSupport = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdSupports(oneCandidateWeVoteId);
+//     let organizationsToFollowOppose = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdOpposes(oneCandidateWeVoteId);
+//     // console.log("OfficeItemCompressedRaccoon, just retrieved getVoterGuidesToFollowForBallotItemIdSupports");
+//     let candidate_party_text = this.state.oneCandidate.party && this.state.oneCandidate.party.length ? this.state.oneCandidate.party + ". " : "";
+//     let candidate_description_text = this.state.oneCandidate.twitter_description && this.state.oneCandidate.twitter_description.length ? this.state.oneCandidate.twitter_description : "";
+//     let candidate_text = candidate_party_text + candidate_description_text;
+//
+//     let candidate_photo_raccoon = <div onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(this.state.oneCandidate.we_vote_id) : null}>
+//         <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
+//                       sizeClassName="icon-candidate-small u-push--sm "
+//                       imageUrl={this.state.oneCandidate.candidate_photo_url_large}
+//                       alt="candidate-photo"
+//                       kind_of_ballot_item="CANDIDATE" />
+//       </div>;
+//
+//     let candidate_name_raccoon = <h4 className="card-main__candidate-name u-f5">
+//       {this.props.link_to_ballot_item_page ?
+//         <a onClick={() => this.goToCandidateLink(this.state.oneCandidate.we_vote_id)}>
+//           <TextTruncate line={1}
+//                         truncateText="…"
+//                         text={this.state.oneCandidate.ballot_item_display_name}
+//                         textTruncateChild={null}/>
+//         </a> :
+//         <TextTruncate line={1}
+//                       truncateText="…"
+//                       text={this.state.oneCandidate.ballot_item_display_name}
+//                       textTruncateChild={null}/>
+//       }
+//
+//     </h4>;
+//
+//     let positions_display_raccoon = <div>
+//       <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
+//         {/* Positions in Your Network and Possible Voter Guides to Follow */}
+//         <ItemSupportOpposeRaccoon ballotItemWeVoteId={oneCandidateWeVoteId}
+//                                   ballot_item_display_name={this.state.oneCandidate.ballot_item_display_name}
+//                                   display_raccoon_details_flag
+//                                   goToCandidate={() => this.goToCandidateLink(this.state.oneCandidate.we_vote_id)}
+//                                   maximumOrganizationDisplay={this.state.maximum_organization_display}
+//                                   organizationsToFollowSupport={organizationsToFollowSupport}
+//                                   organizationsToFollowOppose={organizationsToFollowOppose}
+//                                   showPositionStatementActionBar={this.props.showPositionStatementActionBar}
+//                                   supportProps={candidateSupportStore}
+//                                   type="CANDIDATE"/>
+//       </div>
+//     </div>;
+//
+//     return <div key={oneCandidateWeVoteId} className="u-stack--md">
+//       <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
+//         {/* Candidate Photo, only shown in Desktop */}
+//         {candidate_photo_raccoon}
+//         <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
+//           {/* Candidate Name */}
+//           {candidate_name_raccoon}
+//           {/* Description under candidate name */}
+//           <LearnMore text_to_display={candidate_text}
+//                      on_click={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(this.state.oneCandidate.we_vote_id) : null}
+//                      num_of_lines={3} />
+//           {/* DESKTOP: If voter has taken position, offer the comment bar */}
+//           {/* comment_display_raccoon_desktop */}
+//           {/* Organization's Followed AND to Follow Items */}
+//           {positions_display_raccoon}
+//         </div>
+//         {/* MOBILE: If voter has taken position, offer the comment bar */}
+//         {/* comment_display_raccoon_mobile */}
+//       </div>
+//     </div>;
+//   }
+// }

--- a/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
@@ -353,11 +353,11 @@ export default class OfficeItemCompressedRaccoon extends Component {
         // If there are issues the voter is following, we should attempt to to create a list of orgs that support or oppose this ballot item
         let organizationNameIssueSupportList = IssueStore.getOrganizationNameSupportListUnderThisBallotItem(candidateWeVoteIdWithHighestIssueScore);
         let organizationNameIssueSupportListDisplay = organizationNameIssueSupportList.map(organizationName => {
-          <span key={organizationName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organizationName} <strong>+1</strong></span></span>;
+          return <span key={organizationName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organizationName} <strong>+1</strong></span></span>;
         });
         let organizationNameIssueOpposeList = IssueStore.getOrganizationNameOpposeListUnderThisBallotItem(candidateWeVoteIdWithHighestIssueScore);
         let organizationNameIssueOpposeListDisplay = organizationNameIssueOpposeList.map(organizationName => {
-          <span key={organizationName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organizationName}<strong>-1</strong></span></span>;
+          return <span key={organizationName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organizationName}<strong>-1</strong></span></span>;
         });
         advisorsThatMakeVoterIssuesScoreDisplay = <span>
           { organizationNameIssueSupportList.length ? <span>{organizationNameIssueSupportListDisplay}</span> : null}
@@ -370,11 +370,11 @@ export default class OfficeItemCompressedRaccoon extends Component {
         // If there are issues the voter is following, we should attempt to to create a list of orgs that support or oppose this ballot item
         let nameNetworkSupportList = SupportStore.getNameSupportListUnderThisBallotItem(candidateWeVoteWithMostSupportFromNetwork);
         let nameNetworkSupportListDisplay = nameNetworkSupportList.map(speakerDisplayName => {
-          <span key={speakerDisplayName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speakerDisplayName} <strong>+1</strong></span></span>;
+          return <span key={speakerDisplayName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speakerDisplayName} <strong>+1</strong></span></span>;
         });
         let nameNetworkOpposeList = SupportStore.getNameOpposeListUnderThisBallotItem(candidateWeVoteWithMostSupportFromNetwork);
         let nameNetworkOpposeListDisplay = nameNetworkOpposeList.map(speakerDisplayName => {
-          <span key={speakerDisplayName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speakerDisplayName} <strong>-1</strong></span></span>;
+          return <span key={speakerDisplayName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speakerDisplayName} <strong>-1</strong></span></span>;
         });
         advisorsThatMakeVoterNetworkScoreDisplay = <span>
           { nameNetworkSupportList.length ? <span>{nameNetworkSupportListDisplay}</span> : null}
@@ -399,7 +399,6 @@ export default class OfficeItemCompressedRaccoon extends Component {
     let candidatePreviewLimit = 5;
     let candidatePreviewList = [];
     let oneCandidateDisplay = <span />;
-    let closeAnchorClass = hasIPhoneNotch() ? "intro-modal__close-anchor intro-modal__close-anchor-iphonex" : "intro-modal__close-anchor";
     const BallotIntroFollowIssuesModal = <Modal bsPrefix="background-brand-blue modal"
                                                 id="ballotIntroFollowIssuesId"
                                                 show={this.state.showBallotIntroFollowIssues}

--- a/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressedRaccoon.jsx
@@ -41,7 +41,7 @@ export default class OfficeItemCompressedRaccoon extends Component {
     organization_we_vote_id: PropTypes.string,
     toggleCandidateModal: PropTypes.func,
     updateOfficeDisplayUnfurledTracker: PropTypes.func,
-    urlWithoutHash: PropTypes.string
+    urlWithoutHash: PropTypes.string,
   };
 
   constructor (props) {
@@ -86,14 +86,14 @@ export default class OfficeItemCompressedRaccoon extends Component {
       });
     }
 
-    if (this.props.we_vote_id) {
-      // console.log("OfficeItemCompressedRaccoon componentDidMount getNumberOfCandidatesRetrievedByOffice:", CandidateStore.getNumberOfCandidatesRetrievedByOffice(this.props.we_vote_id));
-      // DALE 2018-07-31 We now retrieve the full candidate data in voterBallotItemsRetrieve
-      // if (CandidateStore.getNumberOfCandidatesRetrievedByOffice(this.props.we_vote_id) === 0) {
-      //   // console.log("Calling candidatesRetrieve: ", this.props.we_vote_id);
-      //   CandidateActions.candidatesRetrieve(this.props.we_vote_id);
-      // }
-    }
+    // if (this.props.we_vote_id) {
+    //   console.log("OfficeItemCompressedRaccoon componentDidMount getNumberOfCandidatesRetrievedByOffice:", CandidateStore.getNumberOfCandidatesRetrievedByOffice(this.props.we_vote_id));
+    //   DALE 2018-07-31 We now retrieve the full candidate data in voterBallotItemsRetrieve
+    //   if (CandidateStore.getNumberOfCandidatesRetrievedByOffice(this.props.we_vote_id) === 0) {
+    //     // console.log("Calling candidatesRetrieve: ", this.props.we_vote_id);
+    //     CandidateActions.candidatesRetrieve(this.props.we_vote_id);
+    //   }
+    // }
 
     // If there three or fewer offices on this ballot, unfurl them
     if (this.props.allBallotItemsCount && this.props.allBallotItemsCount <= 3) {
@@ -103,7 +103,7 @@ export default class OfficeItemCompressedRaccoon extends Component {
     } else {
       //read from BallotStore
       this.setState({
-        display_office_unfurled: BallotStore.getBallotItemUnfurledStatus(this.props.we_vote_id)
+        display_office_unfurled: BallotStore.getBallotItemUnfurledStatus(this.props.we_vote_id),
       });
     }
   }
@@ -136,14 +136,14 @@ export default class OfficeItemCompressedRaccoon extends Component {
   onCandidateStoreChange () {
     if (this.props.candidate_list && this.props.candidate_list.length && this.props.we_vote_id) {
       // console.log("onCandidateStoreChange");
-      let new_candidate_list = [];
-      this.props.candidate_list.forEach( candidate => {
+      let newCandidateList = [];
+      this.props.candidate_list.forEach(candidate => {
         if (candidate && candidate.we_vote_id) {
-          new_candidate_list.push(CandidateStore.getCandidate(candidate.we_vote_id));
+          newCandidateList.push(CandidateStore.getCandidate(candidate.we_vote_id));
         }
       });
       this.setState({
-        candidateList: new_candidate_list,
+        candidateList: newCandidateList,
       });
       // console.log(this.props.candidate_list);
     }
@@ -196,21 +196,22 @@ export default class OfficeItemCompressedRaccoon extends Component {
     this.setState({ display_all_candidates_flag: !this.state.display_all_candidates_flag });
   }
 
-  toggleExpandDetails (display_office_unfurled) {
-    const { we_vote_id, updateOfficeDisplayUnfurledTracker, urlWithoutHash, currentBallotIdInUrl } = this.props;
+  toggleExpandDetails (displayOfficeUnfurled) {
+    const { we_vote_id: weVoteId, updateOfficeDisplayUnfurledTracker, urlWithoutHash, currentBallotIdInUrl } = this.props;
     // historyPush should be called only when current office Id (we_vote_id) is not currentBallotIdBeingShown in url.
-    if (currentBallotIdInUrl !== we_vote_id) {
-      historyPush(urlWithoutHash + "#" + we_vote_id);
+    if (currentBallotIdInUrl !== weVoteId) {
+      historyPush(urlWithoutHash + "#" + weVoteId);
     }
-    if (typeof display_office_unfurled === "boolean"){
-      this.setState({ display_office_unfurled: display_office_unfurled });
+
+    if (typeof displayOfficeUnfurled === "boolean") {
+      this.setState({ display_office_unfurled: displayOfficeUnfurled });
     } else {
       this.setState({ display_office_unfurled: !this.state.display_office_unfurled });
     }
-    if (this.props.allBallotItemsCount && this.props.allBallotItemsCount <= 3) {
-      //only update tracker if there are more than 3 offices
-    } else {
-      updateOfficeDisplayUnfurledTracker(we_vote_id, !this.state.display_office_unfurled);
+
+    //only update tracker if there are more than 3 offices
+    if (this.props.allBallotItemsCount && this.props.allBallotItemsCount > 3) {
+      updateOfficeDisplayUnfurledTracker(weVoteId, !this.state.display_office_unfurled);
     }
     // console.log('toggling raccoon Details!');
   }
@@ -222,13 +223,13 @@ export default class OfficeItemCompressedRaccoon extends Component {
     }
   }
 
-  getCandidateLink (candidate_we_vote_id) {
+  getCandidateLink (candidateWeVoteId) {
     if (this.state.organization && this.state.organization.organization_we_vote_id) {
       // If there is an organization_we_vote_id, signal that we want to link back to voter_guide for that organization
-      return "/candidate/" + candidate_we_vote_id + "/btvg/" + this.state.organization.organization_we_vote_id;
+      return "/candidate/" + candidateWeVoteId + "/btvg/" + this.state.organization.organization_we_vote_id;
     } else {
       // If no organization_we_vote_id, signal that we want to link back to default ballot
-      return "/candidate/" + candidate_we_vote_id + "/b/btdb/";
+      return "/candidate/" + candidateWeVoteId + "/b/btdb/";
     }
   }
 
@@ -242,14 +243,14 @@ export default class OfficeItemCompressedRaccoon extends Component {
     }
   }
 
-  goToCandidateLink (candidate_we_vote_id) {
-    let candidate_link = this.getCandidateLink(candidate_we_vote_id);
-    historyPush(candidate_link);
+  goToCandidateLink (candidateWeVoteId) {
+    let candidateLink = this.getCandidateLink(candidateWeVoteId);
+    historyPush(candidateLink);
   }
 
   goToOfficeLink () {
-    let office_link = this.getOfficeLink();
-    historyPush(office_link);
+    let officeLink = this.getOfficeLink();
+    historyPush(officeLink);
   }
 
   closeYourNetworkSupportsPopover () {
@@ -266,12 +267,12 @@ export default class OfficeItemCompressedRaccoon extends Component {
 
   render () {
     renderLog(__filename);
-    let { ballot_item_display_name, we_vote_id } = this.props;
+    let { ballot_item_display_name: ballotItemDisplayName, we_vote_id: weVoteId } = this.props;
 
-    ballot_item_display_name = toTitleCase(ballot_item_display_name);
+    ballotItemDisplayName = toTitleCase(ballotItemDisplayName);
     let unsortedCandidateList = this.state.candidateList.slice(0);
-    let total_number_of_candidates_to_display = this.state.candidateList.length;
-    let remaining_candidates_to_display_count = 0;
+    let totalNumberOfCandidatesToDisplay = this.state.candidateList.length;
+    let remainingCandidatesToDisplayCount = 0;
     let advisorsThatMakeVoterIssuesScoreDisplay;
     // let advisorsThatMakeVoterIssuesScoreCount = 0;
     let advisorsThatMakeVoterNetworkScoreCount = 0;
@@ -285,7 +286,7 @@ export default class OfficeItemCompressedRaccoon extends Component {
     let candidateWeVoteIdWithHighestIssueScore = null;
     let voterSupportsAtLeastOneCandidate = false;
     let supportProps;
-    let candidate_has_voter_support;
+    let candidateHasVoterSupport;
     let voterIssuesScoreForCandidate;
     let sortedCandidateList;
     let limitedCandidateList;
@@ -294,12 +295,12 @@ export default class OfficeItemCompressedRaccoon extends Component {
     unsortedCandidateList.forEach((candidate) => {
       supportProps = SupportStore.get(candidate.we_vote_id);
       if (supportProps) {
-        candidate_has_voter_support = supportProps.is_support;
+        candidateHasVoterSupport = supportProps.is_support;
         voterIssuesScoreForCandidate = IssueStore.getIssuesScoreByBallotItemWeVoteId(candidate.we_vote_id);
         candidate.voterNetworkScoreForCandidate = Math.abs(supportProps.support_count - supportProps.oppose_count);
         candidate.voterIssuesScoreForCandidate = Math.abs(voterIssuesScoreForCandidate);
         candidate.is_support = supportProps.is_support;
-        if (candidate_has_voter_support) {
+        if (candidateHasVoterSupport) {
           arrayOfCandidatesVoterSupports.push(candidate.ballot_item_display_name);
           voterSupportsAtLeastOneCandidate = true;
         }
@@ -313,27 +314,27 @@ export default class OfficeItemCompressedRaccoon extends Component {
     sortedCandidateList = unsortedCandidateList;
     if (!this.state.display_all_candidates_flag && this.state.candidateList.length > NUMBER_OF_CANDIDATES_TO_DISPLAY) {
       limitedCandidateList = sortedCandidateList.slice(0, NUMBER_OF_CANDIDATES_TO_DISPLAY);
-      remaining_candidates_to_display_count = this.state.candidateList.length - NUMBER_OF_CANDIDATES_TO_DISPLAY;
+      remainingCandidatesToDisplayCount = this.state.candidateList.length - NUMBER_OF_CANDIDATES_TO_DISPLAY;
     }
 
     // If the voter isn't supporting any candidates, then figure out which candidate the voter's network likes the best
-    if (arrayOfCandidatesVoterSupports.length === 0){
+    if (arrayOfCandidatesVoterSupports.length === 0) {
       // This function finds the highest support count for each office but does not handle ties. If two candidates have
       // the same network support count, only the first candidate will be displayed.
       let largestNetworkSupportCount = 0;
-      let network_support_count;
-      let network_oppose_count;
+      let networkSupportCount;
+      let networkOpposeCount;
       let largestIssueScore = 0;
       sortedCandidateList.forEach((candidate) => {
         // Support in voter's network
         supportProps = SupportStore.get(candidate.we_vote_id);
         if (supportProps) {
-          network_support_count = supportProps.support_count;
-          network_oppose_count = supportProps.oppose_count;
+          networkSupportCount = supportProps.support_count;
+          networkOpposeCount = supportProps.oppose_count;
 
-          if (network_support_count > network_oppose_count) {
-            if (network_support_count > largestNetworkSupportCount) {
-              largestNetworkSupportCount = network_support_count;
+          if (networkSupportCount > networkOpposeCount) {
+            if (networkSupportCount > largestNetworkSupportCount) {
+              largestNetworkSupportCount = networkSupportCount;
               candidateWithMostSupportFromNetwork = candidate.ballot_item_display_name;
               candidateWeVoteWithMostSupportFromNetwork = candidate.we_vote_id;
               atLeastOneCandidateChosenByNetwork = true;
@@ -351,12 +352,12 @@ export default class OfficeItemCompressedRaccoon extends Component {
       if (atLeastOneCandidateChosenByIssueScore) {
         // If there are issues the voter is following, we should attempt to to create a list of orgs that support or oppose this ballot item
         let organizationNameIssueSupportList = IssueStore.getOrganizationNameSupportListUnderThisBallotItem(candidateWeVoteIdWithHighestIssueScore);
-        let organizationNameIssueSupportListDisplay = organizationNameIssueSupportList.map( organization_name => {
-          return <span key={organization_name} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organization_name} <strong>+1</strong></span></span>;
+        let organizationNameIssueSupportListDisplay = organizationNameIssueSupportList.map(organizationName => {
+          <span key={organizationName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organizationName} <strong>+1</strong></span></span>;
         });
         let organizationNameIssueOpposeList = IssueStore.getOrganizationNameOpposeListUnderThisBallotItem(candidateWeVoteIdWithHighestIssueScore);
-        let organizationNameIssueOpposeListDisplay = organizationNameIssueOpposeList.map( organization_name => {
-          return <span key={organization_name} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organization_name} <strong>-1</strong></span></span>;
+        let organizationNameIssueOpposeListDisplay = organizationNameIssueOpposeList.map(organizationName => {
+          <span key={organizationName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{organizationName}<strong>-1</strong></span></span>;
         });
         advisorsThatMakeVoterIssuesScoreDisplay = <span>
           { organizationNameIssueSupportList.length ? <span>{organizationNameIssueSupportListDisplay}</span> : null}
@@ -364,15 +365,16 @@ export default class OfficeItemCompressedRaccoon extends Component {
         </span>;
         // advisorsThatMakeVoterIssuesScoreCount = organizationNameIssueSupportList.length + organizationNameIssueOpposeList.length;
       }
+
       if (candidateWeVoteWithMostSupportFromNetwork) {
         // If there are issues the voter is following, we should attempt to to create a list of orgs that support or oppose this ballot item
         let nameNetworkSupportList = SupportStore.getNameSupportListUnderThisBallotItem(candidateWeVoteWithMostSupportFromNetwork);
-        let nameNetworkSupportListDisplay = nameNetworkSupportList.map( speaker_display_name => {
-          return <span key={speaker_display_name} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speaker_display_name} <strong>+1</strong></span></span>;
+        let nameNetworkSupportListDisplay = nameNetworkSupportList.map(speakerDisplayName => {
+          <span key={speakerDisplayName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speakerDisplayName} <strong>+1</strong></span></span>;
         });
         let nameNetworkOpposeList = SupportStore.getNameOpposeListUnderThisBallotItem(candidateWeVoteWithMostSupportFromNetwork);
-        let nameNetworkOpposeListDisplay = nameNetworkOpposeList.map( speaker_display_name => {
-          return <span key={speaker_display_name} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speaker_display_name} <strong>-1</strong></span></span>;
+        let nameNetworkOpposeListDisplay = nameNetworkOpposeList.map(speakerDisplayName => {
+          <span key={speakerDisplayName} className="u-flex u-flex-row u-justify-start u-items-start"><img src={cordovaDot("/img/global/icons/thumbs-down-color-icon.svg")} width="20" height="20" /><span>&nbsp;</span><span>{speakerDisplayName} <strong>-1</strong></span></span>;
         });
         advisorsThatMakeVoterNetworkScoreDisplay = <span>
           { nameNetworkSupportList.length ? <span>{nameNetworkSupportListDisplay}</span> : null}
@@ -418,11 +420,11 @@ export default class OfficeItemCompressedRaccoon extends Component {
 
     return <div className="card-main office-item">
       { BallotIntroFollowIssuesModal }
-      <a className="anchor-under-header" name={we_vote_id} />
+      <a className="anchor-under-header" name={weVoteId} />
       <div className="card-main__content">
         {/* Desktop */}
         <span className="d-none d-sm-block">
-          <BookmarkToggle we_vote_id={we_vote_id} type="OFFICE" />
+          <BookmarkToggle we_vote_id={weVoteId} type="OFFICE" />
         </span>
 
         <h2 className="u-f3 card-main__ballot-name u-gray-dark u-stack--sm">
@@ -432,13 +434,13 @@ export default class OfficeItemCompressedRaccoon extends Component {
               <span className="glyphicon glyphicon-triangle-bottom u-font-size6 d-print-none u-push--xs"/> :
               <span className="glyphicon glyphicon-triangle-right u-font-size6 d-print-none u-push--xs"/>
             }
-            {ballot_item_display_name}
+            {ballotItemDisplayName}
           </span>
 
           {/* Print */}
           {/* TODO DEBUG=1
           <span className="u-f3 visible-print">
-            {ballot_item_display_name}
+            {ballotItemDisplayName}
           </span>
            */}
         </h2>
@@ -447,24 +449,24 @@ export default class OfficeItemCompressedRaccoon extends Component {
         Only show the candidates if the Office is "unfurled"
         ************************* */}
         { this.state.display_office_unfurled ?
-          <span>{limitedCandidateList.map((one_candidate) => {
+          <span>{limitedCandidateList.map((oneCandidate) => {
 
-            if (!one_candidate || !one_candidate.we_vote_id) { return null; }
+            if (!oneCandidate || !oneCandidate.we_vote_id) { return null; }
 
-            let candidate_we_vote_id = one_candidate.we_vote_id;
-            let candidateSupportStore = SupportStore.get(candidate_we_vote_id);
-            let organizationsToFollowSupport = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdSupports(candidate_we_vote_id);
-            let organizationsToFollowOppose = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdOpposes(candidate_we_vote_id);
-            let candidate_party_text = one_candidate.party && one_candidate.party.length ? one_candidate.party + ". " : "";
+            let candidateWeVoteId = oneCandidate.we_vote_id;
+            let candidateSupportStore = SupportStore.get(candidateWeVoteId);
+            let organizationsToFollowSupport = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdSupports(candidateWeVoteId);
+            let organizationsToFollowOppose = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdOpposes(candidateWeVoteId);
+            let candidatePartyText = oneCandidate.party && oneCandidate.party.length ? oneCandidate.party + ". " : "";
 
-            let positions_display_raccoon = <div>
+            let positionsDisplayRaccoon = <div>
               <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
                 {/* Positions in Your Network and Possible Voter Guides to Follow */}
-                <ItemSupportOpposeRaccoon ballotItemWeVoteId={candidate_we_vote_id}
-                                          ballot_item_display_name={one_candidate.ballot_item_display_name}
+                <ItemSupportOpposeRaccoon ballotItemWeVoteId={candidateWeVoteId}
+                                          ballot_item_display_name={oneCandidate.ballot_item_display_name}
                                           currentBallotIdInUrl={this.props.currentBallotIdInUrl}
                                           display_raccoon_details_flag={this.state.display_office_unfurled}
-                                          goToCandidate={() => this.goToCandidateLink(one_candidate.we_vote_id)}
+                                          goToCandidate={() => this.goToCandidateLink(oneCandidate.we_vote_id)}
                                           maximumOrganizationDisplay={this.state.maximum_organization_display}
                                           organizationsToFollowSupport={organizationsToFollowSupport}
                                           organizationsToFollowOppose={organizationsToFollowOppose}
@@ -477,37 +479,37 @@ export default class OfficeItemCompressedRaccoon extends Component {
               </div>
             </div>;
 
-            return <div key={candidate_we_vote_id} className="u-stack--md u-gray-border-bottom">
+            return <div key={candidateWeVoteId} className="u-stack--md u-gray-border-bottom">
               <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
                 {/* Candidate Photo */}
-                <div onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null}>
+                <div onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(oneCandidate.we_vote_id) : null}>
                   <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
                                 sizeClassName="icon-candidate-small u-push--sm "
-                                imageUrl={one_candidate.candidate_photo_url_large}
+                                imageUrl={oneCandidate.candidate_photo_url_large}
                                 alt="candidate-photo"
                                 kind_of_ballot_item="CANDIDATE" />
                 </div>
                 <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
                   {/* Candidate Name */}
                   <h4 className="card-main__candidate-name u-f5">
-                    <a onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null}>
+                    <a onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(oneCandidate.we_vote_id) : null}>
                       <TextTruncate line={1}
                                     truncateText="…"
-                                    text={one_candidate.ballot_item_display_name}
+                                    text={oneCandidate.ballot_item_display_name}
                                     textTruncateChild={null}/>
                     </a>
                   </h4>
                   {/* Description under candidate name */}
-                  <LearnMore on_click={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null}
+                  <LearnMore on_click={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(oneCandidate.we_vote_id) : null}
                              num_of_lines={3}
-                             text_to_display={candidate_party_text}
+                             text_to_display={candidatePartyText}
                              always_show_external_link
                              learn_more_text={"Learn more"}
                              />
                   {/* DESKTOP: If voter has taken position, offer the comment bar */}
                   {/* comment_display_raccoon_desktop */}
                   {/* Organization's Followed AND to Follow Items */}
-                  {positions_display_raccoon}
+                  {positionsDisplayRaccoon}
                 </div>
                 {/* MOBILE: If voter has taken position, offer the comment bar */}
                 {/* comment_display_raccoon_mobile */}
@@ -522,11 +524,12 @@ export default class OfficeItemCompressedRaccoon extends Component {
         ************************* */}
         { !this.state.display_office_unfurled ?
           <div>
-            { this.state.candidateList.map( (one_candidate) => {
+            { this.state.candidateList.map(oneCandidate => {
+              if (!oneCandidate || !oneCandidate.we_vote_id) {
+                return null;
+              }
 
-              if (!one_candidate || !one_candidate.we_vote_id) { return null; }
-
-              const voter_supports_this_candidate = SupportStore.get(one_candidate.we_vote_id) && SupportStore.get(one_candidate.we_vote_id).is_support;
+              const voterSupportsThisCandidate = SupportStore.get(oneCandidate.we_vote_id) && SupportStore.get(oneCandidate.we_vote_id).is_support;
 
               let networkOrIssueScoreSupport;
               if (atLeastOneCandidateChosenByNetwork) {
@@ -534,108 +537,109 @@ export default class OfficeItemCompressedRaccoon extends Component {
                 if (advisorsThatMakeVoterNetworkScoreCount > 0) {
                   // console.log("OfficeItemCompressedRaccoon - Generate yourNetworkSupportsPopover 1");
                   yourNetworkSupportsPopover =
-                    <Popover id="popover-trigger-click-root-close"
-                             title={<span>Your Network Supports <span className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" /></span>}
-                             onClick={this.closeYourNetworkSupportsPopover}>
-                      <strong>{one_candidate.ballot_item_display_name}</strong> has
-                      the highest <strong>Score in Your Network</strong>, based on these friends and organizations:<br />
-                      {advisorsThatMakeVoterNetworkScoreDisplay}
-                    </Popover>;
+                  <Popover id="popover-positioned-right"
+                           title={<span>Your Network Supports <span className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" /></span>}
+                           onClick={this.closeYourNetworkSupportsPopover}>LINE 538 aaaaaaaaaa POPOVER<br/>
+                    <strong>{oneCandidate.ballot_item_display_name}</strong> has
+                    the highest <strong>Score in Your Network</strong>, based on these friends and organizations:<br />
+                    {advisorsThatMakeVoterNetworkScoreDisplay}
+                  </Popover>;
                 } else {
                   // console.log("OfficeItemCompressedRaccoon - Generate yourNetworkSupportsPopover 2");
                   yourNetworkSupportsPopover =
-                    <Popover id="popover-trigger-click-root-close"
+                    <Popover id="popover-positioned-right"
                              title={<span>Your Network Supports <span className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" /></span>}
-                             onClick={this.closeYourNetworkSupportsPopover}>
+                             onClick={this.closeYourNetworkSupportsPopover}>LINE 548 ddddddddd POPOVER<br/>
                       Your friends, and the organizations you listen to, are <strong>Your Network</strong>.
                       Everyone in your network
-                      that <span className="u-no-break"> <img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /> supports</span> {one_candidate.ballot_item_display_name} adds
-                      +1 to {one_candidate.ballot_item_display_name}'s <strong>Score in Your Network</strong>. <strong>{one_candidate.ballot_item_display_name}</strong> has
+                      that <span className="u-no-break"> <img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /> supports</span> {oneCandidate.ballot_item_display_name} adds
+                      +1 to {oneCandidate.ballot_item_display_name}'s <strong>Score in Your Network</strong>. <strong>{oneCandidate.ballot_item_display_name}</strong> has
                       the highest score in your network.
                     </Popover>;
                 }
 
                 // console.log("OfficeItemCompressedRaccoon - networkOrIssueScoreSupport");
                 // Your network supports
-                networkOrIssueScoreSupport = candidateWithMostSupportFromNetwork === one_candidate.ballot_item_display_name ?
+                networkOrIssueScoreSupport = candidateWithMostSupportFromNetwork === oneCandidate.ballot_item_display_name ?
                   <div className="u-flex u-items-center">
+                  <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm u-cursor--pointer"
+                       onClick={ this.props.link_to_ballot_item_page ?
+                                 this.toggleExpandDetails : null }>
+                    {/* Candidate Image */}
+                    <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
+                                  sizeClassName="icon-candidate-small u-push--sm "
+                                  imageUrl={oneCandidate.candidate_photo_url_large}
+                                  alt="candidate-photo"
+                                  kind_of_ballot_item="CANDIDATE" />
+                    {/* Candidate Name */}
+                    <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
+                      <h2 className="h5">
+                        {oneCandidate.ballot_item_display_name}
+                      </h2>
+                    </div>
+                  </div>
+                  <div className="u-flex-none u-justify-end">
+                    <OverlayTrigger trigger="click"
+                                    ref="supports-overlay"
+                                    onExit={this.closeYourNetworkSupportsPopover}
+                                    rootClose
+                                    placement="top"
+                                    overlay={yourNetworkSupportsPopover}>
+                      <div>
+                        <span className="u-push--xs u-cursor--pointer">Your network supports</span>
+                        <img src={cordovaDot("/img/global/icons/up-arrow-color-icon.svg")} className="network-positions__support-icon" width="20" height="20" />
+                      </div>
+                    </OverlayTrigger>
+                  </div>
+                </div> :
+                null;
+              } else if (atLeastOneCandidateChosenByIssueScore) {
+                if (candidateWithHighestIssueScore === oneCandidate.ballot_item_display_name) {
+                  // console.log("OfficeItemCompressedRaccoon - atLeastOneCandidateChosenByIssueScore");
+                  const hasHighestIssueScorePopover =
+                  <Popover id="popover-positioned-right"
+                           title={<span>Highest Issue Score <span className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" /></span>}
+                           onClick={this.closeHighestIssueScorePopover}>LINE 598 vvvvvvvvvvv POPOVER<br/>
+                    We took the issues you are following, and added up the opinions of all of the organizations
+                    under those issues. <strong>{oneCandidate.ballot_item_display_name}</strong> has
+                    the most support from these
+                    organizations.<br />
+                    {advisorsThatMakeVoterIssuesScoreDisplay}
+                    <Link onClick={this.toggleExpandDetails}> learn more</Link>
+                  </Popover>;
+
+                  networkOrIssueScoreSupport = <div className="u-flex u-items-center">
                     <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm u-cursor--pointer"
                          onClick={ this.props.link_to_ballot_item_page ?
                                    this.toggleExpandDetails : null }>
                       {/* Candidate Image */}
                       <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
                                     sizeClassName="icon-candidate-small u-push--sm "
-                                    imageUrl={one_candidate.candidate_photo_url_large}
+                                    imageUrl={oneCandidate.candidate_photo_url_large}
                                     alt="candidate-photo"
                                     kind_of_ballot_item="CANDIDATE" />
                       {/* Candidate Name */}
                       <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
                         <h2 className="h5">
-                          {one_candidate.ballot_item_display_name}
+                          {oneCandidate.ballot_item_display_name}
                         </h2>
                       </div>
                     </div>
                     <div className="u-flex-none u-justify-end">
                       <OverlayTrigger trigger="click"
-                                      ref="supports-overlay"
-                                      onExit={this.closeYourNetworkSupportsPopover}
+                                      ref="highest-issue-score-overlay"
+                                      onExit={this.closeHighestIssueScorePopover}
                                       rootClose
                                       placement="top"
-                                      overlay={yourNetworkSupportsPopover}>
+                                      overlay={hasHighestIssueScorePopover}>
                         <div>
-                          <span className="u-push--xs u-cursor--pointer">Your network supports</span>
-                          <img src={cordovaDot("/img/global/icons/up-arrow-color-icon.svg")} className="network-positions__support-icon" width="20" height="20" />
+                          <span className="u-push--xs u-cursor--pointer">Has the highest <strong>Issue Score</strong></span>
+                          <img src={cordovaDot("/img/global/icons/up-arrow-color-icon.svg")}
+                               className="network-positions__support-icon" width="20" height="20"/>
                         </div>
                       </OverlayTrigger>
                     </div>
-                  </div> :
-                  null;
-              } else if (atLeastOneCandidateChosenByIssueScore) {
-                if (candidateWithHighestIssueScore === one_candidate.ballot_item_display_name) {
-                  // console.log("OfficeItemCompressedRaccoon - atLeastOneCandidateChosenByIssueScore");
-                  const hasHighestIssueScorePopover =
-                    <Popover id="popover-trigger-click-root-close"
-                             title={<span>Highest Issue Score <span className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" /></span>}
-                             onClick={this.closeHighestIssueScorePopover}>
-                      We took the issues you are following, and added up the opinions of all of the organizations
-                      under those issues. <strong>{one_candidate.ballot_item_display_name}</strong> has
-                      the most support from these
-                      organizations.<br />
-                      {advisorsThatMakeVoterIssuesScoreDisplay}
-                      <Link onClick={this.toggleExpandDetails}> learn more</Link>
-                    </Popover>;
-                  networkOrIssueScoreSupport = <div className="u-flex u-items-center">
-                      <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm u-cursor--pointer"
-                           onClick={ this.props.link_to_ballot_item_page ?
-                                     this.toggleExpandDetails : null }>
-                        {/* Candidate Image */}
-                        <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
-                                      sizeClassName="icon-candidate-small u-push--sm "
-                                      imageUrl={one_candidate.candidate_photo_url_large}
-                                      alt="candidate-photo"
-                                      kind_of_ballot_item="CANDIDATE" />
-                        {/* Candidate Name */}
-                        <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
-                          <h2 className="h5">
-                            {one_candidate.ballot_item_display_name}
-                          </h2>
-                        </div>
-                      </div>
-                      <div className="u-flex-none u-justify-end">
-                        <OverlayTrigger trigger="click"
-                                        ref="highest-issue-score-overlay"
-                                        onExit={this.closeHighestIssueScorePopover}
-                                        rootClose
-                                        placement="top"
-                                        overlay={hasHighestIssueScorePopover}>
-                          <div>
-                            <span className="u-push--xs u-cursor--pointer">Has the highest <strong>Issue Score</strong></span>
-                            <img src={cordovaDot("/img/global/icons/up-arrow-color-icon.svg")}
-                                 className="network-positions__support-icon" width="20" height="20"/>
-                          </div>
-                        </OverlayTrigger>
-                      </div>
-                    </div>;
+                  </div>;
                 }
                 /* END OF if (atLeastOneCandidateChosenByNetwork) / else if (atLeastOneCandidateChosenByIssueScore) */
               } else {
@@ -644,40 +648,40 @@ export default class OfficeItemCompressedRaccoon extends Component {
                 // preview list.
                 candidatePreviewCount += 1;
                 if (candidatePreviewCount <= candidatePreviewLimit) {
-                  oneCandidateDisplay = <div key={ "candidate_preview-" + one_candidate.we_vote_id } className="u-stack--md u-gray-border-bottom">
-                      <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm u-cursor--pointer">
-                        {/* Candidate Image */}
-                        <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
-                                      sizeClassName="icon-candidate-small u-push--sm "
-                                      imageUrl={one_candidate.candidate_photo_url_large}
-                                      alt="candidate-photo"
-                                      kind_of_ballot_item="CANDIDATE" />
-                        {/* Candidate Name */}
-                        <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
-                          <h4 className="card-main__candidate-name u-f5">{one_candidate.ballot_item_display_name}</h4>
-                        </div>
+                  oneCandidateDisplay = <div key={ "candidate_preview-" + oneCandidate.we_vote_id } className="u-stack--md u-gray-border-bottom">
+                    <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm u-cursor--pointer">
+                      {/* Candidate Image */}
+                      <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
+                                    sizeClassName="icon-candidate-small u-push--sm "
+                                    imageUrl={oneCandidate.candidate_photo_url_large}
+                                    alt="candidate-photo"
+                                    kind_of_ballot_item="CANDIDATE" />
+                      {/* Candidate Name */}
+                      <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
+                        <h4 className="card-main__candidate-name u-f5">{oneCandidate.ballot_item_display_name}</h4>
                       </div>
-                    </div>;
+                    </div>
+                  </div>;
                   candidatePreviewList.push(oneCandidateDisplay);
                 }
               }
 
-              return <div key={one_candidate.we_vote_id}>
+              return <div key={oneCandidate.we_vote_id}>
                 {/* *** Candidate name *** */}
-                { voter_supports_this_candidate ?
+                { voterSupportsThisCandidate ?
                   <div className="u-flex u-items-center">
-                    <div className="u-flex-auto u-cursor--pointer" onClick={ this.props.link_to_ballot_item_page ?
+                    <div className="o-media-object u-flex-auto u-cursor--pointer u-stack--sm" onClick={ this.props.link_to_ballot_item_page ?
                     this.toggleExpandDetails : null }>
                       {/* Candidate Image */}
                       <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
                                     sizeClassName="icon-candidate-small u-push--sm "
-                                    imageUrl={one_candidate.candidate_photo_url_large}
+                                    imageUrl={oneCandidate.candidate_photo_url_large}
                                     alt="candidate-photo"
                                     kind_of_ballot_item="CANDIDATE" />
                       {/* Candidate Name */}
                       <div className="u-flex-auto u-justify-between">
-                        <h2 className="h5">
-                        {one_candidate.ballot_item_display_name}
+                        <h2 className="h5 candidate-h2">
+                        {oneCandidate.ballot_item_display_name}
                         </h2>
                       </div>
                     </div>
@@ -717,11 +721,11 @@ export default class OfficeItemCompressedRaccoon extends Component {
           null
         }
 
-        { !this.state.display_all_candidates_flag && this.state.display_office_unfurled && remaining_candidates_to_display_count ?
+        { !this.state.display_all_candidates_flag && this.state.display_office_unfurled && remainingCandidatesToDisplayCount ?
           <Link onClick={this.toggleDisplayAllCandidates}>
             <span className="u-items-center u-no-break d-print-none">
               <i className="fa fa-plus BallotItem__view-more-plus" aria-hidden="true" />
-              <span> Show {remaining_candidates_to_display_count} more candidate{ remaining_candidates_to_display_count !== 1 ? "s" : null }</span>
+              <span> Show {remainingCandidatesToDisplayCount} more candidate{ remainingCandidatesToDisplayCount !== 1 ? "s" : null }</span>
             </span>
           </Link> : null
         }
@@ -733,14 +737,14 @@ export default class OfficeItemCompressedRaccoon extends Component {
           <Link onClick={this.toggleExpandDetails}>
             <div className="BallotItem__view-more u-items-center u-no-break d-print-none">
               <i className="fa fa-plus BallotItem__view-more-plus" aria-hidden="true" />
-              { total_number_of_candidates_to_display > 1 ?
-                <span> View all {total_number_of_candidates_to_display} candidates</span> :
+              { totalNumberOfCandidatesToDisplay > 1 ?
+                <span> View all {totalNumberOfCandidatesToDisplay} candidates</span> :
                 <span> View candidate</span>
               }
             </div>
           </Link>
         }
         </div>
-      </div>;
+    </div>;
   }
 }

--- a/src/js/components/Donation/DonationList.jsx
+++ b/src/js/components/Donation/DonationList.jsx
@@ -61,7 +61,7 @@ export default class DonationList extends Component {
 
   // October 2018: This is a workaround, since the current react-bootstrap does not handle the "d-none d-sm-block" correctly in th and td styles
   isNotMobile () {
-    let bootstrapDetectedSizeXs = $('#users-device-size').find('div:visible').first().attr('id');
+    let bootstrapDetectedSizeXs = $("#users-device-size").find("div:visible").first().attr("id");
     return bootstrapDetectedSizeXs === undefined;
   }
 

--- a/src/js/components/Friends/FriendInvitationProcessedList.jsx
+++ b/src/js/components/Friends/FriendInvitationProcessedList.jsx
@@ -40,7 +40,7 @@ export default class FriendInvitationProcessedList extends Component {
 
     return <div className="guidelist card-child__list-group">
         <TransitionGroup transitionName="org-ignore" transitionEnterTimeout={2000} transitionLeaveTimeout={2000}>
-          {friendInvitationsList.map((friend) => {
+          {this.state.friendInvitationsList.map((friend) => {
             if (this.props.invitationsSentByMe) {
               return <CSSTransition key={++counter} timeout={500} classNames="fade">
                   <FriendInvitationProcessedDisplayForList key={counter} {...friend}

--- a/src/js/components/Navigation/SecondaryNavBarItem.jsx
+++ b/src/js/components/Navigation/SecondaryNavBarItem.jsx
@@ -38,7 +38,7 @@ export default class SecondaryNavBarItem extends Component {
     } else if (this.props.iconEmail) {
       // icon = <span className="glyphicon glyphicon-envelope fa-2x"/>;
       // icon = <i className="fa fa-envelope fa-2x"/>;
-      icon = <Icon name="glyphicons-pro-halflings/glyphicons-halflings-4-envelope" color={"#51708e"} width={40} height={40} />;
+      icon = <Icon name="glyphicons-pro-halflings/glyphicons-halflings-4-envelope" className={{margin: -10}} color={"#51708e"} width={40} height={40} />;
     } else if (this.props.iconFacebook) {
       icon = <i className="fa fa-facebook-square fa-2x"/>;
     } else if (this.props.iconTwitter) {

--- a/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
+++ b/src/js/components/Position/ItemTinyPositionBreakdownList.jsx
@@ -232,15 +232,15 @@ export default class ItemTinyPositionBreakdownList extends Component {
             </Popover>;
 
           return <OverlayTrigger
-              key={`trigger-${organization_we_vote_id}`}
-              ref={`position-overlay-${organization_we_vote_id}`}
-              onMouseOver={() => this.onTriggerEnter(organization_we_vote_id)}
-              onMouseOut={() => this.onTriggerLeave(organization_we_vote_id)}
-              onExiting={() => this.onTriggerLeave(organization_we_vote_id)}
-              trigger={this.props.visibility === "mobile" ? "click" : ["focus", "hover", "click"]}
-              rootClose
-              placement="bottom"
-              overlay={organizationPopover}>
+            key={`trigger-${organization_we_vote_id}`}
+            ref={`position-overlay-${organization_we_vote_id}`}
+            onMouseOver={() => this.onTriggerEnter(organization_we_vote_id)}
+            onMouseOut={() => this.onTriggerLeave(organization_we_vote_id)}
+            onExiting={() => this.onTriggerLeave(organization_we_vote_id)}
+            trigger={this.props.visibility === "mobile" ? "click" : ["focus", "hover", "click"]}
+            rootClose
+            placement="bottom"
+            overlay={organizationPopover}>
             <span className="position-rating__source with-popover">
               <OrganizationTinyDisplay {...one_organization}
                                        showPlaceholderImage

--- a/src/js/components/Search/SearchBar.jsx
+++ b/src/js/components/Search/SearchBar.jsx
@@ -1,8 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { renderLog } from "../../utils/logging";
-import {cordovaDot} from "../../utils/cordovaUtils";
-import {Link} from "react-router";
 import Icon from "react-svg-icons";
 
 

--- a/src/js/components/Settings/VoterGuideSettingsSuggestedBallotItems.jsx
+++ b/src/js/components/Settings/VoterGuideSettingsSuggestedBallotItems.jsx
@@ -1,79 +1,79 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import BallotStore from "../../stores/BallotStore";
-import CandidateItemCompressed from "../../components/Ballot/CandidateItemCompressed";
-import Icon from "react-svg-icons";
-import LoadingWheel from "../../components/LoadingWheel";
-import { renderLog } from "../../utils/logging";
-
-
-export default class VoterGuideSettingsSuggestedBallotItems extends Component {
-  static propTypes = {
-    maximumSuggestedItems: PropTypes.number,
-  };
-
-  constructor (props) {
-    super(props);
-    this.state = {
-    };
-  }
-
-  render () {
-    renderLog(__filename);
-    if (!this.props.maximumSuggestedItems) {
-      return LoadingWheel;
-    }
-
-    let suggestedBallotItemsHtml = "";
-    let suggestedItemsCount = 0;
-    const maximumSuggestedItems = this.props.maximumSuggestedItems || 3;
-    let candidateList;
-    let ballotItemList = BallotStore.ballot;
-    if (ballotItemList) {
-      suggestedBallotItemsHtml = ballotItemList.map(ballotItem => {
-        if (suggestedItemsCount >= maximumSuggestedItems) {
-          return null;
-        } else if (ballotItem.kind_of_ballot_item === "OFFICE") {
-          candidateList = ballotItem.candidate_list;
-          if (candidateList) {
-            return candidateList.map(oneCandidate => {
-              if (suggestedItemsCount >= maximumSuggestedItems) {
-                return null;
-              } else {
-                suggestedItemsCount += 1;
-                return <CandidateItemCompressed oneCandidate={oneCandidate} />;
-              }
-            });
-          } else {
-            return null;
-          }
-        } else if (ballotItem.kind_of_ballot_item === "MEASURE") {
-          return null;
-        } else {
-          return null;
-        }
-      });
-    }
-
-    const icon_size = 18;
-    let icon_color = "#999";
-
-    return <span>{ suggestedItemsCount > 0 ?
-      <div>
-        <div className="card">
-          <div className="card-main">
-            <h3 className="h3">Suggestions</h3>
-            <div className="u-padding-bottom--sm">
-              Click <span className="u-no-break"><span className="btn__icon"><Icon name="thumbs-up-icon"
-                                                                                   width={icon_size} height={icon_size} color={icon_color} /></span> Support</span> or&nbsp;
-              <span className="u-no-break"><span className="btn__icon"><Icon name="thumbs-down-icon"
-                                                                             width={icon_size} height={icon_size} color={icon_color} /></span> Oppose</span> to
-              add any of these suggestions to your ballot.
-            </div>
-            <div className="">{suggestedBallotItemsHtml}</div>
-          </div>
-        </div>
-      </div> :
-      null }</span>;
-  }
-}
+// import React, { Component } from "react";
+// import PropTypes from "prop-types";
+// import BallotStore from "../../stores/BallotStore";
+// import CandidateItemCompressed from "../../components/Ballot/CandidateItemCompressed";
+// import Icon from "react-svg-icons";
+// import LoadingWheel from "../../components/LoadingWheel";
+// import { renderLog } from "../../utils/logging";
+//
+//
+// export default class VoterGuideSettingsSuggestedBallotItems extends Component {
+//   static propTypes = {
+//     maximumSuggestedItems: PropTypes.number,
+//   };
+//
+//   constructor (props) {
+//     super(props);
+//     this.state = {
+//     };
+//   }
+//
+//   render () {
+//     renderLog(__filename);
+//     if (!this.props.maximumSuggestedItems) {
+//       return LoadingWheel;
+//     }
+//
+//     let suggestedBallotItemsHtml = "";
+//     let suggestedItemsCount = 0;
+//     const maximumSuggestedItems = this.props.maximumSuggestedItems || 3;
+//     let candidateList;
+//     let ballotItemList = BallotStore.ballot;
+//     if (ballotItemList) {
+//       suggestedBallotItemsHtml = ballotItemList.map(ballotItem => {
+//         if (suggestedItemsCount >= maximumSuggestedItems) {
+//           return null;
+//         } else if (ballotItem.kind_of_ballot_item === "OFFICE") {
+//           candidateList = ballotItem.candidate_list;
+//           if (candidateList) {
+//             return candidateList.map(oneCandidate => {
+//               if (suggestedItemsCount >= maximumSuggestedItems) {
+//                 return null;
+//               } else {
+//                 suggestedItemsCount += 1;
+//                 return <CandidateItemCompressed oneCandidate={oneCandidate} />;
+//               }
+//             });
+//           } else {
+//             return null;
+//           }
+//         } else if (ballotItem.kind_of_ballot_item === "MEASURE") {
+//           return null;
+//         } else {
+//           return null;
+//         }
+//       });
+//     }
+//
+//     const icon_size = 18;
+//     let icon_color = "#999";
+//
+//     return <span>{ suggestedItemsCount > 0 ?
+//       <div>
+//         <div className="card">
+//           <div className="card-main">
+//             <h3 className="h3">Suggestions</h3>
+//             <div className="u-padding-bottom--sm">
+//               Click <span className="u-no-break"><span className="btn__icon"><Icon name="thumbs-up-icon"
+//                                                                                    width={icon_size} height={icon_size} color={icon_color} /></span> Support</span> or&nbsp;
+//               <span className="u-no-break"><span className="btn__icon"><Icon name="thumbs-down-icon"
+//                                                                              width={icon_size} height={icon_size} color={icon_color} /></span> Oppose</span> to
+//               add any of these suggestions to your ballot.
+//             </div>
+//             <div className="">{suggestedBallotItemsHtml}</div>
+//           </div>
+//         </div>
+//       </div> :
+//       null }</span>;
+//   }
+// }

--- a/src/js/components/VoterGuide/VoterGuideBallotItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallotItemCompressed.jsx
@@ -1,39 +1,39 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { renderLog } from "../../utils/logging";
-import MeasureItemCompressed from "../../components/Ballot/MeasureItemCompressed";
-import VoterGuideOfficeItemCompressed from "../../components/VoterGuide/VoterGuideOfficeItemCompressed";
-
-const TYPES = require("keymirror")({
-  OFFICE: null,
-  MEASURE: null
-});
-
-export default class VoterGuideBallotItemCompressed extends Component {
-  static propTypes = {
-    ballot_item_display_name: PropTypes.string.isRequired,
-    candidate_list: PropTypes.array,
-    kind_of_ballot_item: PropTypes.string.isRequired,
-    organization: PropTypes.object.isRequired,
-    organization_we_vote_id: PropTypes.string.isRequired,
-    toggleCandidateModal: PropTypes.func,
-    toggleMeasureModal: PropTypes.func,
-    we_vote_id: PropTypes.string.isRequired,
-  };
-
-  isMeasure () {
-    return this.props.kind_of_ballot_item === TYPES.MEASURE;
-  }
-
-  render () {
-    renderLog(__filename);
-    return <div className="BallotItem card" id={this.props.we_vote_id}>
-        { this.isMeasure() ?
-          <MeasureItemCompressed {...this.props}
-                   link_to_ballot_item_page /> :
-          <VoterGuideOfficeItemCompressed {...this.props}
-                   link_to_ballot_item_page />
-        }
-      </div>;
-  }
-}
+// import React, { Component } from "react";
+// import PropTypes from "prop-types";
+// import { renderLog } from "../../utils/logging";
+// import MeasureItemCompressed from "../../components/Ballot/MeasureItemCompressed";
+// import VoterGuideOfficeItemCompressed from "../../components/VoterGuide/VoterGuideOfficeItemCompressed";
+//
+// const TYPES = require("keymirror")({
+//   OFFICE: null,
+//   MEASURE: null
+// });
+//
+// export default class VoterGuideBallotItemCompressed extends Component {
+//   static propTypes = {
+//     ballot_item_display_name: PropTypes.string.isRequired,
+//     candidate_list: PropTypes.array,
+//     kind_of_ballot_item: PropTypes.string.isRequired,
+//     organization: PropTypes.object.isRequired,
+//     organization_we_vote_id: PropTypes.string.isRequired,
+//     toggleCandidateModal: PropTypes.func,
+//     toggleMeasureModal: PropTypes.func,
+//     we_vote_id: PropTypes.string.isRequired,
+//   };
+//
+//   isMeasure () {
+//     return this.props.kind_of_ballot_item === TYPES.MEASURE;
+//   }
+//
+//   render () {
+//     renderLog(__filename);
+//     return <div className="BallotItem card" id={this.props.we_vote_id}>
+//         { this.isMeasure() ?
+//           <MeasureItemCompressed {...this.props}
+//                    link_to_ballot_item_page /> :
+//           <VoterGuideOfficeItemCompressed {...this.props}
+//                    link_to_ballot_item_page />
+//         }
+//       </div>;
+//   }
+// }

--- a/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
@@ -1,537 +1,537 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { OverlayTrigger, Popover } from "react-bootstrap";
-import { Link } from "react-router";
-import { cordovaDot, historyPush } from "../../utils/cordovaUtils";
-import TextTruncate from "react-text-truncate";
-import { toTitleCase } from "../../utils/textFormat";
-import BookmarkToggle from "../Bookmarks/BookmarkToggle";
-import ImageHandler from "../ImageHandler";
-import IssueStore from "../../stores/IssueStore";
-import ItemActionBar from "../Widgets/ItemActionBar";
-import ItemPositionStatementActionBar from "../Widgets/ItemPositionStatementActionBar";
-import ItemSupportOpposeRaccoon from "../Widgets/ItemSupportOpposeRaccoon";
-import LearnMore from "../Widgets/LearnMore";
-import { renderLog } from "../../utils/logging";
-import OrganizationPositionItem from "./OrganizationPositionItem";
-import OrganizationStore from "../../stores/OrganizationStore";
-import SupportStore from "../../stores/SupportStore";
-import VoterGuideStore from "../../stores/VoterGuideStore";
-
-const NUMBER_OF_CANDIDATES_TO_DISPLAY = 30; // On voter guide pages, we want to show all
-
-// This is based on components/Ballot/OfficeItemCompressed
-export default class VoterGuideOfficeItemCompressed extends Component {
-  static propTypes = {
-    we_vote_id: PropTypes.string.isRequired,
-    ballot_item_display_name: PropTypes.string.isRequired,
-    candidate_list: PropTypes.array,
-    kind_of_ballot_item: PropTypes.string.isRequired,
-    link_to_ballot_item_page: PropTypes.bool,
-    location: PropTypes.object,
-    organization: PropTypes.object.isRequired,
-    organization_we_vote_id: PropTypes.string.isRequired,
-    toggleCandidateModal: PropTypes.func,
-  };
-
-  constructor (props) {
-    super(props);
-    this.state = {
-      candidateList: [],
-      display_all_candidates_flag: false,
-      display_office_unfurled: false,
-      editMode: false,
-      maximum_organization_display: 4,
-      organization: {},
-      show_position_statement: true,
-      transitioning: false,
-    };
-
-    this.getCandidateLink = this.getCandidateLink.bind(this);
-    this.getOfficeLink = this.getOfficeLink.bind(this);
-    this.goToCandidateLink = this.goToCandidateLink.bind(this);
-    this.goToOfficeLink = this.goToOfficeLink.bind(this);
-    this.openCandidateModal = this.openCandidateModal.bind(this);
-    this.toggleDisplayAllCandidates = this.toggleDisplayAllCandidates.bind(this);
-    this.toggleExpandDetails = this.toggleExpandDetails.bind(this);
-  }
-
-  componentDidMount () {
-    this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
-    this.organizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
-    this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
-    this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
-    this.onVoterGuideStoreChange();
-
-    if (this.props.candidate_list && this.props.candidate_list.length) {
-      // DALE 2018-07-31 We now retrieve the full candidate data in voterBallotItemsRetrieve
-      // if (CandidateStore.getNumberOfCandidatesRetrievedByOffice(this.props.we_vote_id) === 0) {
-      //   // console.log("Calling candidatesRetrieve: ", this.props.we_vote_id);
-      //   CandidateActions.candidatesRetrieve(this.props.we_vote_id);
-      // }
-
-      // this.props.candidate_list.forEach( function (candidate) {
-      //   if (candidate && candidate.hasOwnProperty("we_vote_id") && !CandidateStore.isCandidateInStore(candidate.we_vote_id)) {
-      //     // Slows down the browser too much when run for all candidates
-      //     // VoterGuideActions.voterGuidesToFollowRetrieveByBallotItem(candidate.we_vote_id, "CANDIDATE");
-      //   }
-      // });
-      this.setState({
-        candidateList: this.props.candidate_list,
-      });
-    }
-    if (this.props.organization && this.props.organization.organization_we_vote_id) {
-      this.setState({
-        organization: this.props.organization,
-      });
-    }
-  }
-
-  componentWillReceiveProps (nextProps) {
-    // console.log("officeItemCompressed componentWillReceiveProps, nextProps.candidate_list:", nextProps.candidate_list);
-    // 2018-05-10 I don't think we need to trigger a new render because the incoming candidate_list should be the same
-    // if (nextProps.candidate_list && nextProps.candidate_list.length) {
-    //   this.setState({
-    //     candidateList: nextProps.candidate_list,
-    //   });
-    // }
-
-    // Only update organization if it is a different organization
-    if (nextProps.organization && nextProps.organization.organization_we_vote_id && this.state.organization.organization_we_vote_id !== nextProps.organization.organization_we_vote_id) {
-      this.setState({
-        organization: OrganizationStore.getOrganizationByWeVoteId(nextProps.organization.organization_we_vote_id),
-      });
-    }
-  }
-
-  componentWillUnmount () {
-    this.issueStoreListener.remove();
-    this.organizationStoreListener.remove();
-    this.supportStoreListener.remove();
-    this.voterGuideStoreListener.remove();
-  }
-
-  onIssueStoreChange () {
-    this.setState({
-      transitioning: false,
-    });
-  }
-
-  onVoterGuideStoreChange () {
-    this.setState({ transitioning: false });
-  }
-
-  onOrganizationStoreChange (){
-    // console.log("VoterGuideOfficeItemCompressed onOrganizationStoreChange, org_we_vote_id: ", this.state.organization.organization_we_vote_id);
-    this.setState({
-      organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
-    });
-  }
-
-  onSupportStoreChange () {
-    // Whenever positions change, we want to make sure to get the latest organization, because it has
-    //  position_list_for_one_election and position_list_for_all_except_one_election attached to it
-    this.setState({
-      organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
-      transitioning: false,
-    });
-  }
-
-  toggleDisplayAllCandidates () {
-    this.setState({ display_all_candidates_flag: !this.state.display_all_candidates_flag });
-  }
-
-  toggleExpandDetails () {
-    let { location: { pathname, search, hash }, we_vote_id } = this.props;
-    let currentUrlWithoutHash = pathname + search;
-    let currentBallotIdInUrl = hash.slice(1);
-    if (currentBallotIdInUrl !== we_vote_id) {
-      historyPush(currentUrlWithoutHash + "#" + we_vote_id);
-    }
-    this.setState({ display_office_unfurled: !this.state.display_office_unfurled });
-  }
-
-  openCandidateModal (candidate) {
-    // console.log("this.state.candidate: ", this.state.candidate);
-    if (candidate && candidate.we_vote_id) {
-      this.props.toggleCandidateModal(candidate);
-    }
-  }
-
-  getCandidateLink (candidate_we_vote_id) {
-    return "/candidate/" + candidate_we_vote_id + "/btvg/" + this.state.organization.organization_we_vote_id;
-  }
-
-  getOfficeLink () {
-    return "/office/" + this.props.we_vote_id + "/btvg/" + this.state.organization.organization_we_vote_id;
-  }
-
-  goToCandidateLink (candidate_we_vote_id) {
-    let candidate_link = this.getCandidateLink(candidate_we_vote_id);
-    historyPush(candidate_link);
-  }
-
-  goToOfficeLink () {
-    let office_link = this.getOfficeLink();
-    historyPush(office_link);
-  }
-
-  doesOrganizationHavePositionOnCandidate (candidate_we_vote_id) {
-    return OrganizationStore.doesOrganizationHavePositionOnCandidate(this.state.organization.organization_we_vote_id, candidate_we_vote_id);
-  }
-
-  getOrganizationPositionForThisCandidate (candidate_we_vote_id, position_list_for_one_election) {
-    // console.log("getOrganizationPositionForThisCandidate position_list_for_one_election: ", position_list_for_one_election);
-    let one_position_to_return = {};
-    if (position_list_for_one_election) {
-      position_list_for_one_election.forEach((one_position) => {
-        // console.log("getOrganizationPositionForThisCandidate candidate_we_vote_id: ", candidate_we_vote_id, ", one_position: ", one_position);
-        if (one_position.ballot_item_we_vote_id === candidate_we_vote_id) {
-          // console.log("getOrganizationPositionForThisCandidate one_position found to return");
-          // Because this is a forEach, we aren't able to break out of the loop
-          one_position_to_return = one_position;
-        }
-      });
-    }
-
-    return one_position_to_return;
-  }
-
-  closeYourNetworkIsUndecidedPopover () {
-    this.refs["undecided-overlay"].hide();
-  }
-
-  render () {
-    renderLog(__filename);
-    let { ballot_item_display_name, we_vote_id } = this.props;
-    ballot_item_display_name = toTitleCase(ballot_item_display_name);
-    let unsortedCandidateList = this.state.candidateList.slice(0);
-    let total_number_of_candidates_to_display = this.state.candidateList.length;
-    let remaining_candidates_to_display_count = 0;
-    // let advisorsThatMakeVoterIssuesScoreDisplay;
-    // let advisorsThatMakeVoterIssuesScoreCount = 0;
-    // let advisorsThatMakeVoterNetworkScoreCount = 0;
-    // let advisorsThatMakeVoterNetworkScoreDisplay = null;
-    let arrayOfCandidatesVoterSupports = [];
-    let atLeastOneCandidateChosenByNetwork = false;
-    // let atLeastOneCandidateChosenByIssueScore = false;
-    // let candidateWithMostSupportFromNetwork = null;
-    // let candidateWeVoteWithMostSupportFromNetwork = null;
-    // let candidateWithHighestIssueScore = null;
-    // let candidateWeVoteIdWithHighestIssueScore = null;
-    let voterSupportsAtLeastOneCandidate = false;
-    let supportProps;
-    let candidate_has_voter_support;
-    let voterIssuesScoreForCandidate;
-    let sortedCandidateList;
-    let limitedCandidateList;
-
-    // Prepare an array of candidate names that are supported by voter
-    unsortedCandidateList.forEach((candidate) => {
-      supportProps = SupportStore.get(candidate.we_vote_id);
-      if (supportProps) {
-        candidate_has_voter_support = supportProps.is_support;
-        voterIssuesScoreForCandidate = IssueStore.getIssuesScoreByBallotItemWeVoteId(candidate.we_vote_id);
-        candidate.voterNetworkScoreForCandidate = Math.abs(supportProps.support_count - supportProps.oppose_count);
-        candidate.voterIssuesScoreForCandidate = Math.abs(voterIssuesScoreForCandidate);
-        candidate.is_support = supportProps.is_support;
-        if (candidate_has_voter_support) {
-          arrayOfCandidatesVoterSupports.push(candidate.ballot_item_display_name);
-          voterSupportsAtLeastOneCandidate = true;
-        }
-      }
-    });
-
-    unsortedCandidateList.sort((optionA, optionB)=>optionB.voterNetworkScoreForCandidate - optionA.voterNetworkScoreForCandidate ||
-                                                   (optionA.is_support === optionB.is_support ? 0 : optionA.is_support ? -1 : 1) ||
-                                                   optionB.voterIssuesScoreForCandidate - optionA.voterIssuesScoreForCandidate);
-    limitedCandidateList = unsortedCandidateList;
-    sortedCandidateList = unsortedCandidateList;
-    if (!this.state.display_all_candidates_flag && this.state.candidateList.length > NUMBER_OF_CANDIDATES_TO_DISPLAY) {
-      limitedCandidateList = sortedCandidateList.slice(0, NUMBER_OF_CANDIDATES_TO_DISPLAY);
-      remaining_candidates_to_display_count = this.state.candidateList.length - NUMBER_OF_CANDIDATES_TO_DISPLAY;
-    }
-    // If the voter isn't supporting any candidates, then figure out which candidate the voter's network likes the best
-    if (arrayOfCandidatesVoterSupports.length === 0){
-      // This function finds the highest support count for each office but does not handle ties. If two candidates have
-      // the same network support count, only the first candidate will be displayed.
-      let largestNetworkSupportCount = 0;
-      let network_support_count;
-      let network_oppose_count;
-
-      sortedCandidateList.forEach((candidate) => {
-        // Support in voter's network
-        supportProps = SupportStore.get(candidate.we_vote_id);
-        if (supportProps) {
-          network_support_count = supportProps.support_count;
-          network_oppose_count = supportProps.oppose_count;
-
-          if (network_support_count > network_oppose_count) {
-            if (network_support_count > largestNetworkSupportCount) {
-              largestNetworkSupportCount = network_support_count;
-              // candidateWithMostSupportFromNetwork = candidate.ballot_item_display_name;
-              // candidateWeVoteWithMostSupportFromNetwork = candidate.we_vote_id;
-              atLeastOneCandidateChosenByNetwork = true;
-            }
-          }
-        }
-      });
-    }
-
-    let organization_position_for_this_candidate;
-    let candidate_we_vote_id;
-    let candidateSupportStore;
-    const yourNetworkIsUndecidedPopover =
-      <Popover id="popover-trigger-click-root-close"
-               title={<span>Your Network is Undecided <span className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" /></span>}
-               onClick={this.closeYourNetworkIsUndecidedPopover}>
-        Your friends, and the organizations you listen to, are <strong>Your Network</strong>.
-        Everyone in your network
-        that <span className="u-no-break"> <img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /> supports</span> a
-        candidate adds
-        +1 to that candidate's <strong>Score in Your Network</strong>. None of the candidates running
-        for {ballot_item_display_name} have more support in your network than the other candidates.
-      </Popover>;
-
-    return <div className="card-main office-item">
-      <a className="anchor-under-header" name={we_vote_id} />
-      <div className="card-main__content">
-        {/* Desktop */}
-        <span className="d-none d-sm-block">
-          <BookmarkToggle we_vote_id={we_vote_id} type="OFFICE" />
-        </span>
-        {/* Mobile - "show more" and "show less" not used */}
-
-        {/* On the voter guide, we bring the size of the office name down so we can emphasize the candidate being supported */}
-        <h2 className="h4 u-f5 card-main__ballot-name u-gray-dark u-stack--sm">
-          <span className="d-print-none" onClick={this.toggleExpandDetails}>
-            { this.state.display_office_unfurled ?
-              <span className="glyphicon glyphicon-triangle-bottom u-font-size6 d-print-none u-push--xs"/> :
-              null
-            }
-            {ballot_item_display_name}
-          </span>
-
-          {/* Print */}
-          <span className="u-f3 visible-print">
-            {ballot_item_display_name}
-          </span>
-        </h2>
-
-        {/* *************************
-        Only show the candidates if the Office is "unfurled"
-        ************************* */}
-        { this.state.display_office_unfurled ?
-          <span>{limitedCandidateList.map((one_candidate) => {
-            candidate_we_vote_id = one_candidate.we_vote_id;
-            candidateSupportStore = SupportStore.get(candidate_we_vote_id);
-            let organizationsToFollowSupport = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdSupports(candidate_we_vote_id);
-            let organizationsToFollowOppose = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdOpposes(candidate_we_vote_id);
-
-            let candidate_party_text = one_candidate.party && one_candidate.party.length ? one_candidate.party + ". " : "";
-            let candidate_description_text = one_candidate.twitter_description && one_candidate.twitter_description.length ? one_candidate.twitter_description : "";
-            let candidate_text = candidate_party_text + candidate_description_text;
-
-            organization_position_for_this_candidate = this.getOrganizationPositionForThisCandidate(candidate_we_vote_id, this.state.organization.position_list_for_one_election);
-
-            return <div key={candidate_we_vote_id} className="u-stack--md">
-              <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
-                {/* Candidate Photo, only shown in Desktop */}
-                {this.state.display_office_unfurled ?
-                  <div className="d-none d-sm-block" onClick={this.props.link_to_ballot_item_page ? this.toggleExpandDetails : null}>
-                    <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
-                                  sizeClassName="icon-candidate-small u-push--sm "
-                                  imageUrl={one_candidate.candidate_photo_url_large}
-                                  alt="candidate-photo"
-                                  kind_of_ballot_item="CANDIDATE" />
-                  </div> :
-                  null
-                }
-                <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
-                  {/* Candidate Name */}
-                  <h4 className={"card-main__candidate-name" + (this.doesOrganizationHavePositionOnCandidate(candidate_we_vote_id) ? " u-f2" : " u-f6")}>
-                    <a onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null}>
-                      <TextTruncate line={1}
-                                    truncateText="…"
-                                    text={one_candidate.ballot_item_display_name}
-                                    textTruncateChild={null}/>
-                    </a>
-                  </h4>
-                  {/* Description under candidate name */}
-                  <LearnMore text_to_display={candidate_text}
-                             on_click={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null} />
-
-                  {/* Organization Endorsement */}
-                  { this.doesOrganizationHavePositionOnCandidate(candidate_we_vote_id) && organization_position_for_this_candidate ?
-                    <OrganizationPositionItem key={organization_position_for_this_candidate.position_we_vote_id}
-                                              position={organization_position_for_this_candidate}
-                                              organization={this.state.organization}
-                                              editMode={this.state.editMode}
-                                              turnOffLogo
-                                              turnOffName
-                             /> :
-                    null }
-
-                  {/* Organization's Followed AND to Follow Items -- only show for promoted candidate */}
-                  { this.doesOrganizationHavePositionOnCandidate(candidate_we_vote_id) ?
-                    <div>
-                      <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
-                        {/* Positions in Your Network and Possible Voter Guides to Follow */}
-                        <ItemSupportOpposeRaccoon ballotItemWeVoteId={candidate_we_vote_id}
-                                                  ballot_item_display_name={one_candidate.ballot_item_display_name}
-                                                  currentBallotIdInUrl={this.props.location.hash.slice(1)}
-                                                  display_raccoon_details_flag={this.state.display_office_unfurled}
-                                                  goToCandidate={() => this.goToCandidateLink(one_candidate.we_vote_id)}
-                                                  maximumOrganizationDisplay={this.state.maximum_organization_display}
-                                                  organizationsToFollowSupport={organizationsToFollowSupport}
-                                                  organizationsToFollowOppose={organizationsToFollowOppose}
-                                                  popoverBottom
-                                                  supportProps={candidateSupportStore}
-                                                  type="CANDIDATE"
-                                                  urlWithoutHash={this.props.location.pathname + this.props.location.search}
-                                                  we_vote_id={this.props.we_vote_id} />
-                      </div>
-                    </div> :
-                    null}
-                </div>
-              </div>
-            </div>;
-          })}</span> :
-          null
-        }
-
-        {/* *************************
-        If the office is "rolled up", show some details for the organization's endorsement
-        ************************* */}
-        { !this.state.display_office_unfurled ?
-          <div>
-            { this.state.candidateList.map( (one_candidate) => {
-                if (this.doesOrganizationHavePositionOnCandidate(one_candidate.we_vote_id) ) {
-                  organization_position_for_this_candidate = this.getOrganizationPositionForThisCandidate(one_candidate.we_vote_id, this.state.organization.position_list_for_one_election);
-
-                  if (organization_position_for_this_candidate) {
-                    candidate_we_vote_id = one_candidate.we_vote_id;
-                    candidateSupportStore = SupportStore.get(candidate_we_vote_id);
-
-                    let is_support = false;
-                    let is_oppose = false;
-                    let voter_statement_text = false;
-                    if (candidateSupportStore !== undefined) {
-                      is_support = candidateSupportStore.is_support;
-                      is_oppose = candidateSupportStore.is_oppose;
-                      voter_statement_text = candidateSupportStore.voter_statement_text;
-                    }
-
-                    return <div key={candidate_we_vote_id}>
-                      {/* Organization Endorsement */}
-                      <OrganizationPositionItem ballotItemLink={this.getCandidateLink(candidate_we_vote_id)}
-                                                key={organization_position_for_this_candidate.position_we_vote_id}
-                                                position={organization_position_for_this_candidate}
-                                                organization={this.state.organization}
-                                                editMode={this.state.editMode}
-                      />
-                      <div className="flex">
-                          <ItemActionBar ballot_item_display_name={one_candidate.ballot_item_display_name}
-                                         ballot_item_we_vote_id={candidate_we_vote_id}
-                                         commentButtonHide
-                                         currentBallotIdInUrl={this.props.location.hash.slice(1)}
-                                         shareButtonHide
-                                         supportProps={candidateSupportStore}
-                                         transitioning={this.state.transitioning}
-                                         type="CANDIDATE"
-                                         urlWithoutHash={this.props.location.pathname + this.props.location.search}
-                                         we_vote_id={this.props.we_vote_id}
-                                         />
-                      </div>
-                      {/* DESKTOP: If voter has taken position, offer the comment bar */}
-                      {is_support || is_oppose || voter_statement_text ?
-                        <div className="hidden-xs o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
-                          <div
-                            className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm">&nbsp;
-                          </div>
-                          <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
-                            <ItemPositionStatementActionBar ballot_item_display_name={one_candidate.ballot_item_display_name}
-                                                            ballot_item_we_vote_id={candidate_we_vote_id}
-                                                            supportProps={candidateSupportStore}
-                                                            transitioning={this.state.transitioning}
-                                                            type="CANDIDATE"
-                                                            shown_in_list/>
-                          </div>
-                        </div> :
-                        null }
-                      {/* MOBILE: If voter has taken position, offer the comment bar */}
-                      {is_support || is_oppose || voter_statement_text ?
-                        <div className="d-block d-sm-none o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
-                          <div
-                            className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm">&nbsp;
-                          </div>
-                          <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
-                            <ItemPositionStatementActionBar ballot_item_display_name={one_candidate.ballot_item_display_name}
-                                                            ballot_item_we_vote_id={candidate_we_vote_id}
-                                                            supportProps={candidateSupportStore}
-                                                            transitioning={this.state.transitioning}
-                                                            type="CANDIDATE"
-                                                            shown_in_list/>
-                          </div>
-                        </div> :
-                        null }
-                    </div>;
-                  }
-                }
-                return null;
-              })
-            }
-            {/* Now that we are out of the candidate loop... */}
-            { voterSupportsAtLeastOneCandidate ?
-              null :
-              <span>
-                { atLeastOneCandidateChosenByNetwork ?
-                  null :
-                  <div className="u-tr">
-                    <OverlayTrigger trigger="click"
-                                  ref="undecided-overlay"
-                                  onExit={this.closeYourNetworkIsUndecidedPopover}
-                                  rootClose
-                                  placement="top"
-                                  overlay={yourNetworkIsUndecidedPopover}>
-                      <span className=" u-cursor--pointer">Your network is undecided <i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover d-print-none" aria-hidden="true" /></span>
-                    </OverlayTrigger>
-                  </div>
-                }
-              </span>
-            }
-          </div> :
-          null
-        }
-
-        { !this.state.display_all_candidates_flag && this.state.display_office_unfurled && remaining_candidates_to_display_count ?
-          <Link onClick={this.toggleDisplayAllCandidates}>
-            <span className="u-items-center u-no-break d-print-none">
-              Click to show {remaining_candidates_to_display_count} more candidate{ remaining_candidates_to_display_count !== 1 ? "s" : null }...</span>
-          </Link> : null
-        }
-        {/* this.state.display_all_candidates_flag && this.state.candidateList.length > NUMBER_OF_CANDIDATES_TO_DISPLAY ?
-          <BallotSideBarLink url={"#" + this.props.we_vote_id}
-                             label={"Click to show fewer candidates..."}
-                             displaySubtitles={false}
-                             onClick={this.toggleDisplayAllCandidates} /> : null
-        */}
-        { this.state.display_office_unfurled ?
-          <Link onClick={this.toggleExpandDetails}>
-            <div className="BallotItem__view-more u-items-center u-no-break d-print-none">
-              Show less...</div>
-          </Link> :
-          <Link onClick={this.toggleExpandDetails}>
-            <div className="BallotItem__view-more u-items-center u-no-break d-print-none">
-              <i className="fa fa-plus BallotItem__view-more-plus" aria-hidden="true" />
-              { total_number_of_candidates_to_display > 1 ?
-                <span> View all {total_number_of_candidates_to_display} candidates...</span> :
-                <span> View candidate...</span>
-              }
-            </div>
-          </Link>
-        }
-        </div>
-      </div>;
-  }
-}
+// import React, { Component } from "react";
+// import PropTypes from "prop-types";
+// import { OverlayTrigger, Popover } from "react-bootstrap";
+// import { Link } from "react-router";
+// import { cordovaDot, historyPush } from "../../utils/cordovaUtils";
+// import TextTruncate from "react-text-truncate";
+// import { toTitleCase } from "../../utils/textFormat";
+// import BookmarkToggle from "../Bookmarks/BookmarkToggle";
+// import ImageHandler from "../ImageHandler";
+// import IssueStore from "../../stores/IssueStore";
+// import ItemActionBar from "../Widgets/ItemActionBar";
+// import ItemPositionStatementActionBar from "../Widgets/ItemPositionStatementActionBar";
+// import ItemSupportOpposeRaccoon from "../Widgets/ItemSupportOpposeRaccoon";
+// import LearnMore from "../Widgets/LearnMore";
+// import { renderLog } from "../../utils/logging";
+// import OrganizationPositionItem from "./OrganizationPositionItem";
+// import OrganizationStore from "../../stores/OrganizationStore";
+// import SupportStore from "../../stores/SupportStore";
+// import VoterGuideStore from "../../stores/VoterGuideStore";
+//
+// const NUMBER_OF_CANDIDATES_TO_DISPLAY = 30; // On voter guide pages, we want to show all
+//
+// // This is based on components/Ballot/OfficeItemCompressed
+// export default class VoterGuideOfficeItemCompressed extends Component {
+//   static propTypes = {
+//     we_vote_id: PropTypes.string.isRequired,
+//     ballot_item_display_name: PropTypes.string.isRequired,
+//     candidate_list: PropTypes.array,
+//     kind_of_ballot_item: PropTypes.string.isRequired,
+//     link_to_ballot_item_page: PropTypes.bool,
+//     location: PropTypes.object,
+//     organization: PropTypes.object.isRequired,
+//     organization_we_vote_id: PropTypes.string.isRequired,
+//     toggleCandidateModal: PropTypes.func,
+//   };
+//
+//   constructor (props) {
+//     super(props);
+//     this.state = {
+//       candidateList: [],
+//       display_all_candidates_flag: false,
+//       display_office_unfurled: false,
+//       editMode: false,
+//       maximum_organization_display: 4,
+//       organization: {},
+//       show_position_statement: true,
+//       transitioning: false,
+//     };
+//
+//     this.getCandidateLink = this.getCandidateLink.bind(this);
+//     this.getOfficeLink = this.getOfficeLink.bind(this);
+//     this.goToCandidateLink = this.goToCandidateLink.bind(this);
+//     this.goToOfficeLink = this.goToOfficeLink.bind(this);
+//     this.openCandidateModal = this.openCandidateModal.bind(this);
+//     this.toggleDisplayAllCandidates = this.toggleDisplayAllCandidates.bind(this);
+//     this.toggleExpandDetails = this.toggleExpandDetails.bind(this);
+//   }
+//
+//   componentDidMount () {
+//     this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
+//     this.organizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
+//     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
+//     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
+//     this.onVoterGuideStoreChange();
+//
+//     if (this.props.candidate_list && this.props.candidate_list.length) {
+//       // DALE 2018-07-31 We now retrieve the full candidate data in voterBallotItemsRetrieve
+//       // if (CandidateStore.getNumberOfCandidatesRetrievedByOffice(this.props.we_vote_id) === 0) {
+//       //   // console.log("Calling candidatesRetrieve: ", this.props.we_vote_id);
+//       //   CandidateActions.candidatesRetrieve(this.props.we_vote_id);
+//       // }
+//
+//       // this.props.candidate_list.forEach( function (candidate) {
+//       //   if (candidate && candidate.hasOwnProperty("we_vote_id") && !CandidateStore.isCandidateInStore(candidate.we_vote_id)) {
+//       //     // Slows down the browser too much when run for all candidates
+//       //     // VoterGuideActions.voterGuidesToFollowRetrieveByBallotItem(candidate.we_vote_id, "CANDIDATE");
+//       //   }
+//       // });
+//       this.setState({
+//         candidateList: this.props.candidate_list,
+//       });
+//     }
+//     if (this.props.organization && this.props.organization.organization_we_vote_id) {
+//       this.setState({
+//         organization: this.props.organization,
+//       });
+//     }
+//   }
+//
+//   componentWillReceiveProps (nextProps) {
+//     // console.log("officeItemCompressed componentWillReceiveProps, nextProps.candidate_list:", nextProps.candidate_list);
+//     // 2018-05-10 I don't think we need to trigger a new render because the incoming candidate_list should be the same
+//     // if (nextProps.candidate_list && nextProps.candidate_list.length) {
+//     //   this.setState({
+//     //     candidateList: nextProps.candidate_list,
+//     //   });
+//     // }
+//
+//     // Only update organization if it is a different organization
+//     if (nextProps.organization && nextProps.organization.organization_we_vote_id && this.state.organization.organization_we_vote_id !== nextProps.organization.organization_we_vote_id) {
+//       this.setState({
+//         organization: OrganizationStore.getOrganizationByWeVoteId(nextProps.organization.organization_we_vote_id),
+//       });
+//     }
+//   }
+//
+//   componentWillUnmount () {
+//     this.issueStoreListener.remove();
+//     this.organizationStoreListener.remove();
+//     this.supportStoreListener.remove();
+//     this.voterGuideStoreListener.remove();
+//   }
+//
+//   onIssueStoreChange () {
+//     this.setState({
+//       transitioning: false,
+//     });
+//   }
+//
+//   onVoterGuideStoreChange () {
+//     this.setState({ transitioning: false });
+//   }
+//
+//   onOrganizationStoreChange (){
+//     // console.log("VoterGuideOfficeItemCompressed onOrganizationStoreChange, org_we_vote_id: ", this.state.organization.organization_we_vote_id);
+//     this.setState({
+//       organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
+//     });
+//   }
+//
+//   onSupportStoreChange () {
+//     // Whenever positions change, we want to make sure to get the latest organization, because it has
+//     //  position_list_for_one_election and position_list_for_all_except_one_election attached to it
+//     this.setState({
+//       organization: OrganizationStore.getOrganizationByWeVoteId(this.state.organization.organization_we_vote_id),
+//       transitioning: false,
+//     });
+//   }
+//
+//   toggleDisplayAllCandidates () {
+//     this.setState({ display_all_candidates_flag: !this.state.display_all_candidates_flag });
+//   }
+//
+//   toggleExpandDetails () {
+//     let { location: { pathname, search, hash }, we_vote_id } = this.props;
+//     let currentUrlWithoutHash = pathname + search;
+//     let currentBallotIdInUrl = hash.slice(1);
+//     if (currentBallotIdInUrl !== we_vote_id) {
+//       historyPush(currentUrlWithoutHash + "#" + we_vote_id);
+//     }
+//     this.setState({ display_office_unfurled: !this.state.display_office_unfurled });
+//   }
+//
+//   openCandidateModal (candidate) {
+//     // console.log("this.state.candidate: ", this.state.candidate);
+//     if (candidate && candidate.we_vote_id) {
+//       this.props.toggleCandidateModal(candidate);
+//     }
+//   }
+//
+//   getCandidateLink (candidate_we_vote_id) {
+//     return "/candidate/" + candidate_we_vote_id + "/btvg/" + this.state.organization.organization_we_vote_id;
+//   }
+//
+//   getOfficeLink () {
+//     return "/office/" + this.props.we_vote_id + "/btvg/" + this.state.organization.organization_we_vote_id;
+//   }
+//
+//   goToCandidateLink (candidate_we_vote_id) {
+//     let candidate_link = this.getCandidateLink(candidate_we_vote_id);
+//     historyPush(candidate_link);
+//   }
+//
+//   goToOfficeLink () {
+//     let office_link = this.getOfficeLink();
+//     historyPush(office_link);
+//   }
+//
+//   doesOrganizationHavePositionOnCandidate (candidate_we_vote_id) {
+//     return OrganizationStore.doesOrganizationHavePositionOnCandidate(this.state.organization.organization_we_vote_id, candidate_we_vote_id);
+//   }
+//
+//   getOrganizationPositionForThisCandidate (candidate_we_vote_id, position_list_for_one_election) {
+//     // console.log("getOrganizationPositionForThisCandidate position_list_for_one_election: ", position_list_for_one_election);
+//     let one_position_to_return = {};
+//     if (position_list_for_one_election) {
+//       position_list_for_one_election.forEach((one_position) => {
+//         // console.log("getOrganizationPositionForThisCandidate candidate_we_vote_id: ", candidate_we_vote_id, ", one_position: ", one_position);
+//         if (one_position.ballot_item_we_vote_id === candidate_we_vote_id) {
+//           // console.log("getOrganizationPositionForThisCandidate one_position found to return");
+//           // Because this is a forEach, we aren't able to break out of the loop
+//           one_position_to_return = one_position;
+//         }
+//       });
+//     }
+//
+//     return one_position_to_return;
+//   }
+//
+//   closeYourNetworkIsUndecidedPopover () {
+//     this.refs["undecided-overlay"].hide();
+//   }
+//
+//   render () {
+//     renderLog(__filename);
+//     let { ballot_item_display_name, we_vote_id } = this.props;
+//     ballot_item_display_name = toTitleCase(ballot_item_display_name);
+//     let unsortedCandidateList = this.state.candidateList.slice(0);
+//     let total_number_of_candidates_to_display = this.state.candidateList.length;
+//     let remaining_candidates_to_display_count = 0;
+//     // let advisorsThatMakeVoterIssuesScoreDisplay;
+//     // let advisorsThatMakeVoterIssuesScoreCount = 0;
+//     // let advisorsThatMakeVoterNetworkScoreCount = 0;
+//     // let advisorsThatMakeVoterNetworkScoreDisplay = null;
+//     let arrayOfCandidatesVoterSupports = [];
+//     let atLeastOneCandidateChosenByNetwork = false;
+//     // let atLeastOneCandidateChosenByIssueScore = false;
+//     // let candidateWithMostSupportFromNetwork = null;
+//     // let candidateWeVoteWithMostSupportFromNetwork = null;
+//     // let candidateWithHighestIssueScore = null;
+//     // let candidateWeVoteIdWithHighestIssueScore = null;
+//     let voterSupportsAtLeastOneCandidate = false;
+//     let supportProps;
+//     let candidate_has_voter_support;
+//     let voterIssuesScoreForCandidate;
+//     let sortedCandidateList;
+//     let limitedCandidateList;
+//
+//     // Prepare an array of candidate names that are supported by voter
+//     unsortedCandidateList.forEach((candidate) => {
+//       supportProps = SupportStore.get(candidate.we_vote_id);
+//       if (supportProps) {
+//         candidate_has_voter_support = supportProps.is_support;
+//         voterIssuesScoreForCandidate = IssueStore.getIssuesScoreByBallotItemWeVoteId(candidate.we_vote_id);
+//         candidate.voterNetworkScoreForCandidate = Math.abs(supportProps.support_count - supportProps.oppose_count);
+//         candidate.voterIssuesScoreForCandidate = Math.abs(voterIssuesScoreForCandidate);
+//         candidate.is_support = supportProps.is_support;
+//         if (candidate_has_voter_support) {
+//           arrayOfCandidatesVoterSupports.push(candidate.ballot_item_display_name);
+//           voterSupportsAtLeastOneCandidate = true;
+//         }
+//       }
+//     });
+//
+//     unsortedCandidateList.sort((optionA, optionB)=>optionB.voterNetworkScoreForCandidate - optionA.voterNetworkScoreForCandidate ||
+//                                                    (optionA.is_support === optionB.is_support ? 0 : optionA.is_support ? -1 : 1) ||
+//                                                    optionB.voterIssuesScoreForCandidate - optionA.voterIssuesScoreForCandidate);
+//     limitedCandidateList = unsortedCandidateList;
+//     sortedCandidateList = unsortedCandidateList;
+//     if (!this.state.display_all_candidates_flag && this.state.candidateList.length > NUMBER_OF_CANDIDATES_TO_DISPLAY) {
+//       limitedCandidateList = sortedCandidateList.slice(0, NUMBER_OF_CANDIDATES_TO_DISPLAY);
+//       remaining_candidates_to_display_count = this.state.candidateList.length - NUMBER_OF_CANDIDATES_TO_DISPLAY;
+//     }
+//     // If the voter isn't supporting any candidates, then figure out which candidate the voter's network likes the best
+//     if (arrayOfCandidatesVoterSupports.length === 0){
+//       // This function finds the highest support count for each office but does not handle ties. If two candidates have
+//       // the same network support count, only the first candidate will be displayed.
+//       let largestNetworkSupportCount = 0;
+//       let network_support_count;
+//       let network_oppose_count;
+//
+//       sortedCandidateList.forEach((candidate) => {
+//         // Support in voter's network
+//         supportProps = SupportStore.get(candidate.we_vote_id);
+//         if (supportProps) {
+//           network_support_count = supportProps.support_count;
+//           network_oppose_count = supportProps.oppose_count;
+//
+//           if (network_support_count > network_oppose_count) {
+//             if (network_support_count > largestNetworkSupportCount) {
+//               largestNetworkSupportCount = network_support_count;
+//               // candidateWithMostSupportFromNetwork = candidate.ballot_item_display_name;
+//               // candidateWeVoteWithMostSupportFromNetwork = candidate.we_vote_id;
+//               atLeastOneCandidateChosenByNetwork = true;
+//             }
+//           }
+//         }
+//       });
+//     }
+//
+//     let organization_position_for_this_candidate;
+//     let candidate_we_vote_id;
+//     let candidateSupportStore;
+//     const yourNetworkIsUndecidedPopover =
+//       <Popover id="popover-trigger-click-root-close"
+//                title={<span>Your Network is Undecided <span className="fa fa-times pull-right u-cursor--pointer" aria-hidden="true" /></span>}
+//                onClick={this.closeYourNetworkIsUndecidedPopover}>
+//         Your friends, and the organizations you listen to, are <strong>Your Network</strong>.
+//         Everyone in your network
+//         that <span className="u-no-break"> <img src={cordovaDot("/img/global/icons/thumbs-up-color-icon.svg")} width="20" height="20" /> supports</span> a
+//         candidate adds
+//         +1 to that candidate's <strong>Score in Your Network</strong>. None of the candidates running
+//         for {ballot_item_display_name} have more support in your network than the other candidates.
+//       </Popover>;
+//
+//     return <div className="card-main office-item">
+//       <a className="anchor-under-header" name={we_vote_id} />
+//       <div className="card-main__content">
+//         {/* Desktop */}
+//         <span className="d-none d-sm-block">
+//           <BookmarkToggle we_vote_id={we_vote_id} type="OFFICE" />
+//         </span>
+//         {/* Mobile - "show more" and "show less" not used */}
+//
+//         {/* On the voter guide, we bring the size of the office name down so we can emphasize the candidate being supported */}
+//         <h2 className="h4 u-f5 card-main__ballot-name u-gray-dark u-stack--sm">
+//           <span className="d-print-none" onClick={this.toggleExpandDetails}>
+//             { this.state.display_office_unfurled ?
+//               <span className="glyphicon glyphicon-triangle-bottom u-font-size6 d-print-none u-push--xs"/> :
+//               null
+//             }
+//             {ballot_item_display_name}
+//           </span>
+//
+//           {/* Print */}
+//           <span className="u-f3 visible-print">
+//             {ballot_item_display_name}
+//           </span>
+//         </h2>
+//
+//         {/* *************************
+//         Only show the candidates if the Office is "unfurled"
+//         ************************* */}
+//         { this.state.display_office_unfurled ?
+//           <span>{limitedCandidateList.map((one_candidate) => {
+//             candidate_we_vote_id = one_candidate.we_vote_id;
+//             candidateSupportStore = SupportStore.get(candidate_we_vote_id);
+//             let organizationsToFollowSupport = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdSupports(candidate_we_vote_id);
+//             let organizationsToFollowOppose = VoterGuideStore.getVoterGuidesToFollowForBallotItemIdOpposes(candidate_we_vote_id);
+//
+//             let candidate_party_text = one_candidate.party && one_candidate.party.length ? one_candidate.party + ". " : "";
+//             let candidate_description_text = one_candidate.twitter_description && one_candidate.twitter_description.length ? one_candidate.twitter_description : "";
+//             let candidate_text = candidate_party_text + candidate_description_text;
+//
+//             organization_position_for_this_candidate = this.getOrganizationPositionForThisCandidate(candidate_we_vote_id, this.state.organization.position_list_for_one_election);
+//
+//             return <div key={candidate_we_vote_id} className="u-stack--md">
+//               <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
+//                 {/* Candidate Photo, only shown in Desktop */}
+//                 {this.state.display_office_unfurled ?
+//                   <div className="d-none d-sm-block" onClick={this.props.link_to_ballot_item_page ? this.toggleExpandDetails : null}>
+//                     <ImageHandler className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
+//                                   sizeClassName="icon-candidate-small u-push--sm "
+//                                   imageUrl={one_candidate.candidate_photo_url_large}
+//                                   alt="candidate-photo"
+//                                   kind_of_ballot_item="CANDIDATE" />
+//                   </div> :
+//                   null
+//                 }
+//                 <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
+//                   {/* Candidate Name */}
+//                   <h4 className={"card-main__candidate-name" + (this.doesOrganizationHavePositionOnCandidate(candidate_we_vote_id) ? " u-f2" : " u-f6")}>
+//                     <a onClick={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null}>
+//                       <TextTruncate line={1}
+//                                     truncateText="…"
+//                                     text={one_candidate.ballot_item_display_name}
+//                                     textTruncateChild={null}/>
+//                     </a>
+//                   </h4>
+//                   {/* Description under candidate name */}
+//                   <LearnMore text_to_display={candidate_text}
+//                              on_click={this.props.link_to_ballot_item_page ? () => this.goToCandidateLink(one_candidate.we_vote_id) : null} />
+//
+//                   {/* Organization Endorsement */}
+//                   { this.doesOrganizationHavePositionOnCandidate(candidate_we_vote_id) && organization_position_for_this_candidate ?
+//                     <OrganizationPositionItem key={organization_position_for_this_candidate.position_we_vote_id}
+//                                               position={organization_position_for_this_candidate}
+//                                               organization={this.state.organization}
+//                                               editMode={this.state.editMode}
+//                                               turnOffLogo
+//                                               turnOffName
+//                              /> :
+//                     null }
+//
+//                   {/* Organization's Followed AND to Follow Items -- only show for promoted candidate */}
+//                   { this.doesOrganizationHavePositionOnCandidate(candidate_we_vote_id) ?
+//                     <div>
+//                       <div className="u-flex u-flex-auto u-flex-row u-justify-between u-items-center u-min-50">
+//                         {/* Positions in Your Network and Possible Voter Guides to Follow */}
+//                         <ItemSupportOpposeRaccoon ballotItemWeVoteId={candidate_we_vote_id}
+//                                                   ballot_item_display_name={one_candidate.ballot_item_display_name}
+//                                                   currentBallotIdInUrl={this.props.location.hash.slice(1)}
+//                                                   display_raccoon_details_flag={this.state.display_office_unfurled}
+//                                                   goToCandidate={() => this.goToCandidateLink(one_candidate.we_vote_id)}
+//                                                   maximumOrganizationDisplay={this.state.maximum_organization_display}
+//                                                   organizationsToFollowSupport={organizationsToFollowSupport}
+//                                                   organizationsToFollowOppose={organizationsToFollowOppose}
+//                                                   popoverBottom
+//                                                   supportProps={candidateSupportStore}
+//                                                   type="CANDIDATE"
+//                                                   urlWithoutHash={this.props.location.pathname + this.props.location.search}
+//                                                   we_vote_id={this.props.we_vote_id} />
+//                       </div>
+//                     </div> :
+//                     null}
+//                 </div>
+//               </div>
+//             </div>;
+//           })}</span> :
+//           null
+//         }
+//
+//         {/* *************************
+//         If the office is "rolled up", show some details for the organization's endorsement
+//         ************************* */}
+//         { !this.state.display_office_unfurled ?
+//           <div>
+//             { this.state.candidateList.map( (one_candidate) => {
+//                 if (this.doesOrganizationHavePositionOnCandidate(one_candidate.we_vote_id) ) {
+//                   organization_position_for_this_candidate = this.getOrganizationPositionForThisCandidate(one_candidate.we_vote_id, this.state.organization.position_list_for_one_election);
+//
+//                   if (organization_position_for_this_candidate) {
+//                     candidate_we_vote_id = one_candidate.we_vote_id;
+//                     candidateSupportStore = SupportStore.get(candidate_we_vote_id);
+//
+//                     let is_support = false;
+//                     let is_oppose = false;
+//                     let voter_statement_text = false;
+//                     if (candidateSupportStore !== undefined) {
+//                       is_support = candidateSupportStore.is_support;
+//                       is_oppose = candidateSupportStore.is_oppose;
+//                       voter_statement_text = candidateSupportStore.voter_statement_text;
+//                     }
+//
+//                     return <div key={candidate_we_vote_id}>
+//                       {/* Organization Endorsement */}
+//                       <OrganizationPositionItem ballotItemLink={this.getCandidateLink(candidate_we_vote_id)}
+//                                                 key={organization_position_for_this_candidate.position_we_vote_id}
+//                                                 position={organization_position_for_this_candidate}
+//                                                 organization={this.state.organization}
+//                                                 editMode={this.state.editMode}
+//                       />
+//                       <div className="flex">
+//                           <ItemActionBar ballot_item_display_name={one_candidate.ballot_item_display_name}
+//                                          ballot_item_we_vote_id={candidate_we_vote_id}
+//                                          commentButtonHide
+//                                          currentBallotIdInUrl={this.props.location.hash.slice(1)}
+//                                          shareButtonHide
+//                                          supportProps={candidateSupportStore}
+//                                          transitioning={this.state.transitioning}
+//                                          type="CANDIDATE"
+//                                          urlWithoutHash={this.props.location.pathname + this.props.location.search}
+//                                          we_vote_id={this.props.we_vote_id}
+//                                          />
+//                       </div>
+//                       {/* DESKTOP: If voter has taken position, offer the comment bar */}
+//                       {is_support || is_oppose || voter_statement_text ?
+//                         <div className="hidden-xs o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
+//                           <div
+//                             className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm">&nbsp;
+//                           </div>
+//                           <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
+//                             <ItemPositionStatementActionBar ballot_item_display_name={one_candidate.ballot_item_display_name}
+//                                                             ballot_item_we_vote_id={candidate_we_vote_id}
+//                                                             supportProps={candidateSupportStore}
+//                                                             transitioning={this.state.transitioning}
+//                                                             type="CANDIDATE"
+//                                                             shown_in_list/>
+//                           </div>
+//                         </div> :
+//                         null }
+//                       {/* MOBILE: If voter has taken position, offer the comment bar */}
+//                       {is_support || is_oppose || voter_statement_text ?
+//                         <div className="d-block d-sm-none o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
+//                           <div
+//                             className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm">&nbsp;
+//                           </div>
+//                           <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
+//                             <ItemPositionStatementActionBar ballot_item_display_name={one_candidate.ballot_item_display_name}
+//                                                             ballot_item_we_vote_id={candidate_we_vote_id}
+//                                                             supportProps={candidateSupportStore}
+//                                                             transitioning={this.state.transitioning}
+//                                                             type="CANDIDATE"
+//                                                             shown_in_list/>
+//                           </div>
+//                         </div> :
+//                         null }
+//                     </div>;
+//                   }
+//                 }
+//                 return null;
+//               })
+//             }
+//             {/* Now that we are out of the candidate loop... */}
+//             { voterSupportsAtLeastOneCandidate ?
+//               null :
+//               <span>
+//                 { atLeastOneCandidateChosenByNetwork ?
+//                   null :
+//                   <div className="u-tr">
+//                     <OverlayTrigger trigger="click"
+//                                   ref="undecided-overlay"
+//                                   onExit={this.closeYourNetworkIsUndecidedPopover}
+//                                   rootClose
+//                                   placement="top"
+//                                   overlay={yourNetworkIsUndecidedPopover}>
+//                       <span className=" u-cursor--pointer">Your network is undecided <i className="fa fa-info-circle fa-md network-positions-stacked__info-icon-for-popover d-print-none" aria-hidden="true" /></span>
+//                     </OverlayTrigger>
+//                   </div>
+//                 }
+//               </span>
+//             }
+//           </div> :
+//           null
+//         }
+//
+//         { !this.state.display_all_candidates_flag && this.state.display_office_unfurled && remaining_candidates_to_display_count ?
+//           <Link onClick={this.toggleDisplayAllCandidates}>
+//             <span className="u-items-center u-no-break d-print-none">
+//               Click to show {remaining_candidates_to_display_count} more candidate{ remaining_candidates_to_display_count !== 1 ? "s" : null }...</span>
+//           </Link> : null
+//         }
+//         {/* this.state.display_all_candidates_flag && this.state.candidateList.length > NUMBER_OF_CANDIDATES_TO_DISPLAY ?
+//           <BallotSideBarLink url={"#" + this.props.we_vote_id}
+//                              label={"Click to show fewer candidates..."}
+//                              displaySubtitles={false}
+//                              onClick={this.toggleDisplayAllCandidates} /> : null
+//         */}
+//         { this.state.display_office_unfurled ?
+//           <Link onClick={this.toggleExpandDetails}>
+//             <div className="BallotItem__view-more u-items-center u-no-break d-print-none">
+//               Show less...</div>
+//           </Link> :
+//           <Link onClick={this.toggleExpandDetails}>
+//             <div className="BallotItem__view-more u-items-center u-no-break d-print-none">
+//               <i className="fa fa-plus BallotItem__view-more-plus" aria-hidden="true" />
+//               { total_number_of_candidates_to_display > 1 ?
+//                 <span> View all {total_number_of_candidates_to_display} candidates...</span> :
+//                 <span> View candidate...</span>
+//               }
+//             </div>
+//           </Link>
+//         }
+//         </div>
+//       </div>;
+//   }
+// }

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -129,7 +129,7 @@ export default class FollowToggle extends Component {
     if (!this.state) { return <div />; }
 
     let { we_vote_id: weVoteId, organization_for_display: organizationForDisplay } = this.props;
-    let classNameOverride = this.props.classNameOverride || "";
+    // let classNameOverride = this.props.classNameOverride || "";
     let isLookingAtSelf = this.state.voter.linked_organization_we_vote_id === weVoteId;
 
     // You should not be able to follow yourself

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -830,8 +830,9 @@ export default class Ballot extends Component {
                               }
                             });
                             return <div className="col-6 col-sm-3 u-stack--md u-inset__h--sm" key={one_type}>
-                              <Button block active={one_type === this.state.ballot_item_filter_type}
-                                      onClick={() => this.setBallotItemFilterType(one_type)}>
+                              <Button variant="outline-secondary" block active={one_type === this.state.ballot_item_filter_type}
+                                      onClick={() => this.setBallotItemFilterType(one_type)}
+                                      className={"btn_ballot_filter"}>
                                 {one_type}&nbsp;({ballotItemsByFilterType.length})
                               </Button>
                             </div>;

--- a/src/js/routes/More/Donate.jsx
+++ b/src/js/routes/More/Donate.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from "react";
-import { Button, FormGroup, Form, InputGroup, FormControl } from "react-bootstrap";
+import { Button, Form, InputGroup, FormControl } from "react-bootstrap";
 import Helmet from "react-helmet";
 import AnalyticsActions from "../../actions/AnalyticsActions";
 import DonationForm from "../../components/Donation/DonationForm";
@@ -8,25 +8,6 @@ import DonateStore from "../../stores/DonateStore";
 import DonationListForm from "../../components/Donation/DonationListForm";
 import { renderLog } from "../../utils/logging";
 import VoterStore from "../../stores/VoterStore";
-
-const styles = {
-  formCheck: {
-    verticalAlign: "middle",
-    textAlign: "center",
-  },
-  td: {
-    verticalAlign: "middle",
-    textAlign: "center",
-  },
-  th: {
-    textAlign: "center",
-  },
-  Card: {
-    borderTopColor: "transparent",
-    height: "500px",
-    overflowY: "auto",
-  },
-};
 
 export default class Donate extends Component {
   constructor (props) {

--- a/src/sass/components/_bootstrap3LeftBehind.scss
+++ b/src/sass/components/_bootstrap3LeftBehind.scss
@@ -1,6 +1,4 @@
 // Some css that was in the old react-bootstrap-sass prior to October 2018
-// eslint turned off in /WebApp/.stylelintrc
-//$white:    #fff !default;
 $gray-100: #f8f9fa !default;
 $gray-200: #e9ecef !default;
 $gray-300: #dee2e6 !default;
@@ -10,7 +8,7 @@ $gray-600: #6c757d !default;
 $gray-700: #495057 !default;
 $gray-800: #343a40 !default;
 $gray-900: #212529 !default;
-//$black:    #000 !default;
+$body-color:                $gray-900 !default;
 
 $padding-base-vertical:     6px !default;
 $padding-base-horizontal:   12px !default;
@@ -24,41 +22,64 @@ $padding-small-horizontal:  10px !default;
 $padding-xs-vertical:       1px !default;
 $padding-xs-horizontal:     5px !default;
 
-$border-width:                1px !default;
-$border-color:                $gray-300 !default;
+$border-width:              1px !default;
+$border-color:              $gray-300 !default;
 
-$font-size-base:              1rem !default;  // assumes the browser derault, typically 16px
-$font-size-large:         ceil(($font-size-base * 1.25)) !default; // ~18px
-$font-size-small:         ceil(($font-size-base * .85)) !default; // ~12px
+$font-size-base:            1rem !default;  // assumes the browser derault, typically 16px
+$font-size-large:           ceil(($font-size-base * 1.25)) !default; // ~18px
+$font-size-small:           ceil(($font-size-base * .85)) !default; // ~12px
 
-$border-radius:               .25rem !default;
-$border-radius-lg:            .3rem !default;
-$border-radius-sm:            .2rem !default;
+$border-radius:             .25rem !default;
+$border-radius-lg:          .3rem !default;
+$border-radius-sm:          .2rem !default;
 
-$input-border-radius:                   $border-radius !default;
-$input-border-radius-lg:                $border-radius-lg !default;
-$input-border-radius-sm:                $border-radius-sm !default;
+$input-border-radius:       $border-radius !default;
+$input-border-radius-lg:    $border-radius-lg !default;
+$input-border-radius-sm:    $border-radius-sm !default;
 $line-height-large:         1.3333333 !default; // extra decimals for Win 8.1 Chrome
 $line-height-small:         1.5 !default;
 
 // Hacks within hacks October 2018
 $input-height-small:        18px;  //     (floor($font-size-small * $line-height-small) + ($padding-small-vertical * 2) + 2) !default;
-$input-border-radius-small:    $input-border-radius-sm;
-$input-border-radius-large:        $input-border-radius-lg;
+$input-border-radius-small: $input-border-radius-sm;
+$input-border-radius-large: $input-border-radius-lg;
 // End hacks within hacks October 2018
 
 
-$input-btn-border-width:      $border-width !default;
-$input-color:                           $gray-700 !default;
-$input-border-color:                    $gray-400 !default;
-$input-border-width:                    $input-btn-border-width !default;
-$input-box-shadow:                      inset 0 1px 1px rgba($black, .075) !default;
+$input-btn-border-width:    $border-width !default;
+$input-color:               $gray-700 !default;
+$input-border-color:        $gray-400 !default;
+$input-border-width:        $input-btn-border-width !default;
+$input-box-shadow:          inset 0 1px 1px rgba($black, .075) !default;
 
 
-$input-group-addon-color:               $input-color !default;
-$input-group-addon-bg:                  $gray-200 !default;
-$input-group-addon-border-color:        $input-border-color !default;
+$input-group-addon-color:           $input-color !default;
+$input-group-addon-bg:              $gray-200 !default;
+$input-group-addon-border-color:    $input-border-color !default;
 
+$popover-font-size:                 $font-size-small !default;
+$popover-bg:                        $white !default;
+$popover-max-width:                 276px !default;
+$popover-border-width:              $border-width !default;
+$popover-border-color:              rgba($black, .2) !default;
+$popover-border-radius:             $border-radius-lg !default;
+$popover-box-shadow:                0 .25rem .5rem rgba($black, .2) !default;
+
+$headings-color:                    inherit !default;
+$popover-header-bg:                 darken($popover-bg, 3%) !default;
+$popover-header-color:              $headings-color !default;
+$popover-header-padding-y:          .5rem !default;
+$popover-header-padding-x:          .75rem !default;
+
+$popover-body-color:                $body-color !default;
+$popover-body-padding-y:            $popover-header-padding-y !default;
+$popover-body-padding-x:            $popover-header-padding-x !default;
+
+$popover-arrow-width:               1rem !default;
+$popover-arrow-height:              .5rem !default;
+$popover-arrow-color:               $popover-bg !default;
+
+$popover-arrow-outer-color:         fade-in($popover-border-color, .05) !default;
 
 .nav>li>a {
   padding: 10px 15px;
@@ -228,6 +249,7 @@ a {
     }
   }
 }
+
 .site-search__button, .site-search__clear {
   border: none;
   height: 34px;
@@ -235,6 +257,31 @@ a {
     background-color: #fff;
     border-color: #ccc;
 }
+
+.candidate-h2 {
+  margin-top: 10px;
+}
+
+.bs-popover-bottom {
+  margin-top: $popover-arrow-height;
+  border-radius: .3rem;
+  border: 1px solid $brand-blue;
+  box-shadow: 2px 2px 4px 2px $gray-light;
+
+  .arrow {
+    top: calc((#{$popover-arrow-height} + #{$popover-border-width}) * -1);
+  }
+
+  .arrow::before,
+  .arrow::after {
+    border-width: 0 ($popover-arrow-width / 2) $popover-arrow-height ($popover-arrow-width / 2);
+  }
+}
+
+.card-popover-body {
+  padding: $space-inset-xs;
+}
+
 
 //
 //.input-group-btn:last-child>.btn, .input-group-btn:last-child>.btn-group {
@@ -277,3 +324,4 @@ a {
 //  -ms-user-select: none;
 //  user-select: none;
 //}
+

--- a/src/sass/components/_buttons.scss
+++ b/src/sass/components/_buttons.scss
@@ -33,3 +33,9 @@
   margin-bottom: $space-sm;
   margin-right: $space-sm;
 }
+
+.btn_ballot_filter {
+  background-color: white;
+  border-color: darkgrey;
+  color: black;
+}

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -404,6 +404,7 @@ $candidate-font-size: .875rem;
   padding-top: $space-none;
   padding-left: $space-none;
   padding-right: $space-none;
+  background-color: white;
   max-width: 350px;
   @include breakpoints (max mid-small) {
     max-width: 290px;
@@ -412,4 +413,9 @@ $candidate-font-size: .875rem;
   &__width--minimum {
     width: 90vw;
   }
+}
+
+.card-popover-header {
+  background-color: $brand-blue;
+  color: white;
 }


### PR DESCRIPTION
Network organizations, listen and ignore renders well now.
The TinyPosition bar renders well, and the Popover now works.
There is an open issue with the organization popovers where the
translate3d css moves them partially off the screen ... will tackle tomorrow.
Lots of other misc. styling fixes, most of which is captured in
_bootstrap3LeftBehind.scss

The "Failed prop type: Invalid prop `outOfBoundaries` of type `boolean`
supplied to `Popover`" warning is still there, it appears to be a known
issue, I'll add a comment to the react-bootstrap package.  It doesn't
seem to cause any problems.

voterGuidesToFollowRetrieve is slower than a month ago, and worst case
can take minutes to complete, so testing is tedious.

The WebApp contains a lot of dead and abandoned code, that was copied
from some other  class, often with comments and variable names that no
longer make sense -- copying provides a short term productivity boost,
that is drowned by long term maintainabilty and reliability issues.  We
should really avoid quickly copying classes, it is painful to dig through
it later, and reduces the chances of reuse.  Reuse brings reliability
through well tested components and then productivity follows.

Figuring out css and rendering issues becomes many times tougher when
there is so much dead code and outdated variable names, since
you start with rendered styles then try to find them in the code.
