### PR TITLE
Add max height to image

### DIFF
--- a/src/js/components/Settings/SettingsSharing.jsx
+++ b/src/js/components/Settings/SettingsSharing.jsx
@@ -366,10 +366,10 @@ class SettingsSharing extends Component {
                       overflow: 'hidden',
                       width: '132px',
                       minWidth: '132px',
-                      // minHeight: '42px',
-                      // height: '42px',
+                      minHeight: '42px',
+                      height: '42px',
                       maxWidth: '132px !important',
-                      // maxHeight: '42px !important',
+                      maxHeight: '42px !important',
                       marginRight: 'auto',
                       textAlign: 'left',
                     }}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2608 

### Changes included this pull request?
I added a max-height to the image container, and now the image prioritizes height, and the width will scale with it.