### PR TITLE
Two null object dereference errors in Facebook login fixed

### DIFF
--- a/src/js/actions/FacebookActions.js
+++ b/src/js/actions/FacebookActions.js
@@ -137,7 +137,11 @@ export default {
       if (isCordova()) {
         this.facebookApi().getLoginStatus(function response (responseReallyLoggedIn) {
           if (responseReallyLoggedIn.status === 'connected') {
-            this.getPicture();
+            if (this && this.getPicture) {
+              this.getPicture();
+            } else {
+              console.log('FacebookActions getPicture() not invoked, this or getPicture() undefined or null');
+            }
           }
         });
       } else {
@@ -268,9 +272,6 @@ export default {
     }
   },
 
-  // November 2018: To debug login from Cordova, you may have to switch from our main facebook id,
-  // to the test environment id, which allows http connections.
-
   login () {
     if (!webAppConfig.FACEBOOK_APP_ID) {
       console.log('ERROR: Missing FACEBOOK_APP_ID from src/js/config.js'); // DO NOT REMOVE THIS!
@@ -284,12 +285,13 @@ export default {
     // FB.getLoginStatus does an ajax call and when you call FB.login on it's response, the popup that would open
     // as a result of this call is blocked. A solution to this problem would be to to specify status: true in the
     // options object of FB.init and you need to be confident that login status has already loaded.
-    oAuthLog(`${'FacebookActions'} this.facebookApi().login`);
+    oAuthLog('FacebookActions this.facebookApi().login');
 
     if (this.facebookApi()) {
       const innerThis = this;
       this.facebookApi().getLoginStatus(
         (response) => {
+          oAuthLog('FacebookActions this.facebookApi().getLoginStatus response: ', response);
           if (response.status === 'connected') {
             Dispatcher.dispatch({
               type: FacebookConstants.FACEBOOK_LOGGED_IN,

--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -16,6 +16,7 @@ import FacebookSignIn from '../Facebook/FacebookSignIn';
 import LoadingWheel from '../LoadingWheel';
 import { oAuthLog, renderLog } from '../../utils/logging';
 import { stringContains } from '../../utils/textFormat';
+import SignInModalGlobalState from '../Widgets/signInModalGlobalState';
 import TwitterActions from '../../actions/TwitterActions';
 import TwitterSignIn from '../Twitter/TwitterSignIn';
 import VoterActions from '../../actions/VoterActions';
@@ -305,6 +306,8 @@ export default class SettingsAccount extends Component {
       }
     }
 
+    const fbAuthMsg = SignInModalGlobalState.get('facebookAuthMessage');
+
     return (
       <div className="">
         <Helmet title={pageTitle} />
@@ -346,6 +349,7 @@ export default class SettingsAccount extends Component {
                   { !hideFacebookSignInButton && !voterIsSignedInFacebook && isOnFacebookSupportedDomainUrl && (
                     <span>
                       <FacebookSignIn toggleSignInModal={this.localToggleSignInModal} buttonText="Sign in with Facebook" />
+                      { fbAuthMsg && fbAuthMsg.length ? <FacebookErrorContainer>{SignInModalGlobalState.get('facebookAuthMessage')}</FacebookErrorContainer> : '' }
                     </span>
                   )
                   }
@@ -524,4 +528,10 @@ const FacebookContainer = styled.span`
   font-size: 1.25rem;
   line-height: 1.5;
   border-radius: 0.3rem;
+`;
+
+const FacebookErrorContainer  = styled.h3`
+  margin-top: 8px;
+  background-color: palegoldenrod;
+  box-shadow: 0px 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12);
 `;

--- a/src/js/components/Widgets/signInModalGlobalState.js
+++ b/src/js/components/Widgets/signInModalGlobalState.js
@@ -1,0 +1,19 @@
+const simState = {};
+
+// Since SignInModal physically covers the UI where facebook error messages appear,
+// we need to save its state here, so that the SignInModal dialog can retrieve it
+export default {
+  set (key, value) {
+    simState.key = value;
+  },
+
+  // eslint-disable-next-line no-unused-vars
+  remove (key) {
+    delete simState.key;
+  },
+
+  // eslint-disable-next-line no-unused-vars
+  get (key) {
+    return simState.key;
+  },
+};

--- a/src/js/routes/Process/FacebookSignInProcess.jsx
+++ b/src/js/routes/Process/FacebookSignInProcess.jsx
@@ -4,9 +4,10 @@ import cookies from '../../utils/cookies';
 import FacebookActions from '../../actions/FacebookActions';
 import FacebookStore from '../../stores/FacebookStore';
 import { cordovaScrollablePaneTopPadding } from '../../utils/cordovaOffsets';
-import { historyPush, isWebApp } from '../../utils/cordovaUtils';
+import { historyPush, isCordova, isWebApp } from '../../utils/cordovaUtils';
 import LoadingWheel from '../../components/LoadingWheel';
 import { oAuthLog, renderLog } from '../../utils/logging';
+import signInModalGlobalState from '../../components/Widgets/signInModalGlobalState';
 import { stringContains } from '../../utils/textFormat';
 import VoterActions from '../../actions/VoterActions';
 import VoterStore from '../../stores/VoterStore';
@@ -189,6 +190,9 @@ export default class FacebookSignInProcess extends Component {
     if (facebookAuthResponse.facebook_sign_in_failed) {
       this.setState({ redirectInProcess: true });
       oAuthLog('facebookAuthResponse.facebook_sign_in_failed redirecting to: /settings/account');
+      if (isCordova()) {
+        signInModalGlobalState.set('facebookAuthMessage', 'Facebook sign in failed. Please try again.');
+      }
       historyPush({
         pathname: '/settings/account',
         state: {
@@ -197,6 +201,10 @@ export default class FacebookSignInProcess extends Component {
         },
       });
       return LoadingWheel;
+    }
+
+    if (isCordova()) {
+      signInModalGlobalState.remove('facebookAuthMessage');
     }
 
     if (yesPleaseMergeAccounts) {


### PR DESCRIPTION
Facebook login failure message now gets displayed in the SignInModal
These changes have been submitted to Google Play as
android:versionCode="100019" android:versionName="1.2.4"
this new version is now live.
This version does not include changes from wevote/WebApp/pull/2641
