### PR TITLE
Fixed "I represent ...." warning issue

### DIFF
--- a/src/js/components/Twitter/ParsedTwitterDescription.jsx
+++ b/src/js/components/Twitter/ParsedTwitterDescription.jsx
@@ -48,9 +48,9 @@ const ParsedTwitterDescription = (props) => {
   return (
     <span className="card-main__description">
       {
-        parsedTwitterDescription.map(snippet => (
+        parsedTwitterDescription.map((snippet, index) => (
           snippet.type === 'text' ? (
-            <span key={snippet.toString()}>
+            <span key={snippet.toString() + index}>
               {props.twitter_description.slice(snippet.location[0], snippet.location[1])}
               &nbsp;
             </span>

--- a/src/js/components/Widgets/CodeCopier.jsx
+++ b/src/js/components/Widgets/CodeCopier.jsx
@@ -172,7 +172,7 @@ export default class CodeCopier extends Component {
                 placeholder="Enter Twitter Handle"
                 onKeyDown={this.resetState}
                 onChange={this.validateTwitterHandle}
-                autoComplete
+                autoComplete="on"
               />
               { this.state.status.length ? (
                 <p className={!this.state.isLoading ?      // eslint-disable-line no-nested-ternary


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
In the I represent section for the candidates, there was an error:
Encountered two children with the same key. `[object Object]`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

I gave the keys unique values.

### Changes included this pull request?
The file parsedTwitterDescription.jsx was revised.
