### PR TITLE
Update width of popover for issues from MaterialUI upgrade

### DIFF
--- a/src/js/components/Values/IssuesByOrganizationDisplayList.jsx
+++ b/src/js/components/Values/IssuesByOrganizationDisplayList.jsx
@@ -233,11 +233,8 @@ const ValueIconAndTextOrganization = styled.span`
 `;
 
 const PopoverWrapper = styled.div`
-  width: calc(100% + 24px);
+  width: calc(100%);
   height: 100%;
-  position: relative;
-  right: 12px;
-  bottom: 8px;
   border-radius: 3px;
 `;
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
This fixed an issue with the issues popover left over from the Material UI V4 upgrade