### PR TITLE
Test page to prove StripeElements usage for the PaidAccountUpgradeModal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -999,6 +999,18 @@
         "@babel/helper-plugin-utils": "^7.0.0"
       }
     },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.5.5.tgz",
+      "integrity": "sha512-6Xmeidsun5rkwnGfMOp6/z9nSzWpHFNVr2Jx7kwoq4mVatQfQx5S56drBgEHF+XQbKOdIaOiMIINvp/kAwMN+w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.0.0",
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "resolve": "^1.8.1",
+        "semver": "^5.5.1"
+      }
+    },
     "@babel/plugin-transform-shorthand-properties": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz",
@@ -4066,8 +4078,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -4088,14 +4099,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -4110,20 +4119,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -4240,8 +4246,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -4253,7 +4258,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -4268,7 +4272,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -4276,14 +4279,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4302,7 +4303,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -4383,8 +4383,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -4396,7 +4395,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -4482,8 +4480,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -4519,7 +4516,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4539,7 +4535,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -4583,14 +4578,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9680,8 +9673,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9702,14 +9694,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9724,20 +9714,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9854,8 +9841,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9867,7 +9853,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9882,7 +9867,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -9890,14 +9874,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9916,7 +9898,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9997,8 +9978,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -10010,7 +9990,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -10096,8 +10075,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -10133,7 +10111,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -10153,7 +10130,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -10197,14 +10173,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -17003,6 +16977,14 @@
         "resize-observer-polyfill": "^1.5.0"
       }
     },
+    "react-stripe-elements": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/react-stripe-elements/-/react-stripe-elements-4.0.1.tgz",
+      "integrity": "sha512-S+O2+hphs6ASz29l85nj6mpS7YWTa3NMwZTonIMt4+8xrfS/jET+0Xd3cNdJoGkHiCtLEId6UimqivONK+liOw==",
+      "requires": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "react-svg": {
       "version": "7.2.14",
       "resolved": "https://registry.npmjs.org/react-svg/-/react-svg-7.2.14.tgz",
@@ -22010,8 +21992,7 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
               "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -22035,15 +22016,13 @@
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
               "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
               "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -22060,22 +22039,19 @@
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
               "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
               "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
               "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -22205,8 +22181,7 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -22220,7 +22195,6 @@
               "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -22237,7 +22211,6 @@
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -22246,15 +22219,13 @@
               "version": "0.0.8",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
               "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -22275,7 +22246,6 @@
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -22359,8 +22329,7 @@
               "version": "1.0.1",
               "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
               "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -22374,7 +22343,6 @@
               "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
               "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -22470,8 +22438,7 @@
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -22512,7 +22479,6 @@
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -22534,7 +22500,6 @@
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -22583,15 +22548,13 @@
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
               "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -22841,8 +22804,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -22863,14 +22825,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -22885,20 +22845,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -23015,8 +22972,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -23028,7 +22984,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -23043,7 +22998,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -23051,14 +23005,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -23077,7 +23029,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -23158,8 +23109,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -23171,7 +23121,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -23257,8 +23206,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -23294,7 +23242,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -23314,7 +23261,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -23358,14 +23304,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -24097,8 +24041,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -24119,14 +24062,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -24141,20 +24082,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -24271,8 +24209,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -24284,7 +24221,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -24299,7 +24235,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -24307,14 +24242,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -24333,7 +24266,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -24414,8 +24346,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -24427,7 +24358,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -24513,8 +24443,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -24550,7 +24479,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -24570,7 +24498,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -24614,14 +24541,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
       ],
       "@babel/plugin-proposal-nullish-coalescing-operator",
       "@babel/plugin-proposal-do-expressions",
