### PR TITLE
Float the PositionPublicToggle to the right, next to the buttons

### DIFF
--- a/src/js/components/Widgets/ItemActionBar/index.jsx
+++ b/src/js/components/Widgets/ItemActionBar/index.jsx
@@ -838,22 +838,20 @@ const styles = theme => ({
 // flex: none;
 const ItemActionBarWrapper = styled.div`
   display: flex;
-  flex-flow: row;
-  justify-content: space-between;
-  flex: auto;
+  width: 100%;
+  justify-content: flex-end;
+  align-items: center;
   border-top: ${({ displayInline }) => (displayInline ? '' : '1px solid #eee !default')};
   margin-top: ${({ displayInline }) => (displayInline ? '' : '16px')};
   margin-right: 0;
-  margin-bottom: 0;
   margin-left: 0;
   padding-top: ${({ displayInline }) => (displayInline ? '0' : '8px')};
-  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
-    margin-bottom: 8px;
-  }
+  margin-bottom: 8px;
 `;
 
 const ButtonGroup = styled.div`
-  margin-left: auto;
+  margin-left: 0;
+  height: fit-content;
 `;
 
 const StackedButton = styled.div`

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -356,7 +356,8 @@ const styles = theme => ({
 });
 
 const Wrapper = styled.div`
-  flex: 1 1 0;
+  margin-left: auto;
+  width: fit-content;
 `;
 
 const PublicToggle = styled.div`


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2609 

### Changes included this pull request?
I updated the flexbox rules for the ItemPostitionActionBar to let the PositionPublicToggle component float to the right, up against the buttons.