### PR TITLE
Issue 1987 - Add "Friend Requests" count to the footer

### DIFF
--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -2,17 +2,40 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import BottomNavigation from '@material-ui/core/BottomNavigation';
 import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
+import Badge from '@material-ui/core/Badge';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
 import DescriptionIcon from '@material-ui/icons/Description';
 import SettingsIcon from '@material-ui/icons/Settings';
 import PeopleIcon from '@material-ui/icons/People';
 import { historyPush } from '../../utils/cordovaUtils';
 import { stringContains } from '../../utils/textFormat';
+import FriendStore from '../../stores/FriendStore';
 
 class FooterBar extends React.Component {
   static propTypes = {
     pathname: PropTypes.string,
   };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      friendInvitationsSentToMe: 0,
+    };
+  }
+
+  componentDidMount () {
+    this.friendStoreListener = FriendStore.addListener(this.onFriendStoreChange.bind(this));
+
+    this.setState({
+      friendInvitationsSentToMe: FriendStore.friendInvitationsSentToMe(),
+    });
+  }
+
+  onFriendStoreChange () {
+    this.setState({
+      friendInvitationsSentToMe: FriendStore.friendInvitationsSentToMe(),
+    });
+  }
 
   handleChange = (event, value) => {
     switch (value) {
@@ -38,8 +61,19 @@ class FooterBar extends React.Component {
     return -1;
   };
 
+  handleNavigation = to => historyPush(to);
+
   render () {
     // console.log('FooterBar render');
+    const numberOfIncomingFriendRequests = this.state.friendInvitationsSentToMe.length || 2;
+    const classes = this.props;
+
+    const badgeStyle = {
+      position: 'absolute',
+      left: 'calc(50% + 25px)',
+      top: '10px',
+    };
+
     return (
       <div className="footer-container u-show-mobile-tablet">
         <BottomNavigation
@@ -49,7 +83,18 @@ class FooterBar extends React.Component {
         >
           <BottomNavigationAction className="no-outline" label="Ballot" showLabel icon={<DescriptionIcon />} />
           <BottomNavigationAction className="no-outline" label="Values" showLabel icon={<QuestionAnswerIcon />} />
-          <BottomNavigationAction className="no-outline" label="Friends" showLabel icon={<PeopleIcon />} />
+          <BottomNavigationAction
+            className="no-outline"
+            label="Friends"
+            showLabel
+            icon={
+            (
+              <span>
+                <PeopleIcon />
+                <Badge classes={{ badge: classes.headerBadge }} badgeContent={numberOfIncomingFriendRequests} color="primary" max={9} style={badgeStyle} onClick={() => this.handleNavigation('/friends')} />
+              </span>
+            )}
+          />
           {/* <BottomNavigationAction className="no-outline" label="Vote" showLabel icon={<ion-icon class="footer-icon" name="clipboard" />} /> */}
           <BottomNavigationAction className="no-outline" id="valuesTabFooterBar" label="Settings" showLabel icon={<SettingsIcon />} />
         </BottomNavigation>

--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -65,7 +65,7 @@ class FooterBar extends React.Component {
 
   render () {
     // console.log('FooterBar render');
-    const numberOfIncomingFriendRequests = this.state.friendInvitationsSentToMe.length || 2;
+    const numberOfIncomingFriendRequests = this.state.friendInvitationsSentToMe.length || 0;
     const classes = this.props;
 
     const badgeStyle = {

--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -76,19 +76,14 @@ class FooterBar extends React.Component {
 
     return (
       <div className="footer-container u-show-mobile-tablet">
-        <BottomNavigation
-          value={this.getSelectedTab()}
-          onChange={this.handleChange}
-          showLabels
-        >
+        <BottomNavigation value={this.getSelectedTab()} onChange={this.handleChange} showLabels>
           <BottomNavigationAction className="no-outline" label="Ballot" showLabel icon={<DescriptionIcon />} />
           <BottomNavigationAction className="no-outline" label="Values" showLabel icon={<QuestionAnswerIcon />} />
           <BottomNavigationAction
             className="no-outline"
             label="Friends"
             showLabel
-            icon={
-            (
+            icon={(
               <span>
                 <PeopleIcon />
                 <Badge classes={{ badge: classes.headerBadge }} badgeContent={numberOfIncomingFriendRequests} color="primary" max={9} style={badgeStyle} onClick={() => this.handleNavigation('/friends')} />


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#1987 

### Changes included this pull request?
Updated the FooterBar.jsx file to count friend requests and display as a badge above the tab on the footer menu.

Change line 68 from
`const numberOfIncomingFriendRequests = this.state.friendInvitationsSentToMe.length || 0;`   
to  
`const numberOfIncomingFriendRequests = this.state.friendInvitationsSentToMe.length || 2;`
to see it in action.

Let me know if this needs some changes.