-      "@babel/plugin-proposal-function-bind"
+      "@babel/plugin-proposal-function-bind",
+      "@babel/plugin-transform-runtime"
     ]
   },
   "react-svg-icons": {
@@ -105,6 +106,7 @@
     "react-router": "^3.2.3",
     "react-router-scroll": "^0.4.4",
     "react-slick": "^0.23.2",
+    "react-stripe-elements": "^4.0.0",
     "react-svg": "^7.2.14",
     "react-text-truncate": "^0.13.1",
     "react-textarea-autosize": "^7.0.4",
@@ -135,9 +137,11 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/plugin-syntax-import-meta": "^7.0.0",
     "@babel/plugin-transform-object-assign": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.5.5",
     "@babel/preset-env": "^7.5.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.4.4",
+    "@babel/runtime": "^7.5.5",
     "@babel/types": "^7.5.0",
     "@wdio/cli": "^5.11.7",
     "@wdio/local-runner": "^5.11.7",

--- a/src/index.html
+++ b/src/index.html
@@ -82,6 +82,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.4/umd/popper.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.1.3/js/bootstrap.min.js"></script>
     <script src="https://checkout.stripe.com/checkout.js"></script>
+    <script src="https://js.stripe.com/v3/"></script>
     <script src="/javascript/google-analytics.js"></script>
     <script src="https://tool.votinginfoproject.org/app.js"></script>
     <script type="text/javascript" async src="//platform.twitter.com/widgets.js"></script>

--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -14,6 +14,7 @@ import Connect from './routes/Connect';
 import Credits from './routes/More/Credits';
 import Donate from './routes/More/Donate';
 import DonateThankYou from './routes/More/DonateThankYou';
+import StripeElementsTest from './routes/More/StripeElementsTest';
 import ElectionReminder from './routes/More/ElectionReminder';
 import Elections from './routes/More/Elections';
 import EmailBallot from './routes/More/EmailBallot';
@@ -167,6 +168,7 @@ const routes = () => (
     <Route path="/more/credits" component={Credits} />
     <Route path="/more/donate" component={Donate} />
     <Route path="/more/donate_thank_you" component={DonateThankYou} />
+    <Route path="/more/stripe_elements_test" component={StripeElementsTest} />
     <Route path="/more/elections" component={Elections} />
     <Route path="/more/email_ballot" component={EmailBallot} />
     <Route path="/more/facebooklandingprocess" component={FacebookLandingProcess} />

--- a/src/js/actions/DonateActions.js
+++ b/src/js/actions/DonateActions.js
@@ -19,12 +19,23 @@ export default {
       });
   },
 
-  donationWithStripe (token, email, donationAmount, monthlyDonation) {
+  donationWithStripe (token, email, donationAmount, monthlyDonation, isOrganizationPlan, planType, couponCode) {
     Dispatcher.loadEndpoint('donationWithStripe', {
       token,
       email,
       donation_amount: donationAmount,
       monthly_donation: monthlyDonation,
+      is_organization_plan: isOrganizationPlan,
+      plan_type_enum: planType,
+      coupon_code: couponCode,
+    });
+  },
+
+  validateCoupon (planType, couponCode) {
+    console.log('validateCoupon');
+    Dispatcher.loadEndpoint('validateCoupon', {
+      plan_type_enum: planType,
+      coupon_code: couponCode,
     });
   },
 };

--- a/src/js/components/Donation/DonationForm.jsx
+++ b/src/js/components/Donation/DonationForm.jsx
@@ -46,8 +46,12 @@ export default class DonationForm extends Component {
         image: cordovaDot('https://stripe.com/img/documentation/checkout/marketplace.png'),
         locale: 'auto',
         token (token) {
-          // console.log("token generated " + token.id + " token.email " + token.email);
-          DonateActions.donationWithStripe(token.id, token.email, self.props.donationAmount, self.props.donateMonthly);
+          console.log(`token generated ${token.id} token.email ${token.email}`);
+          const isOrganizationPlan = false;
+          const couponCode = '';
+          const planType = '';
+          DonateActions.donationWithStripe(token.id, token.email, self.props.donationAmount, self.props.donateMonthly,
+            isOrganizationPlan, planType, couponCode);
           historyPush('/more/processing_donation');
         },
       });

