### PR TITLE
Add source map to fix broken line numbers in console

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,4 +62,5 @@ module.exports = {
     open: true,
     writeToDisk: true,
   },
+  devtool: 'cheap-inline-module-source-map',
 };


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
https://github.com/wevote/WebApp/issues/2465

### Changes included this pull request?
Add a source map that is compatible for production build.  This should fix the broken line numbers you see in the console.  Note that the choice of source map is inefficient for the development build (but still much faster than the previous build without webpack). Ideally we can configure the development build to use a special source map which is even more efficient.  We can work on this later. 