### PR TITLE
Eliminate gray gap above ballot and Network pane for both iOS and Android

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -389,12 +389,16 @@ export default class Application extends Component {
     let headRoomSize;
     if (voterGuideShowGettingStartedNavigation || stringContains("/ballot", pathname) || pathname === "/bookmarks") {
       headRoomSize = isIPhoneXR() ? "headroom-secondary-nav__margin-iphone-xr" : "headroom-secondary-nav__margin";
-    } else if (isWebApp()) {
-      headRoomSize = "headroom-wrapper";
-    } else if (isIOS()) {
-      headRoomSize = "headroom-wrapper__cordova-ios";
-    } else {
-      headRoomSize = "headroom-wrapper__cordova-android";
+    } else if (stringContains("/network", pathname)) {
+      if (isWebApp()) {
+        headRoomSize = "headroom-wrapper";
+      } else if (hasIPhoneNotch()) {
+        headRoomSize = "headroom-wrapper__cordova-ios-network-notch";
+      } else if (isIOS()) {
+        headRoomSize = "headroom-wrapper__cordova-ios-network";
+      } else {
+        headRoomSize = "headroom-wrapper__cordova-android";
+      }
     }
 
     let pageHeaderStyle = this.state.we_vote_branding_off ? "page-header__container_branding_off headroom" : "page-header__container headroom";

--- a/src/js/components/Navigation/HeaderSecondaryNavBar.jsx
+++ b/src/js/components/Navigation/HeaderSecondaryNavBar.jsx
@@ -32,9 +32,9 @@ export default class HeaderSecondaryNavBar extends Component {
     super(props);
     this._toggleBallotIntroFollowIssues = this._toggleBallotIntroFollowIssues.bind(this);
     this._toggleBallotIntroOrganizations = this._toggleBallotIntroOrganizations.bind(this);
-    this._openEmailModal = this._openEmailModal.bind(this);
-    this._openFacebookModal = this._openFacebookModal.bind(this);
-    this._openPollingLocatorModal = this._openPollingLocatorModal.bind(this);
+    this._toggleEmailModal = this._toggleEmailModal.bind(this);
+    this._toggleFacebookModal = this._toggleFacebookModal.bind(this);
+    this._togglePollingLocatorModal = this._togglePollingLocatorModal.bind(this);
     this._nextSliderPage = this._nextSliderPage.bind(this);
     this.afterChangeHandler = this.afterChangeHandler.bind(this);
     this.ballotEmailWasSent = this.ballotEmailWasSent.bind(this);
@@ -51,6 +51,7 @@ export default class HeaderSecondaryNavBar extends Component {
       showBallotIntroOrganizations: false,
       showEmailModal: false,
       showFacebookModal: false,
+      showPollingLocatorModal: false,
       successMessage: undefined,  //Used by EmailBallotModal and EmailBallotToFriendsModal
       sender_email_address: "",   //Used by EmailBallotModal and EmailBallotToFriendsModal
       verification_email_sent: false, //Used by EmailBallotModal and EmailBallotToFriendsModal
@@ -118,15 +119,15 @@ export default class HeaderSecondaryNavBar extends Component {
     window.print();
   }
 
-  _openEmailModal () {
+  _toggleEmailModal () {
     this.setState({ showEmailModal: !this.state.showEmailModal });
   }
 
-  _openFacebookModal () {
+  _toggleFacebookModal () {
     this.setState({ showFacebookModal: !this.state.showFacebookModal });
   }
 
-  _openPollingLocatorModal () {
+  _togglePollingLocatorModal () {
     this.setState({ showPollingLocatorModal: !this.state.showPollingLocatorModal });
   }
 
@@ -225,10 +226,10 @@ export default class HeaderSecondaryNavBar extends Component {
 
     const SendEmailModal = <Modal bsPrefix="background-brand-blue modal"
                                   show={this.state.showEmailModal}
-                                  onHide={() => this._openEmailModal(this)}>
+                                  onHide={() => this._toggleEmailModal(this)}>
       <Modal.Body>
        <div className="intro-modal__close">
-         <a onClick={this._openEmailModal}
+         <a onClick={this._toggleEmailModal}
             className={`intro-modal__close-anchor ${hasIPhoneNotch() ? "intro-modal__close-anchor-iphonex" : ""}`}>
            <img src={cordovaDot("/img/global/icons/x-close.png")} alt="close" />
          </a>
@@ -253,10 +254,10 @@ export default class HeaderSecondaryNavBar extends Component {
 
     const SendFacebookModal = <Modal bsPrefix="background-brand-blue modal"
                                   show={this.state.showFacebookModal}
-                                  onHide={() => this._openFacebookModal(this)}>
+                                  onHide={() => this._toggleFacebookModal(this)}>
       <Modal.Body>
         <div className="intro-modal__close">
-          <a onClick={this._openFacebookModal}
+          <a onClick={this._toggleFacebookModal}
              className={`intro-modal__close-anchor ${hasIPhoneNotch() ? "intro-modal__close-anchor-iphonex" : ""}`}>
             <img src={cordovaDot("/img/global/icons/x-close.png")} alt="close" />
           </a>
@@ -279,8 +280,9 @@ export default class HeaderSecondaryNavBar extends Component {
       </Modal.Body>
     </Modal>;
 
+    // October, 2018 - Bootstrap4: See https://react-bootstrap.netlify.com/components/modal
     const ShowPollingLocatorModal = <PollingPlaceLocatorModal show={this.state.showPollingLocatorModal}
-                                  onHide={() => this._openPollingLocatorModal(this)}/>;
+                                                              onExit={this._togglePollingLocatorModal}/>;
 
     let currentPathname = this.props.pathname ? this.props.pathname : "/ballot";
     let ballotBaseUrl = webAppConfig.WE_VOTE_URL_PROTOCOL + (isWebApp() ? webAppConfig.WE_VOTE_HOSTNAME : "WeVote.US") + currentPathname;
@@ -307,13 +309,13 @@ export default class HeaderSecondaryNavBar extends Component {
                                  title="Print"
                                  iconPrint/>
 
-            <SecondaryNavBarItem show={this._openEmailModal}
+            <SecondaryNavBarItem show={this._toggleEmailModal}
                                  source={cordovaDot("/img/global/svg-icons/nav/email-16.svg")}
                                  title="Email Ballot"/>
 
             {/* July 10, 2018 Steve:  Disable Share Ballot via Facebook, in Cordova, until it is fixed for the Webapp */}
             {isWebApp() &&
-              <SecondaryNavBarItem show={this._openFacebookModal}
+              <SecondaryNavBarItem show={this._toggleFacebookModal}
                                    title="Share Ballot"
                                    iconFacebook/>
             }
@@ -331,7 +333,7 @@ export default class HeaderSecondaryNavBar extends Component {
                                    isExternal/>
             </span>
             <div>
-              <SecondaryNavBarItem show={this._openPollingLocatorModal}
+              <SecondaryNavBarItem show={this._togglePollingLocatorModal}
                                    source={cordovaDot("/img/global/svg-icons/nav/location-16.svg")}
                                    titleDesktop="Polling Location"
                                    titleMobile="Vote"/>

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -30,7 +30,7 @@ export default class ItemActionBar extends Component {
     ballot_item_display_name: PropTypes.string,
     supportOrOpposeHasBeenClicked: PropTypes.func,
     urlWithoutHash: PropTypes.string,
-    we_vote_id: PropTypes.string
+    we_vote_id: PropTypes.string,
   };
 
   constructor (props) {
@@ -261,8 +261,8 @@ export default class ItemActionBar extends Component {
 
   supportItem () {
     // Button to support this item was clicked
-    let { currentBallotIdInUrl, urlWithoutHash, we_vote_id } = this.props;
-    if (currentBallotIdInUrl !== we_vote_id) {
+    let { currentBallotIdInUrl, urlWithoutHash, we_vote_id: weVoteId } = this.props;
+    if (currentBallotIdInUrl !== weVoteId) {
       historyPush(urlWithoutHash + "#" + this.props.we_vote_id);
     }
 
@@ -314,8 +314,8 @@ export default class ItemActionBar extends Component {
   }
 
   opposeItem () {
-    let { currentBallotIdInUrl, urlWithoutHash, we_vote_id } = this.props;
-    if (currentBallotIdInUrl !== we_vote_id) {
+    let { currentBallotIdInUrl, urlWithoutHash, we_vote_id: weVoteId } = this.props;
+    if (currentBallotIdInUrl !== weVoteId) {
       historyPush(urlWithoutHash + "#" + this.props.we_vote_id);
     }
     if (this.props.supportOrOpposeHasBeenClicked) {
@@ -398,7 +398,7 @@ export default class ItemActionBar extends Component {
       this.state.opposeCount === undefined ||
       this.state.isOpposeAPIState === undefined ||
       this.state.isPublicPosition === undefined ||
-      this.state.isSupportAPIState === undefined ) {
+      this.state.isSupportAPIState === undefined) {
       // Do not render until componentDidMount has set the initial states
       return null;
     }

--- a/src/js/routes/Ballot/PollingPlaceLocatorModal.jsx
+++ b/src/js/routes/Ballot/PollingPlaceLocatorModal.jsx
@@ -3,9 +3,12 @@ import { cordovaDot, cordovaOpenSafariView, hasIPhoneNotch, historyPush, isWebAp
 import { Modal } from "react-bootstrap";
 import { renderLog } from "../../utils/logging";
 import PollingPlaceLocator from "../../components/Ballot/PollingPlaceLocator";
+import PropTypes from "prop-types";
 
 export default class PollingPlaceLocatorModal extends Component {
-  static propTypes = {};
+  static propTypes = {
+    onExit: PropTypes.func,
+  };
 
   constructor (props) {
     super(props);
@@ -42,7 +45,7 @@ export default class PollingPlaceLocatorModal extends Component {
     } else {
       return (
         <div>
-          { cordovaOpenSafariView("https://s3-us-west-1.amazonaws.com/wevote/vip.html", 50) }
+          { cordovaOpenSafariView("https://s3-us-west-1.amazonaws.com/wevote/vip.html", this.props.onExit, 50) }
         </div>
       );
     }

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -27,7 +27,7 @@ export function cordovaDot (path) {
   }
 }
 
-function cordovaOpenSafariViewSub (requestURL) {
+function cordovaOpenSafariViewSub (requestURL, onExit) {
 
   // console.log("cordovaOpenSafariView -1- requestURL: " + requestURL);
   SafariViewController.isAvailable(function () {            // eslint-disable-line no-undef
@@ -38,11 +38,14 @@ function cordovaOpenSafariViewSub (requestURL) {
 
       function (result) {
         if (result.event === "opened") {
-          oAuthLog("cordovaOpenSafariView opened url " + requestURL);
+          oAuthLog("cordovaOpenSafariView opened url: " + requestURL);
         } else if (result.event === "loaded") {
-          oAuthLog("cordovaOpenSafariView loaded url " + JSON.stringify(result));
+          oAuthLog("cordovaOpenSafariView loaded url: " + JSON.stringify(result));
         } else if (result.event === "closed") {
-          oAuthLog("cordovaOpenSafariView closed" + JSON.stringify(result));
+          oAuthLog("cordovaOpenSafariView closed: " + JSON.stringify(result));
+          if (onExit) {
+            onExit();
+          }
         }
       },
 
@@ -60,8 +63,8 @@ function cordovaOpenSafariViewSub (requestURL) {
  * @param requestURL, the URL to open
  * @param timeout, a hack delay before invoking, but it fails without the timeout
  */
-export function cordovaOpenSafariView (requestURL, timeout) {
-  setTimeout(cordovaOpenSafariViewSub, timeout, requestURL);
+export function cordovaOpenSafariView (requestURL, onExit, timeout) {
+  setTimeout(cordovaOpenSafariViewSub, timeout, requestURL, onExit);
 }
 
 /*
@@ -160,6 +163,33 @@ export function isAndroid () {
   return isCordova() && window.device && device.platform === "Android";
 }
 
+export function getAndroidSize () {
+  let ratio = window.devicePixelRatio || 1;
+  let screen = {
+    width: window.screen.width * ratio,
+    height: window.screen.height * ratio,
+  };
+
+  let size = screen.width * screen.height;
+  let sizeString = "default";
+
+  /* sm = 480*800 = 384,000      Nexus One
+     md = 1080*1920 = 2,073,600  PixelXL, Nexus5X, Moto G5
+     lg = 1440*2560 = 3,686,400  Nexus6P
+     xl = 2560*1600 = 4,096,000  Nexus10 Tablet   */
+
+  if (size > 3.7E6) {
+    sizeString = "android-xl";
+  } else if (size > 3E6) {
+    sizeString = "android-lg";
+  } else if (size > 1E6) {
+    sizeString = "android-md";
+  } else {
+    sizeString = "android-sm";
+  }
+  return sizeString;
+}
+
 export function getHeadingSize () {
   let sizeString = "";
   if (isCordova()) {
@@ -172,7 +202,7 @@ export function getHeadingSize () {
     } else if (isIPhone678Plus()) {
       sizeString = "i678plus";
     } else if (isAndroid()) {
-      sizeString = "android";
+      sizeString = getAndroidSize();
     } else {
       sizeString = "default";
     }

--- a/src/sass/components/_ballot.scss
+++ b/src/sass/components/_ballot.scss
@@ -4,12 +4,15 @@ $tab-spacing-desktop: 24px;
 $tab-spacing-mobile: $space-md;
 $header-extension-top: 41%;
 $header-correction: -40%;
-$header-correction-cordova-xs-max:  -21vh;
-$header-correction-cordova-x:       -21vh;
-$header-correction-cordova-xr:      -16vh;
-$header-correction-cordova-iplus:   -32vh;
-$header-correction-cordova-android: -39vh;
-$header-correction-cordova-default: -33vh;
+$header-correction-cordova-xs-max:     -21vh;
+$header-correction-cordova-x:          -21vh;
+$header-correction-cordova-xr:         -16vh;
+$header-correction-cordova-iplus:      -32vh;
+$header-correction-cordova-android-sm: -44vh;
+$header-correction-cordova-android-md: -42vh;
+$header-correction-cordova-android-lg: -40vh;
+$header-correction-cordova-android-xl: -84vh;
+$header-correction-cordova-default:    -33vh;
 $header-extension-top-voter-guide: 2%;
 $header-correction-voter-guide: -1%;
 $scrollbar-height: 20px;
@@ -61,8 +64,20 @@ $bottom-spacing-cordova: 50px;
     margin-top: $header-correction-cordova-iplus;
   }
 
-  &__heading-cordova-android {
-    margin-top: $header-correction-cordova-android;
+  &__heading-cordova-android-sm {
+    margin-top: $header-correction-cordova-android-sm;
+  }
+
+  &__heading-cordova-android-md {
+    margin-top: $header-correction-cordova-android-md;
+  }
+
+  &__heading-cordova-android-lg {
+    margin-top: $header-correction-cordova-android-lg;
+  }
+
+  &__heading-cordova-android-xl {
+    margin-top: $header-correction-cordova-android-xl;
   }
 
   &__heading-cordova-default {

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -3,9 +3,10 @@ $icon-color-active: $link-color;
 $icon-color-hover: $gray-dark;
 $glyph-icon-color: $brand-blue;
 $header-height: 54px;
-$header-height-cordova-ios: 70px;
-$header-height-cordova-ios-iphone-xr: 60px;
-$header-height-cordova-android: 50px;
+$header-height-cordova-ballot-ios:        -1vh;
+$header-height-cordova-network-ios-notch: 5vh;
+$header-height-cordova-network-ios:       -1vh;
+$header-height-cordova-android:           -5px;
 $header-height-secondary-nav: 104px;
 $header-height-secondary-nav-iphone-xr: 60px;
 $iphone-x-vertical-spacing: 18px;
@@ -117,7 +118,13 @@ $container-margin: -15px;
 .headroom-wrapper {
   margin-top: $header-height;
   &__cordova-ios {
-    margin-top: $header-height-cordova-ios;
+    margin-top: $header-height-cordova-ballot-ios;
+  }
+  &__cordova-ios-network-notch {
+    margin-top: $header-height-cordova-network-ios-notch;
+  }
+  &__cordova-ios-network {
+    margin-top: $header-height-cordova-network-ios;
   }
   &__cordova-android {
     margin-top: $header-height-cordova-android;


### PR DESCRIPTION
HeaderSecondaryNavBar PollingLocator toggle not called from
PollingPlaceLocatorModal when using Cordova SafariViewController to load
vip.html.  All the _open functions that were actually toggle functions
were renamed.
In cordovaUtils.js, lots of changes to support all the various device
sizes, for iOS we support and have tested on each device from iPhone 6
on to the latest iPhone XS Max.  On Android, we just check for one of
four screen sizes (by ranges of megapixels of screen real-estate) and
make some assumptions.  Worst case with have some grey useless screen
below the SecondaryNavBar, or on top of the Network page.

