### PR TITLE
Reduce number of renders of BallotItemCompressed, add ENABLE_WORKBOX_SERVICE_WORKER configuration

### DIFF
--- a/src/js/components/Ballot/BallotItemCompressed.jsx
+++ b/src/js/components/Ballot/BallotItemCompressed.jsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { renderLog } from '../../utils/logging';
 import MeasureItemCompressed from './MeasureItemCompressed';
 import OfficeItemCompressed from './OfficeItemCompressed';
 
-export default class BallotItemCompressed extends Component {
+export default class BallotItemCompressed extends PureComponent {
   static propTypes = {
     ballotItemDisplayName: PropTypes.string.isRequired,
     candidateList: PropTypes.array,

--- a/src/js/config-template.js
+++ b/src/js/config-template.js
@@ -10,7 +10,7 @@ module.exports = {
   WE_VOTE_SERVER_API_CDN_ROOT_URL: 'https://cdn.wevoteusa.org/apis/v1/',
 
   ENABLE_NEXT_RELEASE_FEATURES: true,
-  ENABLE_WORKBOX_SERVICE_WORKER: false,  // After setting this false, recompile, then in Chrome DevTools go to Application Tab, Application/Service Worker and for the sw.js click the "unregister" button to the right
+  ENABLE_WORKBOX_SERVICE_WORKER: true,  // After setting this false, recompile, then in Chrome DevTools go to Application Tab, Application/Service Worker and for the sw.js click the "unregister" button to the right
 
   DEBUG_MODE: false,
   SHOW_TEST_OPTIONS: false,    // On the DeviceDialog and elsewhere

--- a/src/js/config-template.js
+++ b/src/js/config-template.js
@@ -10,7 +10,7 @@ module.exports = {
   WE_VOTE_SERVER_API_CDN_ROOT_URL: 'https://cdn.wevoteusa.org/apis/v1/',
 
   ENABLE_NEXT_RELEASE_FEATURES: true,
-  ENABLE_WORKBOX_SERVICE_WORKER: true,  // After setting this false, recompile, then in Chrome DevTools go to Application Tab, Application/Service Worker and for the sw.js click the "unregister" button to the right
+  ENABLE_WORKBOX_SERVICE_WORKER: true,  // After setting this false, in Chrome DevTools go to Application Tab, Application/Service Worker and for the sw.js click the "unregister" button to the right
 
   DEBUG_MODE: false,
   SHOW_TEST_OPTIONS: false,    // On the DeviceDialog and elsewhere

--- a/src/js/config-template.js
+++ b/src/js/config-template.js
@@ -10,6 +10,8 @@ module.exports = {
   WE_VOTE_SERVER_API_CDN_ROOT_URL: 'https://cdn.wevoteusa.org/apis/v1/',
 
   ENABLE_NEXT_RELEASE_FEATURES: true,
+  ENABLE_WORKBOX_SERVICE_WORKER: false,  // After setting this false, recompile, then in Chrome DevTools go to Application Tab, Application/Service Worker and for the sw.js click the "unregister" button to the right
+
   DEBUG_MODE: false,
   SHOW_TEST_OPTIONS: false,    // On the DeviceDialog and elsewhere
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,6 +11,8 @@ import routes from './Root';
 import muiTheme from './mui-theme';
 import styledTheme from './styled-theme';
 import { numberOfNeedlesFoundInString } from './utils/search-functions';
+import webAppConfig from './config';
+
 
 // December 2018:  We want to work toward being airbnb style compliant, but for now these are disabled in this file to minimize massive changes
 /* eslint global-require: 1 */
@@ -61,19 +63,20 @@ function startApp () {
 }
 
 // ServiceWorker setup for Workbox Progressive Web App (PWA)
-if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    // Preload /ballot/vote so that it will be in cache even if the first visit is while offline
-    caches.open('WeVoteSVGCache').then((cache) => {
-      cache.match('/ballot/vote').then((response) => {
-        if (!response) {
-          cache.add('/ballot/vote');
-        }
+if (webAppConfig.ENABLE_WORKBOX_SERVICE_WORKER) {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      // Preload /ballot/vote so that it will be in cache even if the first visit is while offline
+      caches.open('WeVoteSVGCache').then((cache) => {
+        cache.match('/ballot/vote').then((response) => {
+          if (!response) {
+            cache.add('/ballot/vote');
+          }
+        });
       });
+      navigator.serviceWorker.register('/sw.js');
     });
-
-    navigator.serviceWorker.register('/sw.js');
-  });
+  }
 }
 
 // If Apache Cordova is available, wait for it to be ready, otherwise start the WebApp


### PR DESCRIPTION
Compared to the 10/24/19 (pre-refactor) version, this new version decreases the number of renders by half.  (The intermediate version from 12/15/19 had increased the number of renders)

[The experiment results](https://docs.google.com/spreadsheets/d/1q9k37o7cIz3Fy7goT1FAC7tUpPfsOG9DnZow1aKgFKE/edit?usp=sharing)

Use of the new ENABLE_WORKBOX_SERVICE_WORKER is explained in a comment in the config-template.js