### PR TITLE
fixed typo in component name

### DIFF
--- a/src/js/components/Intro/IntroNetworkDefinition.jsx
+++ b/src/js/components/Intro/IntroNetworkDefinition.jsx
@@ -12,7 +12,7 @@ assets relative to the HTML. So if the CSS isn't in the same place as the HTML
 then you can't use relative paths."
 */
 
-export default class IntroNetworkDefenition extends Component {
+export default class IntroNetworkDefinition extends Component {
   static propTypes = {
     next: PropTypes.func,
   };


### PR DESCRIPTION
### Changes included this pull request?
A small typo I came across while working on QA. The importing component already uses the correct spelling