### PR TITLE
fix z-index for .pac-container class

### DIFF
--- a/src/sass/overrides/_overrides.scss
+++ b/src/sass/overrides/_overrides.scss
@@ -9,10 +9,10 @@ $white-text-color: $white;
 }
 
 
-// Required because Google Auto-complete needs to appear above modal: https://github.com/twbs/bootstrap/issues/4160
+// Required because Google Auto-complete needs to appear above Material-UI modal: https://material-ui.com/customization/z-index/
 // This is used for the address auto-complete field (.pac-container is injected via Google)
 .pac-container {
-  z-index: 1051 !important;
+  z-index: 1301 !important;
 }
 
 // Used to prevent scrolling underneath a modal(modal)


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2545 
### Changes included this pull request?

Looks like the auto-complete results z-index conflicted with the z-index of the Material UI dialog modal, which has a higher z-index than the previous Bootstrap modal's z-index. As you can see in the accompanying screenshot, it needs a bit of styling to match up with the new component!


![Screenshot from 2019-09-20 17-28-33](https://user-images.githubusercontent.com/35127144/65362540-60c7db80-dbcd-11e9-9e68-06a8bb125832.png)