### PR TITLE
Subscription to a paid plan is working, but still need edge case handling

### DIFF
--- a/src/js/routes/More/StripeElementsTestForm.jsx
+++ b/src/js/routes/More/StripeElementsTestForm.jsx
@@ -40,15 +40,19 @@ class StripeElementsTestForm extends Component {
 
   // This is really minimal, just for testing
   donateStoreChange = () => {
-    const msg = DonateStore.getCouponMessage();
-    if (msg.length > 0) {
-      console.log('updating coupon message success validating coupon');
-      $('.u-no-break').html(msg);
-    }
+    try {
+      const msg = DonateStore.getCouponMessageTest();
+      if (msg.length > 0) {
+        console.log('updating coupon message success validating coupon');
+        $('.u-no-break').html(msg);
+      }
 
-    if (DonateStore.getOrgSubscriptionAlreadyExists()) {
-      console.log('updating coupon message organization subscription already exists');
-      $('.u-no-break').html('A subscription already exists for this organization<br>The existing subscription was not altered, no credit card charge was made.');
+      if (DonateStore.getOrgSubscriptionAlreadyExists()) {
+        console.log('updating coupon message organization subscription already exists');
+        $('.u-no-break').html('A subscription already exists for this organization<br>The existing subscription was not altered, no credit card charge was made.');
+      }
+    } catch (err) {
+      console.log('donateStoreChange caught error: ', err);
     }
   };
 
@@ -68,23 +72,8 @@ class StripeElementsTestForm extends Component {
     const isOrganizationPlan = true;
     const donateMonthly = true;
     const email  = '';
-    DonateActions.donationWithStripe(token.id, email, 100, donateMonthly,  // TEMPORARY HACK STEVE $100
+    DonateActions.donationWithStripe(token.id, email, 0, donateMonthly,  // TEMPORARY HACK STEVE $100
       isOrganizationPlan, planType, couponCode);
-
-    // DonateActions.businessInitialCharge(token.id, planType, couponCode);
-    // const url = `https://bb94acbb.ngrok.io/apis/v1/businessInitialCharge/?token=${token.id}&voter_device_id=${cookies.getItem('voter_device_id')}`;
-    // console.log('Stripe Test URL: ', url);
-    // const response = await fetch(url, {
-    //   method: 'GET',
-    //   headers: { 'Content-Type': 'text/plain' },
-    //   credentials: 'include',
-    // });
-    //
-    // if (response.ok) {
-    //   // eslint-disable-next-line react/no-unused-state
-    //   this.setState({ complete: true });
-    //   console.log('Purchase Complete! ', response);
-    // }
   }
 
   async redeem () {

--- a/src/js/stores/DonateStore.js
+++ b/src/js/stores/DonateStore.js
@@ -61,6 +61,10 @@ class DonateStore extends ReduceStore {
     return this.getState().donationHistory || {};
   }
 
+  getCouponMessageTest () {
+    return this.getState().coupon_applied_message;
+  }
+
   getCouponMessage () {
     const { lastCouponResponseReceived } = this.state;
     if (!lastCouponResponseReceived) {
@@ -104,8 +108,6 @@ class DonateStore extends ReduceStore {
     let couponCodeString = '';
     let couponMatchFound = '';
     let couponStillValid = '';
-    const discountedPriceMonthlyCredit = '';
-    let listPriceMonthlyCredit = '';
     let enterprisePlanCouponPricePerMonthPayMonthly = '';
     let enterprisePlanCouponPricePerMonthPayYearly = '';
     let enterprisePlanFullPricePerMonthPayMonthly = '';
@@ -233,20 +235,32 @@ class DonateStore extends ReduceStore {
         };
 
       case 'validateCoupon':
-        ({
-          coupon_applied_message: couponAppliedMessage,
-          coupon_match_found: couponMatchFound,
-          list_price_monthly_credit: listPriceMonthlyCredit,
-        } = action.res);
         return {
-          success: true,
-          couponAppliedMessage,
-          couponMatchFound,
-          couponStillValid,
-          discountedPriceMonthlyCredit,
-          listPriceMonthlyCredit,
-          status,
+          annual_price_stripe: action.res.annual_price_stripe,
+          coupon_applied_message: action.res.coupon_applied_message,
+          coupon_match_found: action.res.coupon_match_found,
+          coupon_still_valid: action.res.coupon_still_valid,
+          monthly_price_stripe: action.res.monthly_price_stripe,
+          status: action.res.status,
+          success: action.res.success,
         };
+
+        // // TODO: Dale needs to revive for his new upgrade, contains test code
+        // case 'validateCoupon':
+        //   ({
+        //     coupon_applied_message: couponAppliedMessage,
+        //     coupon_match_found: couponMatchFound,
+        //     list_price_monthly_credit: listPriceMonthlyCredit,
+        //   } = action.res);
+        //   return {
+        //     success: true,
+        //     couponAppliedMessage,
+        //     couponMatchFound,
+        //     couponStillValid,
+        //     discountedPriceMonthlyCredit,
+        //     listPriceMonthlyCredit,
+        //     status,
+        //   };
 
       default:
         return state;


### PR DESCRIPTION
Still need to prevent two paid plans for one organization
Unsubscribe from a paid plan needs work.

Dale's version of validateCoupon was incompatible with my current work
and it is commented out.  I should be done by mid first week in
September, at which point, this can be reversed.

Test page for React is https://localhost:3000/more/stripe_elements_test
Coupon management page is http://localhost:8000/organization_plans/plan_list/

Work towards the completion of wevote/WebApp/issues/2488

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
