### PR TITLE
Resolved issue #1706: Reposition share button & additional minor fix

### DIFF
--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -556,12 +556,12 @@ export default class ItemActionBar extends Component {
             <span className="item-actionbar__position-btn-label">Comment</span>
           </button>
         </div> }
-      </div>
 
       { this.props.shareButtonHide ?
         null :
         <ShareButtonDropdown urlBeingShared={urlBeingShared} shareIcon={shareIcon} shareText={"Share"} /> }
       { this.state.showSupportOrOpposeHelpModal ? SupportOrOpposeHelpModal : null}
+      </div>
     </div>;
   }
 }

--- a/src/js/components/Widgets/ShareButtonDropdown.jsx
+++ b/src/js/components/Widgets/ShareButtonDropdown.jsx
@@ -59,7 +59,7 @@ export default class ShareButtonDropdown extends Component {
 
   onButtonBlur () {
     // Delay closing the drop down so that onClick has time to work
-    setTimeout(function () {
+    setTimeout(() => {
       this.closeDropdown();
     }, 250);
   }
@@ -79,13 +79,13 @@ export default class ShareButtonDropdown extends Component {
           {shareIcon} {shareText} <span className="caret" />
         </button>
         {this.state.open ?
-          <ul className="dropdown-menu">
-            <li>
+          <ul className="dropdown-menu d-block">
+            <li className="dropdown-item">
               <a onClick={onCopyLinkClick}>
                   Copy link
               </a>
             </li>
-            <li>
+            <li className="dropdown-item">
               <a onClick={this.shareFacebookComment.bind(this)}>
                   Share on Facebook
               </a>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Resolves issue #1706 and one additional untracked issue

### Changes included this pull request?
ShareButtonDropdown.jsx
- onButtonBlur setTimeout callback encloses context
- dropdown-menu css display:none overwritten with appropriate bootstrap class

ItemActionBar.jsx
- closing div for button group moved down to include share button



