### PR TITLE
#1772 change edit link to button to match the save button

### DIFF
--- a/src/js/components/Widgets/EditAddressInPlace.jsx
+++ b/src/js/components/Widgets/EditAddressInPlace.jsx
@@ -69,8 +69,8 @@ export default class EditAddressInPlace extends Component {
     } else {
       return <span>
           <h4 className="h4">Your Address</h4>
-          <span className="ballot__edit-address-preview">{ this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximumAddressDisplayLength) : noAddressMessage }</span>
-          <span className="d-print-none ballot__edit-address-preview-link u-padding-left--sm"> (<a onClick={this.toggleEditingAddress}>Edit</a>)</span>
+          <span className="ballot__edit-address-preview">{ this.state.text_for_map_search.length ? shortenText(this.state.text_for_map_search, maximumAddressDisplayLength) : noAddressMessage }  </span>
+          <span className="d-print-none ballot__edit-address-preview-link u-padding-left--sm"><button className="btn btn-primary" onClick={this.toggleEditingAddress}>Edit</button></span>
         </span>;
     }
   }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1772 change edit link to button to match the save button

### Changes included this pull request?
changed from link to button. Used the same className as the save button and moved text slightly so theres space between address and button.