### PR TITLE
Fix a couple issues in Browserstack tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "lint": "eslint --format stylish --ext .jsx --ext .js src/js",
     "lint-css": "gulp lint-css",
     "test": "npm run lint && npm run lint-css",
-    "test-browserstack": "./node_modules/.bin/wdio ./tests/browserstack-wdio/wdio.config.js",
+    "test-browserstack": "./node_modules/.bin/wdio ./tests/browserstack/wdio.config.js",
     "start": "gulp",
     "start-profile": "node --inspect-brk ./node_modules/.bin/gulp",
     "prod": "NODE_ENV=production gulp build",

--- a/tests/browserstack/specs/test.js
+++ b/tests/browserstack/specs/test.js
@@ -2,8 +2,8 @@ const assert = require('assert');
 
 describe('Basic cross-platform WeVote test',  () => {
   it('can visit the different pages in the app', async () => {
-    const isWebApp = !!driver.getContexts;
-    if (isWebApp) {
+    const isCordova = !!driver.getContexts;
+    if (isCordova) {
       // switch contexts and click through intro
       await driver.switchContext('WEBVIEW_org.wevote.cordova');
       const firstNextButton = await $('.background--image2 .btn.btn-lg');
@@ -18,7 +18,7 @@ describe('Basic cross-platform WeVote test',  () => {
       await browser.url('https://quality.wevote.us/');
 
     }
-    const valuesButtonSelector = (isWebApp) ? 'span=Values' : 'button[id="valuesTabHeaderBar"]';
+    const valuesButtonSelector = (isCordova) ? 'span=Values' : 'button[id="valuesTabHeaderBar"]';
     const valuesButton =
       await $(valuesButtonSelector);
     await valuesButton.click();

--- a/tests/browserstack/wdio.config.js
+++ b/tests/browserstack/wdio.config.js
@@ -31,7 +31,6 @@ exports.config = {
       'browserstack.geoLocation': 'US',
     },
   ],
-  
   coloredLogs: true,
   baseUrl: '',
   waitforTimeout: 10000,

--- a/tests/browserstack/wdio.config.js
+++ b/tests/browserstack/wdio.config.js
@@ -33,7 +33,7 @@ exports.config = {
   ],
   coloredLogs: true,
   baseUrl: '',
-  waitforTimeout: 10000,
+  waitforTimeout: 50000,
   connectionRetryTimeout: 90000,
   connectionRetryCount: 3,
 

--- a/tests/browserstack/wdio.config.js
+++ b/tests/browserstack/wdio.config.js
@@ -5,8 +5,7 @@ exports.config = {
   key: browserStackConfig.BROWSERSTACK_KEY,
   updateJob: false,
   specs: [
-    // CHANGE THIS AFTER RENAMING FOLDER
-    './tests/browserstack-2/specs/test.js',
+    './tests/browserstack/specs/test.js',
   ],
   exclude: [],
   capabilities: [


### PR DESCRIPTION
### Changes included this pull request?

I was a bit hasty last time I committed changes to the test script. This fixes a couple of issues:

1) Use correct folder names
2) Rename "isWebApp" to "isCordova" to reflect what the variable is doing
3) Increase Webdriverio's global timeout limit so that our android tests don't halt waiting for the app to load

After making these changes, I ran the tests again and they passed.