### PR TITLE
Back to candidate buttons

### DIFF
--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -248,6 +248,7 @@ const routes = () => (
 
     {/* Any route that is not found -> @return TwitterHandleLanding component */}
     <Route path=":twitter_handle" component={TwitterHandleLanding} />
+    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable" component={TwitterHandleLanding} />
     <Route path=":twitter_handle/followers" component={props => <TwitterHandleLanding {...props} active_route="followers" />} />
     <Route path=":twitter_handle/following" component={props => <TwitterHandleLanding {...props} active_route="following" />} />
     <Route path=":twitter_handle/positions" component={props => <TwitterHandleLanding {...props} active_route="positions" />} />

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -175,7 +175,7 @@ class PositionItem extends Component {
                         placement="auto"
                         id="positions-popover-trigger-click-root-close"
                       >
-                        <Link to={speakerLink}>
+                        <Link to={`${speakerLink}/btcand/${this.props.params.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`}>
                           { position.speaker_display_name }
                         </Link>
                       </StickyPopover>
@@ -257,7 +257,7 @@ class PositionItem extends Component {
             <PositionItemMobile className={`position-item--${supportOpposeInfo} position-item`}>
               <MobileItemHeader>
                 <MobileItemImage>
-                  <Link to={speakerLink} className="u-no-underline">
+                  <Link to={`${speakerLink}/btcand/${this.props.params.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`} className="u-no-underline">
                     { position.speaker_image_url_https_medium ? (
                       <ImageHandler
                         className="card-child__avatar"
@@ -271,7 +271,7 @@ class PositionItem extends Component {
                 {/* Visible for most phones */}
                 <MobileItemNameIssuesContainer>
                   <MobileItemName>
-                    <Link to={speakerLink} className="u-break-word">
+                    <Link to={`${speakerLink}/btcand/${this.props.params.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`} className="u-break-word">
                       { position.speaker_display_name }
                     </Link>
                   </MobileItemName>
@@ -286,7 +286,7 @@ class PositionItem extends Component {
                 {/* Visible on iPhone 5/se */}
                 <MobileSmallItemNameContainer>
                   <MobileItemName>
-                    <Link to={speakerLink} className="u-break-word">
+                    <Link to={`${speakerLink}/btcand/${this.props.params.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`}className="u-break-word">
                       { position.speaker_display_name }
                     </Link>
                   </MobileItemName>

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -149,7 +149,7 @@ class PositionItem extends Component {
                     id="positions-popover-trigger-click-root-close"
                   >
                     <Link
-                      to={`${speakerLink}/btcand/${position.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`}
+                      to={`${speakerLink}/btcand/${this.props.params.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`}
                       className="u-no-underline"
                     >
                       { position.speaker_image_url_https_medium ? (

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -18,6 +18,7 @@ class PositionItem extends Component {
   static propTypes = {
     ballotItemDisplayName: PropTypes.string.isRequired,
     position: PropTypes.object.isRequired,
+    params: PropTypes.object,
   };
 
   constructor (props) {
@@ -286,7 +287,7 @@ class PositionItem extends Component {
                 {/* Visible on iPhone 5/se */}
                 <MobileSmallItemNameContainer>
                   <MobileItemName>
-                    <Link to={`${speakerLink}/btcand/${this.props.params.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`}className="u-break-word">
+                    <Link to={`${speakerLink}/btcand/${this.props.params.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`} className="u-break-word">
                       { position.speaker_display_name }
                     </Link>
                   </MobileItemName>

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -148,7 +148,10 @@ class PositionItem extends Component {
                     placement="auto"
                     id="positions-popover-trigger-click-root-close"
                   >
-                    <Link to={speakerLink} className="u-no-underline">
+                    <Link
+                      to={`${speakerLink}/btcand/${position.candidate_we_vote_id}/b/${this.props.params.back_to_variable}`}
+                      className="u-no-underline"
+                    >
                       { position.speaker_image_url_https_medium ? (
                         <ImageHandler
                           className="card-child__avatar"

--- a/src/js/components/Ballot/PositionList.jsx
+++ b/src/js/components/Ballot/PositionList.jsx
@@ -144,6 +144,7 @@ export default class PositionList extends Component {
               key={`${onePosition.position_we_vote_id}-${onePosition.voter_guide_we_vote_id}-${onePosition.speaker_display_name}`}
               ballotItemDisplayName={this.props.ballotItemDisplayName}
               position={onePosition}
+              params={this.props.params}
             />
           ))
         }

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -337,8 +337,9 @@ class HeaderBackToBallot extends Component {
     // console.log('HeaderBackToBallot render');
 
     let backToLink;
+    let backToLinkText;
     if (this.props.params.back_to_cand_we_vote_id) {
-      backToLink = `/candidate/${this.props.params.back_to_cand_we_vote_id}/b/${this.props.params.back_to_variable}`;
+      backToLink = `/candidate/${this.props.params.back_to_cand_we_vote_id}/b/${this.props.params.back_to_variable}/`;
     } else if (organizationWeVoteId && candidate && candidate.google_civic_election_id) {
       backToLink = this.getVoterGuideLink(); // Default to this when there is an organizationWeVoteId
     } else if (candidate && candidate.google_civic_election_id) {
@@ -347,20 +348,23 @@ class HeaderBackToBallot extends Component {
       backToLink = `/ballot#${this.props.params.measure_we_vote_id}`;
     } else {
       backToLink = '/ballot'; // Default to this
+      backToLinkText = 'Back';
     }
 
-    if (this.props.params.back_to_variable === 'bto' || this.props.params.back_to_variable === 'btdo') { // back-to-default-office
+    if ((this.props.params.back_to_variable === 'bto' || this.props.params.back_to_variable === 'btdo') && !this.props.params.back_to_cand_we_vote_id) { // back-to-default-office
       backToLink = this.getOfficeLink();
     }
 
-    let backToLinkText;
     if (organizationWeVoteId) {
       backToLinkText = 'Voter Guide'; // Back to
     } else {
       backToLinkText = 'Ballot'; // Back to
     }
 
-    if (this.props.params.back_to_variable === 'bto' || this.props.params.back_to_variable === 'btdo') { // back-to-default-office
+
+    if (this.props.params.back_to_cand_we_vote_id) {
+      backToLinkText = 'Candidate';
+    } else if (this.props.params.back_to_variable === 'bto' || this.props.params.back_to_variable === 'btdo') { // back-to-default-office
       if (this.state.officeName) {
         backToLinkText = `${this.state.officeName}`; // Back to
       } else {

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -337,7 +337,9 @@ class HeaderBackToBallot extends Component {
     // console.log('HeaderBackToBallot render');
 
     let backToLink;
-    if (organizationWeVoteId && candidate && candidate.google_civic_election_id) {
+    if (this.props.params.back_to_cand_we_vote_id) {
+      backToLink = `/candidate/${this.props.params.back_to_cand_we_vote_id}/b/${this.props.params.back_to_variable}`;
+    } else if (organizationWeVoteId && candidate && candidate.google_civic_election_id) {
       backToLink = this.getVoterGuideLink(); // Default to this when there is an organizationWeVoteId
     } else if (candidate && candidate.google_civic_election_id) {
       backToLink = `/ballot/election/${candidate.google_civic_election_id}`;

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -348,7 +348,6 @@ class HeaderBackToBallot extends Component {
       backToLink = `/ballot#${this.props.params.measure_we_vote_id}`;
     } else {
       backToLink = '/ballot'; // Default to this
-      backToLinkText = 'Back';
     }
 
     if ((this.props.params.back_to_variable === 'bto' || this.props.params.back_to_variable === 'btdo') && !this.props.params.back_to_cand_we_vote_id) { // back-to-default-office
@@ -361,9 +360,8 @@ class HeaderBackToBallot extends Component {
       backToLinkText = 'Ballot'; // Back to
     }
 
-
     if (this.props.params.back_to_cand_we_vote_id) {
-      backToLinkText = 'Candidate';
+      backToLinkText = this.state.candidate.ballot_item_display_name;
     } else if (this.props.params.back_to_variable === 'bto' || this.props.params.back_to_variable === 'btdo') { // back-to-default-office
       if (this.state.officeName) {
         backToLinkText = `${this.state.officeName}`; // Back to

--- a/src/js/components/Navigation/HeaderBackToButton.jsx
+++ b/src/js/components/Navigation/HeaderBackToButton.jsx
@@ -1,10 +1,11 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { Link } from 'react-router';
 import Button from '@material-ui/core/Button';
 import KeyboardBackspaceIcon from '@material-ui/icons/ArrowBack';
 import KeyboardBackSpaceIconCordovaIOS from '@material-ui/icons/ArrowBackIos';
 import { withStyles } from '@material-ui/core/styles';
-import { historyPush, isIOS } from '../../utils/cordovaUtils';
+import { isIOS } from '../../utils/cordovaUtils';
 
 import { shortenText } from '../../utils/textFormat';
 import { renderLog } from '../../utils/logging';
@@ -32,23 +33,23 @@ class HeaderBackToButton extends Component {
     const { classes, backToLink, backToLinkText } = this.props;
 
     return (
-      <Button
-        variant="text"
-        color="primary"
-        classes={{ root: classes.root }}
-        className="page-header__backToButton"
-        id="backToLinkTabHeader"
-        onClick={() => historyPush(backToLink)}
-      >
-        {isIOS() ? (
-          <KeyboardBackSpaceIconCordovaIOS className="button-icon" />
-        ) : (
-          <KeyboardBackspaceIcon className="button-icon" />
-        )}
-        <span className="u-show-desktop-tablet u-no-break">{shortenText(backToLinkText, 60)}</span>
-        <span className="u-show-mobile u-no-break">{shortenText(backToLinkText, 23)}</span>
-      </Button>
-
+      <Link to={backToLink}>
+        <Button
+          variant="text"
+          color="primary"
+          classes={{ root: classes.root }}
+          className="page-header__backToButton"
+          id="backToLinkTabHeader"
+        >
+          {isIOS() ? (
+            <KeyboardBackSpaceIconCordovaIOS className="button-icon" />
+          ) : (
+            <KeyboardBackspaceIcon className="button-icon" />
+          )}
+          <span className="u-show-desktop-tablet u-no-break">{shortenText(backToLinkText, 60)}</span>
+          <span className="u-show-mobile u-no-break">{shortenText(backToLinkText, 23)}</span>
+        </Button>
+      </Link>
     );
   }
 }

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -41,6 +41,7 @@ import VoterStore from '../../stores/VoterStore';
 import webAppConfig from '../../config';
 import { formatVoterBallotList, checkShouldUpdate } from './utils';
 import AppActions from '../../actions/AppActions';
+import {Button} from '@material-ui/core';
 
 
 // Related to WebApp/src/js/components/VoterGuide/VoterGuideBallot.jsx

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -206,6 +206,7 @@ export default class Candidate extends Component {
             <PositionList
               incomingPositionList={this.state.allCachedPositionsForThisCandidate}
               ballotItemDisplayName={this.state.candidate.ballot_item_display_name}
+              params={this.props.params}
             />
           ) : null
           }

--- a/src/js/utils/applicationUtils.js
+++ b/src/js/utils/applicationUtils.js
@@ -83,6 +83,9 @@ export function getApplicationViewBooleans (pathname) {
   if (stringContains('/btdb/', pathnameLowerCase) || // back-to-default-ballot
     stringContains('/btdo/', pathnameLowerCase) || // back-to-default-office
     stringContains('/bto/', pathnameLowerCase) ||
+    stringContains('/btdb', pathnameLowerCase) || // back-to-default-ballot
+    stringContains('/btdo', pathnameLowerCase) || // back-to-default-office
+    stringContains('/bto', pathnameLowerCase) ||
     stringContains('/btvg/', pathnameLowerCase)) {
     // If here, we want the top header to be "Back To..."
     // "/btdb/" stands for "Back To Default Ballot Page" back-to-default-ballot


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2310 
### Changes included this pull request?
The organization pages now display a back to link to the candidate. However, I can't figure out the measures, as it's throwing this error when I go onto a measure page: ```cannot read property of candidate_we_vote_id```. What's weird is this error is coming from the PositionItem.jsx file, NOT the MeasureItem.jsx file.