### PR TITLE
[Issue #1829] Remove "Upcoming Elections" when there are no upcoming …

### DIFF
--- a/src/js/components/Ballot/BallotElectionList.jsx
+++ b/src/js/components/Ballot/BallotElectionList.jsx
@@ -328,7 +328,15 @@ export default class BallotElectionList extends Component {
       const upcomingElectionListOutsideCount = upcomingElectionList.length - upcomingElectionListInState.length;
       const priorElectionListOutsideCount = priorElectionList.length - priorElectionListInState.length;
 
+      // If there are no upcoming state elections and no upcoming elections, return empty div
+      if (!upcomingElectionListInState.length && !upcomingElectionList.length) {
+        return (
+          <div />
+        );
+      }
+
       // December 2018, these nested ternary expression should get fixed at some point
+
       return (
         <div className="ballot-election-list__list">
           <div className="ballot-election-list__upcoming">


### PR DESCRIPTION
…elections

### What github.com/wevote/WebApp/issues does this fix?
Issue #1829 
### Changes included this pull request?
If `props.showRelevantElections` is true but there are no upcoming state elections and no upcoming elections, return empty div.