### PR TITLE
[#1995] show Settings and Address icons on header when logged in

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -347,6 +347,15 @@ class HeaderBar extends Component {
                 </Tooltip>
                 )
               }
+              <Link to="/settings/menu" className="header-link">
+                <Tooltip title="Settings" aria-label="settings" classes={{ tooltipPlacementBottom: classes.tooltipPlacementBottom }}>
+                  <IconButton
+                    classes={{ root: classes.iconButtonRoot }}
+                  >
+                    <MoreVertIcon />
+                  </IconButton>
+                </Tooltip>
+              </Link>
               {voterPhotoUrlMedium ? (
                 <div id="js-header-avatar" className="header-nav__avatar-container" onClick={this.toggleProfilePopUp}>
                   <img

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -335,6 +335,18 @@ class HeaderBar extends Component {
               {
             (showFullNavigation && voterIsSignedIn) && (
             <div className="header-nav__avatar-wrapper u-cursor--pointer u-flex-none">
+              {
+                showEditAddressButton && (
+                <Tooltip title="Change my location" aria-label="Change Address" classes={{ tooltipPlacementBottom: classes.tooltipPlacementBottom }}>
+                  <IconButton
+                    classes={{ root: classes.iconButtonRoot }}
+                    onClick={this.toggleSelectBallotModal}
+                  >
+                    <PlaceIcon />
+                  </IconButton>
+                </Tooltip>
+                )
+              }
               {voterPhotoUrlMedium ? (
                 <div id="js-header-avatar" className="header-nav__avatar-container" onClick={this.toggleProfilePopUp}>
                   <img
@@ -347,18 +359,6 @@ class HeaderBar extends Component {
                 </div>
               ) : (
                 <div>
-                  {
-                    showEditAddressButton && (
-                    <Tooltip title="Change my location" aria-label="Change Address" classes={{ tooltipPlacementBottom: classes.tooltipPlacementBottom }}>
-                      <IconButton
-                        classes={{ root: classes.iconButtonRoot }}
-                        onClick={this.toggleSelectBallotModal}
-                      >
-                        <PlaceIcon />
-                      </IconButton>
-                    </Tooltip>
-                    )
-                  }
                   <IconButton
                       onClick={this.toggleProfilePopUp}
                       classes={{ root: classes.iconButtonRoot }}

--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -256,12 +256,13 @@ $container-margin: -15px;
     border-radius: $radius-sm;
     background: #fff;
     overflow: hidden;
-    height: 34px;
-    width: 34px;
-    display: block;
+    display: inline;
     @include breakpoints(max mid-small) {
       margin-top: $space-xs;
       margin-bottom: $space-xs;
+    }
+    &-container {
+      display: inline;
     }
   }
 
@@ -269,9 +270,7 @@ $container-margin: -15px;
     border-radius: $radius-sm;
     background: #fff;
     overflow: hidden;
-    height: 34px;
-    width: 34px;
-    display: block;
+    display: inline;
   }
 
   &__avatar-iphone-xr {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1995
### Changes included this pull request?
When `showFullNavigation && voterIsSignedIn` is true, show the settings and address icons.
`header-nav__avatar`, `header-nav__avatar-cordova` and `header-nav__avatar-container` now have `display: inline` CSS rule. Hardcoded width and height values have been removed because inline elements ignore these style rules.