### PR TITLE
iOS testing script and some housekeeping

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,8 +7,7 @@
   "env": {
     "browser": true,
     "node": true,
-    "es6": true,
-    "mocha": true
+    "es6": true
   },
 
   "extends": "airbnb",

--- a/.eslintrc
+++ b/.eslintrc
@@ -72,7 +72,6 @@
     "template-curly-spacing": ["warn", "never"]
   },
     "plugins": [
-        "react",
-        "wdio"
+        "react"
     ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -72,6 +72,7 @@
     "template-curly-spacing": ["warn", "never"]
   },
     "plugins": [
-        "react"
+        "react",
+        "wdio"
     ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -160,7 +160,7 @@ staticfiles
 src/js/config.js
 src/js/config-qa.js
 src/js/config-www.js
-tests/browserstack/config.js
+tests/browserstack/browserstack.config.js
 src/javascript/google-tag-manager.js
 src/javascript/google-tag-manager-qa.js
 src/javascript/google-tag-manager-www.js

--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jsx-a11y": "^6.1.2",
     "eslint-plugin-react": "^7.11.1",
+    "eslint-plugin-wdio": "^5.7.8",
     "express": "^4.16.4",
     "fastclick": "^1.0.6",
     "gulp": "^4.0.0",

--- a/tests/browserstack/.eslintrc
+++ b/tests/browserstack/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "mocha": true
+  },
+
+  "extends": "plugin:wdio/recommended",
+
+  "plugins": [
+      "wdio"
+  ]
+}

--- a/tests/browserstack/specs/test.js
+++ b/tests/browserstack/specs/test.js
@@ -6,11 +6,14 @@ describe('Basic cross-platform WeVote test',  () => {
     if (isCordova) {
       // switch contexts and click through intro
       await driver.switchContext('WEBVIEW_org.wevote.cordova');
-      const firstNextButton = await $('.background--image2 .btn.btn-lg');
+      const firstNextButton = await $('div[data-index="0"] .intro-story__btn--bottom');
+      await browser.pause(1000);
       await firstNextButton.click();
-      const secondNextButton = await $('.background--image4 .btn.btn-lg');
+      const secondNextButton = await $('div[data-index="1"] .intro-story__btn--bottom');
+      await browser.pause(1000);
       await secondNextButton.click();
-      const thirdNextButton = await $('.background--image5 .btn.btn-lg');
+      const thirdNextButton = await $('div[data-index="2"] .intro-story__btn--bottom');
+      await browser.pause(1000);
       await thirdNextButton.click();
       await browser.pause(1000);
     } else {

--- a/tests/browserstack/specs/test.js
+++ b/tests/browserstack/specs/test.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 const assert = require('assert');
 
 const ANDROID_CONTEXT = 'WEBVIEW_org.wevote.cordova';
@@ -26,7 +24,6 @@ describe('Basic cross-platform WeVote test',  () => {
     } else {
       // navigate browser to WeVote QA site
       await browser.url('https://quality.wevote.us/ballot');
-
     }
     const valuesButtonSelector = (isCordova) ? 'span=Values' : '#valuesTabHeaderBar';
     const valuesButton =

--- a/tests/browserstack/specs/test.js
+++ b/tests/browserstack/specs/test.js
@@ -1,11 +1,16 @@
 const assert = require('assert');
 
+const ANDROID_CONTEXT = 'WEBVIEW_org.wevote.cordova';
+const IOS_CONTEXT = 'WEBVIEW_1';
+
 describe('Basic cross-platform WeVote test',  () => {
   it('can visit the different pages in the app', async () => {
     const isCordova = !!driver.getContexts;
     if (isCordova) {
       // switch contexts and click through intro
-      await driver.switchContext('WEBVIEW_org.wevote.cordova');
+      const contexts = await driver.getContexts();
+      const context = contexts.includes(ANDROID_CONTEXT) ? ANDROID_CONTEXT : IOS_CONTEXT;
+      await driver.switchContext(context);
       const firstNextButton = await $('div[data-index="0"] .intro-story__btn--bottom');
       await browser.pause(1000);
       await firstNextButton.click();
@@ -18,10 +23,10 @@ describe('Basic cross-platform WeVote test',  () => {
       await browser.pause(1000);
     } else {
       // navigate browser to WeVote QA site
-      await browser.url('https://quality.wevote.us/');
+      await browser.url('https://quality.wevote.us/ballot');
 
     }
-    const valuesButtonSelector = (isCordova) ? 'span=Values' : 'button[id="valuesTabHeaderBar"]';
+    const valuesButtonSelector = (isCordova) ? 'span=Values' : '#valuesTabHeaderBar';
     const valuesButton =
       await $(valuesButtonSelector);
     await valuesButton.click();

--- a/tests/browserstack/specs/test.js
+++ b/tests/browserstack/specs/test.js
@@ -1,3 +1,5 @@
+/* eslint-env mocha */
+
 const assert = require('assert');
 
 const ANDROID_CONTEXT = 'WEBVIEW_org.wevote.cordova';

--- a/tests/browserstack/wdio.config.js
+++ b/tests/browserstack/wdio.config.js
@@ -20,7 +20,7 @@ exports.config = {
       'browserstack.debug': true,
       'browserstack.geoLocation': 'US',
     },
-    /* {
+    {
       // capabilities for a cordova android test
       name: browserStackConfig.NAME,
       build: browserStackConfig.BUILD,
@@ -39,7 +39,7 @@ exports.config = {
       app: browserStackConfig.BROWSERSTACK_IPA_URL,
       'browserstack.debug': true,
       'browserstack.geoLocation': 'US',
-    }, */
+    },
   ],
   coloredLogs: true,
   baseUrl: '',

--- a/tests/browserstack/wdio.config.js
+++ b/tests/browserstack/wdio.config.js
@@ -20,7 +20,7 @@ exports.config = {
       'browserstack.debug': true,
       'browserstack.geoLocation': 'US',
     },
-    {
+    /* {
       // capabilities for a cordova android test
       name: browserStackConfig.NAME,
       build: browserStackConfig.BUILD,
@@ -30,6 +30,16 @@ exports.config = {
       'browserstack.debug': true,
       'browserstack.geoLocation': 'US',
     },
+    {
+      // capabilities for a cordova iOS test
+      name: browserStackConfig.NAME,
+      build: browserStackConfig.BUILD,
+      device: 'iPhone 8 Plus',
+      os_version: '11',
+      app: browserStackConfig.BROWSERSTACK_IPA_URL,
+      'browserstack.debug': true,
+      'browserstack.geoLocation': 'US',
+    }, */
   ],
   coloredLogs: true,
   baseUrl: '',


### PR DESCRIPTION
### Changes included this pull request?

These changes resulted in 3/3 passing tests before making a PR.

* Added iOS capabilities to config file and handled switching to webview context for iOS in test script.
* Updates selectors to reflect changes to cordova and live QA site
* removed 'mocha' environment from the global .eslintrc file in favor of using it in a separete .eslintrc for the tests/browserstack folder. Added a new dependency, eslint-plugin-wdio, and included it in that file as well. Basically, this just prevents the Webdriverio globals ($, $$, browser, and driver) from raising linting warnings.
* updated .gitignore to reflect new name for user's local config file  (which was changed after we switched to using Webdriverio from Selenium Webdriver)