### PR TITLE
Update issues popover card

### DIFF
--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -310,12 +310,15 @@ const MoreWrapper = styled.p`
 `;
 
 const PopoverWrapper = styled.div`
-  width: calc(100% + 24px);
+  overflow-x: hidden;
+  width: 100%;
   height: 100%;
   position: relative;
   right: 12px;
   bottom: 8px;
   border-radius: 3px;
+  margin-left: 12px;
+  margin-top: 8px;
 `;
 
 const PopoverHeader = styled.div`


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2500 
### Changes included this pull request?
I updated the width of the popover wrapper so it displays like it used to before the Material UI v4 upgrade