--- a/src/js/components/Navigation/HeaderBarLogo.jsx
+++ b/src/js/components/Navigation/HeaderBarLogo.jsx
@@ -9,11 +9,6 @@ import logoDark from '../../../img/global/svg-icons/we-vote-logo-horizontal-colo
 const HeaderBarLogo = ({ isBeta, light }) => (
   <HeaderBarWrapper>
     <Link to={`${isCordova() ? '/ballot' : '/welcome'}`} className="page-logo page-logo-full-size" id="logoHeaderBar">
-      {/* <img */}
-      {/*  className="header-logo-img" */}
-      {/*  alt="We Vote logo" */}
-      {/*  src={cordovaDot(`/img/global/svg-icons/we-vote-logo-horizontal-color${light ? '-200x66' : '-dark-141x46'}.svg`)} */}
-      {/* /> */}
       <img
         className="header-logo-img"
         alt="We Vote logo"

--- a/src/js/config-template.js
+++ b/src/js/config-template.js
@@ -12,7 +12,7 @@ module.exports = {
   DEBUG_MODE: false,
   SHOW_TEST_OPTIONS: false,    // On the DeviceDialog and elsewhere
 
-  LOG_RENDER_EVENTS: false,
+  LOG_RENDER_EVENTS: true,
   LOG_ONLY_FIRST_RENDER_EVENTS: false,
   LOG_HTTP_REQUESTS: false,
   LOG_ROUTING: false,

--- a/src/js/routes/More/StripeElementsTest.jsx
+++ b/src/js/routes/More/StripeElementsTest.jsx
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import { Elements, StripeProvider } from 'react-stripe-elements';
+import Helmet from 'react-helmet';
+import styled from 'styled-components';
+import { withStyles } from '@material-ui/core';
+import StripeElementsTestForm from './StripeElementsTestForm';
+import { renderLog } from '../../utils/logging';
+import WelcomeAppbar from '../../components/Navigation/WelcomeAppbar';
+
+/**
+ * August 16, 2019:  This code can be deleted once its functionality is duplicated in the newly created production UI
+ */
+
+class StripeElementsTest extends Component {
+  render () {
+    renderLog(__filename);
+    return (
+      <Wrapper>
+        <Helmet title="Stripe Elements Test" />
+        <WelcomeAppbar pathname="/more/pricing" />
+        <StripeProvider apiKey="pk_test_bWuWGC3jrMIFH3wvRvHR6Z5H">
+          <div className="example">
+            <h1>Test of Stripe Elements</h1>
+            <Elements>
+              <StripeElementsTestForm />
+            </Elements>
+          </div>
+        </StripeProvider>
+      </Wrapper>
+    );
+  }
+}
+
+const styles = theme => ({
+  buttonContained: {
+    borderRadius: 32,
+    height: 50,
+    [theme.breakpoints.down('md')]: {
+      height: 36,
+    },
+  },
+});
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  background: white;
+  overflow-x: hidden;
+`;
+
+
+export default withStyles(styles)(StripeElementsTest);
+
+

--- a/src/js/routes/More/StripeElementsTestForm.jsx
+++ b/src/js/routes/More/StripeElementsTestForm.jsx
@@ -1,0 +1,164 @@
+import React, { Component } from 'react';
+import { CardElement, injectStripe } from 'react-stripe-elements';
+import Checkbox from '@material-ui/core/Checkbox';
+import { Button } from 'react-bootstrap';
+import PropTypes from 'prop-types';
+import { renderLog } from '../../utils/logging';
+import VoterStore from '../../stores/VoterStore';
+import DonateActions from '../../actions/DonateActions';
+import DonateStore from '../../stores/DonateStore';
+
+/* global $ */
+
+/**
+ * August 16, 2019:  This code can be deleted once its functionality is duplicated in the newly created production UI
+ */
+
+
+class StripeElementsTestForm extends Component {
+  static propTypes = {
+    stripe: PropTypes.object,
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      isChecked: true,
+    };
+    this.submit = this.submit.bind(this);
+    this.redeem = this.redeem.bind(this);
+  }
+
+  componentDidMount () {
+    this.donateStoreListener = DonateStore.addListener(this.donateStoreChange);
+  }
+
+  componentWillUnmount () {
+    this.donateStoreListener.remove();
+  }
+
+  // This is really minimal, just for testing
+  donateStoreChange = () => {
+    const msg = DonateStore.getCouponMessage();
+    if (msg.length > 0) {
+      console.log('updating coupon message success validating coupon');
+      $('.u-no-break').html(msg);
+    }
+
+    if (DonateStore.getOrgSubscriptionAlreadyExists()) {
+      console.log('updating coupon message organization subscription already exists');
+      $('.u-no-break').html('A subscription already exists for this organization<br>The existing subscription was not altered, no credit card charge was made.');
+    }
+  };
+
+  async submit () {
+    const { stripe } = this.props;
+    // TODO: Figure out what is needed for Name
+    const { token } = await stripe.createToken({ name: 'Name' });
+    const planType = this.state.isChecked ? 'PROFESSIONAL_MONTHLY' : 'ENTERPRISE_MONTHLY';
+    let couponCode = $('input[name=couponName]').val()  || '';
+
+    if (couponCode.length === 0) {
+      couponCode = `DEFAULT-${planType}`;
+    }
+
+    // console.log("stripe token object from component/dialog: " + token);
+
+    const isOrganizationPlan = true;
+    const donateMonthly = true;
+    const email  = '';
+    DonateActions.donationWithStripe(token.id, email, 100, donateMonthly,  // TEMPORARY HACK STEVE $100
+      isOrganizationPlan, planType, couponCode);
+
+    // DonateActions.businessInitialCharge(token.id, planType, couponCode);
+    // const url = `https://bb94acbb.ngrok.io/apis/v1/businessInitialCharge/?token=${token.id}&voter_device_id=${cookies.getItem('voter_device_id')}`;
+    // console.log('Stripe Test URL: ', url);
+    // const response = await fetch(url, {
+    //   method: 'GET',
+    //   headers: { 'Content-Type': 'text/plain' },
+    //   credentials: 'include',
+    // });
+    //
+    // if (response.ok) {
+    //   // eslint-disable-next-line react/no-unused-state
+    //   this.setState({ complete: true });
+    //   console.log('Purchase Complete! ', response);
+    // }
+  }
+
+  async redeem () {
+    const couponCode = $('input[name=couponName]').val();
+    const planType = this.state.isChecked ? 'PROFESSIONAL_MONTHLY' : 'ENTERPRISE_MONTHLY';
+    DonateActions.validateCoupon(planType, couponCode);
+  }
+
+  render () {
+    renderLog(__filename);
+    const voter = VoterStore.getVoter();
+    const { full_name: fullName } = voter;
+    console.log(voter);
+    const { redeem, submit } = this;
+
+    return (
+      <div className="checkout">
+        <h3 style={{ color: '#28a745' }}>Payment</h3>
+        <br />
+        <br />
+        <p>All transactions are secure and encrypted.</p>
+        <p>Enter your card to subscribe to We Vote Professional for $100 per month</p>
+        <br />
+        <p style={{ fontStyle: 'italic' }}>{fullName}</p>
+
+        <span>
+          Professional
+          <Checkbox
+            checked={this.state.isChecked}
+            onChange={console.log('checkbox checked')}
+            value="checkedA"
+            inputProps={{
+              'aria-label': 'primary checkbox',
+            }}
+            style={{ color: 'black' }}
+          />
+        </span>
+        <div className="input-group">
+          <label htmlFor="friend1FirstName">
+            <span className="u-no-break">Coupon code</span>
+            <input
+              type="text"
+              id="couponId"
+              name="couponName"
+              className="form-control"
+              placeholder="Optional"
+            />
+          </label>
+          <Button
+            style={{ height: 35, marginTop: 56, marginLeft: 5 }}
+            tabIndex="0"
+            onClick={redeem}
+            variant="success"
+          >
+            <span>Redeem Coupon</span>
+          </Button>
+
+        </div>
+        <br />
+        <div style={{ border: '1px solid black', backgroundColor: '#f3f3f7', padding: 5 }}>
+          <CardElement />
+        </div>
+        <br />
+        <Button
+          tabIndex="0"
+          onClick={submit}
+          variant="success"
+        >
+          <span>Start my Subscription</span>
+        </Button>
+
+      </div>
+    );
+  }
+}
+
+export default injectStripe(StripeElementsTestForm);
+

