### PR TITLE
Disable hover state on candidate page

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -40,6 +40,7 @@ class CandidateItem extends Component {
     twitter_followers_count: PropTypes.number,
     // twitter_handle: PropTypes.string,
     we_vote_id: PropTypes.string.isRequired, // This is the candidate_we_vote_id
+    showHover: PropTypes.bool,
   };
 
   constructor (props) {
@@ -176,7 +177,7 @@ class CandidateItem extends Component {
 
     return (
       <div
-        className={this.state.hover ? (
+        className={this.state.hover && this.props.showHover ? (
           'card-main candidate-card card-main--outline'
         ) : (
           'card-main candidate-card'
@@ -184,7 +185,7 @@ class CandidateItem extends Component {
         onMouseEnter={this.handleEnter}
         onMouseLeave={this.handleLeave}
       >
-        {this.state.hover ? (
+        {this.state.hover && this.props.showHover ? (
           <Link to={this.getCandidateLink} className="card-main__no-underline">
             <div>
               <CandidateInfo className="card-main__media-object">
@@ -197,7 +198,7 @@ class CandidateItem extends Component {
                 </div>
                 <CandidateWrapper>
                   <Candidate>
-                    <h2 className={this.state.hover ? (
+                    <h2 className={this.state.hover && this.props.showHover ? (
                       'card-main__display-name card__blue'
                     ) : (
                       'card-main__display-name'
@@ -227,7 +228,7 @@ class CandidateItem extends Component {
                         'u-gray-darker u-cursor--pointer' :
                         'u-gray-darker'
                       } */
-                      className={this.state.hover ? (
+                      className={this.state.hover && this.props.showHover ? (
                         'card__blue'
                       ) : (
                         ''
@@ -268,7 +269,7 @@ class CandidateItem extends Component {
                   placement="bottom"
                   />
                   {/* If there is a quote about the candidate, show that too. */}
-                  <div className={this.state.hover ? (
+                  <div className={this.state.hover && this.props.showHover ? (
                     'card__blue'
                   ) : (
                     ''
@@ -338,7 +339,7 @@ class CandidateItem extends Component {
               </div>
               <CandidateWrapper>
                 <Candidate>
-                  <h2 className={this.state.hover ? (
+                  <h2 className={this.state.hover && this.props.showHover ? (
                     'card-main__display-name card__blue'
                   ) : (
                     'card-main__display-name'
@@ -368,7 +369,7 @@ class CandidateItem extends Component {
                       'u-gray-darker u-cursor--pointer' :
                       'u-gray-darker'
                     } */
-                    className={this.state.hover ? (
+                    className={this.state.hover && this.props.showHover ? (
                       'card__blue'
                     ) : (
                       ''
@@ -409,7 +410,7 @@ class CandidateItem extends Component {
                   placement="bottom"
                 />
                 {/* If there is a quote about the candidate, show that too. */}
-                <div className={this.state.hover ? (
+                <div className={this.state.hover && this.props.showHover ? (
                   'card__blue'
                 ) : (
                   ''

--- a/src/js/components/Ballot/CandidateList.jsx
+++ b/src/js/components/Ballot/CandidateList.jsx
@@ -17,6 +17,7 @@ export default class CandidateList extends Component {
         { this.props.children.map(child => (
           <div key={child.we_vote_id} className="card">
             <CandidateItem
+              showHover
               key={child.we_vote_id}
               contest_office_name={this.props.contest_office_name}
               hideBallotItemSupportOpposeComment

--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -73,11 +73,15 @@ class IssuesByBallotItemDisplayList extends Component {
 
   render () {
     const handleEnterHoverLocalArea = () => {
-      this.props.handleLeaveCandidateCard();
+      if (this.props.handleLeaveCandidateCard) {
+        this.props.handleLeaveCandidateCard();
+      }
     };
 
     const handleLeaveHoverLocalArea = () => {
-      this.props.handleEnterCandidateCard();
+      if (this.props.handleEnterCandidateCard) {
+        this.props.handleEnterCandidateCard();
+      }
     };
 
     renderLog(__filename);

--- a/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
@@ -268,11 +268,15 @@ class BallotItemSupportOpposeCountDisplay extends Component {
 
   render () {
     const handleEnterHoverLocalArea = () => {
-      this.props.handleLeaveCandidateCard();
+      if (this.props.handleLeaveCandidateCard) {
+        this.props.handleLeaveCandidateCard();
+      }
     };
 
     const handleLeaveHoverLocalArea = () => {
-      this.props.handleEnterCandidateCard();
+      if (this.props.handleEnterCandidateCard) {
+        this.props.handleEnterCandidateCard();
+      }
     };
 
     if (!this.state.ballotItemWeVoteId) return null;

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -1,4 +1,5 @@
 // 'Card' styling for Candidates, Organizations, etc.
+$outline-radius: 3px;
 
 @include media-object('.card-main__media-object', '.card-main__media-object-anchor', '.card-main__media-object-content');
 
@@ -50,7 +51,7 @@
 
     &--outline {
       border: 1px solid $link-color;
-      border-radius: 3px;
+      border-radius: $outline-radius;
     }
 
     &__no-underline *,
@@ -467,7 +468,7 @@
 
   // ----------------------------------------
 
-  &__blue, 
+  &__blue,
   &__blue * {
     color: $link-color !important;
   }

--- a/src/sass/components/_issues.scss
+++ b/src/sass/components/_issues.scss
@@ -234,10 +234,6 @@ $menu-item-padding: 7px;
     width: 18px !important;
     height: 18px !important;
   }
-  &__icon path {
-    width: 18px !important;
-    height: 18px !important;
-  }
   &__menu {
     font-size: 12.5px !important;
     position: absolute !important;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
I added a `showHover` prop to the `CandidateItem.jsx` component.  I only passed in that prop on the pages we wanted the hover state to show on.  On the `Candidate.jsx` page, the hover state is disabled.