### PR TITLE
Bump gulp-livereload version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bootstrap": "^4.1.3",
     "font-awesome": "^4.7.0",
     "fsevents": "^1.2.4",
-    "gulp-livereload": "^4.0.0",
+    "gulp-livereload": "^4.0.1",
     "gulp-uglify": "^2.0.0",
     "headroom.js": "^0.9.3",
     "history": "^3.2.1",


### PR DESCRIPTION
Bump gulp-livereload version so we don't include malicious flatmap-stream package marked as dependency by event-stream@3.3.6

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
