### PR TITLE
Fix measureHeader on scroll up

### DIFF
--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -26,7 +26,7 @@ class MeasureItem extends Component {
       stateCode: '',
       stateDisplayName: '',
       showPositionStatementActionBar: true,
-      scrolledDown: AppStore.getScrolledDown(),
+      // scrolledDown: AppStore.getScrolledDown(),
     };
     this.getMeasureLink = this.getMeasureLink.bind(this);
     this.goToMeasureLink = this.goToMeasureLink.bind(this);
@@ -62,11 +62,11 @@ class MeasureItem extends Component {
     });
   }
 
-  onAppStoreChange () {
-    this.setState({
-      scrolledDown: AppStore.getScrolledDown(),
-    });
-  }
+  // onAppStoreChange () {
+  //   this.setState({
+  //     // scrolledDown: AppStore.getScrolledDown(),
+  //   });
+  // }
 
   // onSupportStoreChange () {
   //   this.setState({ supportProps: SupportStore.get(this.props.we_vote_id) });
@@ -95,7 +95,6 @@ class MeasureItem extends Component {
     } = this.state;
     const {
       measureText, measureWeVoteId, electionDisplayName, regionalDisplayName, stateCode,
-      scrolledDown,
     } = this.state;
     if (stateDisplayName === undefined && stateCode) {
       stateDisplayName = stateCode.toUpperCase();

--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -142,14 +142,10 @@ class MeasureItem extends Component {
           ) :
             null
           }
-          {
-            !scrolledDown && (
-              <BallotItemSupportOpposeComment
-                ballotItemWeVoteId={measureWeVoteId}
-                showPositionStatementActionBar={this.state.showPositionStatementActionBar}
-              />
-            )
-          }
+          {<BallotItemSupportOpposeComment
+              ballotItemWeVoteId={measureWeVoteId}
+              showPositionStatementActionBar={this.state.showPositionStatementActionBar}
+          />}
         </div>
       </div>
     );


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2034 
### Changes included this pull request?
I removed the switch statement at line 145 in MeasureItem.jsx.  It checked if the page was scrolled down or not, and displayed the comment box depending on that switch.  However, I realized that the comment box can just be a static element, as it will scroll off the page and back on when the popover header appears and disappears. 

Don't know if this is what you want, but that's my best shot.