### PR TITLE
Fixed header on /candidate/* path

### DIFF
--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -226,6 +226,9 @@ export function cordovaBallotFilterTopMargin () {
     } else if (isIPhone678()) {
       return '65px';
     } else if (hasIPhoneNotch()) {
+      if (pageEnumeration() === enums.candidateWild) {
+        return '65px';
+      }
       return '74px';
     } else if (isIPhoneXR()) {
       return '46px';
@@ -426,6 +429,7 @@ export function cordovaTopHeaderTopMargin () {
           case enums.officeWild:      style.marginTop = '30px'; break;
           case enums.measureWild:     style.marginTop = '34px'; break;
           case enums.candidate:       style.marginTop = '35px'; break;
+          case enums.candidateWild:   style.marginTop = '17px'; break;
           case enums.valuesList:      style.marginTop = '38px'; break;
           case enums.values:          style.marginTop = '12px'; break;
           case enums.valueWild:       style.marginTop = '32px'; break;

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -402,9 +402,10 @@ export const enums = {
   wevoteintroWild: 102,
   ballotSmHdrWild: 103,
   ballotLgHdrWild: 104,
-  measureWild: 105,
-  valueWild: 106,
-  welcomeWild: 107,
+  candidateWild: 105,
+  measureWild: 106,
+  valueWild: 107,
+  welcomeWild: 108,
   candidate: 200,
   friends: 201,
   opinions: 202,
@@ -431,6 +432,8 @@ export function pageEnumeration () {
     return enums.valuesList;
 
   // then wildcarded second level paths
+  } else if (href.indexOf('/index.html#/candidate/') > 0) {
+    return enums.candidateWild;
   } else if (href.indexOf('/index.html#/office/') > 0) {
     return enums.officeWild;
   } else if (href.indexOf('/index.html#/settings/') > 0) {


### PR DESCRIPTION
Looks better on iPhoneX, and infrastructure for the rest, but the
/candidate/* from a selection on your voter guides, followed by a candidate
selection needs more work.

See wevote/WebApp/issues/2436