### PR TITLE
[Issue #2347] Change badge color in print mode

### DIFF
--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -1092,6 +1092,9 @@ const styles = theme => ({
   badgeColorPrimary: {
     background: 'white',
     color: theme.palette.primary.main,
+    '@media print': {
+      color: theme.palette.primary.main,
+    },
   },
   unselectedBadgeColorPrimary: {
     background: 'rgba(0, 0, 0, .2)',


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2347 

@LohitG this is a Material UI component. In the style overrides, you can add something like this: 
```javascript
'@media print': {
      color: theme.palette.primary.main,
    },
```