### PR TITLE
CodeCopier.js: Updated warning error

### DIFF
--- a/src/js/components/Widgets/CodeCopier.jsx
+++ b/src/js/components/Widgets/CodeCopier.jsx
@@ -172,7 +172,7 @@ export default class CodeCopier extends Component {
                 placeholder="Enter Twitter Handle"
                 onKeyDown={this.resetState}
                 onChange={this.validateTwitterHandle}
-                autoComplete
+                autoComplete="on"
               />
               { this.state.status.length ? (
                 <p className={!this.state.isLoading ?      // eslint-disable-line no-nested-ternary


### PR DESCRIPTION
… non-boolean attribute `autoComplete`. revised to "autoComplete="on" to remove warning error.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
