### PR TITLE
change oppose icon color to gray to match support icon color

### DIFF
--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -414,7 +414,7 @@ export default class ItemActionBar extends Component {
     const chooseIconSize = 24;
     let chooseIconColor = this.isSupportCalculated() ? "white" : "#555";
     const opposeIconSize = 24;
-    let opposeIconColor = this.isOpposeCalculated() ? "white" : "#ff4921";
+    let opposeIconColor = this.isOpposeCalculated() ? "white" : "#555";
 
     let urlBeingShared;
     if (this.props.type === "CANDIDATE") {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Quick update to change Oppose `thumbs-down` icon to gray to match the Support icon color. 

![image](https://user-images.githubusercontent.com/160662/47771969-72954d00-dca2-11e8-88e6-85fec16fa62e.png)