--- a/src/js/stores/DonateStore.js
+++ b/src/js/stores/DonateStore.js
@@ -28,10 +28,23 @@ class DonateStore extends ReduceStore {
     return this.getState().donationHistory || {};
   }
 
+  getCouponMessage () {
+    return this.getState().couponAppliedMessage || '';
+  }
+
+  getOrgSubscriptionAlreadyExists () {
+    return this.getState().orgSubsAlreadyExists || false;
+  }
+
+
   reduce (state, action) {
     if (!action.res) return state;
     const { error_message_for_voter: errorMessageForVoter, saved_stripe_donation: savedStripeDonation, status, success, donation_amount: donationAmount,
-      donation_list: donationHistory, charge_id: charge, subscription_id: subscriptionId, monthly_donation: monthlyDonation } = action.res;
+      donation_list: donationHistory, charge_id: charge, subscription_id: subscriptionId, monthly_donation: monthlyDonation,
+      coupon_applied_message: couponAppliedMessage, coupon_match_found: couponMatchFound, coupon_still_valid: couponStillValid,
+      discounted_price_monthly_credit: discountedPriceMonthlyCredit, list_price_monthly_credit: listPriceMonthlyCredit,
+      org_subs_already_exists: orgSubsAlreadyExists,
+    } = action.res;
     const donationAmountSafe = donationAmount || '';
 
     switch (action.type) {
@@ -46,6 +59,7 @@ class DonateStore extends ReduceStore {
           monthlyDonation,
           savedStripeDonation,
           success,
+          orgSubsAlreadyExists,
           donationResponseReceived: true,
         };
 
@@ -78,6 +92,17 @@ class DonateStore extends ReduceStore {
       case 'voterSignOut':
         // console.log("resetting DonateStore");
         return this.resetState();
+
+      case 'validateCoupon':
+        return {
+          success: true,
+          couponAppliedMessage,
+          couponMatchFound,
+          couponStillValid,
+          discountedPriceMonthlyCredit,
+          listPriceMonthlyCredit,
+          status,
+        };
 
       default:
         return state;


### PR DESCRIPTION
The validation of coupons, and the display of StripeElements is fine,
some of the backend work is ongoing to distinguish between donations and
organization paid subscriptions -- both use Stripe and mostly the same
Python code and SQL tables on the server.

I have a support issue in to stripe on how to recover our plan name code
which does not seem to be in their charge webhook return, but is mentioned
in a [html receipt for the charge which they generate](https://pay.stripe.com/receipts/acct_19sJvMD153UBwRss/ch_1F8YV3D153UBwRss0KKRKr7C/rcpt_FdqBflp8V3DA4lTn95dniG5VUCbP1yt) -- should have the
answer in a few days.

Use https://localhost:3000/more/stripe_elements_test to access page
Only the "25OFF" coupon is defined on the server (plus 'DEFAULT-PROFESSIONAL_MONTHLY' and 'DEFAULT-ENTERPRISE_MONTHLY' for
use when there is no coupon entered by the voter.  See https://github.com/wevote/WeVoteServer/blob/develop/donate/models.py create_initial_coupons().  Once we get the Python Admin UI going for editing coupons, then
we can create as many as we want, and maintain them going forward.

The DonateActions.validateCoupon (planType, couponCode) also returns the list
and discounted prices, for those default coupons (whose coupon code should
not need to be exposed to voters), for default, the discounted and list prices are the same
and can be used to lookup the current prices without having to hard code
them in JavaScript.

further work on wevote/WebApp/issues/2488
