### PR TITLE
More fixes for SignInModal, hide next release features

### DIFF
--- a/src/js/actions/AppActions.js
+++ b/src/js/actions/AppActions.js
@@ -9,10 +9,6 @@ export default {
     Dispatcher.dispatch({ type: 'getVoterGuideSettingsDashboardEditMode', payload: getVoterGuideSettingsDashboardEditMode });
   },
 
-  setHeadroomUnpinned (unpinned) {
-    Dispatcher.dispatch({ type: 'headroomUnpinned', payload: unpinned });
-  },
-
   setScrolled (scrolledDown) {
     Dispatcher.dispatch({ type: 'scrolledDown', payload: scrolledDown });
   },
@@ -36,6 +32,14 @@ export default {
 
   setShowSignInModal (show) {
     Dispatcher.dispatch({ type: 'showSignInModal', payload: show });
+  },
+
+  setIsShowingSignInModal (showing) {
+    Dispatcher.dispatch({ type: 'isShowingSignInModal', payload: showing });
+  },
+
+  setSignInErrorMessage (showing) {
+    Dispatcher.dispatch({ type: 'signInErrorMessage', payload: showing });
   },
 
   siteConfigurationRetrieve (hostname, refresh_string = '') {

--- a/src/js/actions/FacebookActions.js
+++ b/src/js/actions/FacebookActions.js
@@ -1,8 +1,9 @@
-import { isWebApp, isCordova } from '../utils/cordovaUtils'; // eslint-disable-line import/no-cycle
+import { isWebApp } from '../utils/cordovaUtils'; // eslint-disable-line import/no-cycle
 import Dispatcher from '../dispatcher/Dispatcher';
 import FacebookConstants from '../constants/FacebookConstants';
 import FriendActions from './FriendActions';
 import { oAuthLog } from '../utils/logging';
+import signInModalGlobalState from '../components/Widgets/signInModalGlobalState';
 import VoterActions from './VoterActions'; // eslint-disable-line import/no-cycle
 import VoterSessionActions from './VoterSessionActions';
 import webAppConfig from '../config';
@@ -109,7 +110,7 @@ export default {
 
   getPicture () {
     this.facebookApi().api(
-      '/me?fields=picture.type(large)', ['public_profile', 'email'],
+      '/me?fields=picture.type(large)&redirect=false', ['public_profile', 'email'],
       (response) => {
         oAuthLog('getFacebookProfilePicture response', response);
         Dispatcher.dispatch({
@@ -134,19 +135,7 @@ export default {
     // logged into facebook in Cordova, and your're not, you get a distracting login dialog that comes from the facebook native
     // package everytime we refresh the avatar in the header in this function -- so first check if the voter is really logged in.
     if (this.facebookApi()) {
-      if (isCordova()) {
-        this.facebookApi().getLoginStatus(function response (responseReallyLoggedIn) {
-          if (responseReallyLoggedIn.status === 'connected') {
-            if (this && this.getPicture) {
-              this.getPicture();
-            } else {
-              console.log('FacebookActions getPicture() not invoked, this or getPicture() undefined or null');
-            }
-          }
-        });
-      } else {
-        this.getPicture();
-      }
+      this.getPicture();
     } else {
       console.log('FacebookActions.getFacebookProfilePicture was not invoked, this.facebookApi() undefined');
     }
@@ -246,6 +235,7 @@ export default {
   },
 
   loginSuccess (successResponse) {
+    signInModalGlobalState.set('waitingForFacebookApiCompletion', false);
     if (successResponse.authResponse) {
       oAuthLog('FacebookActions loginSuccess userData: ', successResponse);
       Dispatcher.dispatch({
@@ -259,6 +249,7 @@ export default {
   },
 
   loginFailure (errorResponse) {
+    signInModalGlobalState.set('waitingForFacebookApiCompletion', false);
     oAuthLog('FacebookActions loginFailure error response: ', errorResponse);
   },
 
@@ -317,8 +308,8 @@ export default {
   },
 
   // Save incoming auth data from Facebook
-  voterFacebookSignInAuth (data) {
-    // console.log("FacebookActions voterFacebookSignInAuth");
+  saveFacebookSignInAuth (data) {
+    // console.log('saveFacebookSignInAuth (result of incoming data from the FB API) kicking off an api server voterFacebookSignInSave');
     Dispatcher.loadEndpoint('voterFacebookSignInSave', {
       facebook_access_token: data.accessToken || false,
       facebook_user_id: data.userID || false,

--- a/src/js/components/Ballot/EmailBallotToFriendsModal.jsx
+++ b/src/js/components/Ballot/EmailBallotToFriendsModal.jsx
@@ -7,7 +7,7 @@ import FriendStore from '../../stores/FriendStore';
 import LoadingWheel from '../LoadingWheel';
 import { renderLog } from '../../utils/logging';
 import VoterStore from '../../stores/VoterStore';
-import{ validateEmail }from '../../utils/regex-checks';
+import { validateEmail } from '../../utils/regex-checks';
 
 const webAppConfig = require('../../config');
 

--- a/src/js/components/Ballot/FacebookBallotModal.jsx
+++ b/src/js/components/Ballot/FacebookBallotModal.jsx
@@ -7,7 +7,7 @@ import FriendActions from '../../actions/FriendActions';
 import FriendStore from '../../stores/FriendStore';
 import { oAuthLog } from '../../utils/logging';
 import LoadingWheel from '../LoadingWheel';
-import{ validateEmail }from '../../utils/regex-checks';
+import { validateEmail } from '../../utils/regex-checks';
 import VoterStore from '../../stores/VoterStore';
 import webAppConfig from '../../config';
 import SplitIconButton from '../Widgets/SplitIconButton';

--- a/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
+++ b/src/js/components/Ballot/FacebookBallotToFriendsModal.jsx
@@ -9,7 +9,7 @@ import FriendStore from '../../stores/FriendStore';
 import LoadingWheel from '../LoadingWheel';
 import { oAuthLog } from '../../utils/logging';
 import VoterStore from '../../stores/VoterStore';
-import{ validateEmail }from '../../utils/regex-checks';
+import { validateEmail } from '../../utils/regex-checks';
 import webAppConfig from '../../config';
 import { shortenText } from '../../utils/textFormat';
 import SplitIconButton from '../Widgets/SplitIconButton';

--- a/src/js/components/Facebook/FacebookSignIn.jsx
+++ b/src/js/components/Facebook/FacebookSignIn.jsx
@@ -8,7 +8,7 @@ import SplitIconButton from '../Widgets/SplitIconButton';
 
 class FacebookSignIn extends Component {
   static propTypes = {
-    toggleSignInModal: PropTypes.func,
+    closeSignInModal: PropTypes.func,
     buttonText: PropTypes.string,
   };
 
@@ -30,9 +30,9 @@ class FacebookSignIn extends Component {
     historyPush('/facebook_sign_in');
   };
 
-  toggleSignInModalLocal = () => {
-    if (this.props.toggleSignInModal) {
-      this.props.toggleSignInModal();
+  closeSignInModalLocal = () => {
+    if (this.props.closeSignInModal) {
+      this.props.closeSignInModal();
     }
   };
 

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -41,14 +41,14 @@ class AddFriendsByEmail extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
-  componentWillUnmount () {
-    this.friendStoreListener.remove();
-    this.voterStoreListener.remove();
-  }
-  
   shouldComponentUpdate (nextState) {
     if (this.state.friendsToInvite !== nextState.friendsToInvite) return true;
     return false;
+  }
+
+  componentWillUnmount () {
+    this.friendStoreListener.remove();
+    this.voterStoreListener.remove();
   }
 
   onKeyDown = (event) => {
@@ -100,7 +100,7 @@ class AddFriendsByEmail extends Component {
   addFriendsByEmailStepsManager = (event) => {
     // This function is called when the next button is  submitted;
     // this funtion is called twice per cycle
-    console.log("Entering function addFriendsByEmailStepsManager");
+    console.log('Entering function addFriendsByEmailStepsManager');
     const errorMessage = '';
 
     if (this.state.onEnterEmailAddressesStep) {
@@ -124,21 +124,21 @@ class AddFriendsByEmail extends Component {
       // }
 
       if (emailAddressesError) {
-        console.log("addFriendsByEmailStepsManager, emailAddressesError");
+        console.log('addFriendsByEmailStepsManager, emailAddressesError');
         this.setState({
           loading: false,
           emailAddressesError: true,
           errorMessage: 'Error in sending invites.',
         });
       } else if (!this.hasValidEmail()) {
-        console.log("addFriendsByEmailStepsManager, NOT hasValidEmail");
+        console.log('addFriendsByEmailStepsManager, NOT hasValidEmail');
         this.setState({
           loading: false,
           onEnterEmailAddressesStep: false,
           onCollectEmailStep: true,
         });
       } else {
-        console.log("addFriendsByEmailStepsManager, calling friendInvitationByEmailSend");
+        console.log('addFriendsByEmailStepsManager, calling friendInvitationByEmailSend');
         this.friendInvitationByEmailSend(event);
       }
     } else if (this.state.onCollectEmailStep) {
@@ -194,9 +194,9 @@ class AddFriendsByEmail extends Component {
   friendInvitationByEmailSend (e) {
     e.preventDefault();
     // console.log("friendInvitationByEmailSend);
-    const { friendsToInvite,friendContactInfo, friendFirstName, friendLastName } = this.state;
+    const { friendsToInvite, friendContactInfo, friendFirstName, friendLastName } = this.state;
 
-    console.log("FriendsToInvite: ", friendsToInvite);
+    console.log('FriendsToInvite: ', friendsToInvite);
     const emailAddressArray = [];
     const firstNameArray = [];
     const lastNameArray = [];
@@ -215,9 +215,9 @@ class AddFriendsByEmail extends Component {
       lastNameArray.push(friendLastName);
     }
 
-    console.log("emailAddressArray: ", emailAddressArray);
-    console.log("firstNameArray: ", firstNameArray);
-    console.log("lastNameArray: ", lastNameArray);
+    console.log('emailAddressArray: ', emailAddressArray);
+    console.log('firstNameArray: ', firstNameArray);
+    console.log('lastNameArray: ', lastNameArray);
     const response = FriendActions.friendInvitationByEmailSend(emailAddressArray, firstNameArray,
       lastNameArray, '', this.state.add_friends_message,
       this.state.senderEmailAddress);
@@ -251,7 +251,7 @@ class AddFriendsByEmail extends Component {
 
       newArray.push(newFriendObject);
 
-      this.setState({ 
+      this.setState({
         friendsToInvite: [...newArray],
         friendContactInfo: '',
         friendFirstName: '',
@@ -263,12 +263,10 @@ class AddFriendsByEmail extends Component {
   deleteFriendFromList (friend) {
     const { friendsToInvite } = this.state;
 
-    const newArray = [...friendsToInvite].filter((item) => {
-      return item.email !== friend.email;
-    });
+    const newArray = [...friendsToInvite].filter(item => item.email !== friend.email);
 
-    console.log("New array: ", newArray);
-    console.log("Email: ", friend.email);
+    console.log('New array: ', newArray);
+    console.log('Email: ', friend.email);
 
     this.setState({ friendsToInvite: [...newArray]});
   }
@@ -341,7 +339,7 @@ class AddFriendsByEmail extends Component {
                     <div className="col col-6">
                       <Label>
                         First Name
-                        {' (optional)'}
+                         (optional)
                       </Label>
                       <TextField
                         variant="outlined"
@@ -358,7 +356,7 @@ class AddFriendsByEmail extends Component {
                     <div className="col col-6">
                       <Label>
                         Last Name
-                        {' (optional)'}
+                         (optional)
                       </Label>
                       <TextField
                         variant="outlined"
@@ -415,9 +413,7 @@ class AddFriendsByEmail extends Component {
                   </ButtonContainer>
                 </form>
               </div>
-              <FriendsAlert>
-
-              </FriendsAlert>
+              <FriendsAlert />
             </FormWrapper>
           </>
         ) : null

--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -8,11 +8,14 @@ import BallotIcon from '@material-ui/icons/Ballot';
 import HowToVoteIcon from '@material-ui/icons/HowToVote';
 import PeopleIcon from '@material-ui/icons/People';
 import styled from 'styled-components';
+import AppStore from '../../stores/AppStore';
 import { cordovaFooterHeight } from '../../utils/cordovaOffsets';
 import { historyPush } from '../../utils/cordovaUtils';
 import { stringContains } from '../../utils/textFormat';
 import FriendStore from '../../stores/FriendStore';
 import { renderLog } from '../../utils/logging';
+
+const webAppConfig = require('../../config');
 
 
 class FooterBar extends React.Component {
@@ -33,6 +36,15 @@ class FooterBar extends React.Component {
     this.setState({
       friendInvitationsSentToMe: FriendStore.friendInvitationsSentToMe(), // eslint-disable-line react/no-unused-state
     });
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  shouldComponentUpdate (nextProps, nextState) {
+    if (AppStore.isShowingSignInModal()) {
+      renderLog('DO NOT RENDER FooterBar');
+      return false;
+    }
+    return true;
   }
 
   componentWillUnmount () {
@@ -79,7 +91,7 @@ class FooterBar extends React.Component {
       display: 'inline-block',
     };
 
-    const enableFriends = true;   // DALE: FRIENDS TEMPORARILY DISABLED
+    const enableFriends = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;   // DALE: FRIENDS TEMPORARILY DISABLED
 
     return (
       <FooterBarWrapper>

--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -9,6 +9,7 @@ import HeaderBackToVoterGuides from './HeaderBackToVoterGuides';
 import HeaderBar from './HeaderBar';
 import { stringContains } from '../../utils/textFormat';
 import { renderLog } from '../../utils/logging';
+import AppStore from '../../stores/AppStore';
 
 
 export default class Header extends Component {
@@ -20,14 +21,14 @@ export default class Header extends Component {
     weVoteBrandingOff: PropTypes.bool,
   };
 
-  // componentDidUpdate () {
-  //   console.log("React Header ---------------   componentDidMount ()");
-  //   let heightA = $("#app-header").outerHeight();
-  //   let heightHC = $("#header-container").outerHeight();
-  //   let height2N = $("#secondary-nav-bar").outerHeight();
-  //   let heightW = $("#headroom-wrapper").outerHeight();
-  //   console.log("header rectangle height: " + heightA + ", " + heightHC + ", " + height2N + ", " + heightW);
-  // }
+  // eslint-disable-next-line no-unused-vars
+  shouldComponentUpdate (nextProps, nextState) {
+    if (AppStore.isShowingSignInModal()) {
+      renderLog('DO NOT RENDER Header');
+      return false;
+    }
+    return true;
+  }
 
   render () {
     renderLog('Header');  // Set LOG_RENDER_EVENTS to log all renders

--- a/src/js/components/Navigation/HeaderBackTo.jsx
+++ b/src/js/components/Navigation/HeaderBackTo.jsx
@@ -322,7 +322,7 @@ class HeaderBackTo extends Component {
         {showSignInModal && (
           <SignInModal
             show={showSignInModal}
-            toggleFunction={this.closeSignInModal}
+            closeFunction={this.closeSignInModal}
           />
         )}
       </AppBar>

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -592,7 +592,7 @@ class HeaderBackToBallot extends Component {
         {showSignInModal && (
           <SignInModal
             show={showSignInModal}
-            toggleFunction={this.closeSignInModal}
+            closeFunction={this.closeSignInModal}
           />
         )}
       </AppBar>

--- a/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
+++ b/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
@@ -344,7 +344,7 @@ class HeaderBackToVoterGuides extends Component {
         {showSignInModal && (
           <SignInModal
             show={showSignInModal}
-            toggleFunction={this.closeSignInModal}
+            closeFunction={this.closeSignInModal}
           />
         )}
         {showNewVoterGuideModal && (

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -31,6 +31,9 @@ import VoterStore from '../../stores/VoterStore';
 import { stringContains } from '../../utils/textFormat';
 import shouldHeaderRetreat from '../../utils/shouldHeaderRetreat';
 
+const webAppConfig = require('../../config');
+
+
 class HeaderBar extends Component {
   static goToGetStarted () {
     const getStartedNow = '/ballot';
@@ -47,7 +50,7 @@ class HeaderBar extends Component {
   constructor (props) {
     super(props);
     this.state = {
-      aboutMenuOpen: false,
+      // aboutMenuOpen: false,
       chosenSiteLogoUrl: '',
       componentDidMountFinished: false,
       friendInvitationsSentToMe: 0,
@@ -59,6 +62,7 @@ class HeaderBar extends Component {
       showSelectBallotModal: false,
       showSignInModal: false,
       showPaidAccountUpgradeModal: false,
+      // renderAfterSignInModal: false,
       voter: {},
     };
     this.hideProfilePopUp = this.hideProfilePopUp.bind(this);
@@ -91,84 +95,100 @@ class HeaderBar extends Component {
       voter: this.props.voter,
       voterIsSignedIn: this.props.voter && this.props.voter.is_signed_in,
       we_vote_branding_off: weVoteBrandingOffFromUrl || weVoteBrandingOffFromCookie,
+      // renderAfterSignInModal: false,
     });
   }
 
-  shouldComponentUpdate (nextProps, nextState) {
-    // This lifecycle method tells the component to NOT render if componentWillReceiveProps didn't see any changes
-    if (this.state.componentDidMountFinished === false) {
-      // console.log("shouldComponentUpdate: componentDidMountFinished === false");
-      return true;
-    }
-    if (this.state.profilePopUpOpen !== nextState.profilePopUpOpen) {
-      // console.log("shouldComponentUpdate: this.state.profilePopUpOpen", this.state.profilePopUpOpen, ", nextState.profilePopUpOpen", nextState.profilePopUpOpen);
-      return true;
-    }
-    if (this.state.aboutMenuOpen !== nextState.aboutMenuOpen) {
-      // console.log("shouldComponentUpdate: this.state.aboutMenuOpen", this.state.aboutMenuOpen, ", nextState.aboutMenuOpen", nextState.aboutMenuOpen);
-      return true;
-    }
-    if (this.state.chosenSiteLogoUrl !== nextState.chosenSiteLogoUrl) {
-      // console.log("shouldComponentUpdate: this.state.chosenSiteLogoUrl", this.state.chosenSiteLogoUrl, ", nextState.chosenSiteLogoUrl", nextState.chosenSiteLogoUrl);
-      return true;
-    }
-    if (this.state.hideWeVoteLogo !== nextState.hideWeVoteLogo) {
-      // console.log("shouldComponentUpdate: this.state.hideWeVoteLogo", this.state.hideWeVoteLogo, ", nextState.hideWeVoteLogo", nextState.hideWeVoteLogo);
-      return true;
-    }
-    if (this.state.friendInvitationsSentToMe !== nextState.friendInvitationsSentToMe) {
-      // console.log("shouldComponentUpdate: this.state.friendInvitationsSentToMe", this.state.friendInvitationsSentToMe, ", nextState.friendInvitationsSentToMe", nextState.friendInvitationsSentToMe);
-      return true;
-    }
-    if (this.state.showEditAddressButton !== nextState.showEditAddressButton) {
-      return true;
-    }
-    if (this.state.showPaidAccountUpgradeModal !== nextState.showPaidAccountUpgradeModal) {
-      return true;
-    }
-    if (this.state.scrolledDown !== nextState.scrolledDown) {
-      return true;
-    }
-    if (this.state.showSignInModal !== nextState.showSignInModal) {
-      return true;
-    }
-    if (this.state.showSelectBallotModal !== nextState.showSelectBallotModal) {
-      return true;
-    }
-    if (this.state.voterIsSignedIn !== nextState.voterIsSignedIn) {
-      return true;
-    }
-    const currentPathnameExists = this.props.location && this.props.location.pathname;
-    const nextPathnameExists = nextProps.location && nextProps.location.pathname;
-    // One exists, and the other doesn't
-    if ((currentPathnameExists && !nextPathnameExists) || (!currentPathnameExists && nextPathnameExists)) {
-      // console.log("shouldComponentUpdate: PathnameExistsDifference");
-      return true;
-    }
-    if (currentPathnameExists && nextPathnameExists && this.props.location.pathname !== nextProps.location.pathname) {
-      // console.log("shouldComponentUpdate: this.props.location.pathname", this.props.location.pathname, ", nextProps.location.pathname", nextProps.location.pathname);
-      return true;
-    }
-    const thisVoterExists = this.state.voter !== undefined;
-    const nextVoterExists = nextState.voter !== undefined;
-    if (nextVoterExists && !thisVoterExists) {
-      // console.log("shouldComponentUpdate: thisVoterExists", thisVoterExists, ", nextVoterExists", nextVoterExists);
-      return true;
-    }
-    if (thisVoterExists && nextVoterExists && this.state.voter.signed_in_twitter !== nextState.voter.signed_in_twitter) {
-      // console.log("shouldComponentUpdate: this.state.voter.signed_in_twitter", this.state.voter.signed_in_twitter, ", nextState.voter.signed_in_twitter", nextState.voter.signed_in_twitter);
-      return true;
-    }
-    if (thisVoterExists && nextVoterExists && this.state.voter.signed_in_facebook !== nextState.voter.signed_in_facebook) {
-      // console.log("shouldComponentUpdate: this.state.voter.signed_in_facebook", this.state.voter.signed_in_facebook, ", nextState.voter.signed_in_facebook", nextState.voter.signed_in_facebook);
-      return true;
-    }
-    if (thisVoterExists && nextVoterExists && this.state.voter.signed_in_with_email !== nextState.voter.signed_in_with_email) {
-      return true;
-    }
-    // console.log('HeaderBar shouldComponentUpdate false');
-    return false;
-  }
+  // 11/17/19, this became unworkable with the additon of SignInModal.  It is a realtively light weight component, and will have to be re-rendered each time.
+  // shouldComponentUpdate (nextProps, nextState) {
+  //   // This lifecycle method tells the component to NOT render if componentWillReceiveProps didn't see any changes
+  //   if (AppStore.isShowingSignInModal()) {
+  //     return true;
+  //   }
+  //   if (this.state.renderAfterSignInModal === true) {
+  //     return true;
+  //   }
+  //   if (this.state.componentDidMountFinished === false) {
+  //     // console.log("shouldComponentUpdate: componentDidMountFinished === false");
+  //     return true;
+  //   }
+  //   if (this.state.profilePopUpOpen !== nextState.profilePopUpOpen) {
+  //     // console.log("shouldComponentUpdate: this.state.profilePopUpOpen", this.state.profilePopUpOpen, ", nextState.profilePopUpOpen", nextState.profilePopUpOpen);
+  //     return true;
+  //   }
+  //   if (this.state.aboutMenuOpen !== nextState.aboutMenuOpen) {
+  //     // console.log("shouldComponentUpdate: this.state.aboutMenuOpen", this.state.aboutMenuOpen, ", nextState.aboutMenuOpen", nextState.aboutMenuOpen);
+  //     return true;
+  //   }
+  //   if (this.state.chosenSiteLogoUrl !== nextState.chosenSiteLogoUrl) {
+  //     // console.log("shouldComponentUpdate: this.state.chosenSiteLogoUrl", this.state.chosenSiteLogoUrl, ", nextState.chosenSiteLogoUrl", nextState.chosenSiteLogoUrl);
+  //     return true;
+  //   }
+  //   if (this.state.hideWeVoteLogo !== nextState.hideWeVoteLogo) {
+  //     // console.log("shouldComponentUpdate: this.state.hideWeVoteLogo", this.state.hideWeVoteLogo, ", nextState.hideWeVoteLogo", nextState.hideWeVoteLogo);
+  //     return true;
+  //   }
+  //   if (this.state.friendInvitationsSentToMe !== nextState.friendInvitationsSentToMe) {
+  //     // console.log("shouldComponentUpdate: this.state.friendInvitationsSentToMe", this.state.friendInvitationsSentToMe, ", nextState.friendInvitationsSentToMe", nextState.friendInvitationsSentToMe);
+  //     return true;
+  //   }
+  //   if (this.state.showEditAddressButton !== nextState.showEditAddressButton) {
+  //     return true;
+  //   }
+  //   if (this.state.showPaidAccountUpgradeModal !== nextState.showPaidAccountUpgradeModal) {
+  //     return true;
+  //   }
+  //   if (this.state.scrolledDown !== nextState.scrolledDown) {
+  //     return true;
+  //   }
+  //   if (this.state.showSignInModal !== nextState.showSignInModal) {
+  //     return true;
+  //   }
+  //   if (this.state.showSelectBallotModal !== nextState.showSelectBallotModal) {
+  //     return true;
+  //   }
+  //   if (this.state.voterIsSignedIn !== nextState.voterIsSignedIn) {
+  //     return true;
+  //   }
+  //   const currentPathnameExists = this.props.location && this.props.location.pathname;
+  //   const nextPathnameExists = nextProps.location && nextProps.location.pathname;
+  //   // One exists, and the other doesn't
+  //   if ((currentPathnameExists && !nextPathnameExists) || (!currentPathnameExists && nextPathnameExists)) {
+  //     // console.log("shouldComponentUpdate: PathnameExistsDifference");
+  //     return true;
+  //   }
+  //   if (currentPathnameExists && nextPathnameExists && this.props.location.pathname !== nextProps.location.pathname) {
+  //     // console.log("shouldComponentUpdate: this.props.location.pathname", this.props.location.pathname, ", nextProps.location.pathname", nextProps.location.pathname);
+  //     return true;
+  //   }
+  //   const thisVoterExists = this.state.voter !== undefined;
+  //   const nextVoterExists = nextState.voter !== undefined;
+  //   if (nextVoterExists && !thisVoterExists) {
+  //     // console.log("shouldComponentUpdate: thisVoterExists", thisVoterExists, ", nextVoterExists", nextVoterExists);
+  //     return true;
+  //   }
+  //   if (thisVoterExists && nextVoterExists && this.state.voter.signed_in_twitter !== nextState.voter.signed_in_twitter) {
+  //     // console.log("shouldComponentUpdate: this.state.voter.signed_in_twitter", this.state.voter.signed_in_twitter, ", nextState.voter.signed_in_twitter", nextState.voter.signed_in_twitter);
+  //     return true;
+  //   }
+  //   if (thisVoterExists && nextVoterExists && this.state.voter.signed_in_facebook !== nextState.voter.signed_in_facebook) {
+  //     // console.log("shouldComponentUpdate: this.state.voter.signed_in_facebook", this.state.voter.signed_in_facebook, ", nextState.voter.signed_in_facebook", nextState.voter.signed_in_facebook);
+  //     return true;
+  //   }
+  //   if (thisVoterExists && nextVoterExists && this.state.voter.signed_in_with_email !== nextState.voter.signed_in_with_email) {
+  //     return true;
+  //   }
+  //   console.log('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ HeaderBar shouldComponentUpdate false');
+  //   return false;
+  // }
+
+  // componentWillReceiveProps () {
+  //   if (AppStore.isShowingSignInModal()) {
+  //     this.setState({
+  //       renderAfterSignInModal: true,
+  //     });
+  //   }
+  // }
 
   componentWillUnmount () {
     this.appStoreListener.remove();
@@ -244,10 +264,14 @@ class HeaderBar extends Component {
   closeNewVoterGuideModal () {
     // console.log('HeaderBar closeNewVoterGuideModal');
     AppActions.setShowNewVoterGuideModal(false);
+    AppActions.setIsShowingSignInModal(false);
+    HeaderBar.goToGetStarted();
   }
 
   closeSignInModal () {
     AppActions.setShowSignInModal(false);
+    AppActions.setIsShowingSignInModal(false);
+    HeaderBar.goToGetStarted();
   }
 
   toggleSignInModal () {
@@ -330,7 +354,7 @@ class HeaderBar extends Component {
 
     const doNotShowWeVoteLogo = weVoteBrandingOff || hideWeVoteLogo;
     const showWeVoteLogo = !doNotShowWeVoteLogo;
-    const enableFriends = true;   // DALE: FRIENDS TEMPORARILY DISABLED
+    const enableFriends = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;   // DALE: FRIENDS TEMPORARILY DISABLED
 
     return (
       <Wrapper hasNotch={hasIPhoneNotch()} scrolledDown={scrolledDown && isWebApp() && shouldHeaderRetreat(pathname)}>
@@ -478,7 +502,7 @@ class HeaderBar extends Component {
         {showSignInModal && (
           <SignInModal
             show={showSignInModal}
-            toggleFunction={this.closeSignInModal}
+            closeFunction={this.closeSignInModal}
           />
         )}
         {showSelectBallotModal && (

--- a/src/js/components/Navigation/WelcomeAppbar.jsx
+++ b/src/js/components/Navigation/WelcomeAppbar.jsx
@@ -418,7 +418,7 @@ class WelcomeAppbar extends Component {
         {showSignInModal && (
           <SignInModal
             show={showSignInModal}
-            toggleFunction={this.closeSignInModal}
+            closeFunction={this.closeSignInModal}
           />
         )}
         {showPaidAccountUpgradeModal && (

--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -16,7 +16,6 @@ import FacebookSignIn from '../Facebook/FacebookSignIn';
 import LoadingWheel from '../LoadingWheel';
 import { oAuthLog, renderLog } from '../../utils/logging';
 import { stringContains } from '../../utils/textFormat';
-import SignInModalGlobalState from '../Widgets/signInModalGlobalState';
 import TwitterActions from '../../actions/TwitterActions';
 import TwitterSignIn from '../Twitter/TwitterSignIn';
 import VoterActions from '../../actions/VoterActions';
@@ -34,7 +33,7 @@ export default class SettingsAccount extends Component {
     inModal: PropTypes.bool,
     pleaseSignInTitle: PropTypes.string,
     pleaseSignInSubTitle: PropTypes.string,
-    toggleSignInModal: PropTypes.func,
+    closeSignInModal: PropTypes.func,
   };
 
   constructor (props) {
@@ -82,7 +81,9 @@ export default class SettingsAccount extends Component {
     const oneDayExpires = 86400;
     let pathname = '';
 
-    VoterActions.voterRetrieve();
+    if (!AppStore.isShowingSignInModal()) {
+      VoterActions.voterRetrieve();
+    }
 
     const getStartedMode = AppStore.getStartedMode();
     AnalyticsActions.saveActionAccountPage(VoterStore.electionId());
@@ -171,10 +172,10 @@ export default class SettingsAccount extends Component {
     });
   }
 
-  localToggleSignInModal = () => {
-    // console.log('SettingsAccount localToggleSignInModal');
-    if (this.props.toggleSignInModal) {
-      this.props.toggleSignInModal();
+  localCloseSignInModal = () => {
+    // console.log('SettingsAccount localCloseSignInModal');
+    if (this.props.closeSignInModal) {
+      this.props.closeSignInModal();
     }
   };
 
@@ -306,7 +307,8 @@ export default class SettingsAccount extends Component {
       }
     }
 
-    const fbAuthMsg = SignInModalGlobalState.get('facebookAuthMessage');
+    const fbAuthMsg = AppStore.getSignInErrorMessage();
+    // console.log('In settingsAccount, facebookAuthMessage: ' + fbAuthMsg);
 
     return (
       <div className="">
@@ -339,7 +341,7 @@ export default class SettingsAccount extends Component {
                       <TwitterSignIn
                         buttonText="Sign in with Twitter"
                         inModal={inModal}
-                        toggleSignInModal={this.localToggleSignInModal}
+                        closeSignInModal={this.localCloseSignInModal}
                       />
                     </span>
                   )
@@ -348,8 +350,8 @@ export default class SettingsAccount extends Component {
                 <div className="u-stack--md">
                   { !hideFacebookSignInButton && !voterIsSignedInFacebook && isOnFacebookSupportedDomainUrl && (
                     <span>
-                      <FacebookSignIn toggleSignInModal={this.localToggleSignInModal} buttonText="Sign in with Facebook" />
-                      { fbAuthMsg && fbAuthMsg.length ? <FacebookErrorContainer>{SignInModalGlobalState.get('facebookAuthMessage')}</FacebookErrorContainer> : '' }
+                      <FacebookSignIn closeSignInModal={this.localCloseSignInModal} buttonText="Sign in with Facebook" />
+                      { fbAuthMsg && fbAuthMsg.length ? <FacebookErrorContainer>{fbAuthMsg}</FacebookErrorContainer> : '' }
                     </span>
                   )
                   }

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -54,7 +54,8 @@ class VoterEmailAddressEntry extends Component {
 
   componentDidMount () {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
-    VoterActions.voterRetrieve();
+    // Steve 11/14/19: commenting out the next line: it is expensive and causes trouble in SignInModal, and is almost certainly not needed
+    // VoterActions.voterRetrieve();
     VoterActions.voterEmailAddressRetrieve();
   }
 

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -48,7 +48,8 @@ class VoterPhoneVerificationEntry extends Component {
 
   componentDidMount () {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
-    VoterActions.voterRetrieve();
+    // Steve 11/14/19: commenting out the next line: it is expensive and causes trouble in SignInModal, and is almost certainly not needed
+    // VoterActions.voterRetrieve();
     VoterActions.voterSMSPhoneNumberRetrieve();
   }
 

--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -17,7 +17,7 @@ class TwitterSignIn extends Component {
   static propTypes = {
     buttonText: PropTypes.string,
     inModal: PropTypes.bool,
-    toggleSignInModal: PropTypes.func,
+    closeSignInModal: PropTypes.func,
   };
 
   // TODO: April 17, 2018, this is used by Twitter and SignIn by Email, and should be refactored out of here.  It is really the handleOpenURL function.
@@ -96,8 +96,8 @@ class TwitterSignIn extends Component {
     if (isIOS()) {
       cordovaOpenSafariView(requestURL, null, 50);
       if (inModal) {
-        if (this.props.toggleSignInModal) {
-          this.props.toggleSignInModal();
+        if (this.props.closeSignInModal) {
+          this.props.closeSignInModal();
         }
       }
     } else if (isAndroid()) {
@@ -116,13 +116,13 @@ class TwitterSignIn extends Component {
 
         // inAppBrowserRef.close();
         if (inModal) {
-          if (this.props.toggleSignInModal) {
-            this.props.toggleSignInModal();
+          if (this.props.closeSignInModal) {
+            this.props.closeSignInModal();
           }
         }
       });
     }
-  }
+  };
 
   twitterSignInWebApp () {
     const brandingOff = cookies.getItem('we_vote_branding_off') || 0;

--- a/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
@@ -16,8 +16,8 @@ import SupportStore from '../../stores/SupportStore';
 import { stringContains } from '../../utils/textFormat';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
-import thumbsUpColorIcon from '../../../img/global/icons/thumbs-up-color-icon.svg';
-import thumbsDownColorIcon from '../../../img/global/icons/thumbs-down-color-icon.svg';
+import thumbsUpColorIcon from '../../../img/global/icons/thumbs-up-color-icon.svg';      // 11/17/19, I don't think this is going to work in Cordova without the cordovaDot()
+import thumbsDownColorIcon from '../../../img/global/icons/thumbs-down-color-icon.svg';  // 11/17/19, I don't think this is going to work in Cordova without the cordovaDot()
 // import { findDOMNode } from 'react-dom';
 import StickyPopover from '../Ballot/StickyPopover';
 

--- a/src/js/components/Widgets/BrowserPushMessage.jsx
+++ b/src/js/components/Widgets/BrowserPushMessage.jsx
@@ -4,6 +4,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 import IconButton from '@material-ui/core/IconButton';
 import { withStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
+import AppStore from '../../stores/AppStore';
 import { renderLog } from '../../utils/logging';
 
 const styles = theme => ({
@@ -37,6 +38,15 @@ class BrowserPushMessage extends Component {
         type: nextProps.incomingProps.location.state.message_type,
       });
     }
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  shouldComponentUpdate (nextProps, nextState) {
+    if (AppStore.isShowingSignInModal()) {
+      renderLog('DO NOT RENDER BrowserPushMessage');
+      return false;
+    }
+    return true;
   }
 
   handleClose = () => this.setState({ open: false });

--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -7,6 +7,7 @@ import IconButton from '@material-ui/core/IconButton';
 import CloseIcon from '@material-ui/icons/Close';
 import Typography from '@material-ui/core/Typography';
 import { withStyles, withTheme } from '@material-ui/core/styles';
+import AppActions from '../../actions/AppActions';
 import { renderLog } from '../../utils/logging';
 import { isCordova, isWebApp } from '../../utils/cordovaUtils';
 import SettingsAccount from '../Settings/SettingsAccount';
@@ -16,7 +17,7 @@ class SignInModal extends Component {
   static propTypes = {
     classes: PropTypes.object,
     show: PropTypes.bool,
-    toggleFunction: PropTypes.func.isRequired,
+    closeFunction: PropTypes.func.isRequired,
   };
 
   constructor (props) {
@@ -29,17 +30,20 @@ class SignInModal extends Component {
     this.onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     // When this modal is opened, set a cookie with the current path (done in Application.js)
+    AppActions.setIsShowingSignInModal(true);
   }
 
   componentWillUnmount () {
     this.voterStoreListener.remove();
+    // console.log('SignInModal componentWillUnmount: AppActions.setIsShowingSignInModal(false)');
+    AppActions.setIsShowingSignInModal(false);
   }
 
   onVoterStoreChange () {
     const secretCodeVerificationStatus = VoterStore.getSecretCodeVerificationStatus();
     const { secretCodeVerified } = secretCodeVerificationStatus;
     if (secretCodeVerified) {
-      this.props.toggleFunction();
+      this.props.closeFunction();
     } else {
       const voter = VoterStore.getVoter();
       this.setState({
@@ -68,7 +72,10 @@ class SignInModal extends Component {
       <Dialog
         classes={{ paper: classes.dialogPaper, root: classes.dialogRoot }}
         open={this.props.show}
-        onClose={() => { this.props.toggleFunction(); }}
+        onClose={() => {
+          this.props.closeFunction();
+          AppActions.setIsShowingSignInModal(false);
+        }}
       >
         <DialogTitle>
           <Typography className="text-center">
@@ -77,7 +84,10 @@ class SignInModal extends Component {
           <IconButton
             aria-label="Close"
             classes={{ root: classes.closeButton }}
-            onClick={() => { this.props.toggleFunction(); }}
+            onClick={() => {
+              this.props.closeFunction();
+              AppActions.setIsShowingSignInModal(false);
+            }}
             id="profileCloseSignInModal"
           >
             <CloseIcon />
@@ -93,7 +103,7 @@ class SignInModal extends Component {
               ) : (
                 <div>
                   <SettingsAccount
-                    toggleSignInModal={this.props.toggleFunction}
+                    closeSignInModal={this.props.closeFunction}
                     inModal
                   />
                 </div>

--- a/src/js/components/Widgets/signInModalGlobalState.js
+++ b/src/js/components/Widgets/signInModalGlobalState.js
@@ -1,19 +1,28 @@
-const simState = {};
+const simState = {
+  waitingForFacebookApiCompletion: false,
+};
 
 // Since SignInModal physically covers the UI where facebook error messages appear,
-// we need to save its state here, so that the SignInModal dialog can retrieve it
+// we need to save some state here, so that the SignInModal dialog can retrieve it
+// This global store is needed to set and read state info in the middle of a
+// react dispatch (where a nested dispatch would cause an error to be thrown).
 export default {
   set (key, value) {
-    simState.key = value;
+    simState[key] = value;
   },
 
   // eslint-disable-next-line no-unused-vars
   remove (key) {
-    delete simState.key;
+    delete simState[key];
   },
 
   // eslint-disable-next-line no-unused-vars
   get (key) {
-    return simState.key;
+    return simState[key];
+  },
+
+  // eslint-disable-next-line no-unused-vars
+  getBool (key) {
+    return simState[key] ? simState[key] : false;
   },
 };

--- a/src/js/config-template.js
+++ b/src/js/config-template.js
@@ -9,6 +9,8 @@ module.exports = {
   WE_VOTE_SERVER_API_ROOT_URL: 'https://api.wevoteusa.org/apis/v1/',
   WE_VOTE_SERVER_API_CDN_ROOT_URL: 'https://cdn.wevoteusa.org/apis/v1/',
 
+  ENABLE_NEXT_RELEASE_FEATURES: true,
+
   DEBUG_MODE: false,
   SHOW_TEST_OPTIONS: false,    // On the DeviceDialog and elsewhere
 

--- a/src/js/routes/Settings/HamburgerMenu.jsx
+++ b/src/js/routes/Settings/HamburgerMenu.jsx
@@ -11,6 +11,9 @@ import VoterSessionActions from '../../actions/VoterSessionActions';
 import { renderLog } from '../../utils/logging';
 import avatarGeneric from '../../../img/global/svg-icons/avatar-generic.svg';
 
+const webAppConfig = require('../../config');
+
+
 export default class HamburgerMenu extends Component {
   // This can only be called by a developer running Cordova in an Simulator.  Voters will never see it.
   static clearAllCookies () {
@@ -101,6 +104,7 @@ export default class HamburgerMenu extends Component {
     const { voter_photo_url_medium: photoUrl } = voter;
     isSignedIn = isSignedIn === undefined || isSignedIn === null ? false : isSignedIn;
     const showSettingsInDevelopment = false; // If developing any of the new settings, change this to true
+    const enableNextRelease = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;
 
     // console.log("Hamburger menu this.state.showDeviceDialog " + this.state.showDeviceDialog);
 
@@ -161,7 +165,7 @@ export default class HamburgerMenu extends Component {
               />
             )}
 
-            {isSignedIn && (
+            {isSignedIn && enableNextRelease && (
               <HamburgerMenuRow
                 onClickAction={null}
                 to="/settings/domain"
@@ -171,7 +175,7 @@ export default class HamburgerMenu extends Component {
               />
             )}
 
-            {isSignedIn && (
+            {isSignedIn && enableNextRelease && (
               <HamburgerMenuRow
                 onClickAction={null}
                 to="/settings/sharing"
@@ -181,7 +185,7 @@ export default class HamburgerMenu extends Component {
               />
             )}
 
-            {isSignedIn && (
+            {isSignedIn && enableNextRelease && (
               <HamburgerMenuRow
                 onClickAction={null}
                 to="/settings/subscription"
@@ -191,7 +195,7 @@ export default class HamburgerMenu extends Component {
               />
             )}
 
-            {isSignedIn && (
+            {isSignedIn && enableNextRelease && (
               <HamburgerMenuRow
                 onClickAction={null}
                 to="/settings/analytics"

--- a/src/js/routes/WelcomeForCampaigns.jsx
+++ b/src/js/routes/WelcomeForCampaigns.jsx
@@ -14,7 +14,7 @@ import Footer from '../components/Welcome/Footer';
 import { cordovaScrollablePaneTopPadding } from '../utils/cordovaOffsets';
 import { historyPush, cordovaDot } from '../utils/cordovaUtils';
 import Testimonial from '../components/Widgets/Testimonial';
-import{ validateEmail }from '../utils/regex-checks';
+import { validateEmail } from '../utils/regex-checks';
 import VoterActions from '../actions/VoterActions';
 import VoterConstants from '../constants/VoterConstants';
 import VoterStore from '../stores/VoterStore';

--- a/src/js/routes/WelcomeForVoters.jsx
+++ b/src/js/routes/WelcomeForVoters.jsx
@@ -20,7 +20,7 @@ import Footer from '../components/Welcome/Footer';
 import { renderLog } from '../utils/logging';
 import TextBox from '../components/Welcome/TextBox';
 import Testimonial from '../components/Widgets/Testimonial';
-import{ validateEmail }from '../utils/regex-checks';
+import { validateEmail } from '../utils/regex-checks';
 import VoterActions from '../actions/VoterActions';
 import VoterConstants from '../constants/VoterConstants';
 import VoterStore from '../stores/VoterStore';

--- a/src/js/stores/AppStore.js
+++ b/src/js/stores/AppStore.js
@@ -5,13 +5,15 @@ import { isCordova } from '../utils/cordovaUtils'; // eslint-disable-line import
 import VoterActions from '../actions/VoterActions'; // eslint-disable-line import/no-cycle
 import VoterStore from './VoterStore'; // eslint-disable-line import/no-cycle
 
+/**
+ * AppStore allows you to store state information, in situations where there is no API call needed
+ */
 class AppStore extends ReduceStore {
   getInitialState () {
     return {
       chosenSiteLogoUrl: '',
       getVoterGuideSettingsDashboardEditMode: '',
       getStartedMode: '',
-      headroomUnpinned: false,
       hideWeVoteLogo: false,
       hostname: '',
       scrolledDown: false,
@@ -20,6 +22,8 @@ class AppStore extends ReduceStore {
       showPaidAccountUpgradeModal: false,
       showSelectBallotModal: false,
       showSignInModal: false,
+      isShowingSignInModal: false,
+      signInErrorMessage: '',
       siteConfigurationHasBeenRetrieved: false,
       siteOwnerOrganizationWeVoteId: '',
       storeSignInStartFullUrl: false,
@@ -80,10 +84,6 @@ class AppStore extends ReduceStore {
     return this.getState().onChosenFullDomainUrl;
   }
 
-  headroomIsUnpinned () {
-    return this.getState().headroomUnpinned;
-  }
-
   showEditAddressButton () {
     return this.getState().showEditAddressButton;
   }
@@ -103,6 +103,14 @@ class AppStore extends ReduceStore {
 
   showSignInModal () {
     return this.getState().showSignInModal;
+  }
+
+  isShowingSignInModal () {
+    return this.getState().isShowingSignInModal;
+  }
+
+  getSignInErrorMessage () {
+    return this.getState().signInErrorMessage;
   }
 
   siteConfigurationHasBeenRetrieved () {
@@ -135,8 +143,6 @@ class AppStore extends ReduceStore {
         return { ...state, getStartedMode: action.payload };
       case 'getVoterGuideSettingsDashboardEditMode':
         return { ...state, getVoterGuideSettingsDashboardEditMode: action.payload };
-      case 'headroomUnpinned':
-        return { ...state, headroomUnpinned: action.payload };
       case 'scrolledDown':
         return { ...state, scrolledDown: action.payload };
       case 'showEditAddressButton':
@@ -149,6 +155,10 @@ class AppStore extends ReduceStore {
         return { ...state, showSelectBallotModal: action.payload };
       case 'showSignInModal':
         return { ...state, showSignInModal: action.payload };
+      case 'isShowingSignInModal':
+        return { ...state, isShowingSignInModal: action.payload };
+      case 'signInErrorMessage':
+        return { ...state, signInErrorMessage: action.payload };
       case 'siteConfigurationRetrieve':
         ({
           status: apiStatus,

--- a/src/js/stores/FacebookStore.js
+++ b/src/js/stores/FacebookStore.js
@@ -3,6 +3,7 @@ import Dispatcher from '../dispatcher/Dispatcher';
 import FacebookActions from '../actions/FacebookActions';
 import FacebookConstants from '../constants/FacebookConstants';
 import FriendActions from '../actions/FriendActions';
+import signInModalGlobalState from '../components/Widgets/signInModalGlobalState';
 import VoterActions from '../actions/VoterActions';
 
 class FacebookStore extends ReduceStore {
@@ -111,10 +112,12 @@ class FacebookStore extends ReduceStore {
 
     switch (action.type) {
       case FacebookConstants.FACEBOOK_LOGGED_IN:
+        signInModalGlobalState.set('waitingForFacebookApiCompletion', false);
 
         // console.log("FACEBOOK_LOGGED_IN action.data:", action.data);
-        FacebookActions.voterFacebookSignInAuth(action.data.authResponse);
-        FacebookActions.getFacebookData();
+        FacebookActions.saveFacebookSignInAuth(action.data.authResponse);
+        // FacebookActions.getFacebookData();  // 11/14/19, Removed
+        FacebookActions.getFacebookData();     // Includes a save
         return {
           ...state,
           authData: action.data,
@@ -124,7 +127,7 @@ class FacebookStore extends ReduceStore {
 
         // Cache the data in the API server
         // console.log("FACEBOOK_RECEIVED_DATA action.data:", action.data);
-        FacebookActions.voterFacebookSignInData(action.data);
+        FacebookActions.voterFacebookSignInData(action.data);  // Steve this calls a save to the server
         FacebookActions.getFacebookProfilePicture();
         return {
           ...state,
@@ -175,13 +178,9 @@ class FacebookStore extends ReduceStore {
         };
 
       case 'voterFacebookSignInRetrieve':
-
         // console.log("FacebookStore voterFacebookSignInRetrieve, facebook_sign_in_verified: ", action.res.facebook_sign_in_verified);
         if (action.res.facebook_sign_in_verified) {
           VoterActions.voterRetrieve();
-          /* Sept 6, 2017, has been replaced by facebook Game API friends list
-          FacebookActions.facebookFriendsAction();
-          */
         }
 
         return {

--- a/src/js/stores/SupportStore.js
+++ b/src/js/stores/SupportStore.js
@@ -1,9 +1,10 @@
 import { ReduceStore } from 'flux/utils';
 import assign from 'object-assign';
 import Dispatcher from '../dispatcher/Dispatcher';
+import AppStore from './AppStore';  // eslint-disable-line import/no-cycle
 import { mergeTwoObjectLists } from '../utils/textFormat';
 import SupportActions from '../actions/SupportActions';
-import VoterStore from './VoterStore'; // eslint-disable-line import/no-cycle
+import VoterStore from './VoterStore';  // eslint-disable-line import/no-cycle
 
 class SupportStore extends ReduceStore {
   getInitialState () {
@@ -152,8 +153,11 @@ class SupportStore extends ReduceStore {
 
     switch (action.type) {
       case 'voterAddressRetrieve':
-        SupportActions.voterAllPositionsRetrieve();
-        SupportActions.positionsCountForAllBallotItems(VoterStore.electionId());
+        // We should really avoid overly broad cascading API calls like this, they can cause problems
+        if (!AppStore.isShowingSignInModal()) {
+          SupportActions.voterAllPositionsRetrieve();
+          SupportActions.positionsCountForAllBallotItems(VoterStore.electionId());
+        }
         return state;
 
       case 'voterAllPositionsRetrieve':

--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -259,11 +259,13 @@ class VoterStore extends ReduceStore {
   }
 
   reduce (state, action) {
-    // Exit if we don't have a response. "success" is not required though -- we should deal with error conditions below.
-    if (!action.res && !action.payload) {
-      console.log('VoterStore, no action.res or action.payload received. action: ', action);
-      return state;
-    }
+    // 11/14/19, removed by Steve, not sure what this was trying to catch, but this is a bit of a red herring, since calls to the FaceBook api will not have these fields
+    // // Exit if we don't have a response. "success" is not required though -- we should deal with error conditions below.
+    // if (!action.res && !action.payload) {
+    //   // Note that
+    //   console.log('VoterStore, no action.res or action.payload received. (Check to see that this is even meant for VoterStore). action: ', action);
+    //   return state;
+    // }
 
     let facebookPhotoRetrieveLoopCount;
     let address;

--- a/src/js/utils/regex-checks.js
+++ b/src/js/utils/regex-checks.js
@@ -4,7 +4,7 @@
 export function validateEmail (email) {
   const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
   return re.test(email);
-};
+}
 
 export function validatePhoneOrEmail (contactInfo) {
   const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
@@ -12,9 +12,5 @@ export function validatePhoneOrEmail (contactInfo) {
 
   if (emailRegex.test(contactInfo)) {
     return true;
-  } else if (phoneRegex.test(contactInfo)) {
-    return true;
-  } else {
-    return false;
-  }
-};
+  } else return phoneRegex.test(contactInfo);
+}


### PR DESCRIPTION
Stops a flood of no-value API calls while SignInModal is displayed
Adds a new `ENABLE_NEXT_RELEASE_FEATURES: true,` in config.xml, so Cordova
fix builds can be made without exposing next release features.
Some lint fixes that errored in files I hadn't changed.