### PR TITLE
Update to remove underline on hover

### DIFF
--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -52,6 +52,7 @@ $outline-radius: 3px;
     &--outline {
       border: 1px solid $link-color;
       border-radius: $outline-radius;
+      text-decoration: none !important;
     }
 
     &__no-underline *,


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
I noticed an underline on the content when the candidate card was hovered, so I disabled that.  I don't know if that's what you want or not, but here it is. :)