### PR TITLE
Update bootstrap social buttons to material-ui and custom split button

### DIFF
--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import Button from '@material-ui/core/Button';
+import { shortenText } from '../../utils/textFormat';
 import { oAuthLog, renderLog } from '../../utils/logging';
 import $ajax from '../../utils/service';
 import cookies from '../../utils/cookies';
@@ -8,7 +10,7 @@ import {
 } from '../../utils/cordovaUtils';
 import webAppConfig from '../../config';
 import TwitterActions from '../../actions/TwitterActions';
-import ContainedIconButton from './ContainedIconButton';
+// import ContainedIconButton from './ContainedIconButton';
 
 const returnURL = `${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/twitter_sign_in`;
 
@@ -147,12 +149,24 @@ class TwitterSignIn extends Component {
     const { buttonText } = this.props;
     renderLog(__filename);
     return (
-      <ContainedIconButton
-        buttonText={buttonText}
-        color="#55acee"
-        icon={<span className="fab fa-twitter" />}
+      <Button
+        className="split-button split-button__left"
+        color="primary"
+        variant="contained"
         onClick={isWebApp() ? this.twitterSignInWebApp : this.twitterSignInWebAppCordova}
-      />
+        style={{
+          backgroundColor: '#55acee',
+        }}
+        title="Sign in to find voter guides"
+      >
+        <span className="split-button__icon">
+          <i className="fab fa-twitter" />
+        </span>
+        <div className="split-button__seperator split-button__seperator--left" />
+        <span className="split-button__text">
+          {shortenText(buttonText, 22)}
+        </span>
+      </Button>
     );
   }
 }

--- a/src/js/components/Twitter/TwitterSignInCard.jsx
+++ b/src/js/components/Twitter/TwitterSignInCard.jsx
@@ -25,7 +25,6 @@ class TwitterSignInCard extends Component {
           <div className="network-btn">
             <TwitterSignIn
               buttonText="Sign in to Find Voter Guides"
-              className="btn btn-social btn-lg btn-twitter value-btn text-center"
               id="signInToFindVoterGuides"
             />
             {twitterInfoText}

--- a/src/js/components/Widgets/AddEndorsements.jsx
+++ b/src/js/components/Widgets/AddEndorsements.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button } from 'react-bootstrap';
+import Button from '@material-ui/core/Button';
 import OpenExternalWebSite from './OpenExternalWebSite';
 import { cordovaDot } from '../../utils/cordovaUtils';
 
