### PR TITLE
Fixed the height of the Next button on the intro pages for Cordova

### DIFF
--- a/src/js/components/Intro/IntroNetworkBallotIsNext.jsx
+++ b/src/js/components/Intro/IntroNetworkBallotIsNext.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { historyPush, cordovaDot } from '../../utils/cordovaUtils';
+import { cordovaDot, cordovaNetworkNextButtonTop, historyPush } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 
 /*
@@ -48,7 +48,13 @@ export default class IntroNetworkBallotIsNext extends Component {
           Get Started Now
         </div>
         <p className="intro-story__info">Make sure to enter the correct address to have the correct ballot.</p>
-        <button type="button" className="btn intro-story__btn intro-story__btn--bottom" onClick={IntroNetworkBallotIsNext.goToBallotLink}>Next&nbsp;&nbsp;&gt;</button>
+        <button type="button"
+                className="btn intro-story__btn intro-story__btn--bottom"
+                onClick={IntroNetworkBallotIsNext.goToBallotLink}
+                style={{ top: `${cordovaNetworkNextButtonTop()}` }}
+        >
+          Next&nbsp;&nbsp;&gt;
+        </button>
       </div>
     );
   }

--- a/src/js/components/Intro/IntroNetworkDefinition.jsx
+++ b/src/js/components/Intro/IntroNetworkDefinition.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { renderLog } from '../../utils/logging';
-import { cordovaDot } from '../../utils/cordovaUtils';
+import { cordovaDot, cordovaNetworkNextButtonTop } from '../../utils/cordovaUtils';
 
 /*
 The problem with urls in css for Apache Cordova
@@ -47,7 +47,13 @@ export default class IntroNetworkDefinition extends Component {
           See who endorsed each choice on your ballot
         </div>
         <p className="intro-story__info">Learn from the people you trust.</p>
-        <button type="button" className="btn intro-story__btn intro-story__btn--bottom" onClick={this.props.next}>Next&nbsp;&nbsp;&gt;</button>
+        <button type="button"
+                className="btn intro-story__btn intro-story__btn--bottom"
+                onClick={this.props.next}
+                style={{ top: `${cordovaNetworkNextButtonTop()}` }}
+        >
+          Next&nbsp;&nbsp;&gt;
+        </button>
       </div>
     );
   }

--- a/src/js/components/Intro/IntroNetworkSafety.jsx
+++ b/src/js/components/Intro/IntroNetworkSafety.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { cordovaDot, cordovaNetworkNextButtonTop } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
-import { cordovaDot } from '../../utils/cordovaUtils';
 
 /*
 The problem with urls in css for Apache Cordova
@@ -47,7 +47,13 @@ export default class IntroNetworkSafety extends Component {
           Choose your interests
         </div>
         <p className="intro-story__info">Follow topics that interest you.  We will suggest endorsements based on your interests.</p>
-        <button type="button" className="btn intro-story__btn intro-story__btn--bottom" onClick={this.props.next}>Next&nbsp;&nbsp;&gt;</button>
+        <button type="button"
+                className="btn intro-story__btn intro-story__btn--bottom"
+                onClick={this.props.next}
+                style={{ top: `${cordovaNetworkNextButtonTop()}` }}
+        >
+          Next&nbsp;&nbsp;&gt;
+        </button>
       </div>
     );
   }

--- a/src/js/routes/Intro/IntroNetwork.jsx
+++ b/src/js/routes/Intro/IntroNetwork.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
 import Slider from 'react-slick';
-import { cordovaDot, historyPush, isWebApp } from '../../utils/cordovaUtils';
+import { cordovaDot, getAndroidSize, historyPush, isAndroid, isWebApp } from '../../utils/cordovaUtils';
 import IntroNetworkSafety from '../../components/Intro/IntroNetworkSafety';
 import IntroNetworkDefinition from '../../components/Intro/IntroNetworkDefinition';
 import IntroNetworkBallotIsNext from '../../components/Intro/IntroNetworkBallotIsNext';
@@ -40,6 +40,20 @@ export default class IntroNetwork extends Component {
     this.slider.current.slickPrev();
   }
 
+  overrideMediaQueryForAndroidTablets() {
+    // Media queries in CSS often don't work as expected in Cordova, due to window.devicePixelRatio greater than one
+    if (isAndroid()) {
+      const sizeString = getAndroidSize();
+      if (sizeString === '--xl') {
+        return {
+          maxHeight: 'unset',
+          maxWidth: 'unset',
+        };
+      }
+    }
+    return {};
+  }
+
   render () {
     renderLog(__filename);
 
@@ -58,7 +72,7 @@ export default class IntroNetwork extends Component {
     return (
       <div>
         <Helmet title="Welcome to We Vote" />
-        <div className="intro-story container-fluid well u-inset--md">
+        <div className="intro-story container-fluid well u-inset--md" style={this.overrideMediaQueryForAndroidTablets()}>
           <span onClick={IntroNetwork.goToBallotLink}>
             <img
               src={cordovaDot('/img/global/icons/x-close.png')}

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -217,13 +217,16 @@ export function getAndroidSize () {
 
   const size = screen.width * screen.height;
   let sizeString = 'default';
+  const ratioString = parseFloat(ratio).toFixed(2);
 
   /* sm = 480*800 = 384,000      Nexus One
      md = 1080*1920 = 2,073,600  PixelXL, Nexus5X, Moto G5
      lg = 1440*2560 = 3,686,400  Nexus6P
-     xl = 2560*1600 = 4,096,000  Nexus10 Tablet   */
+     xl = 2560*1600 = 4,096,000  Nexus10 Tablet
+     xl = 1200 x 1920 = 2,306,705 Galaxy Tab A 10.1", ratio = 1.3312500715255737
+     June 2019: detecting the Galaxy Tab A by ratio, is a bit of a hack, and could bite us someday if there was an android phone with a 1.33 ratio */
 
-  if (size > 3.7E6) {
+  if (size > 3.7E6 || ratioString === '1.33') {
     sizeString = '--xl';
   } else if (size > 3E6) {
     sizeString = '--lg';
@@ -556,6 +559,28 @@ export function cordovaBallotFilterTopMargin () {
         return '-10px';
       }
       return '31px';
+    }
+  }
+  return undefined;
+}
+
+export function cordovaNetworkNextButtonTop () {
+  if (isIOS()) {
+    if (isIPhone678Plus()) {
+      return '89vh';
+    } else if (isIPhone678()) {
+      return '89vh';
+    } else if (hasIPhoneNotch()) {
+      return '88vh';
+    } else if (isIPad()) {
+      return '89vh';
+    } else if (isIPhone5sSE()) {
+      return '88vh';
+    }
+  } else if (isAndroid()) {
+    const sizeString = getAndroidSize();
+    if (sizeString === '--xl') {
+      return '89vh';
     }
   }
   return undefined;


### PR DESCRIPTION
Also fixed the layout of the intro pages for the Galaxy Tab A 10.1 like in
in wevote/WebApp/issues/2357,
but I don't have access to a simulator for the Galaxy Tab S4 so I can't
test for that device.
