### PR TITLE
Tightened up widths of header tabs to prevent Sign In link from being pushed off the far right side. In SettingsVerifySecretCode, remove the error message as soon as voter starts typing in number boxes. Fixed errors in Friend invitation process.

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -376,16 +376,30 @@ class HeaderBar extends Component {
                 classes={{ indicator: classes.indicator }}
               >
                 {showFullNavigation && (
-                  <Tab classes={{ root: classes.tabRoot }} id="ballotTabHeaderBar" label="Ballot" onClick={() => this.handleNavigation('/ballot')} />
+                  <Tab classes={{ root: classes.tabRootBallot }} id="ballotTabHeaderBar" label="Ballot" onClick={() => this.handleNavigation('/ballot')} />
                 )}
                 {showFullNavigation && (
-                  <Tab classes={{ root: classes.tabRoot }} id="valuesTabHeaderBar" label="My Values" onClick={() => this.handleNavigation('/values')} />
+                  <Tab classes={{ root: classes.tabRootDefault }} id="valuesTabHeaderBar" label="My Values" onClick={() => this.handleNavigation('/values')} />
                 )}
                 { enableFriends && showFullNavigation && (
-                  <Tab classes={{ root: classes.tabRoot }} id="friendsTabHeaderBar" label={<Badge classes={{ badge: classes.headerBadge }} badgeContent={numberOfIncomingFriendRequests} color="primary" max={9}>My Friends</Badge>} onClick={() => this.handleNavigation('/friends')} />
+                  <Tab
+                    classes={(numberOfIncomingFriendRequests > 0) ? { root: classes.tabRootIncomingFriendRequests } : { root: classes.tabRootDefault }}
+                    id="friendsTabHeaderBar"
+                    label={(
+                      <Badge
+                        classes={{ badge: classes.headerBadge }}
+                        badgeContent={numberOfIncomingFriendRequests}
+                        color="primary"
+                        max={9}
+                      >
+                        My Friends
+                      </Badge>
+                    )}
+                    onClick={() => this.handleNavigation('/friends')}
+                  />
                 )}
                 {showFullNavigation && (
-                  <Tab classes={{ root: classes.tabRoot }} id="voteTabHeaderBar" label="Vote" onClick={() => this.handleNavigation('/ballot/vote')} />
+                  <Tab classes={{ root: classes.tabRootVote }} id="voteTabHeaderBar" label="Vote" onClick={() => this.handleNavigation('/ballot/vote')} />
                 )}
               </Tabs>
             </div>
@@ -584,8 +598,17 @@ const styles = theme => ({
       padding: 2,
     },
   },
-  tabRoot: {
+  tabRootBallot: {
+    minWidth: 90,
+  },
+  tabRootDefault: {
     minWidth: 110,
+  },
+  tabRootIncomingFriendRequests: {
+    minWidth: 130,
+  },
+  tabRootVote: {
+    minWidth: 70,
   },
   indicator: {
     height: 4,

--- a/src/js/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/components/Settings/SettingsVerifySecretCode.jsx
@@ -147,6 +147,7 @@ class SettingsVerifySecretCode extends Component {
       }
       this.setState({
         digit1: digit,
+        errorToDisplay: false,
         errorMessageToDisplay: '',
       });
       e.target.value = digit;
@@ -154,7 +155,11 @@ class SettingsVerifySecretCode extends Component {
       e.target.parentElement.nextElementSibling.firstElementChild.nextElementSibling.focus();
     } else {
       e.target.value = '';
-      this.setState({ digit1: '' });
+      this.setState({
+        digit1: '',
+        errorToDisplay: false,
+        errorMessageToDisplay: '',
+      });
     }
   }
 
@@ -172,6 +177,7 @@ class SettingsVerifySecretCode extends Component {
       }
       this.setState({
         digit2: digit,
+        errorToDisplay: false,
         errorMessageToDisplay: '',
       });
       e.target.value = digit;
@@ -179,7 +185,11 @@ class SettingsVerifySecretCode extends Component {
       e.target.parentElement.nextElementSibling.firstElementChild.nextElementSibling.focus();
     } else {
       e.target.value = '';
-      this.setState({ digit2: '' });
+      this.setState({
+        digit2: '',
+        errorToDisplay: false,
+        errorMessageToDisplay: '',
+      });
     }
   }
 
@@ -197,6 +207,7 @@ class SettingsVerifySecretCode extends Component {
       }
       this.setState({
         digit3: digit,
+        errorToDisplay: false,
         errorMessageToDisplay: '',
       });
       e.target.value = digit;
@@ -204,7 +215,11 @@ class SettingsVerifySecretCode extends Component {
       e.target.parentElement.nextElementSibling.firstElementChild.nextElementSibling.focus();
     } else {
       e.target.value = '';
-      this.setState({ digit3: '' });
+      this.setState({
+        digit3: '',
+        errorToDisplay: false,
+        errorMessageToDisplay: '',
+      });
     }
   }
 
@@ -222,6 +237,7 @@ class SettingsVerifySecretCode extends Component {
       }
       this.setState({
         digit4: digit,
+        errorToDisplay: false,
         errorMessageToDisplay: '',
       });
       e.target.value = digit;
@@ -229,7 +245,11 @@ class SettingsVerifySecretCode extends Component {
       e.target.parentElement.nextElementSibling.firstElementChild.nextElementSibling.focus();
     } else {
       e.target.value = '';
-      this.setState({ digit4: '' });
+      this.setState({
+        digit4: '',
+        errorToDisplay: false,
+        errorMessageToDisplay: '',
+      });
     }
   }
 
