### PR TITLE
style autocomplete icon to be display: none

### DIFF
--- a/src/sass/overrides/_overrides.scss
+++ b/src/sass/overrides/_overrides.scss
@@ -15,6 +15,10 @@ $white-text-color: $white;
   z-index: 1301 !important;
 }
 
+.pac-icon {
+  display: none !important;
+}
+
 // Used to prevent scrolling underneath a modal(modal)
 // Reference: Issue #1415
 .modal-open {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2550 
### Changes included this pull request?
Add "display: none" style rule to the pac-icon class. This goes a good way in cleaning up the look of the autocomplete dropdown as discussed in today's standup