### PR TITLE
Fix 404 error because some images wasn't copy to img/global from src

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ module.exports = {
     }),
     new CopyPlugin([
       { from: 'src/javascript/', to: 'javascript/' },
+      { from: 'src/img/global/icons/', to: 'img/global/icons/' },
     ]),
   ],
   module: {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
https://github.com/wevote/WebApp/issues/2475

### Changes included this pull request?
Leverage CopyWebpackPlugin to copy all `src/img/global/icons` into build directory
CopyWebpackPlugin Doc: https://webpack.js.org/plugins/copy-webpack-plugin/