### PR TITLE
Fix FollowToggle component

### DIFF
--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -106,7 +106,7 @@ class PositionItem extends Component {
                     </Link>
                   </StickyPopover>
                 </DesktopItemImage>
-                <FollowToggle organizationWeVoteId={organizationWeVoteId} lightModeOn hideDropdownButtonUntilFollowing />
+                <FollowToggle organizationWeVoteId={organizationWeVoteId} lightModeOn hideDropdownButtonUntilFollowing anchorLeft />
               </DesktopItemLeft>
               <PositionItemDesktop className={`position-item--${supportOpposeInfo} position-item`}>
                 <DesktopItemHeader>

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -22,6 +22,7 @@ export default class FollowToggle extends Component {
     organizationWeVoteId: PropTypes.string,
     hideDropdownButtonUntilFollowing: PropTypes.bool,
     lightModeOn: PropTypes.bool,
+    anchorLeft: PropTypes.bool,
   };
 
   constructor (props) {
@@ -263,9 +264,9 @@ export default class FollowToggle extends Component {
             )}
           </Button>
         ) : (
-          <div>
+          <>
             {this.props.hideDropdownButtonUntilFollowing ? (
-              <div>
+              <>
                 {this.props.lightModeOn ? (
                   <Button type="button" className="dropdown-toggle dropdown-toggle-split issues-follow-btn issues-follow-btn__main issues-follow-btn__main--radius issues-follow-btn--white" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                     Follow
@@ -275,7 +276,11 @@ export default class FollowToggle extends Component {
                     Follow
                   </Button>
                 )}
-                <div className="dropdown-menu dropdown-menu-right issues-follow-btn__menu">
+                <div className={this.props.anchorLeft ? (
+                  "dropdown-menu dropdown-menu-left issues-follow-btn__menu"
+                ) : (
+                  "dropdown-menu dropdown-menu-right issues-follow-btn__menu"
+                )}>
                   {this.state.isFollowing ? (
                     <span className="d-print-none">
                       { this.props.hideStopFollowingButton ?
@@ -299,10 +304,9 @@ export default class FollowToggle extends Component {
                     Ignore
                   </Button>
                 </div>
-              </div>
-
+              </>
             ) : (
-              <div>
+              <>
                 {this.props.lightModeOn ? (
                   <Button type="button" className="issues-follow-btn issues-follow-btn__main issues-follow-btn--white" onClick={() => this.followInstantly(followFunction, currentBallotIdInUrl, urlWithoutHash, ballotItemWeVoteId)}>
                     Follow
@@ -312,19 +316,23 @@ export default class FollowToggle extends Component {
                     Follow
                   </Button>
                 )}
-              </div>
+              </>
             )}
-          </div>
+          </>
         )}
         {this.props.hideDropdownButtonUntilFollowing ? (
-          <div>
+          <>
             {this.state.isFollowing || this.state.isIgnoring ? (
-              <React.Fragment>
+              <>
                 <div className="issues-follow-btn__seperator" />
                 <Button type="button" className="dropdown-toggle dropdown-toggle-split issues-follow-btn issues-follow-btn__dropdown issues-follow-btn--white" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span className="sr-only">Toggle Dropdown</span>
                 </Button>
-                <div className="dropdown-menu dropdown-menu-right issues-follow-btn__menu">
+                <div className={this.props.anchorLeft ? (
+                  "dropdown-menu dropdown-menu-left issues-follow-btn__menu"
+                ) : (
+                  "dropdown-menu dropdown-menu-right issues-follow-btn__menu"
+                )}>
                   {this.state.isFollowing ? (
                     <span className="d-print-none">
                       { this.props.hideStopFollowingButton ?
@@ -348,20 +356,20 @@ export default class FollowToggle extends Component {
                     Ignore
                   </Button>
                 </div>
-              </React.Fragment>
+              </>
             ) : (
               null
             )}
-          </div>
+          </>
         ) : (
-          <div>
+          <>
             {this.state.isFollowing || this.state.isIgnoring ? (
-              <React.Fragment>
+              <>
                 <div className="issues-follow-btn__seperator" />
                 <Button type="button" className="dropdown-toggle dropdown-toggle-split issues-follow-btn issues-follow-btn__dropdown issues-follow-btn--white" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   <span className="sr-only">Toggle Dropdown</span>
                 </Button>
-                <div className="dropdown-menu dropdown-menu-right issues-follow-btn__menu">
+                <div className="dropdown-menu issues-follow-btn__menu">
                   {this.state.isFollowing ? (
                     <span className="d-print-none">
                       { this.props.hideStopFollowingButton ?
@@ -385,9 +393,9 @@ export default class FollowToggle extends Component {
                     Ignore
                   </Button>
                 </div>
-              </React.Fragment>
+              </>
             ) : (
-              <React.Fragment>
+              <>
                 <div className="issues-follow-btn__seperator" />
                 {this.props.lightModeOn ? (
                   <Button type="button" className="dropdown-toggle dropdown-toggle-split issues-follow-btn issues-follow-btn__dropdown issues-follow-btn--white" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -398,7 +406,11 @@ export default class FollowToggle extends Component {
                     <span className="sr-only">Toggle Dropdown</span>
                   </Button>
                 )}
-                <div className="dropdown-menu dropdown-menu-right issues-follow-btn__menu">
+                <div className={this.props.anchorLeftLeft ? (
+                  "dropdown-menu dropdown-menu-left issues-follow-btn__menu"
+                ) : (
+                  "dropdown-menu dropdown-menu-right issues-follow-btn__menu"
+                )}>
                   {this.state.isFollowing ? (
                     <span className="d-print-none">
                       { this.props.hideStopFollowingButton ?
@@ -422,9 +434,9 @@ export default class FollowToggle extends Component {
                     Ignore
                   </Button>
                 </div>
-              </React.Fragment>
+              </>
             )}
-          </div>
+          </>
         )}
       </div>
     );

--- a/src/js/components/Widgets/FollowToggle.jsx
+++ b/src/js/components/Widgets/FollowToggle.jsx
@@ -277,10 +277,11 @@ export default class FollowToggle extends Component {
                   </Button>
                 )}
                 <div className={this.props.anchorLeft ? (
-                  "dropdown-menu dropdown-menu-left issues-follow-btn__menu"
+                  'dropdown-menu dropdown-menu-left issues-follow-btn__menu'
                 ) : (
-                  "dropdown-menu dropdown-menu-right issues-follow-btn__menu"
-                )}>
+                  'dropdown-menu dropdown-menu-right issues-follow-btn__menu'
+                )}
+                >
                   {this.state.isFollowing ? (
                     <span className="d-print-none">
                       { this.props.hideStopFollowingButton ?
@@ -329,10 +330,11 @@ export default class FollowToggle extends Component {
                   <span className="sr-only">Toggle Dropdown</span>
                 </Button>
                 <div className={this.props.anchorLeft ? (
-                  "dropdown-menu dropdown-menu-left issues-follow-btn__menu"
+                  'dropdown-menu dropdown-menu-left issues-follow-btn__menu'
                 ) : (
-                  "dropdown-menu dropdown-menu-right issues-follow-btn__menu"
-                )}>
+                  'dropdown-menu dropdown-menu-right issues-follow-btn__menu'
+                )}
+                >
                   {this.state.isFollowing ? (
                     <span className="d-print-none">
                       { this.props.hideStopFollowingButton ?
@@ -406,11 +408,12 @@ export default class FollowToggle extends Component {
                     <span className="sr-only">Toggle Dropdown</span>
                   </Button>
                 )}
-                <div className={this.props.anchorLeftLeft ? (
-                  "dropdown-menu dropdown-menu-left issues-follow-btn__menu"
+                <div className={this.props.anchorLeft ? (
+                  'dropdown-menu dropdown-menu-left issues-follow-btn__menu'
                 ) : (
-                  "dropdown-menu dropdown-menu-right issues-follow-btn__menu"
-                )}>
+                  'dropdown-menu dropdown-menu-right issues-follow-btn__menu'
+                )}
+                >
                   {this.state.isFollowing ? (
                     <span className="d-print-none">
                       { this.props.hideStopFollowingButton ?

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -4,12 +4,13 @@ $outline-radius: 3px;
 @include media-object('.card-main__media-object', '.card-main__media-object-anchor', '.card-main__media-object-content');
 
 .card {
+  position: relative !important;
   $item-padding: $space-md;
   background-color: $white;
   border-radius: $radius-sm;
   box-shadow: $default-box-shadow;
   margin-bottom: $space-md;
-  overflow: hidden;
+  overflow-y: hidden;
   border: none;
   @include clearfix;
   @include breakpoints(max mid-small) {

--- a/src/sass/components/_issues.scss
+++ b/src/sass/components/_issues.scss
@@ -262,8 +262,6 @@ $menu-item-padding: 7px;
     min-width: 0 !important;
     max-width: 140px !important;
     padding: $space-none !important;
-    z-index: 999 !important;
-    left: 16px !important;
   }
   &__menu * {
     width: 140px !important;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2259 
### Changes included this pull request?
I added a position of relative to the parent elements that were overlapping the follow toggle drop-down menu so Popper.js would recognize them and re position the menu. As far as I can see nothing else has been affected, let me know if you find anything!

** I also added an anchorLeft prop so we can display that better for different situations, as well as get rid of unneeded divs by changing them to React.Fragments