### PR TITLE
Update cancel button to close modal

### DIFF
--- a/src/js/components/Ballot/SelectBallotModal.jsx
+++ b/src/js/components/Ballot/SelectBallotModal.jsx
@@ -76,6 +76,7 @@ class SelectBallotModal extends Component {
             defaultIsEditingAddress
             pathname={this.state.pathname}
             toggleFunction={this.props.toggleFunction}
+            cancelButtonAction={this.props.toggleFunction}
           />
           <BallotElectionListWithFilters
             ballotBaseUrl={ballotBaseUrl}
@@ -91,7 +92,7 @@ class SelectBallotModal extends Component {
 const styles = theme => ({
   dialogPaper: {
     marginTop: hasIPhoneNotch() ? 68 : 48,
-    [theme.breakpoints.down('sm')]: {
+    [theme.breakpoints.down('xs')]: {
       minWidth: '95%',
       maxWidth: '95%',
       width: '95%',

--- a/src/js/components/Widgets/EditAddressInPlace.jsx
+++ b/src/js/components/Widgets/EditAddressInPlace.jsx
@@ -13,6 +13,7 @@ export default class EditAddressInPlace extends Component {
     pathname: PropTypes.string,
     toggleFunction: PropTypes.func.isRequired,
     defaultIsEditingAddress: PropTypes.bool,
+    cancelButtonAction: PropTypes.func,
   };
 
   constructor (props, context) {
@@ -73,7 +74,7 @@ export default class EditAddressInPlace extends Component {
         <span>
           <h4 className="h4">Address</h4>
           <AddressBox
-            cancelEditAddress={this.toggleEditingAddress}
+            cancelEditAddress={this.props.cancelButtonAction ? this.props.cancelButtonAction : this.toggleEditingAddress}
             saveUrl={ballotBaseUrl}
             toggleSelectAddressModal={this.props.toggleFunction}
           />

--- a/src/js/components/Widgets/EditAddressInPlace.jsx
+++ b/src/js/components/Widgets/EditAddressInPlace.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Button } from '@material-ui/core/Button';
 import AddressBox from '../AddressBox';
 import { historyPush, isWebApp } from '../../utils/cordovaUtils';
 import { calculateBallotBaseUrl, shortenText } from '../../utils/textFormat';
@@ -89,14 +90,14 @@ export default class EditAddressInPlace extends Component {
             {' '}
           </span>
           <span className="d-print-none ballot__edit-address-preview-link u-padding-left--sm">
-            <button
-              className="btn btn-primary"
+            <Button
+              variant="contained"
+              color="primary"
               id="editAddressInPlaceModalEditButton"
               onClick={this.toggleEditingAddress}
-              type="button"
             >
               Edit
-            </button>
+            </Button>
           </span>
         </span>
       );


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
I updated the ballot modal to close if the location cancel button is hit
### Changes included this pull request?
