### PR TITLE
Update the mobile version of the placeholder images

### DIFF
--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -319,11 +319,19 @@ const MobileItemHeader = styled.div`
 `;
 
 const MobileItemImage = styled.div`
-  margin-right: 8px;
+  margin-right: 16px;
   width: 50px;
   height: 50px;
   * {
     border-radius: 50px;
+    width: 50px !important;
+    height: 50px !important;
+    max-width: 50px !important;
+    display: flex;
+    align-items: flex-start;
+    &::before {
+      font-size: 50px !important;
+    }
   }
 `;
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Mobile image placeholders are now the correct size