### PR TITLE
removed the warnings

### DIFF
--- a/src/js/routes/OpinionsFollowed.jsx
+++ b/src/js/routes/OpinionsFollowed.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import { Link } from "react-router";
 import Helmet from "react-helmet";
 import { _ } from "lodash";
@@ -10,19 +9,13 @@ import OpinionsFollowedList from "../components/Organization/OpinionsFollowedLis
 import SearchBar from "../components/Search/SearchBar";
 
 export default class OpinionsFollowed extends Component {
-  static propTypes = {
-    children: PropTypes.object,
-    history: PropTypes.object,
-  };
-
   constructor (props) {
     super(props);
     this.state = {
       organizations_followed_list: [],
       editMode: false,
-      search_query: "",
+      searchQuery: "",
     };
-
     this.searchFunction = this.searchFunction.bind(this);
     this.clearFunction = this.clearFunction.bind(this);
   }
@@ -39,27 +32,17 @@ export default class OpinionsFollowed extends Component {
     this.organizationStoreListener.remove();
   }
 
-  _onOrganizationStoreChange () {
-    this.setState({
-      organizations_followed_list: OrganizationStore.getOrganizationsVoterIsFollowing(),
-    });
-  }
-
-  getCurrentRoute () {
-    const current_route = "/opinions_followed";
-    return current_route;
-  }
-
-  toggleEditMode () {
-    this.setState({ editMode: !this.state.editMode });
-  }
-
   onKeyDownEditMode (event) {
     const enterAndSpaceKeyCodes = [13, 32];
     const scope = this;
     if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
       scope.setState({ editMode: !this.state.editMode });
     }
+  }
+
+  getCurrentRoute () {
+    const currentRoute = "/opinions_followed";
+    return currentRoute;
   }
 
   getFollowingType () {
@@ -72,8 +55,18 @@ export default class OpinionsFollowed extends Component {
     }
   }
 
-  searchFunction (search_query) {
-    this.setState({ search_query });
+  toggleEditMode () {
+    this.setState(() => ({ editMode: !this.state.editMode }));
+  }
+
+  _onOrganizationStoreChange () {
+    this.setState({
+      organizations_followed_list: OrganizationStore.getOrganizationsVoterIsFollowing(),
+    });
+  }
+
+  searchFunction (searchQuery) {
+    this.setState({ searchQuery });
   }
 
   clearFunction () {
@@ -82,14 +75,14 @@ export default class OpinionsFollowed extends Component {
 
   render () {
     renderLog(__filename);
-    let organizations_followed_list_for_display = [];
-    if (this.state.search_query.length > 0) {
-      const search_query_lowercase = this.state.search_query.toLowerCase();
-      organizations_followed_list_for_display = _.filter(this.state.organizations_followed_list,
-        one_organization => one_organization.organization_name.toLowerCase().includes(search_query_lowercase) ||
-            one_organization.organization_twitter_handle.toLowerCase().includes(search_query_lowercase));
+    let organizationsFollowedListForDisplay = [];
+    if (this.state.searchQuery.length > 0) {
+      const searchQueryLowercase = this.state.searchQuery.toLowerCase();
+      organizationsFollowedListForDisplay = _.filter(this.state.organizations_followed_list,
+        oneOrganization => oneOrganization.organization_name.toLowerCase().includes(searchQueryLowercase) ||
+            oneOrganization.organization_twitter_handle.toLowerCase().includes(searchQueryLowercase));
     } else {
-      organizations_followed_list_for_display = this.state.organizations_followed_list;
+      organizationsFollowedListForDisplay = this.state.organizations_followed_list;
     }
 
     // console.log("OpinionsFollowed, this.state.organizations_followed_list: ", this.state.organizations_followed_list);
@@ -126,7 +119,7 @@ export default class OpinionsFollowed extends Component {
                 {
                 this.state.organizations_followed_list && this.state.organizations_followed_list.length ? (
                   <OpinionsFollowedList
-                    organizationsFollowed={organizations_followed_list_for_display}
+                    organizationsFollowed={organizationsFollowedListForDisplay}
                     editMode={this.state.editMode}
                     instantRefreshOn
                   />

--- a/src/js/routes/OpinionsFollowed.jsx
+++ b/src/js/routes/OpinionsFollowed.jsx
@@ -12,7 +12,7 @@ export default class OpinionsFollowed extends Component {
   constructor (props) {
     super(props);
     this.state = {
-      organizations_followed_list: [],
+      organizationsFollowedList: [],
       editMode: false,
       searchQuery: "",
     };
@@ -24,7 +24,7 @@ export default class OpinionsFollowed extends Component {
     this.organizationStoreListener = OrganizationStore.addListener(this._onOrganizationStoreChange.bind(this));
     OrganizationActions.organizationsFollowedRetrieve();
     this.setState({
-      organizations_followed_list: OrganizationStore.getOrganizationsVoterIsFollowing(),
+      organizationsFollowedList: OrganizationStore.getOrganizationsVoterIsFollowing(),
     });
   }
 
@@ -61,7 +61,7 @@ export default class OpinionsFollowed extends Component {
 
   _onOrganizationStoreChange () {
     this.setState({
-      organizations_followed_list: OrganizationStore.getOrganizationsVoterIsFollowing(),
+      organizationsFollowedList: OrganizationStore.getOrganizationsVoterIsFollowing(),
     });
   }
 
@@ -78,14 +78,14 @@ export default class OpinionsFollowed extends Component {
     let organizationsFollowedListForDisplay = [];
     if (this.state.searchQuery.length > 0) {
       const searchQueryLowercase = this.state.searchQuery.toLowerCase();
-      organizationsFollowedListForDisplay = _.filter(this.state.organizations_followed_list,
+      organizationsFollowedListForDisplay = _.filter(this.state.organizationsFollowedList,
         oneOrganization => oneOrganization.organization_name.toLowerCase().includes(searchQueryLowercase) ||
             oneOrganization.organization_twitter_handle.toLowerCase().includes(searchQueryLowercase));
     } else {
-      organizationsFollowedListForDisplay = this.state.organizations_followed_list;
+      organizationsFollowedListForDisplay = this.state.organizationsFollowedList;
     }
 
-    // console.log("OpinionsFollowed, this.state.organizations_followed_list: ", this.state.organizations_followed_list);
+    // console.log("OpinionsFollowed, this.state.organizationsFollowedList: ", this.state.organizationsFollowedList);
     return (
       <div className="opinions-followed__container">
         <Helmet title="Organizations You Listen To - We Vote" />
@@ -117,7 +117,7 @@ export default class OpinionsFollowed extends Component {
             <div className="voter-guide-list card">
               <div className="card-child__list-group">
                 {
-                this.state.organizations_followed_list && this.state.organizations_followed_list.length ? (
+                this.state.organizationsFollowedList && this.state.organizationsFollowedList.length ? (
                   <OpinionsFollowedList
                     organizationsFollowed={organizationsFollowedListForDisplay}
                     editMode={this.state.editMode}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Issue #1896 --> Fix ESlint warnings in routes/OpinionsFollowed.jsx 

Updated the code to remove most warnings for this file (when you run npm test):
WebApp/src/js/routes/OpinionsFollowed.jsx

The following warnings are still apearing:
1. Expected 'this' to be used by class method 'getCurrentRoute'
2. Anchor used as a button

### Changes included this pull request?
Yes