### PR TITLE
Added white space to candidate bio #1682

### DIFF
--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -57,6 +57,16 @@ $candidate-font-size: .875rem;
       flex-direction: column;
     }
 
+    &__media-object-content {
+      // additional styling set with 'media-object' mixin
+      @include breakpoints (mid-small) {
+        //more space and spacing for candidate bio
+        padding: 5px 30px;
+        margin-bottom: 30px;
+        font-size: 16px;
+      }
+    }
+
     &__avatar {
       max-width: 60px;
       border-radius: $radius-xs;

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -61,8 +61,8 @@ $candidate-font-size: .875rem;
       // additional styling set with 'media-object' mixin
       @include breakpoints (mid-small) {
         //more space and spacing for candidate bio
-        padding: 5px 30px;
-        margin-bottom: 30px;
+        padding: $space-xs $space-lg;
+        margin-bottom: $space-lg;
         font-size: 16px;
       }
     }
@@ -144,7 +144,7 @@ $candidate-font-size: .875rem;
         font-size: 18px;
       }
       @include print {
-        font-size: 18px;
+        font-size: 22px;
       }
     }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
-Gave more padding for the candidate description
-Added margin on the bottom to separate the description and sponsors
-font changed from 14px to 16px

### Changes included this pull request?
changed were made to _card.scss &__media-object-content
@include breakpoints (mid-small)