### PR TITLE
Friends/Public toggle fit on screen on iPhone 5

### DIFF
--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -486,7 +486,7 @@ class ItemActionBar extends PureComponent {
         classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
         size="small"
       >
-        <DoneIcon classes={{ root: classes.buttonIcon }} />
+        <DoneIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -526,7 +526,7 @@ class ItemActionBar extends PureComponent {
         classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
         size="small"
       >
-        <ThumbsUpIcon classes={{ root: classes.buttonIcon }} />
+        <ThumbsUpIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -568,7 +568,7 @@ class ItemActionBar extends PureComponent {
         classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
         size="small"
       >
-        <NotInterestedIcon classes={{ root: classes.buttonIcon }} />
+        <NotInterestedIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -608,7 +608,7 @@ class ItemActionBar extends PureComponent {
         classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
         size="small"
       >
-        <ThumbsDownIcon classes={{ root: classes.buttonIcon }} />
+        <ThumbsDownIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -653,7 +653,7 @@ class ItemActionBar extends PureComponent {
             inTestMode
           />
         )}
-        <div className={`${this.props.buttonsOnly ? '' : 'btn-group'} ${!this.props.shareButtonHide ? ' u-push--sm' : ''}`}>
+        <ButtonGroup className={`${this.props.buttonsOnly ? '' : 'btn-group'} ${!this.props.shareButtonHide ? ' u-push--sm' : ''}`}>
           {/* Start of Support Button */}
           {/* Visible on desktop screens */}
           {this.props.buttonsOnly ? (
@@ -676,10 +676,10 @@ class ItemActionBar extends PureComponent {
             </StackedButton>
           ) : (
             <>
-              <div className="u-push--xs d-none d-sm-block d-lg-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+              <div className="u-push--xs d-lg-none d-xl-none d-sm-block d-none ">
                 {this.props.type === 'CANDIDATE' ? supportButton : measureYesButton}
               </div>
-              <div className="u-push--xs d-block d-sm-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+              <div className="u-push--xs d-block d-sm-none ">
                 {this.props.type === 'CANDIDATE' ? supportButtonMobile : measureYesButtonMobile}
               </div>
             </>
@@ -707,10 +707,10 @@ class ItemActionBar extends PureComponent {
             </StackedButton>
           ) : (
             <>
-              <div className="u-push--xs d-none d-sm-block d-lg-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+              <div className="u-push--xs d-lg-none d-xl-none d-sm-block d-none ">
                 {this.props.type === 'CANDIDATE' ? opposeButton : measureNoButton}
               </div>
-              <div className="u-push--xs d-block d-sm-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+              <div className="u-push--xs d-block d-sm-none ">
                 {this.props.type === 'CANDIDATE' ? opposeButtonMobile : measureNoButtonMobile}
               </div>
             </>
@@ -726,7 +726,7 @@ class ItemActionBar extends PureComponent {
             null :
             <ShareButtonDropDown showMoreId="itemActionBarShowMoreFooter" urlBeingShared={urlBeingShared} shareIcon={shareIcon} shareText="Share" /> }
           { this.state.showSupportOrOpposeHelpModal ? SupportOrOpposeHelpModal : null}
-        </div>
+        </ButtonGroup>
       </div>
     );
   }
@@ -751,11 +751,26 @@ const styles = theme => ({
       marginLeft: '.1rem',
       marginTop: '.3rem',
     },
+    [theme.breakpoints.down('xs')]: {
+      width: 42.5,
+      minWidth: 42.5,
+      maxWidth: 42.5,
+      height: 40,
+      minHeight: 40,
+      maxHeight: 40,
+      fontSize: '15px !important',
+    },
   },
   buttonOutlinedPrimary: {
     background: 'white',
   },
 });
+
+const ButtonGroup = styled.div`
+  margin-left: auto;
+  width: fit-content;
+  flex: none;
+`;
 
 const StackedButton = styled.div`
   margin: 0;

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -477,19 +477,6 @@ class ItemActionBar extends PureComponent {
       </Button>
     );
 
-    const supportButtonMobile = (
-      <Button
-        id="itemActionBarSupportButton"
-        variant={this.isSupportCalculated() ? 'contained' : 'outlined'}
-        color="primary"
-        onClick={() => this.supportItem()}
-        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
-        size="small"
-      >
-        <DoneIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
-      </Button>
-    );
-
     const measureYesButton = (
       <Button
         id="itemActionBarYesButton"
@@ -514,19 +501,6 @@ class ItemActionBar extends PureComponent {
             Vote Yes
           </span>
         )}
-      </Button>
-    );
-
-    const measureYesButtonMobile = (
-      <Button
-        id="itemActionBarYesButton"
-        variant={this.isSupportCalculated() ? 'contained' : 'outlined'}
-        color="primary"
-        onClick={() => this.supportItem()}
-        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
-        size="small"
-      >
-        <ThumbsUpIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -558,20 +532,6 @@ class ItemActionBar extends PureComponent {
       </Button>
     );
 
-    const opposeButtonMobile = (
-      <Button
-        id="itemActionBarOpposeButton"
-        variant={this.isOpposeCalculated() ? 'contained' : 'outlined'}
-        color="primary"
-        className={`${this.props.opposeHideInMobile ? 'd-none d-sm-block ' : ''}`}
-        onClick={() => this.opposeItem()}
-        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
-        size="small"
-      >
-        <NotInterestedIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
-      </Button>
-    );
-
     const measureNoButton = (
       <Button
         id="itemActionBarNoButton"
@@ -596,19 +556,6 @@ class ItemActionBar extends PureComponent {
             Vote No
           </span>
         )}
-      </Button>
-    );
-
-    const measureNoButtonMobile = (
-      <Button
-        id="itemActionBarNoButton"
-        variant={this.isOpposeCalculated() ? 'contained' : 'outlined'}
-        color="primary"
-        onClick={() => this.opposeItem()}
-        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
-        size="small"
-      >
-        <ThumbsDownIcon className="supportOpposeMobileIcon" classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -676,11 +623,8 @@ class ItemActionBar extends PureComponent {
             </StackedButton>
           ) : (
             <>
-              <div className="u-push--xs d-lg-none d-xl-none d-sm-block d-none ">
+              <div className="u-push--xs u-push--xs d-lg-none">
                 {this.props.type === 'CANDIDATE' ? supportButton : measureYesButton}
-              </div>
-              <div className="u-push--xs d-block d-sm-none ">
-                {this.props.type === 'CANDIDATE' ? supportButtonMobile : measureYesButtonMobile}
               </div>
             </>
           )}
@@ -707,11 +651,8 @@ class ItemActionBar extends PureComponent {
             </StackedButton>
           ) : (
             <>
-              <div className="u-push--xs d-lg-none d-xl-none d-sm-block d-none ">
+              <div className="u-push--xs d-lg-none">
                 {this.props.type === 'CANDIDATE' ? opposeButton : measureNoButton}
-              </div>
-              <div className="u-push--xs d-block d-sm-none ">
-                {this.props.type === 'CANDIDATE' ? opposeButtonMobile : measureNoButtonMobile}
               </div>
             </>
           )}
@@ -751,14 +692,9 @@ const styles = theme => ({
       marginLeft: '.1rem',
       marginTop: '.3rem',
     },
-    [theme.breakpoints.down('xs')]: {
-      width: 42.5,
-      minWidth: 42.5,
-      maxWidth: 42.5,
-      height: 40,
-      minHeight: 40,
-      maxHeight: 40,
-      fontSize: '15px !important',
+    [theme.breakpoints.down('sm')]: {
+      width: 80,
+      minWidth: 80,
     },
   },
   buttonOutlinedPrimary: {

--- a/src/js/components/Widgets/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar.jsx
@@ -477,6 +477,19 @@ class ItemActionBar extends PureComponent {
       </Button>
     );
 
+    const supportButtonMobile = (
+      <Button
+        id="itemActionBarSupportButton"
+        variant={this.isSupportCalculated() ? 'contained' : 'outlined'}
+        color="primary"
+        onClick={() => this.supportItem()}
+        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
+        size="small"
+      >
+        <DoneIcon classes={{ root: classes.buttonIcon }} />
+      </Button>
+    );
+
     const measureYesButton = (
       <Button
         id="itemActionBarYesButton"
@@ -501,6 +514,19 @@ class ItemActionBar extends PureComponent {
             Vote Yes
           </span>
         )}
+      </Button>
+    );
+
+    const measureYesButtonMobile = (
+      <Button
+        id="itemActionBarYesButton"
+        variant={this.isSupportCalculated() ? 'contained' : 'outlined'}
+        color="primary"
+        onClick={() => this.supportItem()}
+        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
+        size="small"
+      >
+        <ThumbsUpIcon classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -532,6 +558,20 @@ class ItemActionBar extends PureComponent {
       </Button>
     );
 
+    const opposeButtonMobile = (
+      <Button
+        id="itemActionBarOpposeButton"
+        variant={this.isOpposeCalculated() ? 'contained' : 'outlined'}
+        color="primary"
+        className={`${this.props.opposeHideInMobile ? 'd-none d-sm-block ' : ''}`}
+        onClick={() => this.opposeItem()}
+        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
+        size="small"
+      >
+        <NotInterestedIcon classes={{ root: classes.buttonIcon }} />
+      </Button>
+    );
+
     const measureNoButton = (
       <Button
         id="itemActionBarNoButton"
@@ -556,6 +596,19 @@ class ItemActionBar extends PureComponent {
             Vote No
           </span>
         )}
+      </Button>
+    );
+
+    const measureNoButtonMobile = (
+      <Button
+        id="itemActionBarNoButton"
+        variant={this.isOpposeCalculated() ? 'contained' : 'outlined'}
+        color="primary"
+        onClick={() => this.opposeItem()}
+        classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
+        size="small"
+      >
+        <ThumbsDownIcon classes={{ root: classes.buttonIcon }} />
       </Button>
     );
 
@@ -622,9 +675,14 @@ class ItemActionBar extends PureComponent {
               {this.props.type === 'CANDIDATE' ? supportButton : measureYesButton}
             </StackedButton>
           ) : (
-            <div className="u-push--xs d-lg-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
-              {this.props.type === 'CANDIDATE' ? supportButton : measureYesButton}
-            </div>
+            <>
+              <div className="u-push--xs d-none d-sm-block d-lg-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+                {this.props.type === 'CANDIDATE' ? supportButton : measureYesButton}
+              </div>
+              <div className="u-push--xs d-block d-sm-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+                {this.props.type === 'CANDIDATE' ? supportButtonMobile : measureYesButtonMobile}
+              </div>
+            </>
           )}
 
           {/* Start of Oppose Button */}
@@ -648,9 +706,14 @@ class ItemActionBar extends PureComponent {
               {this.props.type === 'CANDIDATE' ? opposeButton : measureNoButton}
             </StackedButton>
           ) : (
-            <div className="u-push--xs d-lg-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
-              {this.props.type === 'CANDIDATE' ? opposeButton : measureNoButton}
-            </div>
+            <>
+              <div className="u-push--xs d-none d-sm-block d-lg-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+                {this.props.type === 'CANDIDATE' ? opposeButton : measureNoButton}
+              </div>
+              <div className="u-push--xs d-block d-sm-none d-xl-none item-actionbar__position-bar item-actionbar__position-bar--mobile">
+                {this.props.type === 'CANDIDATE' ? opposeButtonMobile : measureNoButtonMobile}
+              </div>
+            </>
           )}
           { this.props.commentButtonHide ?
             null : (

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -187,10 +187,10 @@ class PositionPublicToggle extends Component {
     );
 
     return (
-      <div className={this.props.className}>
+      <Wrapper className={this.props.className}>
         { this.state.showPositionPublicHelpModal ? PositionPublicToggleHelpModal : null }
         <PublicToggle onKeyDown={onKeyDown}>
-          <FormControl>
+          <FormControl classes={{ root: classes.formControl }}>
             <RadioGroup
               onChange={this.handlePositionToggle}
             >
@@ -229,7 +229,7 @@ class PositionPublicToggle extends Component {
             </RadioGroup>
           </FormControl>
         </PublicToggle>
-      </div>
+      </Wrapper>
     );
   }
 }
@@ -253,7 +253,14 @@ const styles = theme => ({
       fontSize: '11px',
     },
   },
+  formControl: {
+    width: '100%',
+  },
 });
+
+const Wrapper = styled.div`
+  flex: 1 1 0;
+`;
 
 const PublicToggle = styled.div`
   display: flex;
@@ -277,6 +284,7 @@ const PublicToggle = styled.div`
 
 const RadioGroup = styled.div`
   display: flex;
+  width: 100%;
   flex-flow: row nowrap;
   @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
     margin-bottom: -10px;

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -230,7 +230,6 @@ class PositionPublicToggle extends Component {
                   }
                 />
               </RadioItem>
-              
             </RadioGroup>
           </FormControl>
         </PublicToggle>

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -194,38 +194,43 @@ class PositionPublicToggle extends Component {
             <RadioGroup
               onChange={this.handlePositionToggle}
             >
-              <FormControlLabel
-                classes={{ label: classes.radioLabel }}
-                id="positionPublicToggleFriendsOnly"
-                value="Friends Only"
-                label="Friends Only"
-                labelPlacement="end"
-                control={
-                  (
-                    <Radio
-                      classes={{ colorPrimary: classes.radioPrimary }}
-                      color="primary"
-                      checked={showToThePublicOn === false}
-                    />
-                  )
-                }
-              />
-              <FormControlLabel
-                id="positionPublicTogglePublic"
-                classes={{ label: classes.radioLabel }}
-                value="Public"
-                label="Public"
-                labelPlacement="end"
-                control={
-                  (
-                    <Radio
-                      classes={{ colorPrimary: classes.radioPrimary }}
-                      color="primary"
-                      checked={showToThePublicOn === true}
-                    />
-                  )
-                }
-              />
+              <RadioItem>
+                <FormControlLabel
+                  classes={{ label: classes.radioLabel }}
+                  id="positionPublicToggleFriendsOnly"
+                  value="Friends Only"
+                  label="Friends Only"
+                  labelPlacement="end"
+                  control={
+                    (
+                      <Radio
+                        classes={{ colorPrimary: classes.radioPrimary }}
+                        color="primary"
+                        checked={showToThePublicOn === false}
+                      />
+                    )
+                  }
+                />
+              </RadioItem>
+              <RadioItem>
+                <FormControlLabel
+                  id="positionPublicTogglePublic"
+                  classes={{ label: classes.radioLabel }}
+                  value="Public"
+                  label="Public"
+                  labelPlacement="end"
+                  control={
+                    (
+                      <Radio
+                        classes={{ colorPrimary: classes.radioPrimary }}
+                        color="primary"
+                        checked={showToThePublicOn === true}
+                      />
+                    )
+                  }
+                />
+              </RadioItem>
+              
             </RadioGroup>
           </FormControl>
         </PublicToggle>
@@ -263,12 +268,17 @@ const Wrapper = styled.div`
 `;
 
 const PublicToggle = styled.div`
-  display: flex;
-  flex-flow: row wrap;
   padding-left: 15px;
   @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
     padding-top: 4px;
     margin-bottom: 4px;
+  }
+`;
+
+const RadioItem = styled.div`
+  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
+    width: 100% !important;
+    min-width: 100% !important;
   }
 `;
 
@@ -283,11 +293,13 @@ const PublicToggle = styled.div`
 // `;
 
 const RadioGroup = styled.div`
-  display: flex;
   width: 100%;
-  flex-flow: row nowrap;
   @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
     margin-bottom: -10px;
+  }
+  @media (min-width: ${({ theme }) => theme.breakpoints.sm}) {
+    display: flex;
+    flex-flow: row nowrap;;
   }
 `;
 

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -107,10 +107,3 @@
     background-color: $red;
   }
 }
-
-.supportOpposeMobileIcon {
-  width: 16px !important;
-  height: 16px !important;
-  position: relative;
-  left: 2px;
-}

--- a/src/sass/components/_itemActionBar.scss
+++ b/src/sass/components/_itemActionBar.scss
@@ -67,6 +67,7 @@
   padding-top: $space-none;
   justify-content: space-between;
   flex: auto;
+  margin-bottom: 8px;
 
   &__position-btn-label {
     color: $black;
@@ -105,4 +106,11 @@
   .oppose-at-state {
     background-color: $red;
   }
+}
+
+.supportOpposeMobileIcon {
+  width: 16px !important;
+  height: 16px !important;
+  position: relative;
+  left: 2px;
 }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2262 
### Changes included this pull request?
I didn't stack the toggle component because it was not needed after I changed the support oppose buttons and added flex: 1 1 0; to the toggle component so it does not get cut off.

**iPhone 5 display**
![Capture4](https://user-images.githubusercontent.com/46693952/59216837-8be06f00-8b8a-11e9-8365-ca36835aadae.PNG)

If you don't like this, I can stack the toggle options and revert the buttons.