### PR TITLE
[Issue #1714] Show 1st available ballot items when user changes address

### DIFF
--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Button from '@material-ui/core/Button';
 import BallotStore from "../stores/BallotStore";
+import BallotActions from '../actions/BallotActions';
 import { historyPush, isCordova, prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from "../utils/cordovaUtils";
 import LoadingWheel from "./LoadingWheel";
 import { renderLog } from "../utils/logging";
@@ -151,6 +152,7 @@ export default class AddressBox extends Component {
   voterAddressSave (event) {
     event.preventDefault();
     VoterActions.voterAddressSave(this.state.text_for_map_search);
+    BallotActions.completionLevelFilterTypeSave('filterAllBallotItems');
     this.setState({ loading: true });
   }
 

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -653,7 +653,9 @@ export default class Ballot extends Component {
               &nbsp;ballot items yet.
               <br />
               <br />
-              Click on &quot;Remaining Choices&quot; to see the&nbsp;
+              Click on &quot;
+              {window.innerWidth > 575 ? 'Remaining Choices' : 'Choices'}
+              &quot; to see the&nbsp;
               {raceLevel}
               &nbsp;ballot items you need to decide on.
             </h3>
@@ -668,7 +670,9 @@ export default class Ballot extends Component {
               &nbsp;ballot items to decide on.
               <br />
               <br />
-              Click on &quot;Items Decided&quot; to see the&nbsp;
+              Click on &quot;
+              {window.innerWidth > 575 ? 'Items Decided' : 'Decided'}
+              &quot; to see the&nbsp;
               {raceLevel}
               &nbsp;ballot items you&apos;ve decided on.
             </h3>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1714 
### Changes included this pull request?
* Reset completionLevelFilter back to 'filterAllBallots' when the user changes their address (doing this in case the user had the filter on "Decided," seemed to make sense from a UX standpoint)
* Moved the default race filter check from onBallotStoreChange to componentDidUpdate