### PR TITLE
Guides list churn

### DIFF
--- a/src/js/actions/VoterGuideActions.js
+++ b/src/js/actions/VoterGuideActions.js
@@ -17,7 +17,7 @@ export default {
 
   voterGuidesToFollowRetrieve: function (election_id, search_string, add_voter_guides_not_from_election, start_retrieve_at_this_number = 0) {
     let maximum_number_to_retrieve = 50;
-    Dispatcher.loadEndpoint("voterGuidesToFollowRetrieve", {
+    return Dispatcher.loadEndpoint("voterGuidesToFollowRetrieve", {
       google_civic_election_id: election_id,
       start_retrieve_at_this_number: start_retrieve_at_this_number,
       maximum_number_to_retrieve: maximum_number_to_retrieve,

--- a/src/js/components/Search/SearchGuidesToFollowBox.js
+++ b/src/js/components/Search/SearchGuidesToFollowBox.js
@@ -9,13 +9,22 @@ export default class SearchGuidesToFollowBox extends Component {
   constructor (props) {
     super(props);
 
+    this.state = {
+      searchPending: null
+    };
+
     this.searchFunction = this.searchFunction.bind(this);
     this.clearFunction = this.clearFunction.bind(this);
   }
 
   searchFunction (search_query) {
+    if (this.state.searchPending && this.state.searchPending.state() === "pending") {
+      this.state.searchPending.abort();
+    }
     let election_id = search_query === "" ? VoterStore.election_id() : 0;
-    VoterGuideActions.voterGuidesToFollowRetrieve(election_id, search_query);
+    this.setState({
+      searchPending: VoterGuideActions.voterGuidesToFollowRetrieve(election_id, search_query)
+    });
   }
 
   clearFunction () {

--- a/src/js/components/Search/SearchGuidesToFollowBox.js
+++ b/src/js/components/Search/SearchGuidesToFollowBox.js
@@ -29,6 +29,6 @@ export default class SearchGuidesToFollowBox extends Component {
                        placeholder="Search by name or Twitter handle"
                        searchFunction={this.searchFunction}
                        clearFunction={this.clearFunction}
-                       searchUpdateDelayTime={1000} />;
+                       searchUpdateDelayTime={100} />;
   }
 }

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -91,7 +91,6 @@ export default class GuideList extends Component {
     //             Ignore
     //           </Button>
     return <div className="guidelist card-child__list-group">
-      <TransitionGroup className="org-ignore">
         {this.state.organizationsToFollow.map((organization) => {
           organizationPositionForThisBallotItem = {};
           if (!organization.is_support_or_positive_rating && !organization.is_oppose_or_negative_rating && !organization.is_information_only && this.state.ballot_item_we_vote_id && organization.organization_we_vote_id) {
@@ -104,26 +103,23 @@ export default class GuideList extends Component {
             }
           }
 
-          return <CSSTransition key={++counter} timeout={500} classNames="fade">
-            <span>
-              <VoterGuideDisplayForList key={organization.organization_we_vote_id}
-                                        {...organization}
-                                        {...organizationPositionForThisBallotItem}>
-                <FollowToggle we_vote_id={organization.organization_we_vote_id}
-                              hide_stop_following_button={this.props.hide_stop_following_button}/>
-                { this.props.hide_ignore_button ?
-                  null :
-                  <button className="btn btn-default btn-sm"
-                          onClick={this.handleIgnore.bind(this, organization.organization_we_vote_id)}>
-                    Ignore
-                  </button>
-                }
-              </VoterGuideDisplayForList>
-            </span>
-          </CSSTransition>;
-          })
+          return (
+            <VoterGuideDisplayForList key={organization.organization_we_vote_id}
+                                      {...organization}
+                                      {...organizationPositionForThisBallotItem}>
+              <FollowToggle we_vote_id={organization.organization_we_vote_id}
+                            hide_stop_following_button={this.props.hide_stop_following_button}/>
+              { this.props.hide_ignore_button ?
+                null :
+                <button className="btn btn-default btn-sm"
+                        onClick={this.handleIgnore.bind(this, organization.organization_we_vote_id)}>
+                  Ignore
+                </button>
+              }
+            </VoterGuideDisplayForList>
+          );
+        })
         }
-      </TransitionGroup>
     </div>;
   }
 }

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Button } from "react-bootstrap";
-import { TransitionGroup, CSSTransition } from "react-transition-group";
 import CandidateStore from "../../stores/CandidateStore";
 import FollowToggle from "../Widgets/FollowToggle";
 import MeasureStore from "../../stores/MeasureStore";
@@ -65,7 +64,6 @@ export default class GuideList extends Component {
     }
 
     // console.log("GuideList organizationsToFollow: ", this.state.organizationsToFollow);
-    let counter = 0;
     let organizationPositionForThisBallotItem = {};
 
     if (this.state.organizationsToFollow === undefined) {

--- a/src/js/dispatcher/Dispatcher.js
+++ b/src/js/dispatcher/Dispatcher.js
@@ -9,7 +9,7 @@ Dispatcher.prototype.loadEndpoint = function (endpoint, data = {}) {
   if (this.$ajax instanceof Function !== true) throw new Error("$ajax handler not initialized");
 
   //console.log("Ajax request in Dispatcher: " + endpoint);
-  this.$ajax({
+  return this.$ajax({
     endpoint,
     data: data,
     success: (res) => {

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -127,7 +127,7 @@ $space-search-right:   10%;
 }
 
 .page-logo > .beta-marker {
-    position: relative;
+  position: relative;
 }
 
 .page-logo > .beta-marker > .beta-marker-inner {
@@ -138,7 +138,7 @@ $space-search-right:   10%;
 }
 
 .page-logo-full-size > .beta-marker > .beta-marker-inner {
-  right: 0px;
+  right: 0;
   top: 18px;
 }
 


### PR DESCRIPTION
Fixes #1710 

- TransitionGroup & CSSTransition were causing a noticeable delay in processing list updates and it seemed queuing prior updates so these are removed. (See also: #1767)
- The loadEndpoint ajax request is bubbled up to the action caller so that in _can_ be aborted. This ensures render for the most recent search term rather then render for the most recent search response. i.e. avoids overlapping requests/response.
- The delay between last change to the search term and making the request is reduced to 100ms to make it more responsive (the above fixes mean it no longer needs to be delayed to 1s).

It would also be a good thing™️ to give the user feedback that a change to the list is underway (initial load or responding to a search term). I've noticed > 5 second response times. Perhaps adding a "pending-" + endpoint action dispatch to Dispatcher.js could be a future improvement.

