### PR TITLE
Fix styles issue with Webpack

### DIFF
--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -4,6 +4,8 @@
 // 1. Setup
 // ===============================================
 
+@import '~bootstrap/dist/css/bootstrap';
+
 // -------------------------------
 // Base Variables & Mixins
 // -------------------------------
@@ -116,5 +118,3 @@
 // ===============================================
 
 @import 'vendor/react-toggle-style';
-
-@import '~bootstrap/dist/css/bootstrap';


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
I fixed the issue with the styling from the _variables.scss file not applying to the site, which affected the background color, heading styles and many other aspects. It turns out that in main.scss, the styles are applied based off of when they are imported. Because the `@import '~bootstrap/dist/css/bootstrap';` occurred after all the other files, it reset the styling of the site.

I don't know if this fixes some of the other issues, I just know it's a major fix as far as styling of the site goes (although it was just one line)