### PR TITLE
Added feature that "rolls up" the sign in component when in iOS App or Android App to deal with the keyboard taking up so much space. Fixed bug where trying to view an empty "completion state" on the ballot, caused the ballot to stop displaying. Moved these API calls to the CDN: candidateRetrieve, electionsRetrieve, measureRetrieve and organizationRetrieve.

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -520,7 +520,7 @@ const styles = theme => ({
       paddingTop: 6,
       marginLeft: 2,
       paddingLeft: 0,
-      paddingRight: 0,
+      paddingRight: 10,
     },
   },
   headerButtonRoot: {

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -503,17 +503,25 @@ class Ballot extends Component {
         // Ballot is found but ballot is empty. We want to stay put.
         // console.log('onBallotStoreChange: ballotWithItemsFromCompletionFilterType is empty');
       } else {
+        const ballotWithAllItems = BallotStore.getBallotByCompletionLevelFilterType('all');
         // console.log('completionLevelFilterType: ', completionLevelFilterType);
-        const ballotWithItemsFromCompletionFilterType = BallotStore.getBallotByCompletionLevelFilterType(completionLevelFilterType);
-        this.setState({
-          ballotWithAllItems: BallotStore.getBallotByCompletionLevelFilterType('all'),
-          ballotWithItemsFromCompletionFilterType,
-        });
+        let ballotWithItemsFromCompletionFilterType = BallotStore.getBallotByCompletionLevelFilterType(completionLevelFilterType);
         if (ballotWithItemsFromCompletionFilterType && ballotWithItemsFromCompletionFilterType.length) {
           const raceLevelFilterItems = ballotWithItemsFromCompletionFilterType.filter(item => item.race_office_level === raceLevelFilterType ||
             item.kind_of_ballot_item === raceLevelFilterType.toUpperCase());
-          this.setState({ doubleFilteredBallotItemsLength: raceLevelFilterItems.length });
+          this.setState({
+            doubleFilteredBallotItemsLength: raceLevelFilterItems.length,
+          });
+        } else {
+          // If here, the 'completionLevelFilterType' has been made obsolete.
+          // Unfortunately we can't reset it without creating a dispatch loop
+          // BallotActions.completionLevelFilterTypeSave('all');
+          ballotWithItemsFromCompletionFilterType = ballotWithAllItems;
         }
+        this.setState({
+          ballotWithAllItems,
+          ballotWithItemsFromCompletionFilterType,
+        });
       }
     }
     if (ballotProperties) {
@@ -871,7 +879,8 @@ class Ballot extends Component {
     );
 
     // console.log('ballotWithItemsFromCompletionFilterType.length: ', ballotWithItemsFromCompletionFilterType.length);
-    const emptyBallot = ballotWithItemsFromCompletionFilterType.length === 0 ? (
+    // Was: ballotWithItemsFromCompletionFilterType
+    const emptyBallot = ballotWithAllItems.length === 0 ? (
       <div>
         <h3 className="text-center">{this.getEmptyMessageByFilterType(completionLevelFilterType)}</h3>
         {emptyBallotButton}

--- a/src/js/utils/service.js
+++ b/src/js/utils/service.js
@@ -59,7 +59,11 @@ export default function $ajax (options) {
   }
   // Switch between master API server and CDN
   if (options.endpoint === 'allBallotItemsRetrieve' ||
+      options.endpoint === 'candidateRetrieve' ||
       options.endpoint === 'defaultPricing' ||
+      options.endpoint === 'electionsRetrieve' ||
+      options.endpoint === 'measureRetrieve' ||
+      options.endpoint === 'organizationRetrieve' ||
       options.endpoint === 'positionListForBallotItem' ||
       options.endpoint === 'voterGuidesUpcomingRetrieve') {
     // Retrieve API data from CDN


### PR DESCRIPTION
Added feature that "rolls up" the sign in component when in iOS App or Android App to deal with the keyboard taking up so much space. Fixed bug where trying to view an empty "completion state" on the ballot, caused the ballot to stop displaying. Moved these API calls to the CDN: candidateRetrieve, electionsRetrieve, measureRetrieve and organizationRetrieve.