### PR TITLE
Fix console warnings introduced in previous PR

### DIFF
--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -84,7 +84,8 @@ class HeaderBackToBallot extends Component {
         officeWeVoteId = candidate.contest_officeWeVoteId;
         officeName = candidate.contest_office_name;
       } else if (officeWeVoteId && officeWeVoteId !== '') {
-        officeName = OfficeStore.getOffice(officeWeVoteId).ballot_item_display_name;
+        const office = OfficeStore.getOffice(officeWeVoteId);
+        officeName = office ? office.ballot_item_display_name : '';
       }
 
       organizationWeVoteId = this.props.params.organization_we_vote_id || '';
@@ -128,7 +129,8 @@ class HeaderBackToBallot extends Component {
         officeName = candidate.contest_office_name;
       } else if (officeWeVoteId && officeWeVoteId !== '') {
         candidateWeVoteId = '';
-        officeName = OfficeStore.getOffice(officeWeVoteId).ballot_item_display_name;
+        const office = OfficeStore.getOffice(officeWeVoteId);
+        officeName = office ? office.ballot_item_display_name : '';
       }
 
       organizationWeVoteId = nextProps.params.organization_we_vote_id || '';
@@ -182,7 +184,8 @@ class HeaderBackToBallot extends Component {
     } else {
       officeWeVoteId = this.props.params.office_we_vote_id || '';
       if (officeWeVoteId && officeWeVoteId !== '') {
-        officeName = OfficeStore.getOffice(officeWeVoteId).ballot_item_display_name;
+        const office = OfficeStore.getOffice(officeWeVoteId);
+        officeName = office ? office.ballot_item_display_name : '';
       }
     }
 
@@ -204,7 +207,8 @@ class HeaderBackToBallot extends Component {
     const { officeWeVoteId } = this.state;
     let officeName;
     if (officeWeVoteId && officeWeVoteId !== '') {
-      officeName = OfficeStore.getOffice(officeWeVoteId).ballot_item_display_name;
+      const office = OfficeStore.getOffice(officeWeVoteId);
+      officeName = office ? office.ballot_item_display_name : '';
     }
 
     this.setState({

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -266,7 +266,7 @@ class HeaderBackToBallot extends Component {
   }
 
   render () {
-    const { organizationWeVoteId, candidate, voter, officeName, officeWeVoteId, candidateWeVoteId } = this.state;
+    const { organizationWeVoteId, candidate, voter, officeName, officeWeVoteId } = this.state;
     const { classes, pathname } = this.props;
     renderLog(__filename);
     const voterPhotoUrlMedium = voter.voter_photo_url_medium;
@@ -366,7 +366,7 @@ class HeaderBackToBallot extends Component {
           </div>
           )}
         </Toolbar>
-        {!candidateWeVoteId && (
+        {stringContains('/office', pathname)  && officeName && (
           <OfficeItem
           weVoteId={officeWeVoteId}
           ballotItemDisplayName={officeName}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixes the warnings @DaleMcGrew noticed from my previous PR for #1963.

### Changes included this pull request?

1) Renders the OfficeItem component in the HeaderBackToBallot more safely by only rendering it when the path contains '/office' and the state has an officeName.

2) Retreives the officeName more safely from the OfficeStore. It looks like it's possible for the OfficeStore to not be able to retrieve an office object for an officeWeVoteId even when the HeaderBackToBar already has that id in its props. That makes me think there could be a deeper issue going on here, though I'm not sure. In the meantime, I just verified that the OfficeStore returns an object before getting the officeName property off it.