### PR TITLE
Remove inline styles from PricingCards

### DIFF
--- a/src/js/components/More/PricingCard.jsx
+++ b/src/js/components/More/PricingCard.jsx
@@ -35,15 +35,7 @@ class PricingCard extends Component {
                 )}
                 {price === 0 || price ? (
                   <React.Fragment>
-                    <span style={{
-                      fontSize: '18px',
-                      fontWeight: '500',
-                      position: 'relative',
-                      bottom: '8px',
-                    }}
-                    >
-                    $
-                    </span>
+                    <DollarSign>$</DollarSign>
                     <Price>{price}</Price>
                     <PriceDescribe>
                       {priceDescribe}
@@ -617,6 +609,13 @@ const DefaultName = styled.h4`
   color: #2E3C5D;
   font-size: 18px;
   font-weight: bold;
+`;
+
+const DollarSign = styled.span`
+  font-size: 18px;
+  font-weight: 500;
+  position: relative;
+  bottom: 8px;
 `;
 
 const Price = styled.h2`

--- a/src/js/routes/More/Pricing.jsx
+++ b/src/js/routes/More/Pricing.jsx
@@ -47,7 +47,7 @@ class Pricing extends Component {
         <Section>
           <AboutDescriptionContainer>
             <div className="container">
-              <div className="row u-show-mobile-tablet">
+              <div className="u-show-mobile-tablet">
                 <SwitchContainer>
                   <PricingSwitch
                     color="white"
@@ -57,7 +57,7 @@ class Pricing extends Component {
                   />
                 </SwitchContainer>
 
-                <div>
+                <div className="row">
                   {selectedCategoryIndex === 0 ? (
                     <PricingCard
                       fullWidth


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Updated the Pricing Cards to remove the inline styles
