### PR TITLE
Update friends navigation

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -229,7 +229,7 @@ class HeaderBar extends Component {
                 )
                 }
                 {showFullNavigation && (
-                  <Tab classes={{ root: classes.tabRoot }} id="friendsTabHeaderBar" label={<Badge classes={{ badge: classes.headerBadge }} badgeContent={numberOfIncomingFriendRequests} color="primary" max={9} onClick={() => this.handleNavigation('/friends')}>My Friends</Badge>} />
+                  <Tab classes={{ root: classes.tabRoot }} id="friendsTabHeaderBar" label={<Badge classes={{ badge: classes.headerBadge }} badgeContent={numberOfIncomingFriendRequests} color="primary" max={9}>My Friends</Badge>} onClick={() => this.handleNavigation('/friends')} />
                 )
                 }
                 {/* showFullNavigation && isWebApp() && <Tab className="u-show-desktop" label="Vote" /> */}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

Previously, the friends tab did not click to the page if you didn't click on the middle of the tab. This was because the onClick() function was nested inside the badge element.  I moved the onClick() outside of the badge element, as with the other tabs, and now the full tab is clickable.
