### PR TITLE
add close button to sign in modal

### DIFF
--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -60,6 +60,7 @@ class SignInModal extends Component {
             aria-label="Close"
             classes={{ root: classes.closeButton }}
             onClick={() => { this.props.toggleFunction(); }}
+            id="profileCloseSignUpModal"
           >
             <CloseIcon />
           </IconButton>

--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import Dialog from '@material-ui/core/Dialog';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
+import Typography from '@material-ui/core/Typography';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import { renderLog } from '../../utils/logging';
 import { hasIPhoneNotch } from '../../utils/cordovaUtils';
@@ -52,7 +55,14 @@ class SignInModal extends Component {
         onClose={() => { this.props.toggleFunction(); }}
       >
         <DialogTitle>
-          <div className="text-center">Sign In</div>
+          <Typography variant="h6" className="text-center">Sign In</Typography>
+          <IconButton
+            aria-label="Close"
+            classes={{ root: classes.closeButton }}
+            onClick={() => { this.props.toggleFunction(); }}
+          >
+            <CloseIcon />
+          </IconButton>
         </DialogTitle>
         <DialogContent classes={{ root: classes.dialogContent }}>
           <section>
@@ -98,6 +108,11 @@ const styles = theme => ({
     [theme.breakpoints.down('md')]: {
       padding: '0 8px 8px',
     },
+  },
+  closeButton: {
+    position: 'absolute',
+    right: `${theme.spacing.unit}px`,
+    top: `${theme.spacing.unit}px`,
   },
 });
 

--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -60,7 +60,7 @@ class SignInModal extends Component {
             aria-label="Close"
             classes={{ root: classes.closeButton }}
             onClick={() => { this.props.toggleFunction(); }}
-            id="profileCloseSignUpModal"
+            id="profileCloseSignInModal"
           >
             <CloseIcon />
           </IconButton>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
This change came up when discussing issue #2341. Still working on the tests for that issue though
### Changes included this pull request?
Using a pattern from the material-ui demos, I added a button with an 'x' symbol in the top right of the SignInModal component that closes the modal. I also included an id, 'profileCloseSignInModal' and added it to the google doc