### PR TITLE
[Issue #2315] Welcome Pages: Our Network Section too large on desktop

### DIFF
--- a/src/js/components/Welcome/Section.jsx
+++ b/src/js/components/Welcome/Section.jsx
@@ -145,8 +145,8 @@ const NetworkContainer = styled.div`
 
 const NetworkImage = styled.img`
   filter: grayscale(100%);
-  flex: 25%
-  max-width: 25%
+  flex: 25%;
+  max-width: 25%;
   padding: 0 2%;
   object-fit: scale-down;
   @media (max-width: ${({ theme }) => theme.breakpoints.md}) {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2315
### Changes included this pull request?

Looks like I forgot to add a couple semicolons in the CSS and the browser interpreted three lines as a single CSS rule. Oddly, this just started happening. Perhaps something in the build process was adding semicolons in and is no longer doing so?

Also, it looks like this fixes the spacing issue.