@@ -27,20 +27,23 @@ class AddEndorsements extends Component {
           <div className="network-btn">
             <OpenExternalWebSite
               url="https://api.wevoteusa.org/vg/create/"
-              className="opinions-followed__missing-org-link"
+              className="u-no-underline"
               target="_blank"
               title="ENDORSEMENTS MISSING?"
               body={(
                 <Button
-                  bsPrefix="u-margin-top--sm u-stack--xs"
-                  className="btn btn-social btn-lg value-btn value-btn__endorsements text-center"
+                  className="split-button split-button__left"
                   id="myValuesAddEndorsementsToWeVote"
-                  variant="primary"
+                  color="primary"
+                  variant="contained"
                 >
-                  <span>
-                    <img src={cordovaDot('/img/global/svg-icons/positions-icon-24-x-24.svg')} className="value-btn__endorsements--icon" alt="" />
+                  <span className="split-button__icon">
+                    <img src={cordovaDot('/img/global/svg-icons/positions-icon-24-x-24.svg')} alt="" />
                   </span>
-                  Add endorsements to We Vote
+                  <div className="split-button__seperator split-button__seperator--left" />
+                  <span className="split-button__text">
+                    Add endorsements
+                  </span>
                 </Button>
               )}
             />

--- a/src/js/components/Widgets/EndorsementCard.jsx
+++ b/src/js/components/Widgets/EndorsementCard.jsx
@@ -1,6 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import Button from '@material-ui/core/Button';
 import { cordovaDot } from '../../utils/cordovaUtils';
 import OpenExternalWebSite from './OpenExternalWebSite';
 
@@ -8,7 +8,7 @@ class EndorsementCard extends PureComponent {
   static propTypes = {
     buttonText: PropTypes.string,
     title: PropTypes.string,
-    bsPrefix: PropTypes.string,
+    // bsPrefix: PropTypes.string,
     text: PropTypes.string,
   };
 
@@ -22,12 +22,20 @@ class EndorsementCard extends PureComponent {
                 url="https://api.wevoteusa.org/vg/create/"
                 target="_blank"
                 title={this.props.title}
+                className="u-no-underline"
                 body={(
-                  <Button className="btn endorsement-card__btn btn-social" bsPrefix={this.props.bsPrefix} variant="primary">
-                    <span>
-                      <img src={cordovaDot('/img/global/svg-icons/positions-icon-24-x-24.svg')} className="endorsement-card__btn--icon" alt="" />
+                  <Button
+                    className="split-button split-button__left"
+                    color="primary"
+                    variant="contained"
+                  >
+                    <span className="split-button__icon">
+                      <img src={cordovaDot('/img/global/svg-icons/positions-icon-24-x-24.svg')} alt="" />
                     </span>
-                    {this.props.buttonText}
+                    <div className="split-button__seperator split-button__seperator--left" />
+                    <span className="split-button__text">
+                      {this.props.buttonText}
+                    </span>
                   </Button>
                 )}
               />

--- a/src/js/components/Widgets/ThisIsMeAction.jsx
+++ b/src/js/components/Widgets/ThisIsMeAction.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'react-bootstrap';
+import Button from '@material-ui/core/Button';
 import { Link } from 'react-router';
 import { renderLog } from '../../utils/logging';
 import VoterStore from '../../stores/VoterStore';
@@ -8,7 +8,6 @@ import { cordovaDot } from '../../utils/cordovaUtils';
 
 export default class ThisIsMeAction extends Component {
   static propTypes = {
-    bsPrefix: PropTypes.string,
     kindOfOwner: PropTypes.string,
     nameBeingViewed: PropTypes.string,
     twitterHandleBeingViewed: PropTypes.string,
@@ -72,15 +71,22 @@ export default class ThisIsMeAction extends Component {
             <div className="card">
               <div className="card-main">
                 <div className="endorsement-card">
-                  <Link to={`/verifythisisme/${twitterHandleBeingViewed}`}>
-                    <Button className="btn endorsement-card__btn btn-social" bsPrefix={this.props.bsPrefix} variant="primary">
-                      <span>
-                        <img src={cordovaDot('/img/global/svg-icons/glyphicons-pro-social/glyphicons-social-32-twitter.svg')} className="endorsement-card__btn--icon" alt="" />
+                  <Link to={`/verifythisisme/${twitterHandleBeingViewed}`} className="u-no-underline">
+                    <Button
+                      className="split-button split-button__left"
+                      color="primary"
+                      variant="contained"
+                    >
+                      <span className="split-button__icon">
+                        <i className="fab fa-twitter-square" />
                       </span>
-                      Claim
-                      {' '}
-                      @
-                      {this.props.twitterHandleBeingViewed}
+                      <div className="split-button__seperator split-button__seperator--left" />
+                      <span className="split-button__text">
+                        Claim
+                        {' '}
+                        @
+                        {this.props.twitterHandleBeingViewed}
+                      </span>
                     </Button>
                   </Link>
                   <div className="endorsement-card__text">

--- a/src/sass/components/_issues.scss
+++ b/src/sass/components/_issues.scss
@@ -310,3 +310,54 @@ $menu-item-padding: 7px;
   height: 1px !important;
   background: $gray-light !important;
 }
+
+.split-button {
+  padding: 0 !important;
+  box-shadow: none !important;
+  width: 100%;
+  > span {
+    padding: 10px 0 !important;
+    height: 100%;
+    display: flex;
+    align-items: center;
+  }
+  &__left > span {
+    justify-content: flex-start;
+  }
+  &__seperator {
+    display: inline-block;
+    height: 100%;
+    width: 1.5px !important;
+    flex: none;
+    background: rgba(204, 204, 204, .425);
+    z-index: 1;
+    position: absolute;
+    &--left {
+      left: 44px;
+    }
+    &--right {
+      right: 44px;
+    }
+  }
+  &__icon {
+    width: 44px;
+    flex: none;
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: 0px 12px;
+    * {
+      width: 100%;
+      font-size: 22px;
+    }
+  }
+  &__text {
+    padding: 0px 8px 0;
+    font-size: 13px;
+    text-align: center;
+    flex: 1 1 0;
+  }
+  * {
+    text-decoration: none !important;
+  }
+}

--- a/src/sass/components/_network.scss
+++ b/src/sass/components/_network.scss
@@ -40,15 +40,6 @@ $mobile-btn-padding: 52px;
     font-size: 14px;
     padding: $space-sm $space-md $space-sm $space-xl;
   }
-  &__endorsements {
-    background: $brand-blue;
-    color: $white;
-    &--icon {
-      vertical-align: baseline;
-      position: relative;
-      top: -$space-xs / 2;
-    }
-  }
 }
 
 .network-btn {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2305 
### Changes included this pull request?
I updated this icon, and I also updated the endorsement buttons and twitter sign in button to use a custom split button I designed so the style is consistent with the rest of the site. If you would like, I could get rid of the CSS I used and create an entirely new component (SplitButton.jsx) and use styled-component and pass in props to adjust button text and colors, etc;  Let me know what you think!