### PR TITLE
Fixed bugs on the BallotItemSupportOpposeCountDisplay and changed some color schemes when printing

### DIFF
--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -110,6 +110,8 @@ class PositionItem extends Component {
       supportOpposeInfo = 'supportFollow';
     } else if (!position.followed && position.is_support) {
       supportOpposeInfo = 'support';
+    } else if (position.followed && position.is_oppose) {
+      supportOpposeInfo = 'opposeFollow';
     } else if (!position.support) {
       supportOpposeInfo = 'oppose';
     }
@@ -189,19 +191,27 @@ class PositionItem extends Component {
                       </SupportFollow>
                     ) : (
                       <>
-                        {supportOpposeInfo === 'support' ? (
-                          <Support>
-                            <ThumbUpIcon />
-                          </Support>
+                        {supportOpposeInfo === 'opposeFollow' ? (
+                          <OpposeFollow>
+                            -1
+                          </OpposeFollow>
                         ) : (
-                          <>
-                            {supportOpposeInfo === 'oppose' ? (
-                              <Oppose>
-                                <ThumbDownIcon />
-                              </Oppose>
-                            ) : (
-                              null
-                            )}
+                        <>
+                          {supportOpposeInfo === 'support' ? (
+                            <Support>
+                              <ThumbUpIcon />
+                            </Support>
+                          ) : (
+                              <>
+                                {supportOpposeInfo === 'oppose' ? (
+                                  <Oppose>
+                                    <ThumbDownIcon />
+                                  </Oppose>
+                                ) : (
+                                  null
+                                )}
+                              </>
+                          )}
                           </>
                         )}
                       </>
@@ -276,11 +286,17 @@ class PositionItem extends Component {
                       </SupportFollow>
                     ) : (
                       <>
-                        {supportOpposeInfo === 'support' ? (
-                          <Support>
-                            <ThumbUpIcon />
-                          </Support>
+                        {supportOpposeInfo === 'opposeFollow' ? (
+                          <OpposeFollow>
+                            -1
+                          </OpposeFollow>
                         ) : (
+                        <>
+                          {supportOpposeInfo === 'support' ? (
+                            <Support>
+                              <ThumbUpIcon />
+                            </Support>
+                          ) : (
                           <>
                             {supportOpposeInfo === 'oppose' ? (
                               <Oppose>
@@ -289,6 +305,8 @@ class PositionItem extends Component {
                             ) : (
                               null
                             )}
+                            </>
+                          )}
                           </>
                         )}
                       </>
@@ -509,6 +527,20 @@ const DesktopItemFooter = styled.div`
 const SupportFollow = styled.div`
   color: white;
   background: #1fc06f;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 50px;
+  height: 50px;
+  border-radius: 5px;
+  float: right;
+  font-size: 16px;
+  font-weight: bold;
+`;
+
+const OpposeFollow = styled.div`
+  color: white;
+  background: rgb(255, 73, 34);
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
@@ -21,7 +21,6 @@ import StickyPopover from '../Ballot/StickyPopover';
 // December 2018:  We want to work toward being airbnb style compliant, but for now these are disabled in this file to minimize complex changes
 /* eslint react/no-find-dom-node: 1 */
 /* eslint array-callback-return: 1 */
-
 class BallotItemSupportOpposeCountDisplay extends Component {
   static propTypes = {
     ballotItemWeVoteId: PropTypes.string.isRequired,
@@ -327,14 +326,18 @@ class BallotItemSupportOpposeCountDisplay extends Component {
     let networkOpposeCount = 0;
     let totalNetworkScore = 0;
     let totalNetworkScoreWithSign;
+    let totalNetworkScoreIsNegative = false;
+    let totalNetworkScoreIsPositive = false;
     if (this.state.ballotItemSupportProps !== undefined) {
       networkSupportCount = parseInt(this.state.ballotItemSupportProps.support_count) || 0;
       networkOpposeCount = parseInt(this.state.ballotItemSupportProps.oppose_count) || 0;
       totalNetworkScore = parseInt(networkSupportCount - networkOpposeCount);
       if (totalNetworkScore > 0) {
         totalNetworkScoreWithSign = `+${totalNetworkScore}`;
+        totalNetworkScoreIsPositive = true;
       } else if (totalNetworkScore < 0) {
         totalNetworkScoreWithSign = totalNetworkScore;
+        totalNetworkScoreIsNegative = true;
       } else {
         totalNetworkScoreWithSign = totalNetworkScore;
       }
@@ -620,7 +623,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
         onMouseLeave={handleLeaveHoverLocalArea}
       >
         { isVoterSupport ? (
-          <NetworkScore className={classes.voterSupports}>
+          <NetworkScore className={classes.voterSupports} totalNetworkScoreIsNegative={totalNetworkScoreIsNegative} totalNetworkScoreIsPositive={totalNetworkScoreIsPositive}>
             <VoterChoiceWrapper>
               <DoneIcon classes={{ root: classes.buttonIcon }} />
             </VoterChoiceWrapper>
@@ -630,7 +633,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
         }
 
         { isVoterOppose ? (
-          <NetworkScore className={classes.voterOpposes}>
+          <NetworkScore className={classes.voterOpposes} totalNetworkScoreIsNegative={totalNetworkScoreIsNegative} totalNetworkScoreIsPositive={totalNetworkScoreIsPositive}>
             <VoterChoiceWrapper>
               <NotInterestedIcon classes={{ root: classes.buttonIcon }} />
             </VoterChoiceWrapper>
@@ -697,10 +700,10 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             openOnClick
             showCloseIcon
           >
-            <NetworkScore>
+            <NetworkScore totalNetworkScoreIsNegative={totalNetworkScoreIsNegative} totalNetworkScoreIsPositive={totalNetworkScoreIsPositive}>
               { totalNetworkScore === 0 ? (
-                <span className="u-margin-left--md">
-                  { totalNetworkScoreWithSign }
+                <span className="u-margin-left-right--sm">
+                  { totalNetworkScoreWithSign}
                 </span>
               ) : (
                 <span className="u-margin-left--xs">
@@ -811,7 +814,7 @@ const EndorsementCount = styled.div`
 
 const NetworkScore = styled.div`
   font-size: 18px;
-  background: rgb(31, 192, 111);
+  background: ${({ totalNetworkScoreIsNegative, totalNetworkScoreIsPositive }) => ((totalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (totalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || '#888')};
   color: white;
   padding: 8px;
   border-radius: 8px;
@@ -824,14 +827,14 @@ const NetworkScore = styled.div`
   @media print{
     border-width: 1 px;
     border-style: solid;
-    border-color: #888;
+    border-color: ${({ totalNetworkScoreIsNegative, totalNetworkScoreIsPositive }) => ((totalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (totalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || '#888')};
   }
 `;
 
 const VoterChoiceWrapper = styled.div`
   color: white;
   @media print{
-    color: #888;
+    color: #1fc06f;
   }
 `;
 

--- a/src/sass/components/_issues.scss
+++ b/src/sass/components/_issues.scss
@@ -206,6 +206,10 @@ $space-button-span: 10px;
     font-weight: 600 !important;
     border: 1px solid $gray-light !important;
   }
+  &__icon svg {
+    width: 18px !important;
+    height: 18px !important;
+  }
   &__main {
     height: 32px !important;
     border-radius: $radius-sm3 !important;
@@ -252,10 +256,6 @@ $space-button-span: 10px;
   }
   &__dropdown ::after {
     font-size: 16px !important;
-  }
-  &__icon svg {
-    width: 18px !important;
-    height: 18px !important;
   }
   &__menu {
     font-size: 12.5px !important;

--- a/src/sass/overrides/_print.scss
+++ b/src/sass/overrides/_print.scss
@@ -3,7 +3,7 @@
     size: portrait
   }
   body {
-    background-color: $white !important;
+    background-color: white !important;
     color: $black;
   }
   //.ballot__filter__container,
@@ -27,4 +27,5 @@
   a, a:not(.btn) {
     text-decoration: none;
   }
+
 }


### PR DESCRIPTION
Following a person who opposes a candidate will cause a "-1" to replace the thumbs down. This matches what happens when a "+1" appears when you follow a person who supports a candidate. Negative endorsement totals are now red and a 0 net endorsements is grey. Some minor changes in colors when printing were made.
