### PR TITLE
Set MuiButton print color to white globally

### DIFF
--- a/src/js/mui-theme.js
+++ b/src/js/mui-theme.js
@@ -4,6 +4,9 @@ const overrides = {
   MuiButton: {
     root: {
       userSelect: 'none',
+      '@media print': {
+        color: '#fff',
+      },
     },
   },
   MuiTooltip: {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2347 
### Changes included this pull request?
@ffrancetic Hopefully this resolves the Firefox print color issue.