### PR TITLE
Disabled StickyHeaders in Cordova

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -58,7 +58,7 @@ class Application extends Component {
     this.appStoreListener = AppStore.addListener(this.onAppStoreChange.bind(this));
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     if (isWebApp()) {
-      // disabled for cordova June 2019, see note in tbd
+      // disabled for cordova June 2019, see note in https://github.com/wevote/WebApp/pull/2303
       window.addEventListener('scroll', this.handleWindowScroll);
     }
   }

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -57,7 +57,10 @@ class Application extends Component {
 
     this.appStoreListener = AppStore.addListener(this.onAppStoreChange.bind(this));
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
-    window.addEventListener('scroll', this.handleWindowScroll);
+    if (isWebApp()) {
+      // disabled for cordova June 2019, see note in tbd
+      window.addEventListener('scroll', this.handleWindowScroll);
+    }
   }
 
   componentDidUpdate () {
@@ -168,7 +171,7 @@ class Application extends Component {
   }
 
   handleWindowScroll = (evt) => {
-    const { scrollTop } = evt.target.scrollingElement;
+    const {scrollTop} = evt.target.scrollingElement;
     if (scrollTop > 60 && !AppStore.getScrolledDown()) {
       AppActions.setScrolled(true);
     }
@@ -176,6 +179,7 @@ class Application extends Component {
       AppActions.setScrolled(false);
     }
   };
+
 
   incomingVariableManagement () {
     // console.log("Application, incomingVariableManagement, this.props.location.query: ", this.props.location.query);


### PR DESCRIPTION
On iOS, the StickyHeader only appears after you stop scrolling, this results in the header often appearing over what you are currently reading.  Apple does this on purpose, queues updates until scrolling stops, to avoid repainting the DOM while scrolling.

See:  https://github.com/sroze/ngInfiniteScroll/issues/104#issuecomment-68000337

Later comments on the thread incorrectly indicate that the issue is fixed.  When I switched from 'scroll' to 'touchmove' you could see the touchmove data, but the actual on screen behavior confirmed the (purposeful by apple) issue.  Also when I put a console.log in the event handler, the entries made it to the log, only after scrolling had stopped.