### PR TITLE
Android fixes for header on /candidate/* path.

### DIFF
--- a/src/js/attributions.js
+++ b/src/js/attributions.js
@@ -106,7 +106,7 @@ module.exports = [
   'Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)\n',
   // Jan 2019, https://github.com/FezVrasta/popper.js/blob/master/LICENSE.md
   'FezVrasta/popper.js is licensed under the MIT License (MIT)\n' +
-  'Copyright © 2016 Federico Zivolo and contributors\n',
+  'Copyright (c) 2016 Federico Zivolo and contributors\n',
   // Jan 2019, https://github.com/facebook/prop-types/blob/master/LICENSE
   ' facebook/prop-types is licensed under the MIT License (MIT)\n' +
   '\n' +

--- a/src/js/components/Settings/SettingsProfile.jsx
+++ b/src/js/components/Settings/SettingsProfile.jsx
@@ -56,10 +56,6 @@ export default class SettingsProfile extends Component {
                 closeEditFormOnChoice
                 showEditToggleOption
               />
-              <div className="card-child__fine_print">
-                Your internal We Vote id: &nbsp;
-                {VoterStore.getVoter().we_vote_id}
-              </div>
             </div>
           </div>
         </div>

--- a/src/js/components/Widgets/DeviceDialog.jsx
+++ b/src/js/components/Widgets/DeviceDialog.jsx
@@ -14,6 +14,7 @@ import { withStyles, withTheme } from '@material-ui/core/styles';
 import { Link } from 'react-router';
 import { hasIPhoneNotch } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
+import VoterStore from "../../stores/VoterStore";
 
 const webAppConfig = require('../../config');
 
@@ -109,8 +110,8 @@ class DeviceDialog extends Component {
               </TableRow>
             </TableBody>
           </Table>
-          {/* Show the developer options if on the simulator, or if Cordova offset logging is turned on -- should not show in release builds */}
-          {(window.location.href.startsWith('file:///Users') || window.location.href.startsWith('file:///android') || webAppConfig.LOG_CORDOVA_OFFSETS) &&
+          {/* Show the developer options if on the simulator in iOS, or the SHOW_TEST_OPTIONS is on, or Cordova offset logging is turned on -- should not show in release builds */}
+          {(window.location.href.startsWith('file:///Users') || webAppConfig.SHOW_TEST_OPTIONS || webAppConfig.LOG_CORDOVA_OFFSETS) &&
             (
               <div style={{ marginTop: 20 }}>
                 <div style={{ marginTop: 5 }}>
@@ -131,6 +132,10 @@ class DeviceDialog extends Component {
               </div>
             )
           }
+          <div className="card-child__fine_print" style={{ marginTop: '0.5rem', fontSize: '0.75rem' }}>
+            Your internal We Vote id: &nbsp;
+            {VoterStore.getVoter().we_vote_id}
+          </div>
         </DialogContent>
         <DialogActions>
           <Button onClick={this.props.visibilityOffFunction} color="primary">

--- a/src/js/config-template.js
+++ b/src/js/config-template.js
@@ -10,6 +10,7 @@ module.exports = {
   WE_VOTE_SERVER_API_CDN_ROOT_URL: 'https://cdn.wevoteusa.org/apis/v1/',
 
   DEBUG_MODE: false,
+  SHOW_TEST_OPTIONS: false,    // On the DeviceDialog and elsewhere
 
   LOG_RENDER_EVENTS: false,
   LOG_ONLY_FIRST_RENDER_EVENTS: false,

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -171,6 +171,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.officeWild:      return '79px';
         case enums.measureWild:     return '57px';
         case enums.candidate:       return '64px';
+        case enums.candidateWild:   return '53px';
         case enums.ballotSmHdrWild: return '123px';
         case enums.ballotVote:      return isSignedIn ? '123px' : '119px';
         case enums.moreTerms:       return '32px';
@@ -181,6 +182,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.officeWild:      return '78px';
         case enums.measureWild:     return '40px';
         case enums.candidate:       return '55px';
+        case enums.candidateWild:   return '53px';
         case enums.ballotSmHdrWild: return '118px';
         case enums.ballotVote:      return isSignedIn ? '102px' : '109px';
         case enums.moreTerms:       return '32px';
@@ -191,6 +193,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.officeWild:      return '77px';
         case enums.measureWild:     return '53px';
         case enums.candidate:       return '53px';
+        case enums.candidateWild:   return '51px';
         case enums.ballotSmHdrWild: return '116px';
         case enums.ballotVote:      return isSignedIn ? '106px' : '105px';
         case enums.moreTerms:       return '32px';
@@ -201,6 +204,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.officeWild:      return '42px';
         case enums.measureWild:     return '42px';
         case enums.candidate:       return '24px';
+        case enums.candidateWild:   return '36px';
         case enums.ballotSmHdrWild: return '130px';
         case enums.ballotVote:      return isSignedIn ? '103px' : '102px';
         case enums.moreTerms:       return '32px';


### PR DESCRIPTION
Move the voter id display from Settings to the DeviceDialog.
Fixed a utf8 issue in attributions.
Added SHOW_TEST_OPTIONS to the config-template, this control turns on
the display of testing links on the DeviceDialog -- allows you to Navigate
to the Welcome screen, delete the Welcome Guess cookie, and clear all
cookies -- these are needed for testing in Cordova, where you don't
have access to the URL or the cookies via a browser.