### PR TITLE
Renamed SettingsSMSVerify to SettingsVerifySecretCode so we can use it for verifying both SMS and email codes. Moved VoterEmailAddressEntry and VoterPhoneVerificationEntry into components/Settings folder.

### DIFF
--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -17,10 +17,10 @@ import { oAuthLog, renderLog } from '../../utils/logging';
 import TwitterActions from '../../actions/TwitterActions';
 import TwitterSignIn from '../Twitter/TwitterSignIn';
 import VoterActions from '../../actions/VoterActions';
-import VoterEmailAddressEntry from '../VoterEmailAddressEntry';
+import VoterEmailAddressEntry from './VoterEmailAddressEntry';
 import VoterSessionActions from '../../actions/VoterSessionActions';
 import VoterStore from '../../stores/VoterStore';
-import VoterPhoneVerificationEntry from '../VoterPhoneVerificationEntry';
+import VoterPhoneVerificationEntry from './VoterPhoneVerificationEntry';
 
 const debugMode = false;
 

--- a/src/js/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/components/Settings/SettingsVerifySecretCode.jsx
@@ -13,7 +13,7 @@ import {
 } from '@material-ui/core';
 import { hasIPhoneNotch, isIOS, isCordova } from '../../utils/cordovaUtils';
 
-class SettingsSMSVerify extends Component {
+class SettingsVerifySecretCode extends Component {
   static propTypes = {
     classes: PropTypes.object,
     show: PropTypes.bool,
@@ -377,5 +377,5 @@ const InputContainer = styled.div`
   margin-top: ${props => (props.condensed ? '16px' : '32px')};
 `;
 
-export default withStyles(styles)(SettingsSMSVerify);
+export default withStyles(styles)(SettingsVerifySecretCode);
 

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -7,10 +7,10 @@ import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import Mail from '@material-ui/icons/Mail';
 import InputBase from '@material-ui/core/InputBase';
-import LoadingWheel from './LoadingWheel';
-import { renderLog } from '../utils/logging';
-import VoterActions from '../actions/VoterActions';
-import VoterStore from '../stores/VoterStore';
+import LoadingWheel from '../LoadingWheel';
+import { renderLog } from '../../utils/logging';
+import VoterActions from '../../actions/VoterActions';
+import VoterStore from '../../stores/VoterStore';
 
 class VoterEmailAddressEntry extends Component {
   static propTypes = {

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -7,11 +7,11 @@ import Button from '@material-ui/core/Button';
 import Paper from '@material-ui/core/Paper';
 import Phone from '@material-ui/icons/Phone';
 import InputBase from '@material-ui/core/InputBase';
-import LoadingWheel from './LoadingWheel';
-import { renderLog } from '../utils/logging';
-import VoterActions from '../actions/VoterActions';
-import VoterStore from '../stores/VoterStore';
-import SettingsSMSVerify from './Settings/SettingsSMSVerify';
+import LoadingWheel from '../LoadingWheel';
+import { renderLog } from '../../utils/logging';
+import VoterActions from '../../actions/VoterActions';
+import VoterStore from '../../stores/VoterStore';
+import SettingsVerifySecretCode from './SettingsVerifySecretCode';
 // import {FormHelperText} from "@material-ui/core";
 
 class VoterPhoneVerificationEntry extends Component {
@@ -110,7 +110,7 @@ class VoterPhoneVerificationEntry extends Component {
           </Button>
         </form>
         {showVerifyModal ? (
-          <SettingsSMSVerify
+          <SettingsVerifySecretCode
             show={showVerifyModal}
             toggleFunction={this.closeVerifyModal}
             voterPhoneNumber={voterPhoneNumber}

--- a/src/js/components/Widgets/ItemActionBar/ChooseOrOppose.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ChooseOrOppose.jsx
@@ -10,7 +10,7 @@ import PositionPublicToggle from '../PositionPublicToggle';
 import Slides from './Slides';
 import TwitterSignIn from '../../Twitter/TwitterSignIn';
 import FacebookSignIn from '../../Facebook/FacebookSignIn';
-import VoterEmailAddressEntry from '../../VoterEmailAddressEntry';
+import VoterEmailAddressEntry from '../../Settings/VoterEmailAddressEntry';
 
 class ChooseOrOppose extends Component {
   static propTypes = {


### PR DESCRIPTION
Renamed SettingsSMSVerify to SettingsVerifySecretCode so we can use it for verifying both SMS and email codes. Moved VoterEmailAddressEntry and VoterPhoneVerificationEntry into components/Settings folder.