### PR TITLE
On office detail page, if there aren't any values or endorsements to show, show the candidate's bio. Changed some LearnMore component styling. Fixed eslint problems on Welcome page. Turned off mobile and tablet footer on the "Back to" pages. Shifted up the Zendesk help widget so it never sits on top of the mobile footer.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -92,6 +92,7 @@
         webWidget: {
           color: { theme: '#2E3C5D' },
           offset: {
+            vertical: '55px',
             mobile: {
               vertical: '55px'
             }

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -77,16 +77,6 @@ class Application extends Component {
     window.removeEventListener('scroll', this.handleWindowScroll);
   }
 
-  handleWindowScroll = (evt) => {
-    const { scrollTop } = evt.target.scrollingElement;
-    if (scrollTop > 60 && !AppStore.getScrolledDown()) {
-      AppActions.setScrolled(true);
-    }
-    if (scrollTop < 60 && AppStore.getScrolledDown()) {
-      AppActions.setScrolled(false);
-    }
-  }
-
   initCordova () { // eslint-disable-line
     if (isCordova()) {
       console.log(`Application initCordova ------------ ${__filename}`);
@@ -146,6 +136,16 @@ class Application extends Component {
     // console.log("SignedIn Voter in Application onVoterStoreChange voter: ", VoterStore.getVoter().full_name);
   }
 
+  handleWindowScroll = (evt) => {
+    const { scrollTop } = evt.target.scrollingElement;
+    if (scrollTop > 60 && !AppStore.getScrolledDown()) {
+      AppActions.setScrolled(true);
+    }
+    if (scrollTop < 60 && AppStore.getScrolledDown()) {
+      AppActions.setScrolled(false);
+    }
+  }
+
   incomingVariableManagement () {
     // console.log("Application, incomingVariableManagement, this.props.location.query: ", this.props.location.query);
     if (this.props.location.query) {
@@ -162,7 +162,8 @@ class Application extends Component {
         cookies.setItem('show_full_navigation', '1', Infinity, '/');
       }
 
-      this.setState({ we_vote_branding_off: weVoteBrandingOffFromUrl || weVoteBrandingOffFromCookie });
+      // Currently not used, but it seems like it should be
+      // this.setState({ we_vote_branding_off: weVoteBrandingOffFromUrl || weVoteBrandingOffFromCookie });
 
       const hideIntroModalFromUrl = this.props.location.query ? this.props.location.query.hide_intro_modal : 0;
       const hideIntroModalFromUrlTrue = hideIntroModalFromUrl === 1 || hideIntroModalFromUrl === '1' || hideIntroModalFromUrl === 'true';
@@ -211,7 +212,6 @@ class Application extends Component {
       }
     }
   }
-
 
   render () {
     renderLog(__filename);
@@ -281,7 +281,6 @@ class Application extends Component {
       );
     } else if (settingsMode) {
       // console.log("settingsMode", settingsMode);
-
       return (
         <div className={getAppBaseClass(pathname)} id="app-base-id">
           <ToastContainer closeButton={false} className={getToastClass()} />
@@ -298,7 +297,7 @@ class Application extends Component {
               </div>
             </div>
           </Wrapper>
-          {(
+          {(pathname === '/settings/menu') && (
             <div className="footroom-wrapper">
               <FooterBar location={this.props.location} pathname={pathname} voter={this.state.voter} />
             </div>
@@ -333,7 +332,13 @@ class Application extends Component {
               </div>
             </Wrapper>
           )}
-        { pathname !== '/welcome' && (
+        {/* Do not show the FooterBar if any of these pathname patterns are found */}
+        { !(pathname && pathname.startsWith('/candidate')) &&
+          !(pathname && pathname.startsWith('/friends/')) &&
+          !(pathname && pathname.startsWith('/measure')) &&
+          !(pathname && pathname.startsWith('/office')) &&
+          !(pathname && pathname.startsWith('/values/')) &&
+          !(pathname === '/welcome') && (
           <div className="footroom-wrapper">
             <FooterBar location={this.props.location} pathname={pathname} voter={this.state.voter} />
           </div>

--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -213,27 +213,6 @@ class CandidateItem extends Component {
             </Candidate>
             <BallotItemSupportOpposeCountDisplay ballotItemWeVoteId={candidateWeVoteId} />
           </CandidateWrapper>
-          { candidateText.length ? (
-            <div className={`u-stack--sm${this.props.link_to_ballot_item_page ? ' card-main__description-container--truncated' : ' card-main__description-container'}`}>
-              <div className="card-main__description">
-                <LearnMore
-                    learn_more_text="Read more on Ballotpedia"
-                    num_of_lines={3}
-                    learn_more_link={ballotpediaCandidateUrl}
-                    text_to_display={candidateText}
-                />
-              </div>
-              <Link to={this.getCandidateLink}>
-                { this.props.link_to_ballot_item_page ? <span className="card-main__read-more-pseudo" /> : null }
-              </Link>
-              { this.props.link_to_ballot_item_page ?
-                <Link to={this.getCandidateLink} className="card-main__read-more-link">&nbsp;Read more</Link> :
-                null
-              }
-            </div>
-          ) :
-            null
-          }
           {' '}
           {/* END .card-main__media-object-content */}
         </CandidateInfo>
@@ -251,7 +230,30 @@ class CandidateItem extends Component {
               <TopCommentByBallotItem
                 ballotItemWeVoteId={candidateWeVoteId}
                 learnMoreUrl={this.getCandidateLink()}
-              />
+              >
+                {/* If there aren't any comments about the candidate, show the text description of the candidate */}
+                { candidateText.length ? (
+                  <div className={`u-stack--sm${this.props.link_to_ballot_item_page ? ' card-main__description-container--truncated' : ' card-main__description-container'}`}>
+                    <div className="card-main__description">
+                      <LearnMore
+                          learn_more_text="Read more on Ballotpedia"
+                          num_of_lines={2}
+                          learn_more_link={ballotpediaCandidateUrl}
+                          text_to_display={candidateText}
+                      />
+                    </div>
+                    <Link to={this.getCandidateLink}>
+                      { this.props.link_to_ballot_item_page ? <span className="card-main__read-more-pseudo" /> : null }
+                    </Link>
+                    { this.props.link_to_ballot_item_page ?
+                      <Link to={this.getCandidateLink} className="card-main__read-more-link">&nbsp;more</Link> :
+                      null
+                    }
+                  </div>
+                ) :
+                  null
+                }
+              </TopCommentByBallotItem>
             )
             }
           </div>

--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -39,6 +39,7 @@ class FooterBar extends React.Component {
   };
 
   render () {
+    // console.log('FooterBar render');
     return (
       <div className="footer-container u-show-mobile-tablet">
         <BottomNavigation

--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -31,6 +31,7 @@ export default class Header extends Component {
   }
 
   render () {
+    // console.log('Header render');
     renderLog(__filename);
 
     const { params, location, pathname, voter, weVoteBrandingOff } = this.props;

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -154,8 +154,8 @@ class HeaderBar extends Component {
 
   getSelectedTab = () => {
     const { pathname } = this.props;
-    // if (stringContains('/ballot', pathname.slice(0, 7))) return 0;
-    if (pathname.indexOf('/ballot') === 0) return 0;
+    // if (pathname.indexOf('/ballot') === 0) return 0; // If '/ballot' is found any
+    if (pathname && pathname.startsWith('/ballot')) return 0;
     if (stringContains('/friends', pathname)) return 2;
     if (stringContains('/values', pathname)) return 1;
     return false;
@@ -194,6 +194,7 @@ class HeaderBar extends Component {
   }
 
   render () {
+    // console.log('HeaderBar render');
     renderLog(__filename);
     const { voter, classes, pathname } = this.props;
     const { showEditAddressButton, scrolledDown } = this.state;

--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -12,6 +12,7 @@ import VoterGuideStore from '../../stores/VoterGuideStore';
 class IssuesByBallotItemDisplayList extends Component {
   static propTypes = {
     ballotItemWeVoteId: PropTypes.string.isRequired,
+    children: PropTypes.object,
   };
 
   constructor (props) {
@@ -85,7 +86,8 @@ class IssuesByBallotItemDisplayList extends Component {
       !issuesUnderThisBallotItemVoterIsFollowingFound &&
       !issuesUnderThisBallotItemVoterIsNotFollowingFound
     ) {
-      return null;
+      // If we don't have any endorsement text, show the alternate component passed in
+      return this.props.children || null;
     }
 
     let localCounter = 0;

--- a/src/js/components/Widgets/LearnMore.jsx
+++ b/src/js/components/Widgets/LearnMore.jsx
@@ -1,15 +1,18 @@
 import React, { Component } from 'react';
+import Button from '@material-ui/core/Button';
+import { withStyles } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import TextTruncate from 'react-text-truncate';
 import OpenExternalWebSite from '../../utils/OpenExternalWebSite';
 import { renderLog } from '../../utils/logging';
 
-export default class LearnMore extends Component {
+class LearnMore extends Component {
   static propTypes = {
+    classes: PropTypes.object,
     text_to_display: PropTypes.node.isRequired,
-    show_more_text: PropTypes.node,
+    show_more_text: PropTypes.string,
     learn_more_link: PropTypes.string,
-    learn_more_text: PropTypes.node,
+    learn_more_text: PropTypes.string,
     num_of_lines: PropTypes.number,
     on_click: PropTypes.func,
     always_show_external_link: PropTypes.bool,
@@ -21,6 +24,7 @@ export default class LearnMore extends Component {
     this.state = {
       readMore: true,
     };
+    this.onKeyDown = this.onKeyDown.bind(this);
     this.showMore = this.showMore.bind(this);
   }
 
@@ -45,19 +49,16 @@ export default class LearnMore extends Component {
   render () {
     renderLog(__filename);
     let {
-      text_to_display: textToDisplay, show_more_text: showMoreText, num_of_lines: numOfLines,
+      text_to_display: textToDisplay, num_of_lines: numOfLines,
       learn_more_text: learnMoreText,
     } = this.props;
     const {
-      learn_more_link: learnMoreLink, on_click: onClick, always_show_external_link: alwaysShowExternalLink,
+      always_show_external_link: alwaysShowExternalLink, classes, learn_more_link: learnMoreLink,
+      on_click: onClick, show_more_text: showMoreText,
     } = this.props;
     // default prop values
     if (numOfLines === undefined) {
       numOfLines = 1;
-    }
-
-    if (showMoreText === undefined) {
-      showMoreText = 'more';
     }
 
     if (learnMoreText === undefined) {
@@ -129,12 +130,14 @@ export default class LearnMore extends Component {
         )}
       />
     ) : (
-      <a
+      <Button
+        color="primary"
+        classes={{ root: classes.headerButtonRoot }}
         onClick={onClick}
-        onKeyDown={this.onKeyDown.bind(this)}
+        onKeyDown={this.onKeyDown}
       >
         {learnMoreText}
-      </a>
+      </Button>
     );
     if (notEnoughTextToTruncate) {
       return (
@@ -147,7 +150,7 @@ export default class LearnMore extends Component {
         </span>
       );
     }
-
+    // console.log('numOfLines: ', numOfLines, ', textToDisplay: ', textToDisplay, ', showMoreText:', showMoreText);
     if (this.state.readMore) {
       return (
         <span>
@@ -155,14 +158,16 @@ export default class LearnMore extends Component {
             line={numOfLines}
             truncateText="..."
             text={textToDisplay}
-            textTruncateChild={(
-              <a
+            textTruncateChild={showMoreText ? (
+              <Button
+                color="primary"
+                classes={{ root: classes.headerButtonRoot }}
                 onClick={this.showMore}
-                onKeyDown={this.onKeyDown.bind(this)}
+                onKeyDown={this.onKeyDown}
               >
                 {showMoreText}
-              </a>
-            )}
+              </Button>
+            ) : null}
           />
         </span>
       );
@@ -180,3 +185,21 @@ export default class LearnMore extends Component {
     }
   }
 }
+
+const styles = theme => ({
+  headerButtonRoot: {
+    paddingTop: 2,
+    paddingBottom: 2,
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
+    color: 'rgb(6, 95, 212)',
+    marginLeft: '1rem',
+    outline: 'none !important',
+    [theme.breakpoints.down('md')]: {
+      marginLeft: '.1rem',
+    },
+  },
+});
+
+export default withStyles(styles)(LearnMore);

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -18,7 +18,6 @@ class PositionPublicToggle extends Component {
     ballotItemWeVoteId: PropTypes.string.isRequired,
     className: PropTypes.string.isRequired,
     inTestMode: PropTypes.bool,
-    // onToggleChangeFunction: PropTypes.func, // This was written for react-bootstrap-toggle version 2.3.1, but we are having some troubles upgrading
     supportProps: PropTypes.object,
     type: PropTypes.string.isRequired,
     classes: PropTypes.object,
@@ -31,8 +30,6 @@ class PositionPublicToggle extends Component {
       positionPublicToggleCurrentState: '',
       showToThePublicOn: false,
     };
-
-    this.onToggleChangeFunction = this.onToggleChangeFunction.bind(this);
   }
 
   componentDidMount () {
@@ -52,17 +49,12 @@ class PositionPublicToggle extends Component {
     this.setState({ voter: VoterStore.getVoter() });
   }
 
-  onToggleChangeFunction (state) {
-    // This was written for react-bootstrap-toggle version 2.3.1, but we are having some troubles upgrading
-    console.log('PositionPublicToggle onToggleChangeFunction, state:', state);
-    if (state === 'SHOW_PUBLIC') {
-      this.setState({
-        positionPublicToggleCurrentState: 'Show publicly',
-      });
+  handlePositionToggle = (evt) => {
+    const { value } = evt.target;
+    if (value === 'Public') {
+      this.showItemToPublic();
     } else {
-      this.setState({
-        positionPublicToggleCurrentState: 'Show to friends only',
-      });
+      this.showItemToFriendsOnly();
     }
   }
 
@@ -102,15 +94,6 @@ class PositionPublicToggle extends Component {
     this.setState({
       showPositionPublicHelpModal: !showPositionPublicHelpModal,
     });
-  }
-
-  handlePositionToggle = (evt) => {
-    const { value } = evt.target;
-    if (value === 'Public') {
-      this.showItemToPublic();
-    } else {
-      this.showItemToFriendsOnly();
-    }
   }
 
   render () {

--- a/src/js/components/Widgets/TopCommentByBallotItem.jsx
+++ b/src/js/components/Widgets/TopCommentByBallotItem.jsx
@@ -146,7 +146,7 @@ export default class TopCommentByBallotItem extends Component {
     const { endorsementOrganization, endorsementText } = this.state;
     if (!endorsementText) {
       // console.log('TopCommentByBallotItem no endorsementText');
-      // If we don't have any endorsement text, show the Values
+      // If we don't have any endorsement text, show the alternate component passed in
       return this.props.children || null;
     }
 

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -893,6 +893,7 @@ class Ballot extends Component {
                                         color={(oneTypeOfBallotItem === raceLevelFilterType && !isSearching) ? 'primary' : 'default'}
                                         badgeContent={ballotItemsByFilterType.length}
                                         invisible={ballotItemsByFilterType.length === 0}
+                                        onClick={() => this.setBallotItemFilterType(oneTypeOfBallotItem, ballotItemsByFilterType.length)}
                                       >
                                         <Chip variant="outlined"
                                           color={(oneTypeOfBallotItem === raceLevelFilterType && !isSearching) ? 'primary' : 'default'}
@@ -1055,6 +1056,7 @@ const styles = theme => ({
     right: 14,
     background: 'rgba(46, 60, 93, 0.08)',
     color: '#333',
+    cursor: 'pointer',
     [theme.breakpoints.down('md')]: {
       fontSize: 9,
       width: 16,

--- a/src/js/routes/Welcome.jsx
+++ b/src/js/routes/Welcome.jsx
@@ -1,24 +1,24 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import Helmet from "react-helmet";
-import { Link } from "react-router";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
+import { Link } from 'react-router';
 import {
   Button, FormGroup, Row, OverlayTrigger, Tooltip,
-} from "react-bootstrap";
-import cookies from "../utils/cookies";
+} from 'react-bootstrap';
+import cookies from '../utils/cookies';
 import {
   cordovaDot, historyPush, isCordova, isWebApp,
-} from "../utils/cordovaUtils";
-import AnalyticsActions from "../actions/AnalyticsActions";
-import validateEmail from "../utils/email-functions";
-import FacebookStore from "../stores/FacebookStore";
-import FacebookActions from "../actions/FacebookActions";
-import { oAuthLog, renderLog } from "../utils/logging";
-import OpenExternalWebSite from "../utils/OpenExternalWebSite";
-import VoterActions from "../actions/VoterActions";
-import VoterConstants from "../constants/VoterConstants";
-import VoterStore from "../stores/VoterStore";
-import webAppConfig from "../config";
+} from '../utils/cordovaUtils';
+import AnalyticsActions from '../actions/AnalyticsActions';
+import validateEmail from '../utils/email-functions';
+import FacebookStore from '../stores/FacebookStore';
+import FacebookActions from '../actions/FacebookActions';
+import { oAuthLog, renderLog } from '../utils/logging';
+import OpenExternalWebSite from '../utils/OpenExternalWebSite';
+import VoterActions from '../actions/VoterActions';
+import VoterConstants from '../constants/VoterConstants';
+import VoterStore from '../stores/VoterStore';
+import webAppConfig from '../config';
 
 export default class Intro extends Component {
   static propTypes = {
@@ -42,8 +42,8 @@ export default class Intro extends Component {
       maximum_friends_display: 5,
       facebook_friends_using_we_vote_list: FacebookStore.facebookFriendsUsingWeVoteList(),
       submit_enabled: false,
-      voter_email_address: "",
-      voter_full_name: "",
+      voter_email_address: '',
+      voter_full_name: '',
     };
 
     this._toggleBallotFeature = this._toggleBallotFeature.bind(this);
@@ -66,7 +66,7 @@ export default class Intro extends Component {
     this.onFacebookStoreChange();
     this.facebookStoreListener = FacebookStore.addListener(this.onFacebookStoreChange.bind(this));
     const weVoteBrandingOffFromUrl = this.props.location.query ? this.props.location.query.we_vote_branding_off : 0;
-    const weVoteBrandingOffFromCookie = cookies.getItem("we_vote_branding_off");
+    const weVoteBrandingOffFromCookie = cookies.getItem('we_vote_branding_off');
     this.setState({
       we_vote_branding_off: weVoteBrandingOffFromUrl || weVoteBrandingOffFromCookie,
     });
@@ -75,6 +75,33 @@ export default class Intro extends Component {
   componentWillUnmount () {
     this.voterStoreListener.remove();
     this.facebookStoreListener.remove();
+  }
+
+  onFacebookStoreChange () {
+    this.setState({
+      facebook_friends_using_we_vote_list: FacebookStore.facebookFriendsUsingWeVoteList(),
+    });
+  }
+
+  onVoterStoreChange () {
+    // console.log('is_verification_email_sent:  ' + VoterStore.isVerificationEmailSent());
+    this.setState({
+      newsletter_opt_in_true: VoterStore.getNotificationSettingsFlagState(VoterConstants.NOTIFICATION_NEWSLETTER_OPT_IN),
+
+      // is_verification_email_sent: VoterStore.isVerificationEmailSent(),
+      voter: VoterStore.getVoter(),
+    });
+  }
+
+  voterEmailAddressSignUpSave = (event) => {
+    // Only proceed after we have a valid email address, which will enable the submit
+    if (this.state.submit_enabled) {
+      event.preventDefault();
+      const sendLinkToSignIn = true;
+      VoterActions.voterEmailAddressSave(this.state.voter_email_address, sendLinkToSignIn);
+      VoterActions.voterFullNameSoftSave('', '', this.state.voter_full_name);
+      VoterActions.voterUpdateNotificationSettingsFlags(VoterConstants.NOTIFICATION_NEWSLETTER_OPT_IN);
+    }
   }
 
   _toggleBallotFeature () {
@@ -107,25 +134,9 @@ export default class Intro extends Component {
     this.setState({ showFeaturesVote: !showFeaturesVote });
   }
 
-  onVoterStoreChange () {
-    // console.log("is_verification_email_sent:  " + VoterStore.isVerificationEmailSent());
-    this.setState({
-      newsletter_opt_in_true: VoterStore.getNotificationSettingsFlagState(VoterConstants.NOTIFICATION_NEWSLETTER_OPT_IN),
-
-      // is_verification_email_sent: VoterStore.isVerificationEmailSent(),
-      voter: VoterStore.getVoter(),
-    });
-  }
-
-  onFacebookStoreChange () {
-    this.setState({
-      facebook_friends_using_we_vote_list: FacebookStore.facebookFriendsUsingWeVoteList(),
-    });
-  }
-
   goToGetStarted () {
     // Link to onboarding sequence: /wevoteintro/network
-    const getStartedNow = "/ballot";
+    const getStartedNow = '/ballot';
     historyPush(getStartedNow);
   }
 
@@ -148,57 +159,46 @@ export default class Intro extends Component {
     });
   }
 
-  voterEmailAddressSignUpSave = (event) => {
-    // Only proceed after we have a valid email address, which will enable the submit
-    if (this.state.submit_enabled) {
-      event.preventDefault();
-      const sendLinkToSignIn = true;
-      VoterActions.voterEmailAddressSave(this.state.voter_email_address, sendLinkToSignIn);
-      VoterActions.voterFullNameSoftSave("", "", this.state.voter_full_name);
-      VoterActions.voterUpdateNotificationSettingsFlags(VoterConstants.NOTIFICATION_NEWSLETTER_OPT_IN);
-    }
-  }
-
   shareToFacebookButton () {
     const api = isWebApp() ? window.FB : window.facebookConnectPlugin; // eslint-disable-line no-undef
     api.ui({
-      display: "popup",
+      display: 'popup',
       redirect_uri: `${webAppConfig.WE_VOTE_HOSTNAME}/welcome`,
-      method: "share",
+      method: 'share',
       mobile_iframe: true,
       href: webAppConfig.WE_VOTE_HOSTNAME,
-      quote: "I am getting ready to vote at We Vote. Join me! https://WeVote.US #Vote #WeVote",
+      quote: 'I am getting ready to vote at We Vote. Join me! https://WeVote.US #Vote #WeVote',
     }, (response) => {
       if (response === undefined || response.error_code === 4201) {
-        console.log("Voter Canceled the share request");
+        console.log('Voter Canceled the share request');
       } else if (response) {
-        oAuthLog("Successfully Shared", response);
+        oAuthLog('Successfully Shared', response);
       }
     });
   }
 
   render () {
     renderLog(__filename);
-    let actualFullName = "";
+    let actualFullName = '';
     let isVoterSignedIn = false;
-    const mailToUrl = "mailto:?subject=Check out We Vote&body=I am using We Vote to discuss what is on my ballot. You can see it at https://WeVote.US too.";
+    const mailToUrl = 'mailto:?subject=Check out We Vote&body=I am using We Vote to discuss what is on my ballot. You can see it at https://WeVote.US too.';
     if (this.state.voter) {
       isVoterSignedIn = this.state.voter.is_signed_in;
       if (this.state.voter.first_name || this.state.voter.last_name) {
         actualFullName = this.state.voter.full_name;
-        if (actualFullName.startsWith("voter")) {
-          actualFullName = "";
+        if (actualFullName.startsWith('voter')) {
+          actualFullName = '';
         }
       }
     }
 
-    let pleaseShareString = "Please share or donate to help us reach more voters.";
+    let pleaseShareString = 'Please share or donate to help us reach more voters.';
     if (isCordova()) {
-      pleaseShareString = "Please share to help us reach more voters.";
+      pleaseShareString = 'Please share to help us reach more voters.';
     }
 
-    const ballotBaseUrl = "https://WeVote.US/welcome";
-    const encodedMessage = encodeURIComponent("I am getting ready to vote @WeVote. Join me!");
+    const ballotBaseUrl = 'https://WeVote.US/welcome';
+    const encodedMessage = encodeURIComponent('I am getting ready to vote @WeVote. Join me!');
     const twitterIntent = `https://twitter.com/intent/tweet?url=${encodeURIComponent(ballotBaseUrl)}&text=${encodedMessage}&hashtags=Voting,WeVote`;
 
     let localCounter = 0;
@@ -229,7 +229,7 @@ export default class Intro extends Component {
       <div className="welcome-page">
         <Helmet title="Welcome to We Vote" />
         <section className="hero__section__container">
-          <div className="hero__section" style={isCordova() ? { backgroundImage: "url(./img/welcome/header-image-desktop.png)" } : null}>
+          <div className="hero__section" style={isCordova() ? { backgroundImage: 'url(./img/welcome/header-image-desktop.png)' } : null}>
             <div className="container">
               <Row bsPrefix="hero__section__row">
                 <div className="col-md-12">
@@ -249,7 +249,7 @@ export default class Intro extends Component {
                       }
                       <section className="quick-links__section--mobile u-flex">
                         {/* Link to onboarding sequence: /wevoteintro/network */}
-                        <a className="quick-links__button quick-links__button--left" onClick={() => historyPush("/ballot")}>Get Started</a>
+                        <a className="quick-links__button quick-links__button--left" onClick={() => historyPush('/ballot')}>Get Started</a>
                       </section>
 
                       <div className="share-your-vision__h1">
@@ -257,7 +257,7 @@ export default class Intro extends Component {
 
                         <section className="quick-links__section--mobile u-flex">
                           {/* When we want to bring this link back to internal:
-                            <a className="quick-links__button quick-links__button--right" onClick={() => historyPush("/voterguidegetstarted")}>Enter Voter Guide</a> */}
+                            <a className="quick-links__button quick-links__button--right" onClick={() => historyPush('/voterguidegetstarted')}>Enter Voter Guide</a> */}
                           <OpenExternalWebSite
                             url="https://api.wevoteusa.org/vg/create/"
                             className="quick-links__button quick-links__button--right"
@@ -283,18 +283,18 @@ export default class Intro extends Component {
                       }
                       <section className="quick-links__section--desktop u-flex">
                         {/* Link to onboarding sequence: /wevoteintro/network */}
-                        <a className="quick-links__button quick-links__button--left" onClick={() => historyPush("/ballot")}>Get Started</a>
+                        <a className="quick-links__button quick-links__button--left" onClick={() => historyPush('/ballot')}>Get Started</a>
                       </section>
                     </h1>
 
                     <h1 className="col-md-6 u-f1 u-stack--lg">
                     Share your vision.
                       <br />
-                      {" "}
+                      {' '}
                       <br />
                       <section className="quick-links__section--desktop u-flex">
                         {/* When we want to bring this link back to internal:
-                            <a className="quick-links__button quick-links__button--right" onClick={() => historyPush("/voterguidegetstarted")}>Enter Voter Guide</a> */}
+                            <a className="quick-links__button quick-links__button--right" onClick={() => historyPush('/voterguidegetstarted')}>Enter Voter Guide</a> */}
                         <OpenExternalWebSite
                               url="https://api.wevoteusa.org/vg/create/"
                               className="quick-links__button quick-links__button--right"
@@ -404,8 +404,8 @@ export default class Intro extends Component {
                 {/* <div className="features__block features__block__row1" onClick={this._toggleBallotFeature}> */}
                 <div className="features__block features__block__row1">
                   <Link to="/wevoteintro/network">
-                    {/* <img className={this.state.showFeaturesBallot ? "d-none d-sm-block features__image" : "features__image"} src={cordovaDot("/img/welcome/benefits/view-your-ballot.svg")} width="55%" /> */}
-                    <img className="features__image" src={cordovaDot("/img/welcome/benefits/view-your-ballot.svg")} width="55%" />
+                    {/* <img className={this.state.showFeaturesBallot ? "d-none d-sm-block features__image" : "features__image"} src={cordovaDot('/img/welcome/benefits/view-your-ballot.svg')} width="55%" /> */}
+                    <img className="features__image" src={cordovaDot('/img/welcome/benefits/view-your-ballot.svg')} width="55%" />
                     <h3 className="features__h3">View Your Ballot</h3>
                     {/* <p className={this.state.showFeaturesBallot ? "features__p" : "features__p d-none d-sm-block"}>See your actual ballot, including candidates and measures.</p> */}
                     <p className="features__p">See your actual ballot, including candidates and measures.</p>
@@ -416,7 +416,7 @@ export default class Intro extends Component {
                 <div className="features__block features__block__row1a" onClick={this._toggleOrganizationsFeature}>
                   <Link to="/more/network/issues">
                     {/* <img className={this.state.showFeaturesOrganizations ? "d-none d-sm-block features__image" : "features__image"} src={cordovaDot("/img/welcome/benefits/learn-issues-orgs.svg")} width="60%" /> */}
-                    <img className="features__image" src={cordovaDot("/img/welcome/benefits/learn-issues-orgs.svg")} width="60%" />
+                    <img className="features__image" src={cordovaDot('/img/welcome/benefits/learn-issues-orgs.svg')} width="60%" />
                     <h3 className="features__h3">Learn From Issues and Organizations</h3>
                     {/* <p className={this.state.showFeaturesOrganizations ? "features__p" : "features__p d-none d-sm-block"}>Follow the issues and Listen to the voter guides of groups you trust. See what they support or oppose.</p> */}
                     <p className="features__p">Follow the issues and Listen to the voter guides of groups you trust. See what they support or oppose.</p>
@@ -426,7 +426,7 @@ export default class Intro extends Component {
               <div className="col-sm-12 col-md-4 u-flex u-justify-center features__block__container">
                 <div className="features__block features__block__row2" onClick={this._togglePositionsFeature}>
                   <Link to="/ballot">
-                    <img className={this.state.showFeaturesPositions ? "d-none d-sm-block features__image" : "features__image"} src={cordovaDot("/img/welcome/benefits/network-position.svg")} />
+                    <img className={this.state.showFeaturesPositions ? 'd-none d-sm-block features__image' : 'features__image'} src={cordovaDot('/img/welcome/benefits/network-position.svg')} />
                     <h3 className="features__h3">See Your Network&apos;s Positions</h3>
                     {/* <p className={this.state.showFeaturesPositions ? "features__p" : "features__p d-none d-sm-block"}>See how many in your network support or oppose each candidate or measure.</p> */}
                     <p className="features__p">See how many in your network support or oppose each candidate or measure.</p>
@@ -436,7 +436,7 @@ export default class Intro extends Component {
               <div className="col-sm-12 col-md-4 u-flex u-justify-center features__block__container">
                 <div className="features__block features__block__row2a" onClick={this._toggleNetworkFeature}>
                   <Link to="/more/network/friends">
-                    <img className={this.state.showFeaturesNetwork ? "d-none d-sm-block features__image" : "features__image"} src={cordovaDot("/img/welcome/benefits/choose-friends.svg")} width="60%" />
+                    <img className={this.state.showFeaturesNetwork ? 'd-none d-sm-block features__image' : 'features__image'} src={cordovaDot('/img/welcome/benefits/choose-friends.svg')} width="60%" />
                     <h3 className="features__h3">Invite Friends to Your We Vote Network</h3>
                     {/* <p className={this.state.showFeaturesNetwork ? "features__p" : "features__p d-none d-sm-block"}>Talk politics with friends who share your values. Avoid flame wars!</p> */}
                     <p className="features__p">Talk politics with friends who share your values. Avoid flame wars!</p>
@@ -446,7 +446,7 @@ export default class Intro extends Component {
               <div className="col-sm-12 col-md-4 u-flex u-justify-center features__block__container">
                 <div className="features__block features__block__row3" onClick={this._toggleVisionFeature}>
                   <Link to="/voterguidegetstarted">
-                    <img className={this.state.showFeaturesVision ? "d-none d-sm-block features__image" : "features__image"} src={cordovaDot("/img/welcome/benefits/share-vision.svg")} width="55%" />
+                    <img className={this.state.showFeaturesVision ? 'd-none d-sm-block features__image' : 'features__image'} src={cordovaDot('/img/welcome/benefits/share-vision.svg')} width="55%" />
                     <h3 className="features__h3">Share Your Vision</h3>
                     {/* <p className={this.state.showFeaturesVision ? "features__p" : "features__p d-none d-sm-block"}>Empower other voters with what you&apos;ve learned. Help your friends.</p> */}
                     <p className="features__p">Empower other voters with what you&apos;ve learned. Help your friends.</p>
@@ -456,7 +456,7 @@ export default class Intro extends Component {
               <div className="col-sm-12 col-md-4 u-flex u-justify-center features__block__container">
                 <div className="features__block features__block__row3a" onClick={this._toggleVoteFeature}>
                   <Link to="/wevoteintro/network">
-                    <img className={this.state.showFeaturesVote ? "d-none d-sm-block features__image" : "features__image"} src={cordovaDot("/img/welcome/benefits/decide.svg")} width="60%" />
+                    <img className={this.state.showFeaturesVote ? 'd-none d-sm-block features__image' : 'features__image'} src={cordovaDot('/img/welcome/benefits/decide.svg')} width="60%" />
                     <h3 className="features__h3">Decide & Vote</h3>
                     {/* <p className={this.state.showFeaturesVote ? "features__p" : "features__p d-none d-sm-block"}>Cast your vote with confidence after using We Vote.</p> */}
                     <p className="features__p">Cast your vote with confidence after using We Vote.</p>
@@ -474,10 +474,10 @@ export default class Intro extends Component {
             <div className="container">
               <h2 className="u-f2 u-stack--lg">Our Network</h2>
               <div className="partner__logos">
-                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot("/img/welcome/partners/google-logo.svg")} alt="Google" width="150" />
-                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot("/img/welcome/partners/center-for-technology.png")} alt="Center for Technology and Civic Life" width="200" />
-                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot("/img/welcome/partners/vote-org.png")} alt="Vote.org" width="169" />
-                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot("/img/welcome/partners/voting-information-project.png")} alt="Voting Information Project" width="193" />
+                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot('/img/welcome/partners/google-logo.svg')} alt="Google" width="150" />
+                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot('/img/welcome/partners/center-for-technology.png')} alt="Center for Technology and Civic Life" width="200" />
+                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot('/img/welcome/partners/vote-org.png')} alt="Vote.org" width="169" />
+                <img className="partner-logo u-push--lg u-stack--lg" src={cordovaDot('/img/welcome/partners/voting-information-project.png')} alt="Voting Information Project" width="193" />
               </div>
             </div>
           </section>
@@ -498,7 +498,7 @@ export default class Intro extends Component {
                     onClick={this.shareToFacebookButton}
                   >
                     <span className="fa fa-facebook" />
-                    {" "}
+                    {' '}
                     Facebook
                   </Button>
                   <OpenExternalWebSite
@@ -529,7 +529,7 @@ export default class Intro extends Component {
                   <Link to="/more/donate">
                     <button className="btn btn-social btn-danger u-push--sm" type="button">
                       <span className="fa fa-heart" />
-                      {" "}
+                      {' '}
                       Donate
                     </button>
                   </Link>
@@ -566,11 +566,11 @@ export default class Intro extends Component {
             <div className="u-f--small u-stack--lg">
               <p>
                 WeVote.US is brought to you by a partnership between two registered nonprofit organizations, one
-                {" "}
+                {' '}
                 <span className="u-no-break">501(c)(3)</span>
-                {" "}
+                {' '}
                 and one
-                {" "}
+                {' '}
                 <span className="u-no-break">501(c)(4)</span>
                 .
                 <br />

--- a/src/js/stores/CandidateStore.js
+++ b/src/js/stores/CandidateStore.js
@@ -373,7 +373,7 @@ class CandidateStore extends ReduceStore {
                 // Only proceed if the position doesn't already exist
                 if (Object.prototype.hasOwnProperty.call(onePosition, 'ballot_item_we_vote_id')) {
                   // Do not proceed
-                  console.log('voterGuidesToFollowRetrieve Support position already exists');
+                  // console.log('voterGuidesToFollowRetrieve Support position already exists');
                 } else {
                   onePosition = this.createCandidatePosition(oneCandidateWeVoteId, oneVoterGuide);
                   // These are support positions
@@ -399,7 +399,7 @@ class CandidateStore extends ReduceStore {
                 // Only proceed if the position doesn't already exist
                 if (Object.prototype.hasOwnProperty.call(onePosition, 'ballot_item_we_vote_id')) {
                   // Do not proceed
-                  console.log('voterGuidesToFollowRetrieve Info only position already exists');
+                  // console.log('voterGuidesToFollowRetrieve Info only position already exists');
                 } else {
                   onePosition = this.createCandidatePosition(oneCandidateWeVoteId, oneVoterGuide);
                   // These are information only positions
@@ -424,7 +424,7 @@ class CandidateStore extends ReduceStore {
 
                 if (Object.prototype.hasOwnProperty.call(onePosition, 'ballot_item_we_vote_id')) {
                   // Do not proceed
-                  console.log('voterGuidesToFollowRetrieve Oppose position already exists');
+                  // console.log('voterGuidesToFollowRetrieve Oppose position already exists');
                 } else {
                   onePosition = this.createCandidatePosition(oneCandidateWeVoteId, oneVoterGuide);
                   // These are oppose positions

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -164,6 +164,7 @@
 
     &__description {
       color: $gray-dark;
+      font-size: 12px;
     }
 
     &__rating-description {
@@ -184,7 +185,7 @@
         overflow: hidden;
         position: relative;
         height: $text-container-height;
-        line-height: $line-height;
+        // line-height: $line-height;
 
         &::before {
           content: '';
@@ -200,7 +201,7 @@
         }
 
         &::after {
-          content: '\00A0 Read More';
+          // content: '\00A0 Read More';
           box-sizing: content-box;
           float: right;
           position: relative;


### PR DESCRIPTION
On office detail page, if there aren't any values or endorsements to show, show the candidate's bio. Changed some LearnMore component styling. Fixed eslint problems on Welcome page. Turned off mobile and tablet footer on the "Back to" pages. Shifted up the Zendesk help widget so it never sits on top of the mobile footer.