@@ -247,6 +267,7 @@ class SettingsVerifySecretCode extends Component {
       }
       this.setState({
         digit5: digit,
+        errorToDisplay: false,
         errorMessageToDisplay: '',
       });
       e.target.value = digit;
@@ -254,7 +275,11 @@ class SettingsVerifySecretCode extends Component {
       e.target.parentElement.nextElementSibling.firstElementChild.nextElementSibling.focus();
     } else {
       e.target.value = '';
-      this.setState({ digit5: '' });
+      this.setState({
+        digit5: '',
+        errorToDisplay: false,
+        errorMessageToDisplay: '',
+      });
     }
   }
 
@@ -268,12 +293,17 @@ class SettingsVerifySecretCode extends Component {
     } else if (e.keyCode !== 8 && regex.test(digit)) {
       this.setState({
         digit6: digit,
+        errorToDisplay: false,
         errorMessageToDisplay: '',
       });
       e.target.value = digit;
     } else {
       e.target.value = '';
-      this.setState({ digit6: '' });
+      this.setState({
+        digit6: '',
+        errorToDisplay: false,
+        errorMessageToDisplay: '',
+      });
     }
   }
 
@@ -298,6 +328,10 @@ class SettingsVerifySecretCode extends Component {
         digit6: allDigits[5],
       });
       document.getElementById('digit6').focus();
+      this.setState({
+        errorToDisplay: false,
+        errorMessageToDisplay: '',
+      });
     } else {
       this.setState({
         digit1: '',

--- a/src/js/routes/Process/FriendInvitationByEmailVerifyProcess.jsx
+++ b/src/js/routes/Process/FriendInvitationByEmailVerifyProcess.jsx
@@ -85,12 +85,25 @@ export default class FriendInvitationByEmailVerifyProcess extends Component {
 
     // console.log('FriendInvitationByEmailVerifyProcess, invitation_secret_key:', invitationSecretKey);
     // console.log('FriendInvitationByEmailVerifyProcess, invitationStatus:', invitationStatus);
-    if (!invitationSecretKey || saving || !invitationStatus || !invitationStatus.voterDeviceId) {
+    if (saving || !invitationStatus) {
+      // console.log('FriendInvitationByEmailVerifyProcess, saving:', saving, ', or waiting for invitationStatus:', invitationStatus);
+      return LoadingWheel;
+    } else if (!invitationSecretKey) {
+      historyPush({
+        pathname: '/friends',
+        state: {
+          message: 'Invitation secret key not found. Invitation not accepted.',
+          message_type: 'warning',
+        },
+      });
       return LoadingWheel;
     }
 
     // This process starts when we return from attempting friendInvitationByEmailVerify
-    if (!invitationStatus.invitationFound) {
+    if (!invitationStatus.voterDeviceId) {
+      console.log('voterDeviceId Missing');
+      return LoadingWheel;
+    } else if (!invitationStatus.invitationFound) {
       historyPush({
         pathname: '/friends',
         state: {
@@ -99,9 +112,7 @@ export default class FriendInvitationByEmailVerifyProcess extends Component {
         },
       });
       return LoadingWheel;
-    }
-
-    if (invitationStatus.attemptedToApproveOwnInvitation) {
+    } else if (invitationStatus.attemptedToApproveOwnInvitation) {
       historyPush({
         pathname: '/friends',
         state: {
@@ -110,9 +121,7 @@ export default class FriendInvitationByEmailVerifyProcess extends Component {
         },
       });
       return LoadingWheel;
-    }
-
-    if (invitationStatus.invitationSecretKeyBelongsToThisVoter) {
+    } else if (invitationStatus.invitationSecretKeyBelongsToThisVoter) {
       // We don't need to do anything more except redirect to the email management page
       historyPush({
         pathname: '/friends',

--- a/src/js/stores/FriendStore.js
+++ b/src/js/stores/FriendStore.js
@@ -85,8 +85,8 @@ class FriendStore extends ReduceStore {
   }
 
   reduce (state, action) {
-    // Exit if we don't have a successful response (since we expect certain variables in a successful response below)
-    if (!action.res || !action.res.success) return state;
+    // Exit if we don't receive a response
+    if (!action.res) return state;  //  || !action.res.success // We deal with failures below
 
     switch (action.type) {
       case 'friendInviteResponse':
@@ -137,20 +137,12 @@ class FriendStore extends ReduceStore {
         };
 
       case 'friendInvitationByEmailSend':
-        if (action.res.sender_voter_email_address_missing) {
-          // Return the person to the form where they can fill in their email address
-          return {
-            ...state,
-            addFriendsByEmailStep: 'on_collect_email_step',
-            errorMessageToShowVoter: action.res.error_message_to_show_voter,
-          };
-        } else {
-          // Reset the invitation form
-        }
+        // console.log('FriendStore friendInvitationByEmailSend, action.res:', action.res);
         FriendActions.friendInvitationsSentByMe();
         FriendActions.friendInvitationsWaitingForVerification();
         return {
           ...state,
+          errorMessageToShowVoter: action.res.error_message_to_show_voter,
         };
 
       case 'emailBallotData':


### PR DESCRIPTION
Tightened up widths of header tabs to prevent Sign In link from being pushed off the far right side. In SettingsVerifySecretCode, remove the error message as soon as voter starts typing in number boxes. Fixed errors in Friend invitation process.