### PR TITLE
Show AppBar logo in print

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -329,7 +329,7 @@ class HeaderBar extends Component {
             }
             {
               !voterIsSignedIn && (
-              <div className="header-nav__avatar-wrapper u-cursor--pointer u-flex-none">
+              <div className="header-nav__avatar-wrapper u-cursor--pointer u-flex-none d-print-none">
                 {
                   showEditAddressButton && (
                     <Tooltip title="Change my location" aria-label="Change Address" classes={{ tooltipPlacementBottom: classes.tooltipPlacementBottom }}>

--- a/src/sass/overrides/_print.scss
+++ b/src/sass/overrides/_print.scss
@@ -6,8 +6,7 @@
     background-color: $white !important;
     color: $black;
   }
-  .headroom-wrapper,
-  .page-header__container,
+  .ballot__filter__container,
   .sidebar-menu {
     display: none;
   }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
Shows the AppBar with logo, but not the sign in button when in print mode. Also set the ballot filter row display to none when in print mode.