### PR TITLE
Ballot Share Button on Mobile

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -372,7 +372,7 @@ class Application extends Component {
             </div>
           )}
           {showBallotShareButtonFooter && (
-            <BallotShareButtonFooter />
+            <BallotShareButtonFooter pathname={pathname} />
           )}
         </div>
       );
@@ -420,7 +420,7 @@ class Application extends Component {
           </div>
         )}
         {showBallotShareButtonFooter && (
-          <BallotShareButtonFooter />
+          <BallotShareButtonFooter pathname={pathname} />
         )}
       </div>
     );

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -21,6 +21,7 @@ import webAppConfig from './config';
 import { stringContains } from './utils/textFormat';
 import SnackNotifier from './components/Widgets/SnackNotifier';
 import displayFriendsTabs from './utils/displayFriendsTabs';
+import BallotShareButtonFooter from './components/Ballot/BallotShareButtonFooter';
 
 class Application extends Component {
   static propTypes = {
@@ -282,6 +283,8 @@ class Application extends Component {
     const waitForStripe = (String(pathname) === '/more/donate' && StripeCheckout === undefined);
     // console.log('Application render, pathname:', pathname);
 
+    console.log(showBallotShareButtonFooter);
+
     if (this.state.voter === undefined || this.props.location === undefined || waitForStripe) {
       if (waitForStripe) {
         console.log('Waiting for stripe to load, on an initial direct URL to DonationForm');
@@ -301,7 +304,7 @@ class Application extends Component {
 
     routingLog(pathname);
 
-    const { inTheaterMode, contentFullWidthMode, settingsMode, showFooterBar, voterGuideCreatorMode, voterGuideMode } = getApplicationViewBooleans(pathname);
+    const { inTheaterMode, contentFullWidthMode, settingsMode, showFooterBar, showBallotShareButtonFooter, voterGuideCreatorMode, voterGuideMode } = getApplicationViewBooleans(pathname);
 
     if (inTheaterMode) {
       // console.log('inTheaterMode', inTheaterMode);
@@ -368,6 +371,9 @@ class Application extends Component {
               <FooterBar location={this.props.location} pathname={pathname} voter={this.state.voter} />
             </div>
           )}
+          {showBallotShareButtonFooter && (
+            <BallotShareButtonFooter />
+          )}
         </div>
       );
     }
@@ -412,6 +418,9 @@ class Application extends Component {
           <div className="footroom-wrapper">
             <FooterBar location={this.props.location} pathname={pathname} voter={this.state.voter} />
           </div>
+        )}
+        {showBallotShareButtonFooter && (
+          <BallotShareButtonFooter />
         )}
       </div>
     );

--- a/src/js/components/Ballot/BallotShareButtonFooter.jsx
+++ b/src/js/components/Ballot/BallotShareButtonFooter.jsx
@@ -1,0 +1,246 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Button from '@material-ui/core/esm/Button';
+import Comment from '@material-ui/icons/Comment';
+import { Tooltip, MenuItem } from '@material-ui/core/esm';
+import { withStyles } from '@material-ui/core/esm/styles';
+import Reply from '@material-ui/icons/Reply';
+import styled from 'styled-components';
+import AppActions from '../../actions/AppActions';
+
+class BallotShareButtonFooter extends Component {
+  static propTypes = {
+    classes: PropTypes.object,
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      open: false,
+      anchorEl: null,
+    };
+    this.handleClick = this.handleClick.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  shouldComponentUpdate (nextState) {
+    if (this.state.open !== nextState.open) return true;
+    if (this.state.anchorEl !== nextState.anchorEl) return true;
+    return false;
+  }
+
+  handleClick (event) {
+    this.setState({ anchorEl: event.currentTarget, open: true });
+  }
+
+  handleClose () {
+    this.setState({ anchorEl: null, open: false });
+  }
+
+  openShareModal () {
+    // console.log('SettingsDomain openPaidAccountUpgradeModal');
+    AppActions.setShowShareModal(true);
+  }
+
+  render () {
+    const { classes } = this.props;
+    const { anchorEl } = this.state;
+
+    return (
+      <>
+        <Button aria-controls="share-menu" onClick={this.handleClick} aria-haspopup="true" className={classes.button} variant="contained" color="primary">
+          <Icon>
+            <Reply
+              classes={{ root: classes.shareIcon }}
+            />
+            {/* <i className="fas fa-share" /> */}
+          </Icon>
+          Share
+        </Button>
+        <Menu
+          id="share-menu"
+          open={this.state.open}
+          onClose={this.handleClose}
+          getContentAnchorEl={null}
+          anchorEl={anchorEl}
+        >
+          <Container>
+            <ModalTitleArea>
+              <Title>
+                Share:
+                {' '}
+                <strong>Ballot for Nov 2019 Elections</strong>
+              </Title>
+              <SubTitle>Share a link to this election so that your friends can get ready to vote. Your opinions are not included.</SubTitle>
+            </ModalTitleArea>
+            <MenuItem className={classes.menuItem} onClick={this.openShareModal}>
+              <MenuFlex>
+                <MenuIcon>
+                  <i className="fas fa-list" />
+                </MenuIcon>
+                <MenuText>
+                  Ballot
+                </MenuText>
+                <MenuInfo>
+                  <Tooltip title="Share a link to this election so that your friends can get ready to vote. Your opinions are not included." arrow enterDelay={300}>
+                    <i className="fas fa-info-circle" />
+                  </Tooltip>
+                </MenuInfo>
+              </MenuFlex>
+            </MenuItem>
+            <MenuSeparator />
+            <MenuItem className={classes.menuItem} onClick={this.openShareModal}>
+              <MenuFlex>
+                <MenuIcon>
+                  <Comment />
+                </MenuIcon>
+                <MenuText>
+                  Your Ballot Opinions
+                </MenuText>
+                <MenuInfo>
+                  <Tooltip title="Share a link to the choices you've made for this election so that your friends can get ready to vote. This includes your public and friend's-only opinions." arrow enterDelay={300}>
+                    <i className="fas fa-info-circle" />
+                  </Tooltip>
+                </MenuInfo>
+              </MenuFlex>
+            </MenuItem>
+            <Button className={classes.cancelButton} fullWidth onClick={this.onClose} variant="outlined" color="primary">
+              Cancel
+            </Button>
+          </Container>
+        </Menu>
+      </>
+    );
+  }
+}
+
+const styles = () => ({
+  paper: {
+    borderRadius: '2px !important',
+    marginTop: '10px !important',
+    overflowX: 'visible !important',
+    overflowY: 'visible !important',
+  },
+  button: {
+    padding: '0 12px',
+    position: 'fixed',
+    bottom: '57px',
+    width: '100%',
+    boxShadow: 'none !important',
+    borderRadius: '0 !important',
+    height: '45px !important',
+  },
+  cancelButton: {
+    marginTop: 24,
+  },
+  menuItem: {
+    zIndex: '9 !important',
+    padding: '0 !important',
+    marginBottom: '-2px !important',
+    paddingBottom: '1px !important',
+    '&:last-child': {
+      paddingBottom: '0 !important',
+      paddingTop: '1px !important',
+    },
+    '&:hover': {
+      background: '#efefef',
+    },
+  },
+  shareIcon: {
+    // -webkit-transform: 'scaleX(-1)',
+    transform: 'scaleX(-1)',
+  },
+});
+
+const Menu = styled.div`
+  position: fixed;
+  bottom: 0;
+  width: 100% !important;
+  height: fit-content !important;
+  transform: ${props => (props.open ? 'none' : 'translateY(100%)')} !important;
+  z-index: 999 !important;
+  background: white !important;
+  padding: 0px 12px 32px 12px;
+`;
+
+const Container = styled.div`
+  margin: 0 auto;
+  max-width: 576px;
+`;
+
+const ModalTitleArea = styled.div`
+  text-align: left;
+  width: 100%;
+  padding: 20px 16px 16px 16px;
+  z-index: 999;
+  @media (min-width: 769px) {
+    border-bottom: 2px solid #f7f7f7;
+  }
+  ${({ noBoxShadowMode }) => ((noBoxShadowMode) ? '@media (max-width: 376px) {\n    padding: 8px 6px;\n  }' : '')}
+`;
+
+const Title = styled.h3`
+  font-weight: normal;
+  font-size: 24px;
+  color: black;
+  margin-top: 0;
+  margin-bottom: 12px;
+`;
+
+const SubTitle = styled.div`
+  margin-top: 0;
+  font-size: 14px;
+  width: 80%;
+`;
+
+const Icon = styled.span`
+  margin-right: 4px;
+`;
+
+const MenuFlex = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  height: 100%;
+  padding: 10px 8px 10px 18px;
+`;
+
+const MenuIcon = styled.div`
+  width: 20px !important;
+  height: 20px !important;
+  top: -2px;
+  position: relative;
+  & * {
+    width: 20px !important;
+    height: 20px !important;
+    min-width: 20px !important;
+    min-height: 20px !important;
+  }
+  & svg {
+    position: relative;
+    left: -2px;
+  }
+`;
+
+const MenuText = styled.div`
+  margin-left: 12px;
+`;
+
+const MenuInfo = styled.div`
+  margin-left: auto;
+  margin-top: 1px;
+  padding-left: 10px;
+`;
+
+const MenuSeparator = styled.div`
+  height: 2px;
+  background: #efefef;
+  width: 80%;
+  margin: 0 auto;
+  position: absolute;
+  left: 10%;
+  z-index: 0 !important;
+`;
+
+export default withStyles(styles)(BallotShareButtonFooter);

--- a/src/js/components/Ballot/BallotShareButtonFooter.jsx
+++ b/src/js/components/Ballot/BallotShareButtonFooter.jsx
@@ -2,11 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Button from '@material-ui/core/esm/Button';
 import Comment from '@material-ui/icons/Comment';
-import { Tooltip, MenuItem } from '@material-ui/core/esm';
+import { Tooltip, Menu, MenuItem } from '@material-ui/core/esm';
 import { withStyles } from '@material-ui/core/esm/styles';
 import Reply from '@material-ui/icons/Reply';
 import styled from 'styled-components';
 import AppActions from '../../actions/AppActions';
+import { Slide, Drawer } from '@material-ui/core';
 
 class BallotShareButtonFooter extends Component {
   static propTypes = {
@@ -44,7 +45,6 @@ class BallotShareButtonFooter extends Component {
 
   render () {
     const { classes } = this.props;
-    const { anchorEl } = this.state;
 
     return (
       <>
@@ -57,13 +57,7 @@ class BallotShareButtonFooter extends Component {
           </Icon>
           Share
         </Button>
-        <Menu
-          id="share-menu"
-          open={this.state.open}
-          onClose={this.handleClose}
-          getContentAnchorEl={null}
-          anchorEl={anchorEl}
-        >
+        <Drawer id="share-menu" anchor="bottom" open={this.state.open} direction="up" onClose={this.handleClose}>
           <Container>
             <ModalTitleArea>
               <Title>
@@ -108,19 +102,13 @@ class BallotShareButtonFooter extends Component {
               Cancel
             </Button>
           </Container>
-        </Menu>
+        </Drawer>
       </>
     );
   }
 }
 
 const styles = () => ({
-  paper: {
-    borderRadius: '2px !important',
-    marginTop: '10px !important',
-    overflowX: 'visible !important',
-    overflowY: 'visible !important',
-  },
   button: {
     padding: '0 12px',
     position: 'fixed',
@@ -152,20 +140,10 @@ const styles = () => ({
   },
 });
 
-const Menu = styled.div`
-  position: fixed;
-  bottom: 0;
-  width: 100% !important;
-  height: fit-content !important;
-  transform: ${props => (props.open ? 'none' : 'translateY(100%)')} !important;
-  z-index: 999 !important;
-  background: white !important;
-  padding: 0px 12px 32px 12px;
-`;
-
 const Container = styled.div`
   margin: 0 auto;
   max-width: 576px;
+  padding: '0px 12px 32px 12px',
 `;
 
 const ModalTitleArea = styled.div`

--- a/src/js/components/Ballot/BallotShareButtonFooter.jsx
+++ b/src/js/components/Ballot/BallotShareButtonFooter.jsx
@@ -98,7 +98,7 @@ class BallotShareButtonFooter extends Component {
                 </MenuInfo>
               </MenuFlex>
             </MenuItem>
-            <Button className={classes.cancelButton} fullWidth onClick={this.onClose} variant="outlined" color="primary">
+            <Button className={classes.cancelButton} fullWidth onClick={this.handleClose} variant="outlined" color="primary">
               Cancel
             </Button>
           </Container>
@@ -143,7 +143,7 @@ const styles = () => ({
 const Container = styled.div`
   margin: 0 auto;
   max-width: 576px;
-  padding: '0px 12px 32px 12px',
+  padding: 24px 16px 32px !important;
 `;
 
 const ModalTitleArea = styled.div`

--- a/src/js/components/Ballot/BallotShareButtonFooter.jsx
+++ b/src/js/components/Ballot/BallotShareButtonFooter.jsx
@@ -47,7 +47,7 @@ class BallotShareButtonFooter extends Component {
     const { classes } = this.props;
 
     return (
-      <>
+      <Wrapper>
         <Button aria-controls="share-menu" onClick={this.handleClick} aria-haspopup="true" className={classes.button} variant="contained" color="primary">
           <Icon>
             <Reply
@@ -103,7 +103,7 @@ class BallotShareButtonFooter extends Component {
             </Button>
           </Container>
         </Drawer>
-      </>
+      </Wrapper>
     );
   }
 }
@@ -139,6 +139,13 @@ const styles = () => ({
     transform: 'scaleX(-1)',
   },
 });
+
+const Wrapper = styled.div`
+  display: block
+  @media (min-width: 576px) {
+    display: none;
+  }
+`;
 
 const Container = styled.div`
   margin: 0 auto;
@@ -219,6 +226,10 @@ const MenuSeparator = styled.div`
   position: absolute;
   left: 10%;
   z-index: 0 !important;
+  @media (min-width: 568px) {
+    width: 448px !important;
+    margin: 0 auto;
+  }
 `;
 
 export default withStyles(styles)(BallotShareButtonFooter);

--- a/src/js/components/Ballot/BallotShareButtonFooter.jsx
+++ b/src/js/components/Ballot/BallotShareButtonFooter.jsx
@@ -47,7 +47,7 @@ class BallotShareButtonFooter extends Component {
     const { classes } = this.props;
 
     return (
-      <Wrapper>
+      <Wrapper pinToBottom={this.props.pathname.toLowerCase().startsWith('/candidate') || this.props.pathname.toLowerCase().startsWith('/measure')}>
         <Button aria-controls="share-menu" onClick={this.handleClick} aria-haspopup="true" className={classes.button} variant="contained" color="primary">
           <Icon>
             <Reply
@@ -111,8 +111,6 @@ class BallotShareButtonFooter extends Component {
 const styles = () => ({
   button: {
     padding: '0 12px',
-    position: 'fixed',
-    bottom: '57px',
     width: '100%',
     boxShadow: 'none !important',
     borderRadius: '0 !important',
@@ -141,7 +139,10 @@ const styles = () => ({
 });
 
 const Wrapper = styled.div`
-  display: block
+  position: fixed;
+  width: 100%;
+  bottom: ${props => (props.pinToBottom ? '0' : '57px')};
+  display: block;
   @media (min-width: 576px) {
     display: none;
   }

--- a/src/js/components/Ballot/ShareModal.jsx
+++ b/src/js/components/Ballot/ShareModal.jsx
@@ -134,6 +134,7 @@ const SubTitle = styled.div`
   font-size: 14px;
   width: 80%;
 `;
+
 const Flex = styled.div`
   display: flex;
   flex-wrap: wrap;

--- a/src/js/utils/applicationUtils.js
+++ b/src/js/utils/applicationUtils.js
@@ -162,6 +162,12 @@ export function getApplicationViewBooleans (pathname) {
     showFooterBar = true;
   }
 
+  let showBallotShareButtonFooter = false;
+
+  if (pathnameLowerCase.startsWith('/ballot') || pathnameLowerCase.startsWith('/candidate') || pathnameLowerCase.startsWith('/measure')) {
+    showBallotShareButtonFooter = true;
+  }
+
   // console.log('applicationUtils, showFooterBar: ', showFooterBar, ', pathnameLowerCase:', pathnameLowerCase, ', showBackToSettingsMobile:', showBackToSettingsMobile);
 
   return {
@@ -180,6 +186,7 @@ export function getApplicationViewBooleans (pathname) {
     showBackToValues,
     showBackToVoterGuides,
     showFooterBar,
+    showBallotShareButtonFooter,
   };
 }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2717 

### Changes included this pull request?
I added a new component, BallotShareButtonFooter, and made sure it shows on the Candidate, Measure and Ballot pages. I used the Material UI Drawer component for a slide-up menu that displays the same links as the share button on desktop.