### PR TITLE
Added back in Zendesk help in Cordova, but without the Widget

### DIFF
--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -4,12 +4,13 @@ import BottomNavigation from '@material-ui/core/BottomNavigation';
 import BottomNavigationAction from '@material-ui/core/BottomNavigationAction';
 import Badge from '@material-ui/core/Badge';
 import QuestionAnswerIcon from '@material-ui/icons/QuestionAnswer';
+import HelpOutline from '@material-ui/icons/HelpOutline';
 import BallotIcon from '@material-ui/icons/Ballot';
 import HowToVoteIcon from '@material-ui/icons/HowToVote';
 import PeopleIcon from '@material-ui/icons/People';
 import styled from 'styled-components';
 import { cordovaFooterHeight } from '../../utils/cordovaOffsets';
-import { historyPush } from '../../utils/cordovaUtils';
+import { historyPush, isCordova, cordovaOpenSafariView } from '../../utils/cordovaUtils';
 import { stringContains } from '../../utils/textFormat';
 import FriendStore from '../../stores/FriendStore';
 import { renderLog } from '../../utils/logging';
@@ -104,6 +105,16 @@ class FooterBar extends React.Component {
                 />
               ) : '' }
             <BottomNavigationAction className="no-outline" id="voteTabFooterBar" label="Vote" showLabel icon={<HowToVoteIcon />} />
+            {isCordova() && (
+              <BottomNavigationAction
+                className="no-outline"
+                id="helpTabFooterBar"
+                label=""
+                showLabel
+                icon={<HelpOutline style={{ color: 'rgba(0, 0, 0, 0.541176)' }} />}
+                onClick={() => cordovaOpenSafariView('https://help.wevote.us', null, 50)}
+              />
+            )}
           </BottomNavigation>
         </div>
       </FooterBarWrapper>


### PR DESCRIPTION
I could get the widget working, but after a half day of attempts, was
unable to style it sufficiently to be workable, especially on the full
screen iframe where you enter data and especially on iPhones with
notches.  So I added an icon and link to desktop (viewed in a Cordova
"tab" with a done/return button) from the FooterBar.

Resolves wevote/WebApp/issues/2665

Checked in without honoring pre-commit hook errors for unrelated source files.