### PR TITLE
convert OfficeNameText.jsx to camel case #1875

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -245,9 +245,9 @@ export default class CandidateItem extends Component {
             >
               { contestOfficeName ? (
                 <OfficeNameText
-                  political_party={party}
-                  contest_office_name={contestOfficeName}
-                  office_link={this.props.linkToOfficePage ? this.getOfficeLink() : ""}
+                  politicalParty={party}
+                  contestOfficeName={contestOfficeName}
+                  officeLink={this.props.linkToOfficePage ? this.getOfficeLink() : ""}
                 />
               ) :
                 null

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -246,8 +246,8 @@ export default class OrganizationPositionItem extends Component {
             }
             { position.kind_of_ballot_item === "CANDIDATE" && contest_office_name !== undefined ? (
               <OfficeNameText
-                political_party={political_party}
-                contest_office_name={contest_office_name}
+                politicalParty={political_party}
+                contestOfficeName={contest_office_name}
               />
             ) : null
             }

--- a/src/js/components/VoterGuide/OrganizationVoterGuideCandidateItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideCandidateItem.jsx
@@ -230,9 +230,9 @@ export default class OrganizationVoterGuideCandidateItem extends Component {
             >
               { contest_office_name ? (
                 <OfficeNameText
-                  political_party={party}
-                  contest_office_name={contest_office_name}
-                  office_link={this.props.linkToOfficePage ? this.getOfficeLink() : ""}
+                  politicalParty={party}
+                  contestOfficeName={contest_office_name}
+                  officeLink={this.props.linkToOfficePage ? this.getOfficeLink() : ""}
                 />
               ) : null
               }

--- a/src/js/components/VoterGuide/VoterPositionItem.jsx
+++ b/src/js/components/VoterGuide/VoterPositionItem.jsx
@@ -164,8 +164,10 @@ export default class VoterPositionItem extends Component {
             </Link>
             <br />
             { position.kind_of_ballot_item === "CANDIDATE" && contest_office_name !== undefined ?
-              <OfficeNameText political_party={political_party} contest_office_name={contest_office_name} /> :
-              null
+              <OfficeNameText
+                politicalParty={political_party}
+                contestOfficeName={contest_office_name}
+              /> : null
             }
             {/* show explicit position, if available, otherwise show rating */}
             {/* this.props.link_to_edit_modal_off ?

--- a/src/js/components/Widgets/OfficeNameText.jsx
+++ b/src/js/components/Widgets/OfficeNameText.jsx
@@ -5,9 +5,9 @@ import { renderLog } from "../../utils/logging";
 
 export default class OfficeNameText extends Component {
   static propTypes = {
-    political_party: PropTypes.string,
-    contest_office_name: PropTypes.string,
-    office_link: PropTypes.string,
+    politicalParty: PropTypes.string,
+    contestOfficeName: PropTypes.string,
+    officeLink: PropTypes.string,
   };
 
   constructor (props) {
@@ -24,17 +24,17 @@ export default class OfficeNameText extends Component {
   render () {
     renderLog(__filename);
     let nameText = "";
-    const { contest_office_name, political_party } = this.props;
-    if (political_party === undefined) {
+    const { contestOfficeName, politicalParty } = this.props;
+    if (politicalParty === undefined) {
       nameText = (
         <span className="no-political-party">
           <span>Candidate for </span>
-          { this.props.office_link ? (
-            <Link to={this.props.office_link}>
-              <span className="candidate-card-main__office">{ contest_office_name }</span>
+          { this.props.officeLink ? (
+            <Link to={this.props.officeLink}>
+              <span className="candidate-card-main__office">{ contestOfficeName }</span>
             </Link>
           ) :
-            <span className="candidate-card-main__office">{ contest_office_name }</span>
+            <span className="candidate-card-main__office">{ contestOfficeName }</span>
         }
         </span>
       );
@@ -42,16 +42,16 @@ export default class OfficeNameText extends Component {
       nameText = (
         <span>
           <span className="card-main__political-party u-bold u-gray-darker">
-            {political_party}
+            {politicalParty}
             {" "}
           </span>
           <span>candidate for </span>
-          { this.props.office_link ? (
-            <Link to={this.props.office_link}>
-              <span className="candidate-card-main__office u-bold u-gray-darker">{ contest_office_name }</span>
+          { this.props.officeLink ? (
+            <Link to={this.props.officeLink}>
+              <span className="candidate-card-main__office u-bold u-gray-darker">{ contestOfficeName }</span>
             </Link>
           ) :
-            <span className="candidate-card-main__office u-bold u-gray-darker">{ contest_office_name }</span>
+            <span className="candidate-card-main__office u-bold u-gray-darker">{ contestOfficeName }</span>
         }
         </span>
       );

--- a/src/js/components/Widgets/OfficeNameText.jsx
+++ b/src/js/components/Widgets/OfficeNameText.jsx
@@ -24,13 +24,13 @@ export default class OfficeNameText extends Component {
   render () {
     renderLog(__filename);
     let nameText = "";
-    const { contestOfficeName, politicalParty } = this.props;
+    const { contestOfficeName, politicalParty, officeLink } = this.props;
     if (politicalParty === undefined) {
       nameText = (
         <span className="no-political-party">
           <span>Candidate for </span>
-          { this.props.officeLink ? (
-            <Link to={this.props.officeLink}>
+          { officeLink ? (
+            <Link to={officeLink}>
               <span className="candidate-card-main__office">{ contestOfficeName }</span>
             </Link>
           ) :
@@ -46,8 +46,8 @@ export default class OfficeNameText extends Component {
             {" "}
           </span>
           <span>candidate for </span>
-          { this.props.officeLink ? (
-            <Link to={this.props.officeLink}>
+          { officeLink ? (
+            <Link to={officeLink}>
               <span className="candidate-card-main__office u-bold u-gray-darker">{ contestOfficeName }</span>
             </Link>
           ) :


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1875 
Fix eslint warnings for WebApp/src/js/components/Widgets/OfficeNameText.jsx

### Changes included this pull request?
converted to camel case for OfficeNameText.jsx
Updated props for the following files:
src/js/components/Ballot/CandidateItem.jsx
src/js/components/VoterGuide/OrganizationPositionItem.jsx
src/js/components/VoterGuide/OrganizationVoterGuideCandidateItem.jsx
src/js/components/VoterGuide/VoterPositionItem.jsx

I was able to test in the browser CandidateItem and OrganizationPositionItem. I was not able to test OrganizationVoterGuideCandidateItem.jsx and VoterPositionItem.jsx because I couldn't find them in the browser. I updated it the same way so I think it should be okay. 