### PR TITLE
iOs signin works all 4 ways: FB, Twitter, Text, & Email.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4100,7 +4100,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
@@ -4118,7 +4118,7 @@
     },
     "array-flatten": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
@@ -6064,7 +6064,7 @@
     },
     "browserify": {
       "version": "13.3.0",
-      "resolved": "http://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.3.0.tgz",
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
@@ -6181,7 +6181,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -6949,7 +6949,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
           "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
           "dev": true
         },
@@ -8157,7 +8157,7 @@
     },
     "deps-sort": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
       "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
       "dev": true,
       "requires": {
@@ -9821,7 +9821,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -12023,7 +12023,7 @@
         },
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
@@ -12041,7 +12041,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "dev": true,
           "requires": {
@@ -12784,7 +12784,7 @@
     },
     "htmlescape": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
       "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
       "dev": true
     },
@@ -13437,7 +13437,7 @@
     },
     "is-empty": {
       "version": "0.0.1",
-      "resolved": "http://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-empty/-/is-empty-0.0.1.tgz",
       "integrity": "sha1-Cf3D1kndpZaRVsCFOpt2vXgcWjM=",
       "dev": true
     },
@@ -14202,7 +14202,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -14784,7 +14784,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -14840,7 +14840,7 @@
     },
     "meow": {
       "version": "3.7.0",
-      "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
@@ -15125,7 +15125,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -15134,7 +15134,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
@@ -16077,13 +16077,13 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -16106,7 +16106,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "osenv": {
@@ -16421,7 +16421,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
@@ -16511,7 +16511,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
       "dev": true
     },
@@ -16989,7 +16989,7 @@
     },
     "pretty-hrtime": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
       "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
       "dev": true
     },
@@ -17429,7 +17429,7 @@
     },
     "react-hot-loader": {
       "version": "1.3.1",
-      "resolved": "http://registry.npmjs.org/react-hot-loader/-/react-hot-loader-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-1.3.1.tgz",
       "integrity": "sha1-yVZHrni3Pfzv9uxx/8sEGC/22vk=",
       "dev": true,
       "requires": {
@@ -18398,7 +18398,7 @@
       "dependencies": {
         "convert-source-map": {
           "version": "0.3.5",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
           "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA=",
           "dev": true
         }
@@ -18923,7 +18923,7 @@
     },
     "shasum": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
       "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
       "dev": true,
       "requires": {
@@ -20066,7 +20066,7 @@
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
@@ -20392,7 +20392,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -21930,7 +21930,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
@@ -21977,7 +21977,7 @@
     },
     "timers-browserify": {
       "version": "1.4.2",
-      "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
       "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
       "dev": true,
       "requires": {
@@ -22303,7 +22303,7 @@
         },
         "yargs": {
           "version": "3.10.0",
-          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
           "dev": true,
           "requires": {
@@ -22393,7 +22393,7 @@
     },
     "underscore": {
       "version": "1.8.3",
-      "resolved": "http://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
       "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
       "dev": true
     },
@@ -23025,7 +23025,7 @@
     },
     "vm-browserify": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
       "dev": true,
       "requires": {
@@ -26419,7 +26419,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",
@@ -26519,7 +26519,7 @@
     },
     "yargs": {
       "version": "6.6.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
       "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
       "dev": true,
       "requires": {
@@ -26546,7 +26546,7 @@
         },
         "yargs-parser": {
           "version": "4.2.1",
-          "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
           "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
           "dev": true,
           "requires": {

--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -22,6 +22,7 @@ import { stringContains } from './utils/textFormat';
 import SnackNotifier from './components/Widgets/SnackNotifier';
 import displayFriendsTabs from './utils/displayFriendsTabs';
 import BallotShareButtonFooter from './components/Ballot/BallotShareButtonFooter';
+import signInModalGlobalState from './components/Widgets/signInModalGlobalState';
 
 class Application extends Component {
   static propTypes = {
@@ -137,6 +138,7 @@ class Application extends Component {
   }
 
   onAppStoreChange () {
+    // console.log('Application, onAppStoreChange');
     let signInStartFullUrl = cookies.getItem('sign_in_start_full_url');
     // console.log('Application onAppStoreChange, current signInStartFullUrl: ', signInStartFullUrl);
     // Do not let sign_in_start_full_url be set again. Different logic while we figure out how to call AppActions.unsetStoreSignInStartFullUrl()
@@ -158,27 +160,28 @@ class Application extends Component {
   }
 
   onVoterStoreChange () {
-    // console.log('Application, onVoterStoreChange');
-    const voterDeviceId = VoterStore.voterDeviceId();
-    if (voterDeviceId && voterDeviceId !== '') {
-      if (this.state.voter_initial_retrieve_needed) {
-        VoterActions.voterEmailAddressRetrieve();
-        VoterActions.voterSMSPhoneNumberRetrieve();
-        FriendActions.friendInvitationsSentToMe();
-        this.incomingVariableManagement();
-        this.setState({
-          voter: VoterStore.getVoter(),
-          voter_initial_retrieve_needed: false,
-        });
-      } else {
-        this.setState({
-          voter: VoterStore.getVoter(),
-        });
+    if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+      console.log('Application, onVoterStoreChange');
+      const voterDeviceId = VoterStore.voterDeviceId();
+      if (voterDeviceId && voterDeviceId !== '') {
+        if (this.state.voter_initial_retrieve_needed) {
+          VoterActions.voterEmailAddressRetrieve();
+          VoterActions.voterSMSPhoneNumberRetrieve();
+          FriendActions.friendInvitationsSentToMe();
+          this.incomingVariableManagement();
+          this.setState({
+            voter: VoterStore.getVoter(),
+            voter_initial_retrieve_needed: false,
+          });
+        } else {
+          this.setState({
+            voter: VoterStore.getVoter(),
+          });
+        }
       }
+      // console.log('Application onVoterStoreChange voter: ', VoterStore.getVoter());
+      // console.log('SignedIn Voter in Application onVoterStoreChange voter: ', VoterStore.getVoter().full_name);
     }
-
-    // console.log('Application onVoterStoreChange voter: ', VoterStore.getVoter());
-    // console.log('SignedIn Voter in Application onVoterStoreChange voter: ', VoterStore.getVoter().full_name);
   }
 
   getAppBaseClass = () => {

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -7,18 +7,19 @@ import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import Button from '@material-ui/core/Button';
 import BallotItemSupportOpposeCountDisplay from '../Widgets/BallotItemSupportOpposeCountDisplay';
 import BallotStore from '../../stores/BallotStore';
-import { historyPush } from '../../utils/cordovaUtils';
-import { toTitleCase } from '../../utils/textFormat';
 import CandidateStore from '../../stores/CandidateStore';
 import DelayedLoad from '../Widgets/DelayedLoad';
 import ImageHandler from '../ImageHandler';
 import IssuesByBallotItemDisplayList from '../Values/IssuesByBallotItemDisplayList';
-import { renderLog } from '../../utils/logging';
 import OfficeActions from '../../actions/OfficeActions';
-import { sortCandidateList } from '../../utils/positionFunctions';
 import ShowMoreFooter from '../Navigation/ShowMoreFooter';
 import SupportStore from '../../stores/SupportStore';
 import TopCommentByBallotItem from '../Widgets/TopCommentByBallotItem';
+import { historyPush } from '../../utils/cordovaUtils';
+import { renderLog } from '../../utils/logging';
+import { sortCandidateList } from '../../utils/positionFunctions';
+import { toTitleCase } from '../../utils/textFormat';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 
 const NUMBER_OF_CANDIDATES_TO_DISPLAY = 4;
 
@@ -121,67 +122,70 @@ class OfficeItemCompressed extends Component {
   }
 
   onCandidateStoreChange () {
-    const { candidateList, officeWeVoteId } = this.props;
-    // console.log('OfficeItemCompressed onCandidateStoreChange', officeWeVoteId);
-    let changeFound = false;
-    if (candidateList && candidateList.length && officeWeVoteId) {
-      if (officeWeVoteId &&
-        !this.localPositionListHasBeenRetrievedOnce(officeWeVoteId) &&
-        !BallotStore.positionListHasBeenRetrievedOnce(officeWeVoteId)
-      ) {
-        OfficeActions.positionListForBallotItemPublic(officeWeVoteId);
-        const { positionListHasBeenRetrievedOnce } = this.state;
-        positionListHasBeenRetrievedOnce[officeWeVoteId] = true;
-        this.setState({
-          positionListHasBeenRetrievedOnce,
-        });
-      }
-      if (officeWeVoteId &&
-        !this.localPositionListFromFriendsHasBeenRetrievedOnce(officeWeVoteId) &&
-        !BallotStore.positionListFromFriendsHasBeenRetrievedOnce(officeWeVoteId)
-      ) {
-        OfficeActions.positionListForBallotItemFromFriends(officeWeVoteId);
-        const { positionListFromFriendsHasBeenRetrievedOnce } = this.state;
-        positionListFromFriendsHasBeenRetrievedOnce[officeWeVoteId] = true;
-        this.setState({
-          positionListFromFriendsHasBeenRetrievedOnce,
-        });
-      }
-      const newCandidateList = [];
-      let newCandidate = {};
-      if (candidateList) {
-        candidateList.forEach((candidate) => {
-          if (candidate && candidate.we_vote_id) {
-            newCandidate = CandidateStore.getCandidate(candidate.we_vote_id);
-            if (newCandidate && newCandidate.we_vote_id) {
-              newCandidateList.push(newCandidate);
+    if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+      // console.log('OfficeItemCompressed, onCandidateStoreChange');
+      const { candidateList, officeWeVoteId } = this.props;
+      // console.log('OfficeItemCompressed onCandidateStoreChange', officeWeVoteId);
+      let changeFound = false;
+      if (candidateList && candidateList.length && officeWeVoteId) {
+        if (officeWeVoteId &&
+          !this.localPositionListHasBeenRetrievedOnce(officeWeVoteId) &&
+          !BallotStore.positionListHasBeenRetrievedOnce(officeWeVoteId)
+        ) {
+          OfficeActions.positionListForBallotItemPublic(officeWeVoteId);
+          const { positionListHasBeenRetrievedOnce } = this.state;
+          positionListHasBeenRetrievedOnce[officeWeVoteId] = true;
+          this.setState({
+            positionListHasBeenRetrievedOnce,
+          });
+        }
+        if (officeWeVoteId &&
+          !this.localPositionListFromFriendsHasBeenRetrievedOnce(officeWeVoteId) &&
+          !BallotStore.positionListFromFriendsHasBeenRetrievedOnce(officeWeVoteId)
+        ) {
+          OfficeActions.positionListForBallotItemFromFriends(officeWeVoteId);
+          const { positionListFromFriendsHasBeenRetrievedOnce } = this.state;
+          positionListFromFriendsHasBeenRetrievedOnce[officeWeVoteId] = true;
+          this.setState({
+            positionListFromFriendsHasBeenRetrievedOnce,
+          });
+        }
+        const newCandidateList = [];
+        let newCandidate = {};
+        if (candidateList) {
+          candidateList.forEach((candidate) => {
+            if (candidate && candidate.we_vote_id) {
+              newCandidate = CandidateStore.getCandidate(candidate.we_vote_id);
+              if (newCandidate && newCandidate.we_vote_id) {
+                newCandidateList.push(newCandidate);
+              } else {
+                newCandidateList.push(candidate);
+              }
+              if (!changeFound) {
+                if (candidate.ballot_item_display_name !== newCandidate.ballot_item_display_name) {
+                  changeFound = true;
+                }
+                if (candidate.candidate_photo_url_medium !== newCandidate.candidate_photo_url_medium) {
+                  changeFound = true;
+                }
+                if (candidate.party !== newCandidate.party) {
+                  changeFound = true;
+                }
+              }
             } else {
               newCandidateList.push(candidate);
             }
-            if (!changeFound) {
-              if (candidate.ballot_item_display_name !== newCandidate.ballot_item_display_name) {
-                changeFound = true;
-              }
-              if (candidate.candidate_photo_url_medium !== newCandidate.candidate_photo_url_medium) {
-                changeFound = true;
-              }
-              if (candidate.party !== newCandidate.party) {
-                changeFound = true;
-              }
-            }
-          } else {
-            newCandidateList.push(candidate);
-          }
+          });
+        }
+        let sortedCandidateList = {};
+        if (newCandidateList && newCandidateList.length) {
+          sortedCandidateList = sortCandidateList(newCandidateList);
+        }
+        this.setState({
+          candidateList: sortedCandidateList,
+          // changeFound,
         });
       }
-      let sortedCandidateList = {};
-      if (newCandidateList && newCandidateList.length) {
-        sortedCandidateList = sortCandidateList(newCandidateList);
-      }
-      this.setState({
-        candidateList: sortedCandidateList,
-        // changeFound,
-      });
     }
   }
 

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -14,6 +14,7 @@ import SettingsAccount from '../Settings/SettingsAccount';
 import VoterStore from '../../stores/VoterStore';
 import { validatePhoneOrEmail } from '../../utils/regex-checks';
 import { renderLog } from '../../utils/logging';
+import { prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
 
 class AddFriendsByEmail extends Component {
   static propTypes = {
@@ -40,6 +41,7 @@ class AddFriendsByEmail extends Component {
       voter: {},
       voterIsSignedIn: false,
     };
+    prepareForCordovaKeyboard('AddFriendsByEmail');
     this.addFriend = this.addFriend.bind(this);
     this.cacheFriendData = this.cacheFriendData.bind(this);
   }
@@ -58,6 +60,7 @@ class AddFriendsByEmail extends Component {
   }
 
   componentWillUnmount () {
+    restoreStylesAfterCordovaKeyboard('AddFriendsByEmail');
     this.friendStoreListener.remove();
     this.voterStoreListener.remove();
   }
@@ -123,6 +126,7 @@ class AddFriendsByEmail extends Component {
         loading: false,
         onEnterEmailAddressesStep: false,
       });
+      restoreStylesAfterCordovaKeyboard('AddFriendsByEmail');
       this.friendInvitationByEmailSend(event);
     }
   };
@@ -198,6 +202,7 @@ class AddFriendsByEmail extends Component {
       invitationEmailsAlreadyScheduledStep: false,
       onFriendInvitationsSentStep: true,
     });
+    prepareForCordovaKeyboard('AddFriendsByEmail');
   }
 
   addFriend () {
@@ -237,6 +242,7 @@ class AddFriendsByEmail extends Component {
       invitationEmailsAlreadyScheduledStep, loading,
       onEnterEmailAddressesStep, onFriendInvitationsSentStep, senderEmailAddressError, voterIsSignedIn,
     } = this.state;
+
     // console.log(friendsToInvite);
     const atLeastOneValidated = friendsToInvite.length !== 0 || validatePhoneOrEmail(this.state.friendContactInfo);
 

--- a/src/js/components/Friends/FriendsShareList.jsx
+++ b/src/js/components/Friends/FriendsShareList.jsx
@@ -59,6 +59,7 @@ class FriendShareList extends Component {
         </FormGroup>
         <br />
         <br />
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
         <label htmlFor="message"><strong>Add Personal Message</strong></label>
         <textarea name="message" id="message" className="full-width" rows="5" />
         <br />

--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -14,6 +14,7 @@ import { historyPush, isCordova, cordovaOpenSafariView } from '../../utils/cordo
 import { stringContains } from '../../utils/textFormat';
 import FriendStore from '../../stores/FriendStore';
 import { renderLog } from '../../utils/logging';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 
 
 class FooterBar extends React.Component {
@@ -41,9 +42,12 @@ class FooterBar extends React.Component {
   }
 
   onFriendStoreChange () {
-    this.setState({
-      friendInvitationsSentToMe: FriendStore.friendInvitationsSentToMe(), // eslint-disable-line react/no-unused-state
-    });
+    if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+      // console.log('FooterBar, onFriendStoreChange');
+      this.setState({
+        friendInvitationsSentToMe: FriendStore.friendInvitationsSentToMe(), // eslint-disable-line react/no-unused-state
+      });
+    }
   }
 
   handleChange = (event, value) => {

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -32,6 +32,7 @@ import { shortenText, stringContains } from '../../utils/textFormat';
 import shouldHeaderRetreat from '../../utils/shouldHeaderRetreat';
 import displayFriendsTabs from '../../utils/displayFriendsTabs';
 import ShareModal from '../Ballot/ShareModal';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 
 // const webAppConfig = require('../../config');
 
@@ -203,6 +204,7 @@ class HeaderBar extends Component {
   }
 
   onAppStoreChange () {
+    // console.log('HeaderBar, onAppStoreChange');
     const paidAccountUpgradeMode = AppStore.showPaidAccountUpgradeModal() || '';
     // console.log('HeaderBar paidAccountUpgradeMode:', paidAccountUpgradeMode);
     const showPaidAccountUpgradeModal = paidAccountUpgradeMode && paidAccountUpgradeMode !== '';
@@ -222,23 +224,29 @@ class HeaderBar extends Component {
   }
 
   onFriendStoreChange () {
-    this.setState({
-      friendInvitationsSentToMe: FriendStore.friendInvitationsSentToMe(),
-    });
+    if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+      // console.log('HeaderBar, onFriendStoreChange');
+      this.setState({
+        friendInvitationsSentToMe: FriendStore.friendInvitationsSentToMe(),
+      });
+    }
   }
 
   onVoterStoreChange () {
-    const voter = VoterStore.getVoter();
-    const voterFirstName = VoterStore.getFirstName();
-    const voterIsSignedIn = voter.is_signed_in || false;
+    if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+      // console.log('HeaderBar, onVoterStoreChange'};
+      const voter = VoterStore.getVoter();
+      const voterFirstName = VoterStore.getFirstName();
+      const voterIsSignedIn = voter.is_signed_in || false;
 
-    this.setState({
-      voter,
-      voterFirstName,
-      voterIsSignedIn,
-      showSignInModal: AppStore.showSignInModal(),
-      showShareModal: AppStore.showShareModal(),
-    });
+      this.setState({
+        voter,
+        voterFirstName,
+        voterIsSignedIn,
+        showSignInModal: AppStore.showSignInModal(),
+        showShareModal: AppStore.showShareModal(),
+      });
+    }
   }
 
   getSelectedTab = () => {

--- a/src/js/components/Navigation/HeaderBarProfilePopUp.jsx
+++ b/src/js/components/Navigation/HeaderBarProfilePopUp.jsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router';
 import styled from 'styled-components';
 import { withStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
-import { isCordova, isWebApp } from '../../utils/cordovaUtils';
+import { isCordova, isWebApp, restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 
 class HeaderBarProfilePopUp extends Component {
@@ -27,6 +27,10 @@ class HeaderBarProfilePopUp extends Component {
     this.toggleProfilePopUp = this.props.toggleProfilePopUp.bind(this);
     this.toggleSignInModal = this.props.toggleSignInModal.bind(this);
     this.transitionToYourVoterGuide = this.props.transitionToYourVoterGuide.bind(this);
+  }
+
+  componentWillUnmount () {
+    restoreStylesAfterCordovaKeyboard('HeaderBarProfilePopUp');
   }
 
   signInFromPopUp = () => {

--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -8,8 +8,9 @@ import AnalyticsActions from '../../actions/AnalyticsActions';
 import AppActions from '../../actions/AppActions';
 import AppStore from '../../stores/AppStore';
 import BrowserPushMessage from '../Widgets/BrowserPushMessage';
-import { cordovaSignInModalTopPosition } from '../../utils/cordovaOffsets';
-import { isCordova, isIOS } from '../../utils/cordovaUtils';
+import { historyPush, isCordova, isIPhone4in, isIPhone4p7in, isWebApp,
+  restoreStylesAfterCordovaKeyboard,
+} from '../../utils/cordovaUtils';
 import FacebookActions from '../../actions/FacebookActions';
 import FacebookStore from '../../stores/FacebookStore';
 import FacebookSignIn from '../Facebook/FacebookSignIn';
@@ -23,6 +24,7 @@ import VoterEmailAddressEntry from './VoterEmailAddressEntry';
 import VoterSessionActions from '../../actions/VoterSessionActions';
 import VoterStore from '../../stores/VoterStore';
 import VoterPhoneVerificationEntry from './VoterPhoneVerificationEntry';
+import VoterPhoneEmailCordovaEntryModal from './VoterPhoneEmailCordovaEntryModal';
 
 /* global $ */
 
@@ -42,6 +44,7 @@ export default class SettingsAccount extends Component {
     this.state = {
       facebookAuthResponse: {},
       hideCurrentlySignedInHeader: false,
+      hideDialogForCordova: false,
       hideFacebookSignInButton: false,
       hideTwitterSignInButton: false,
       hideVoterEmailAddressEntry: false,
@@ -56,6 +59,7 @@ export default class SettingsAccount extends Component {
     this.toggleTwitterDisconnectClose = this.toggleTwitterDisconnectClose.bind(this);
     this.toggleTwitterDisconnectOpen = this.toggleTwitterDisconnectOpen.bind(this);
     this.voterSplitIntoTwoAccounts = this.voterSplitIntoTwoAccounts.bind(this);
+    this.hideDialogForCordovaLocal = this.hideDialogForCordovaLocal.bind(this);
   }
 
   // See https://reactjs.org/docs/error-boundaries.html
@@ -136,6 +140,33 @@ export default class SettingsAccount extends Component {
     }, delayBeforeClearingStatus);
   }
 
+  componentDidUpdate () {
+    if (isCordova()) {
+      const sendButtonSMS = $('#voterPhoneSendSMS');
+      const sendButtonEmail = $('#voterEmailAddressEntrySendCode');
+      const cont = $('.MuiDialog-container');
+      const styleWorking = cont.length ? $(cont).attr('style') : '';
+      const translate = isIPhone4in() || isIPhone4p7in() ? 'transform: translateY(10%);' : 'transform: translateY(27%);';
+
+      // The VoterPhoneEmailCordovaEntryModal dialog gets pushed out of the way when the virtual keyboard appears,
+      // so we wait for it to be rendered, then move it into place
+
+      if (sendButtonSMS.length) {
+        console.log('SettingsAccount componentDidUpdate SEND CODE was rendered. sendButtonSMS:', sendButtonSMS);
+      } else if ((sendButtonSMS.length)) {
+        console.log('SettingsAccount componentDidUpdate SEND CODE was rendered. sendButtonEmail:', sendButtonEmail);
+      }
+      if (sendButtonSMS.length || sendButtonSMS.length) {
+        if (styleWorking && !stringContains(translate, styleWorking)) {
+          $(cont).attr('style', `${styleWorking} ${translate}`);
+          console.log(`SettingsAccount componentDidUpdate was rendered. NEW style: ${$(cont).attr('style')}`);
+        } else {
+          console.log(`SettingsAccount componentDidUpdate was rendered. transform was already there. style: ${$(cont).attr('style')}`);
+        }
+      }
+    }
+  }
+
   componentWillUnmount () {
     // console.log("SignIn ---- UN mount");
     this.appStoreListener.remove();
@@ -145,6 +176,7 @@ export default class SettingsAccount extends Component {
       clearTimeout(this.timer);
       this.timer = null;
     }
+    restoreStylesAfterCordovaKeyboard('SettingsAccount');
   }
 
   onAppStoreChange () {
@@ -230,11 +262,24 @@ export default class SettingsAccount extends Component {
     }
   }
 
+  hideDialogForCordovaLocal () {
+    if (!this.state.hideDialogForCordova) {
+      this.setState({ hideDialogForCordova: true });
+      $('.MuiDialog-paperScrollPaper').css('display', 'none');  // Manually hide the underlying dialog title
+    }
+  }
+
   twitterLogOutOnKeyDown (event) {
     const enterAndSpaceKeyCodes = [13, 32];
     if (enterAndSpaceKeyCodes.includes(event.keyCode)) {
       TwitterActions.appLogout();
     }
+  }
+
+  signOut () {
+    // console.log('SettingsAccount.jsx signOut');
+    VoterSessionActions.voterSignOut();
+    historyPush('/ballot');
   }
 
   render () {
@@ -243,7 +288,7 @@ export default class SettingsAccount extends Component {
     const {
       facebookAuthResponse, hideCurrentlySignedInHeader, hideFacebookSignInButton, hideTwitterSignInButton,
       hideVoterEmailAddressEntry, hideVoterPhoneEntry, isOnWeVoteRootUrl, isOnWeVoteSubdomainUrl,
-      isOnFacebookSupportedDomainUrl, pleaseSignInTitle, pleaseSignInSubTitle, voter,
+      isOnFacebookSupportedDomainUrl, pleaseSignInTitle, pleaseSignInSubTitle, voter, hideDialogForCordova,
     } = this.state;
     if (!voter) {
       return LoadingWheel;
@@ -256,6 +301,7 @@ export default class SettingsAccount extends Component {
     } = voter;
     // console.log("SettingsAccount.jsx facebookAuthResponse:", facebookAuthResponse);
     // console.log("SettingsAccount.jsx voter:", voter);
+    // console.log('SettingsAccount.jsx hideDialogForCordova:', hideDialogForCordova);
     if (!voterIsSignedInFacebook && facebookAuthResponse && facebookAuthResponse.length && facebookAuthResponse.facebook_retrieve_attempted) {
       // console.log('SettingsAccount.jsx facebook_retrieve_attempted');
       oAuthLog('SettingsAccount facebook_retrieve_attempted');
@@ -277,31 +323,13 @@ export default class SettingsAccount extends Component {
       }
     }
 
-    if (isCordova()) {
-      // The dialog fades in, so it will not be there on the initial passes through this render() function
-      const dlg = $('[class*="SignInModal-dialogRoot-"]');
-      if (dlg.length) {
-        const collapse = hideVoterEmailAddressEntry === true;
-        // console.log("cordovaSignInModalTopPosition(collapse): ", cordovaSignInModalTopPosition(collapse));
-        // console.log("cordovaSignInModalTopPosition -- collapse: ", collapse);
-        const topStyle = `z-index: 1300; top: ${cordovaSignInModalTopPosition(collapse)}`;
-        $(dlg).attr('style', topStyle);
-        if (isIOS()) {
-          const container = $('.MuiDialog-container');
-          if (collapse) {
-            $(container).attr('style', `${$(container).attr('style')}; height: 240px; transform: translateY(2%);`);
-          } else {
-            $(container).attr('style', $(container).attr('style').replace('height: 240px; transform: translateY(2%);', ''));
-          }
-        }
-      }
-    }
-
     return (
       <>
         <Helmet title={pageTitle} />
-        <BrowserPushMessage incomingProps={this.props} />
-        <div className={inModal ? 'card-main full-width' : 'card'}>
+        {!hideDialogForCordova &&
+          <BrowserPushMessage incomingProps={this.props} />
+        }
+        <div className={inModal ? 'card-main full-width' : 'card'} style={{ display: `${hideDialogForCordova ? ' none' : 'undefined'}` }}>
           <Main inModal={inModal}>
             {voterIsSignedInTwitter && voterIsSignedInFacebook ?
               null :
@@ -325,7 +353,7 @@ export default class SettingsAccount extends Component {
                 }
               </div>
             )}
-            {!voterIsSignedInTwitter || !voterIsSignedInFacebook ? (
+            {(!voterIsSignedInTwitter || !voterIsSignedInFacebook) && !hideDialogForCordova ? (
               <>
                 <div className="u-stack--md">
                   { !hideTwitterSignInButton && !voterIsSignedInTwitter && (isOnWeVoteRootUrl || isOnWeVoteSubdomainUrl) && (
@@ -356,14 +384,14 @@ export default class SettingsAccount extends Component {
               </>
             ) : null
             }
-            {voterIsSignedIn ? (
+            {voterIsSignedIn && !hideDialogForCordova ? (
               <div className="u-stack--md">
                 {!hideCurrentlySignedInHeader && (
                   <div className="u-stack--sm">
                     <span className="h3">Currently Signed In</span>
                     <span className="u-margin-left--sm" />
                     <span className="account-edit-action" onKeyDown={this.twitterLogOutOnKeyDown.bind(this)}>
-                      <span className="pull-right" onClick={VoterSessionActions.voterSignOut}>sign out</span>
+                      <span className="pull-right" onClick={this.signOut.bind(this)}>sign out</span>
                     </span>
                   </div>
                 )}
@@ -429,18 +457,36 @@ export default class SettingsAccount extends Component {
               </div>
             ) : null
             }
-            {!hideVoterPhoneEntry && (
+            {!hideVoterPhoneEntry && isWebApp() && (
               <VoterPhoneVerificationEntry
                 closeSignInModal={this.localCloseSignInModal}
                 inModal={inModal}
                 toggleOtherSignInOptions={this.toggleNonPhoneSignInOptions}
               />
             )}
-            {!hideVoterEmailAddressEntry && (
+            {!hideVoterPhoneEntry && isCordova() && (
+              <VoterPhoneEmailCordovaEntryModal
+                closeSignInModal={this.localCloseSignInModal}
+                inModal={inModal}
+                toggleOtherSignInOptions={this.toggleNonPhoneSignInOptions}
+                isPhone
+                hideDialogForCordova={this.hideDialogForCordovaLocal}
+              />
+            )}
+            {!hideVoterEmailAddressEntry && isWebApp() && (
               <VoterEmailAddressEntry
                 closeSignInModal={this.localCloseSignInModal}
                 inModal={inModal}
                 toggleOtherSignInOptions={this.toggleNonEmailSignInOptions}
+              />
+            )}
+            {!hideVoterEmailAddressEntry && isCordova() && (
+              <VoterPhoneEmailCordovaEntryModal
+                closeSignInModal={this.localCloseSignInModal}
+                inModal={inModal}
+                toggleOtherSignInOptions={this.toggleNonPhoneSignInOptions}
+                isPhone={false}
+                hideDialogForCordova={this.hideDialogForCordovaLocal}
               />
             )}
             {debugMode && (

--- a/src/js/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/components/Settings/SettingsVerifySecretCode.jsx
@@ -101,7 +101,9 @@ class SettingsVerifySecretCode extends Component {
   onVoterStoreChange () {
     const secretCodeVerificationStatus = VoterStore.getSecretCodeVerificationStatus();
     const { incorrectSecretCodeEntered, numberOfTriesRemaining, secretCodeVerified, voterMustRequestNewCode, voterSecretCodeRequestsLocked } = secretCodeVerificationStatus;
+    // console.log('onVoterStoreChange secretCodeVerified: ' + secretCodeVerified);
     if (secretCodeVerified) {
+      // console.log('onVoterStoreChange secretCodeVerified: yes');
       this.closeVerifyModalLocal();
     } else {
       let errorMessageToDisplay = '';
@@ -347,6 +349,7 @@ class SettingsVerifySecretCode extends Component {
   };
 
   closeVerifyModalLocal = () => {
+    // console.log('voterVerifySecretCode this.props.closeVerifyModal:', this.props.closeVerifyModal);
     if (this.props.closeVerifyModal) {
       this.props.closeVerifyModal();
     }
@@ -356,7 +359,7 @@ class SettingsVerifySecretCode extends Component {
     const { digit1, digit2, digit3, digit4, digit5, digit6, voterPhoneNumber } = this.state;
     this.setState({ condensed: false });
     if (digit6 && isCordova()) {
-      // When their is a voterEmailAddress value and the keyboard closes, submit
+      // Jan 2020 this comment looks wrong, but might still contain a clue:  When there is a voterEmailAddress value and the keyboard closes, submit
       const secretCode = `${digit1}${digit2}${digit3}${digit4}${digit5}${digit6}`;
       const codeSentToSMSPhoneNumber = !!voterPhoneNumber;
       VoterActions.voterVerifySecretCode(secretCode, codeSentToSMSPhoneNumber);

--- a/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
+++ b/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
@@ -1,0 +1,125 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import MessageIcon from '@material-ui/icons/Message';
+import MailOutlineIcon from '@material-ui/icons/MailOutline';
+import { withStyles, withTheme } from '@material-ui/core/styles';
+import { renderLog } from '../../utils/logging';
+import VoterPhoneVerificationEntry from './VoterPhoneVerificationEntry';
+import SplitIconButton from '../Widgets/SplitIconButton';
+import VoterEmailAddressEntry from './VoterEmailAddressEntry';
+import { restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
+
+
+// Work around for dialog placement in Cordova when virtual keyboard appears
+class VoterPhoneEmailCordovaEntryModal extends Component {
+  static propTypes = {
+    // classes: PropTypes.object,
+    closeSignInModal: PropTypes.func,
+    // inModal: PropTypes.bool,
+    // toggleOtherSignInOptions: PropTypes.func,
+    isPhone: PropTypes.bool,
+    hideDialogForCordova: PropTypes.func,
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      showDialog: false,
+    };
+    this.closeSignInModalLocal = this.closeSignInModalLocal.bind(this);
+  }
+
+  setDialogVisible () {
+    console.log('VoterPhoneEmailCordovaEntryModal setDialogVisible');
+    this.setState({
+      showDialog: true,
+    });
+    this.props.hideDialogForCordova();
+  }
+
+  closeSignInModalLocal () {
+    console.log('VoterPhoneEmailCordovaEntryModal closeSignInModalLocal showDialog false ======================================');
+    // Because there are multiple listeners on the voterStore, some dispatching will occur for the underlying ballot page,
+    // which totally messes us up here, and leaves this modal on the screen after it should've been dismissed, especially on the iPhone 5.
+    // So as a workaround we close this modal when we detect that they have signed in successfully with the email,
+    // which requires this further hack, Which is sensitive to checking whether the modal actually still exists.
+    restoreStylesAfterCordovaKeyboard('VoterPhoneEmailCordovaEntryModal');
+
+    try {
+      console.log('VoterPhoneEmailCordovaEntryModal closeSignInModalLocal this.props valid');
+      this.props.closeSignInModal();
+    } catch (err) {
+      console.log('VoterPhoneVerificationEntryModal closeSignInModalLocal caught error: ', err);
+    }
+  }
+
+  render () {
+    renderLog('VoterPhoneVerificationEntryModal');  // Set LOG_RENDER_EVENTS to log all renders
+    const { showDialog } = this.state;
+    const { isPhone } = this.props;
+
+    return (
+      <React.Fragment>
+        <div className="u-stack--md">
+          <SplitIconButton
+            backgroundColor="#76d00b"
+            buttonText={isPhone ? 'Sign in with a text' : 'Sign in with an Email'}
+            externalUniqueId={isPhone ? 'smsSignIn' : 'emailSignIn'}
+            icon={isPhone ? <MessageIcon /> : <MailOutlineIcon />}
+            onClick={() => this.setDialogVisible()}
+            separatorColor="rgba(250, 250, 250, .6)"
+            title={isPhone ? 'Sign in by SMS' : 'Sign in by email'}
+          />
+        </div>
+        <Dialog
+          open={showDialog}
+        >
+          <DialogContent>
+            {isPhone ? (
+              <VoterPhoneVerificationEntry
+                closeSignInModal={this.closeSignInModalLocal}
+                inModal
+                // toggleOtherSignInOptions={this.props.toggleNonPhoneSignInOptions}
+              />
+            ) : (
+              <VoterEmailAddressEntry
+                closeSignInModal={this.closeSignInModalLocal}
+                inModal
+                // toggleOtherSignInOptions={this.props.toggleNonEmailSignInOptions}
+              />
+            )}
+          </DialogContent>
+        </Dialog>
+      </React.Fragment>
+    );
+  }
+}
+
+const styles = theme => ({
+  dialogPaper: {
+    marginTop: 48,
+    [theme.breakpoints.down('xs')]: {
+      minWidth: '95%',
+      maxWidth: '95%',
+      width: '95%',
+      minHeight: '90%',
+      maxHeight: '90%',
+      height: '90%',
+      margin: '0 auto',
+    },
+  },
+  dialogContent: {
+    [theme.breakpoints.down('md')]: {
+      padding: '0 8px 8px',
+    },
+  },
+  closeButton: {
+    position: 'absolute',
+    right: `${theme.spacing(1)}px`,
+    top: `${theme.spacing(1)}px`,
+  },
+});
+
+export default withTheme(withStyles(styles)(VoterPhoneEmailCordovaEntryModal));

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -9,7 +9,7 @@ import Paper from '@material-ui/core/Paper';
 import Phone from '@material-ui/icons/Phone';
 import InputBase from '@material-ui/core/InputBase';
 import Alert from 'react-bootstrap/Alert';
-import { isCordova } from '../../utils/cordovaUtils';
+import { isCordova, isWebApp } from '../../utils/cordovaUtils';
 import isMobileScreenSize from '../../utils/isMobileScreenSize';
 import LoadingWheel from '../LoadingWheel';
 import { renderLog } from '../../utils/logging';
@@ -17,6 +17,9 @@ import OpenExternalWebSite from '../Widgets/OpenExternalWebSite';
 import SettingsVerifySecretCode from './SettingsVerifySecretCode';
 import VoterActions from '../../actions/VoterActions';
 import VoterStore from '../../stores/VoterStore';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
+
+/* global $ */
 
 class VoterPhoneVerificationEntry extends Component {
   static propTypes = {
@@ -48,13 +51,17 @@ class VoterPhoneVerificationEntry extends Component {
     this.onPhoneNumberChange = this.onPhoneNumberChange.bind(this);
     this.sendSignInCodeSMS = this.sendSignInCodeSMS.bind(this);
     this.closeVerifyModal = this.closeVerifyModal.bind(this);
+    if (isCordova()) {
+      signInModalGlobalState.set('textOrEmailSignInInProcess', true);
+    }
   }
 
   componentDidMount () {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
-    // Steve 11/14/19: commenting out the next line: it is expensive and causes trouble in SignInModal, and is almost certainly not needed
-    // VoterActions.voterRetrieve();
     VoterActions.voterSMSPhoneNumberRetrieve();
+    if (isCordova()) {
+      $('#enterVoterPhone').focus();
+    }
   }
 
   shouldComponentUpdate (nextProps, nextState) {
@@ -120,7 +127,15 @@ class VoterPhoneVerificationEntry extends Component {
     const secretCodeVerificationStatus = VoterStore.getSecretCodeVerificationStatus();
     const { secretCodeVerified } = secretCodeVerificationStatus;
     // console.log('onVoterStoreChange smsPhoneNumberStatus:', smsPhoneNumberStatus);
-    if (secretCodeVerified) {
+    const voter = VoterStore.getVoter();
+    const { signed_in_with_email: signedInWithEmail, signed_in_facebook: signedInFacebook, signed_in_twitter: signedInTwitter } = voter;
+    // console.log(`VoterEmailAddressEntry onVoterStoreChange isSignedIn: ${isSignedIn}, signedInWithEmail: ${signedInWithEmail}`);
+    // TODO:  Why is there no "signed_in_with_sms"?  This is going to bite us someday, probably right here.
+    if (signedInWithEmail || signedInFacebook || signedInTwitter) {
+      // console.log('VoterEmailAddressEntry onVoterStoreChange signedInWithEmail so doing a hacky fallback close ===================');
+      this.closeSignInModal();
+      return;
+    } else if (secretCodeVerified) {
       this.setState({
         displayPhoneVerificationButton: false,
         showVerifyModal: false,
@@ -195,7 +210,7 @@ class VoterPhoneVerificationEntry extends Component {
   };
 
   closeSignInModal = () => {
-    // console.log('SettingsAccount localCloseSignInModal');
+    // console.log('VoterPhoneVerificationEntry closeSignInModal');
     if (this.props.closeSignInModal) {
       this.props.closeSignInModal();
     }
@@ -272,7 +287,23 @@ class VoterPhoneVerificationEntry extends Component {
       this.displayPhoneVerificationButton();
       this.turnOtherSignInOptionsOff();
     }
-  }
+  };
+
+  onAnimationEndCancel = () => {
+    // In Cordova when the virtual keyboard goes away, the on-click doesn't happen, but the onAnimation does.
+    // This allows us to react to the first click.
+    if (isCordova()) {
+      // console.log('VoterPhoneVerificationEntry onAnimationEndCancel calling onCancel');
+      this.onCancel();
+    }
+  };
+
+  onAnimationEndSend = () => {
+    if (isCordova()) {
+      // console.log('VoterPhoneVerificationEntry onAnimationEndSend calling sendSignInCodeSMS');
+      this.sendSignInCodeSMS();
+    }
+  };
 
   onKeyDown = (event) => {
     // console.log('onKeyDown, event.keyCode:', event.keyCode);
@@ -290,7 +321,7 @@ class VoterPhoneVerificationEntry extends Component {
       event.preventDefault();
       this.sendSignInCodeSMS(event);
     }
-  }
+  };
 
   reSendSignInCodeSMS = (voterSMSPhoneNumber) => {
     if (voterSMSPhoneNumber) {
@@ -305,15 +336,17 @@ class VoterPhoneVerificationEntry extends Component {
         voterSMSPhoneNumber,
       });
     }
-  }
+  };
 
   removeVoterSMSPhoneNumber (smsWeVoteId) {
     VoterActions.removeVoterSMSPhoneNumber(smsWeVoteId);
   }
 
   sendSignInCodeSMS (event) {
-    // console.log('sendSignInCodeSMS');
-    event.preventDefault();
+    console.log('sendSignInCodeSMS');
+    if (event) {
+      event.preventDefault();
+    }
     const { displayPhoneVerificationButton, voterSMSPhoneNumber, voterSMSPhoneNumberIsValid } = this.state;
     if (voterSMSPhoneNumberIsValid && displayPhoneVerificationButton) {
       VoterActions.sendSignInCodeSMS(voterSMSPhoneNumber);
@@ -394,7 +427,8 @@ class VoterPhoneVerificationEntry extends Component {
       </span>
     );
 
-    let enterSMSPhoneNumberTitle = 'Sign in with SMS Phone Number';
+    // "SMS" is techno jargon
+    let enterSMSPhoneNumberTitle = isWebApp() ? 'Sign in with SMS Phone Number' : 'Text the sign in code to';
     if (this.state.voter && this.state.voter.is_signed_in) {
       enterSMSPhoneNumberTitle = 'Add New Phone Number';
     }
@@ -435,6 +469,7 @@ class VoterPhoneVerificationEntry extends Component {
                   className={classes.cancelButton}
                   fullWidth
                   onClick={this.onCancel}
+                  onAnimationEnd={this.onAnimationEndCancel}
                   variant="outlined"
                 >
                   Cancel
@@ -447,6 +482,7 @@ class VoterPhoneVerificationEntry extends Component {
                   disabled={disablePhoneVerificationButton || signInCodeSMSSentAndWaitingForResponse}
                   id="voterPhoneSendSMS"
                   onClick={this.sendSignInCodeSMS}
+                  onAnimationEnd={() => this.onAnimationEndSend()}
                   variant="contained"
                 >
                   {signInCodeSMSSentAndWaitingForResponse ? 'Sending...' : (
@@ -560,11 +596,11 @@ class VoterPhoneVerificationEntry extends Component {
     });
 
     return (
-      <Wrapper>
+      <Wrapper isWeb={isWebApp()}>
         {!hideExistingPhoneNumbers ? (
           <div>
             {verifiedSMSFound && !this.props.inModal ? (
-              <PhoneNumberSection>
+              <PhoneNumberSection isWeb={isWebApp()}>
                 <span className="h3">
                   Your Phone Number
                   {smsPhoneNumberListCount > 1 ? 's' : ''}
@@ -578,7 +614,7 @@ class VoterPhoneVerificationEntry extends Component {
               </span>
             )}
             {unverifiedSMSFound && !this.props.inModal && (
-              <PhoneNumberSection>
+              <PhoneNumberSection isWeb={isWebApp()}>
                 <span className="h3">Phone Numbers to Verify</span>
                 {toVerifySMSListHtml}
               </PhoneNumberSection>
@@ -589,7 +625,7 @@ class VoterPhoneVerificationEntry extends Component {
             {smsPhoneNumberStatusHtml}
           </span>
         )}
-        <PhoneNumberSection>
+        <PhoneNumberSection isWeb={isWebApp()}>
           {enterSMSPhoneNumberHtml}
         </PhoneNumberSection>
         {showVerifyModal && (
@@ -644,11 +680,11 @@ const CancelButtonContainer = styled.div`
 `;
 
 const Wrapper = styled.div`
-  margin-top: 32px;
+  margin-top: ${({ isWeb }) => (isWeb ? '32px;' : '0')};
 `;
 
 const PhoneNumberSection = styled.div`
-  margin-top: 18px;
+  margin-top: ${({ isWeb }) => (isWeb ? '18px;' : '0')};
 `;
 
 const Error = styled.div`

--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -3,9 +3,10 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import IssueStore from '../../stores/IssueStore';
-import { renderLog } from '../../utils/logging';
 import ValueIconAndText from './ValueIconAndText';
 import VoterGuideStore from '../../stores/VoterGuideStore';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
+import { renderLog } from '../../utils/logging';
 
 // Show a voter a horizontal list of all of the issues they are following that relate to this ballot item
 class IssuesByBallotItemDisplayList extends Component {
@@ -119,22 +120,29 @@ class IssuesByBallotItemDisplayList extends Component {
   }
 
   onIssueStoreChange () {
-    const { ballotItemWeVoteId } = this.state;
-    const issuesUnderThisBallotItemVoterIsFollowing = IssueStore.getIssuesUnderThisBallotItemVoterIsFollowing(ballotItemWeVoteId) || [];
-    const issuesUnderThisBallotItemVoterIsNotFollowing = IssueStore.getIssuesUnderThisBallotItemVoterNotFollowing(ballotItemWeVoteId) || [];
-    const issuesUnderThisBallotItemVoterIsFollowingLength = issuesUnderThisBallotItemVoterIsFollowing.length;
-    const issuesUnderThisBallotItemVoterIsNotFollowingLength = issuesUnderThisBallotItemVoterIsNotFollowing.length;
-    this.setState({
-      issuesUnderThisBallotItemVoterIsFollowing,
-      issuesUnderThisBallotItemVoterIsNotFollowing,
-      issuesUnderThisBallotItemVoterIsFollowingLength,
-      issuesUnderThisBallotItemVoterIsNotFollowingLength,
-    });
+    if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+      // console.log('IssuesByBallotItemDisplayList, onIssueStoreChange');
+      const { ballotItemWeVoteId } = this.state;
+      const issuesUnderThisBallotItemVoterIsFollowing = IssueStore.getIssuesUnderThisBallotItemVoterIsFollowing(ballotItemWeVoteId) || [];
+      const issuesUnderThisBallotItemVoterIsNotFollowing = IssueStore.getIssuesUnderThisBallotItemVoterNotFollowing(ballotItemWeVoteId) || [];
+      const issuesUnderThisBallotItemVoterIsFollowingLength = issuesUnderThisBallotItemVoterIsFollowing.length;
+      const issuesUnderThisBallotItemVoterIsNotFollowingLength = issuesUnderThisBallotItemVoterIsNotFollowing.length;
+      this.setState({
+        issuesUnderThisBallotItemVoterIsFollowing,
+        issuesUnderThisBallotItemVoterIsNotFollowing,
+        issuesUnderThisBallotItemVoterIsFollowingLength,
+        issuesUnderThisBallotItemVoterIsNotFollowingLength,
+      });
+    }
   }
 
   onVoterGuideStoreChange () {
-    // We just want to trigger a re-render
-    this.setState();
+    if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+      // console.log('IssuesByBallotItemDisplayList, onVoterGuideStoreChange');
+
+      // We just want to trigger a re-render, if SignInModal is not in use
+      this.setState();
+    }
   }
 
   handleEnterHoverLocalArea = () => {

--- a/src/js/components/Widgets/BrowserPushMessage.jsx
+++ b/src/js/components/Widgets/BrowserPushMessage.jsx
@@ -46,6 +46,7 @@ class BrowserPushMessage extends Component {
     const { classes } = this.props;
     let { message, type } = this.state;
     const { name } = this.state;
+    // console.log(`BrowserPushMessage message: ${message}  type: ${type}`);
 
     if (name === 'test') {
       type = 'danger';

--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -11,13 +11,15 @@ import { withStyles, withTheme } from '@material-ui/core/styles';
 import { renderLog } from '../../utils/logging';
 import {
   isCordova,
-  isAndroidSizeSM, isAndroidSizeMD, isAndroidSizeLG, isAndroidSizeXL,
-  isIPhone3p5in, isIPhone4in, isIPhone4p7in, isIPhone5p5in, isIPhone5p8in, isIPhone6p1in, isIPhone6p5in,
   isWebAppHeight0to568, isWebAppHeight569to667, isWebAppHeight668to736, isWebAppHeight737to896,
-  isWebApp,
+  isWebApp, prepareForCordovaKeyboard, historyPush, restoreStylesAfterCordovaKeyboard,
 } from '../../utils/cordovaUtils';
 import SettingsAccount from '../Settings/SettingsAccount';
 import VoterStore from '../../stores/VoterStore';
+import { stringContains } from '../../utils/textFormat';
+import signInModalGlobalState from './signInModalGlobalState';
+
+/* global $ */
 
 class SignInModal extends Component {
   static propTypes = {
@@ -31,11 +33,31 @@ class SignInModal extends Component {
     this.state = {
       focusedOnSingleInputToggle: false,
     };
+    signInModalGlobalState.set('textOrEmailSignInInProcess', false);
   }
 
   componentDidMount () {
     this.onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
+    if (isCordova()) {
+      prepareForCordovaKeyboard('SignInModal');
+    }
+  }
+
+  componentDidUpdate () {
+    if (isCordova()) {
+      // Cordova really has trouble with animations on dialogs, while the visible area is being compressed to fit the software keyboard
+      // eslint-disable-next-line func-names
+      $('*').each(function () {
+        const styleWorking = $(this).attr('style');
+        if (styleWorking && stringContains('transition', styleWorking)) {
+          console.log(`SignInModal componentDidUpdate transition style removed before: ${styleWorking}`);
+          const cleaned = styleWorking.replace(/transition.*?;/, '');
+          $(this).attr('style', cleaned);
+          console.log(`SignInModal componentDidUpdate transition style removed after: ${cleaned}`);
+        }
+      });
+    }
   }
 
   componentWillUnmount () {
@@ -52,7 +74,10 @@ class SignInModal extends Component {
     const secretCodeVerificationStatus = VoterStore.getSecretCodeVerificationStatus();
     const { secretCodeVerified } = secretCodeVerificationStatus;
     if (secretCodeVerified) {
-      this.props.closeFunction();
+      if (isWebApp()) {
+        // In Cordova something else has already closed the dialog, so this has to be suppressed to avoid an error -- Jan 27, 2020 is this still needed?
+        this.props.closeFunction();
+      }
     } else {
       const voter = VoterStore.getVoter();
       this.setState({
@@ -73,8 +98,17 @@ class SignInModal extends Component {
   };
 
   closeFunction = () => {
+    // console.log('SignInModal closeFunction');
+    signInModalGlobalState.set('textOrEmailSignInInProcess', false);
+
     if (this.props.closeFunction) {
       this.props.closeFunction();
+    }
+
+    if (isCordova()) {
+      // console.log('closeFunction in SignInModal doing restoreStylesAfterCordovaKeyboard and historyPush');
+      restoreStylesAfterCordovaKeyboard('SignInModal');
+      historyPush('/ballot');
     }
   };
 
@@ -124,12 +158,12 @@ class SignInModal extends Component {
             [classes.emailInputWebApp737to896]: isWebAppHeight737to896() && focusedOnSingleInputToggle && focusedInputName === 'email',
             [classes.phoneInputWebApp737to896]: isWebAppHeight737to896() && focusedOnSingleInputToggle && focusedInputName === 'phone',
             // 2020-01-20 These are to be configured and are placeholders
-            [classes.emailInputCordovaSmall]: (isIPhone3p5in() || isAndroidSizeSM()) && focusedOnSingleInputToggle && focusedInputName === 'email',
-            [classes.phoneInputCordovaSmall]: (isIPhone3p5in() || isAndroidSizeSM()) && focusedOnSingleInputToggle && focusedInputName === 'phone',
-            [classes.emailInputCordovaMedium]: (isIPhone4in() || isIPhone4p7in() || isIPhone5p5in() || isIPhone5p8in() || isIPhone6p1in() || isAndroidSizeMD()) && focusedOnSingleInputToggle && focusedInputName === 'email',
-            [classes.phoneInputCordovaMedium]: (isIPhone4in() || isIPhone4p7in() || isIPhone5p5in() || isIPhone5p8in() || isIPhone6p1in() || isAndroidSizeMD()) && focusedOnSingleInputToggle && focusedInputName === 'phone',
-            [classes.emailInputCordovaLarge]: (isIPhone6p5in() || isAndroidSizeLG() || isAndroidSizeXL()) && focusedOnSingleInputToggle && focusedInputName === 'email',
-            [classes.phoneInputCordovaLarge]: (isIPhone6p5in() || isAndroidSizeLG() || isAndroidSizeXL()) && focusedOnSingleInputToggle && focusedInputName === 'phone',
+            // [classes.emailInputCordovaSmall]: (isIPhone3p5in() || isAndroidSizeSM()) && focusedOnSingleInputToggle && focusedInputName === 'email',
+            // [classes.phoneInputCordovaSmall]: (isIPhone3p5in() || isAndroidSizeSM()) && focusedOnSingleInputToggle && focusedInputName === 'phone',
+            // [classes.emailInputCordovaMedium]: (isIPhone4in() || isIPhone4p7in() || isIPhone5p5in() || isIPhone5p8in() || isIPhone6p1in() || isAndroidSizeMD()) && focusedOnSingleInputToggle && focusedInputName === 'email',
+            // [classes.phoneInputCordovaMedium]: (isIPhone4in() || isIPhone4p7in() || isIPhone5p5in() || isIPhone5p8in() || isIPhone6p1in() || isAndroidSizeMD()) && focusedOnSingleInputToggle && focusedInputName === 'phone',
+            // [classes.emailInputCordovaLarge]: (isIPhone6p5in() || isAndroidSizeLG() || isAndroidSizeXL()) && focusedOnSingleInputToggle && focusedInputName === 'email',
+            // [classes.phoneInputCordovaLarge]: (isIPhone6p5in() || isAndroidSizeLG() || isAndroidSizeXL()) && focusedOnSingleInputToggle && focusedInputName === 'phone',
           }),
           root: classes.dialogRoot,
         }}
@@ -181,15 +215,7 @@ be honored, Cordova tries to do the best it can, but sometimes it crashes and lo
 For Cordova eliminate as many fixed vertical dimensions as needed to avoid overconstraint.
 */
 const styles = theme => ({
-  dialogRoot: isWebApp() ? {
-    height: '100%',
-    // position: 'absolute !important', // Causes problem on Firefox
-    top: '-15%',
-    left: '0% !important',
-    right: 'unset !important',
-    bottom: 'unset !important',
-    width: '100%',
-  } : {
+  dialogRoot: {
     height: '100%',
     position: 'absolute !important',
     top: '-15%',
@@ -198,7 +224,24 @@ const styles = theme => ({
     bottom: 'unset !important',
     width: '100%',
   },
-  dialogPaper: isWebApp() ? {
+  // dialogRoot: isWebApp() ? {
+  //   height: '100%',
+  //   // position: 'absolute !important', // Causes problem on Firefox
+  //   top: '-15%',
+  //   left: '0% !important',
+  //   right: 'unset !important',
+  //   bottom: 'unset !important',
+  //   width: '100%',
+  // } : {
+  //   height: '100%',
+  //   position: 'absolute !important',
+  //   top: '-15%',
+  //   left: '0% !important',
+  //   right: 'unset !important',
+  //   bottom: 'unset !important',
+  //   width: '100%',
+  // },
+  dialogPaper: {
     [theme.breakpoints.down('sm')]: {
       minWidth: '95%',
       maxWidth: '95%',
@@ -207,26 +250,37 @@ const styles = theme => ({
       height: 'unset',
       margin: '0 auto',
     },
-  } : {
-    margin: '0 !important',
-    width: '95%',
-    height: 'unset',
-    maxHeight: '90%',
-    offsetHeight: 'unset !important',
-    top: '50%',
-    left: '50%',
-    right: 'unset !important',
-    bottom: 'unset !important',
-    position: 'absolute',
-    transform: 'translate(-50%, -25%)',
   },
-  focusedOnSingleInput: isWebApp() ? {
-    [theme.breakpoints.down('sm')]: {
-      position: 'absolute',
-      top: '75%',
-      left: '73%',
-    },
-  } : {},
+  // dialogPaper: isWebApp() ? {
+  //   [theme.breakpoints.down('sm')]: {
+  //     minWidth: '95%',
+  //     maxWidth: '95%',
+  //     width: '95%',
+  //     maxHeight: '90%',
+  //     height: 'unset',
+  //     margin: '0 auto',
+  //   },
+  // } : {
+  //   margin: '0 !important',
+  //   width: '95%',
+  //   height: 'unset',
+  //   maxHeight: '90%',
+  //   offsetHeight: 'unset !important',
+  //   top: '50%',
+  //   left: '50%',
+  //   right: 'unset !important',
+  //   bottom: 'unset !important',
+  //   position: 'absolute',
+  //   transform: 'translate(-50%, -58%)',
+  // },
+  // focusedOnSingleInput: isWebApp() ? {
+  //   [theme.breakpoints.down('sm')]: {
+  //     position: 'absolute',
+  //     top: '75%',
+  //     left: '73%',
+  //   },
+  // } : {},
+  focusedOnSingleInput: {},
   emailInputWebApp0to568: {
     [theme.breakpoints.down('sm')]: {
       transform: 'translate(-75%, -50%)',
@@ -257,24 +311,24 @@ const styles = theme => ({
       transform: 'translate(-75%, -55%)',
     },
   },
-  emailInputCordovaSmall: {
-    transform: 'translate(-75%, 47%)', // Works ok
-  },
-  phoneInputCordovaSmall: {
-    transform: 'translate(-75%, -25%)', // Works ok.  Verify is modal and needs to be scrolled to see the confirmation area.
-  },
-  emailInputCordovaMedium: {
-    transform: 'translate(-50%, -25%)', // Looks ok, verify page is full screen, and works well.  This does throw "Unable to simultaneously satisfy constraints", but does not crash iPhone 8
-  },
-  phoneInputCordovaMedium: {
-    transform: 'translate(-50%, -25%)', // Looks ok. dialog layout is a bit off.  Verify is modal and needs to be scrolled to see the confirmation area. This does throw "Unable to simultaneously satisfy constraints", but does not crash iPhone 8
-  },
-  emailInputCordovaLarge: {
-    transform: 'translate(-50%, 0%)', // Works ok.
-  },
-  phoneInputCordovaLarge: {
-    transform: 'translate(-50%, 0%)', // Looks ok. dialog layout is a bit off.  Verify is modal and needs to be scrolled to see the confirmation area. This does throw "Unable to simultaneously satisfy constraints", but does not crash iPhone XsMax
-  },                                  // On the iPad, Verify is modal and needs to be scrolled to see the confirmation area.
+  // emailInputCordovaSmall: {
+  //   transform: 'translate(-75%, 47%)',
+  // },
+  // phoneInputCordovaSmall: {
+  //   transform: 'translate(-75%, -25%)',
+  // },
+  // emailInputCordovaMedium: {
+  //   transform: 'translate(-50%, -58%)',
+  // },
+  // phoneInputCordovaMedium: {
+  //   transform: 'translate(-50%, 85%)',
+  // },
+  // emailInputCordovaLarge: {
+  //   transform: 'translate(-50%, 0%)',
+  // },
+  // phoneInputCordovaLarge: {
+  //   transform: 'translate(-50%, 0%)',
+  // },
   dialogContent: {
     [theme.breakpoints.down('md')]: {
       padding: '0 8px 8px',

--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -215,7 +215,15 @@ be honored, Cordova tries to do the best it can, but sometimes it crashes and lo
 For Cordova eliminate as many fixed vertical dimensions as needed to avoid overconstraint.
 */
 const styles = theme => ({
-  dialogRoot: {
+  dialogRoot: isWebApp() ? {
+    height: '100%',
+    // position: 'absolute !important', // Causes problem on Firefox
+    top: '-15%',
+    left: '0% !important',
+    right: 'unset !important',
+    bottom: 'unset !important',
+    width: '100%',
+  } : {
     height: '100%',
     position: 'absolute !important',
     top: '-15%',
@@ -224,24 +232,7 @@ const styles = theme => ({
     bottom: 'unset !important',
     width: '100%',
   },
-  // dialogRoot: isWebApp() ? {
-  //   height: '100%',
-  //   // position: 'absolute !important', // Causes problem on Firefox
-  //   top: '-15%',
-  //   left: '0% !important',
-  //   right: 'unset !important',
-  //   bottom: 'unset !important',
-  //   width: '100%',
-  // } : {
-  //   height: '100%',
-  //   position: 'absolute !important',
-  //   top: '-15%',
-  //   left: '0% !important',
-  //   right: 'unset !important',
-  //   bottom: 'unset !important',
-  //   width: '100%',
-  // },
-  dialogPaper: {
+  dialogPaper: isWebApp() ? {
     [theme.breakpoints.down('sm')]: {
       minWidth: '95%',
       maxWidth: '95%',
@@ -250,37 +241,26 @@ const styles = theme => ({
       height: 'unset',
       margin: '0 auto',
     },
+  } : {
+    margin: '0 !important',
+    width: '95%',
+    height: 'unset',
+    maxHeight: '90%',
+    offsetHeight: 'unset !important',
+    top: '50%',
+    left: '50%',
+    right: 'unset !important',
+    bottom: 'unset !important',
+    position: 'absolute',
+    transform: 'translate(-50%, -25%)',
   },
-  // dialogPaper: isWebApp() ? {
-  //   [theme.breakpoints.down('sm')]: {
-  //     minWidth: '95%',
-  //     maxWidth: '95%',
-  //     width: '95%',
-  //     maxHeight: '90%',
-  //     height: 'unset',
-  //     margin: '0 auto',
-  //   },
-  // } : {
-  //   margin: '0 !important',
-  //   width: '95%',
-  //   height: 'unset',
-  //   maxHeight: '90%',
-  //   offsetHeight: 'unset !important',
-  //   top: '50%',
-  //   left: '50%',
-  //   right: 'unset !important',
-  //   bottom: 'unset !important',
-  //   position: 'absolute',
-  //   transform: 'translate(-50%, -58%)',
-  // },
-  // focusedOnSingleInput: isWebApp() ? {
-  //   [theme.breakpoints.down('sm')]: {
-  //     position: 'absolute',
-  //     top: '75%',
-  //     left: '73%',
-  //   },
-  // } : {},
-  focusedOnSingleInput: {},
+  focusedOnSingleInput: isWebApp() ? {
+    [theme.breakpoints.down('sm')]: {
+      position: 'absolute',
+      top: '75%',
+      left: '73%',
+    },
+  } : {},
   emailInputWebApp0to568: {
     [theme.breakpoints.down('sm')]: {
       transform: 'translate(-75%, -50%)',

--- a/src/js/components/Widgets/signInModalGlobalState.js
+++ b/src/js/components/Widgets/signInModalGlobalState.js
@@ -1,11 +1,19 @@
 const simState = {
+  // Since SignInModal physically covers the UI where facebook error messages appear,
+  // we need to save some state here, so that the SignInModal dialog can retrieve it
+  // This global store is needed to set and read state info in the middle of a
+  // react dispatch (where a nested dispatch would cause an error to be thrown).
   waitingForFacebookApiCompletion: false,
+
+  // Since SignInModal physically covers the UI where all the store listeners are still running,
+  // we need to block those stores from setting state, and thereby closing the sign in model, because if that happens,
+  // any code that is necessary to run on propper close of the SignInModal won't execute.
+  //  As a result you end up with "ghost" dialogs still on the screen, or the dialog background still covering the
+  //  otherwise working ballot page, or close of dialog components attempting to change state which results in "dispatch within dispatch"
+  //  errors from React.
+  textOrEmailSignInInProcess: false,
 };
 
-// Since SignInModal physically covers the UI where facebook error messages appear,
-// we need to save some state here, so that the SignInModal dialog can retrieve it
-// This global store is needed to set and read state info in the middle of a
-// react dispatch (where a nested dispatch would cause an error to be thrown).
 export default {
   set (key, value) {
     simState[key] = value;

--- a/src/js/routes/Friends.jsx
+++ b/src/js/routes/Friends.jsx
@@ -483,6 +483,9 @@ class Friends extends Component {
       </Tabs>
     );
 
+    // friendsfallback 1/27 steve
+    // const friendsHeadClass = isWebApp() ? `friends__heading ${friendsHeaderUnpinned ? 'friends__heading__unpinned' : ''}` : 'friends-heading-cordova';
+
     return (
       <span>
         {displayFriendsTabs() ? (

--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -9,6 +9,7 @@ import OrganizationActions from '../actions/OrganizationActions';
 import { stringContains } from '../utils/textFormat';
 import VoterActions from '../actions/VoterActions'; // eslint-disable-line import/no-cycle
 import VoterGuideActions from '../actions/VoterGuideActions';
+import signInModalGlobalState from '../components/Widgets/signInModalGlobalState';
 
 class VoterStore extends ReduceStore {
   getInitialState () {
@@ -274,14 +275,6 @@ class VoterStore extends ReduceStore {
   }
 
   reduce (state, action) {
-    // 11/14/19, removed by Steve, not sure what this was trying to catch, but this is a bit of a red herring, since calls to the FaceBook api will not have these fields
-    // // Exit if we don't have a response. "success" is not required though -- we should deal with error conditions below.
-    // if (!action.res && !action.payload) {
-    //   // Note that
-    //   console.log('VoterStore, no action.res or action.payload received. (Check to see that this is even meant for VoterStore). action: ', action);
-    //   return state;
-    // }
-
     let facebookPhotoRetrieveLoopCount;
     let address;
     let currentVoterDeviceId;
@@ -567,11 +560,14 @@ class VoterStore extends ReduceStore {
         // }, delayBeforeApiCall);
         VoterActions.voterEmailAddressRetrieve();
         VoterActions.voterSMSPhoneNumberRetrieve();
-        FriendActions.currentFriends();
-        FriendActions.friendInvitationsSentByMe();
-        FriendActions.friendInvitationsSentToMe();
-        FriendActions.friendInvitationsProcessed();
-        BallotActions.voterBallotItemsRetrieve();
+        if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
+          // Cascading actions like this causes serious problems when you have a dialog with components that change stores.
+          FriendActions.currentFriends();
+          FriendActions.friendInvitationsSentByMe();
+          FriendActions.friendInvitationsSentToMe();
+          FriendActions.friendInvitationsProcessed();
+          BallotActions.voterBallotItemsRetrieve();
+        }
         return {
           ...state,
           emailSignInStatus: {

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -56,7 +56,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.candidateWild:   return '57px';
         case enums.ballotVote:      return isSignedIn ? '149px' : '148px';
         case enums.officeWild:      return '84px';
-        case enums.ballotSmHdrWild: return isSignedIn ? '161px' : '160px';
+        case enums.ballotSmHdrWild: return isSignedIn ? '144px' : '160px';
         case enums.ballotLgHdrWild: return showBallotDecisionsTabs() ? '52px' : '36px';
         case enums.moreAbout:       return '22px';
         case enums.moreTerms:       return '40px';
@@ -277,6 +277,10 @@ export function cordovaBallotFilterTopMargin () {
       }
       return '88px';
     } else if (isIPhone6p5in()) {
+      // friendsfallback 1/27 steve
+      // if (window.location.href.indexOf('/index.html#/friends/invite') > 0) {
+      //   return '0px';
+      // } else
       if (window.location.href.indexOf('/index.html#/friends') > 0) {
         return '79px';
       }
@@ -587,7 +591,7 @@ export function cordovaSignInModalTopPosition (collapsed) {
     } else if (isIPhone5p5in()) {             //  6 Plus, 7 Plus and 8 Plus
       return collapsed ? '-3%' : '-170px';
     } else if (isIPhone4p7in()) {             // 6, 7, 8
-      return collapsed ? '-3%' : '-24%';
+      return collapsed ? 'unset' : '-24%';
     } else if (isIPhone4in()) {               // SE
       return collapsed ? '30px' : '-18%';
     } else if (isIPad()) {
@@ -616,6 +620,13 @@ export function cordovaFriendsWrapper () {
       };
     }
     if (isIPhone6p5in()) {
+      // friendsfallback 1/27 steve
+      // if (window.location.href.indexOf('/index.html#/friends/invite') > 0) {
+      //   return {
+      //     paddingTop: '93px',
+      //     paddingBottom: '0px',
+      //   };
+      // }
       return {
         paddingTop: '81px',
         paddingBottom: '90px',

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -247,42 +247,6 @@ export function isIPhone6p5in () {
 export function isIPad () {
   if (isIOS()) {
     if (window.device.model.substring(0, 4) === 'iPad') {
-      // June 2019, save this, we will need it, if we need to distinguish between types of iPads
-      // window.device.model === 'iPad4,1'  ||  // iPad Air
-      // window.device.model === 'iPad4,2'  ||  // iPad Air
-      // window.device.model === 'iPad4,3'  ||  // iPad Air
-      // window.device.model === 'iPad5,3'  ||  // iPad Air 2
-      // window.device.model === 'iPad5,4'  ||  // iPad Air 2
-      // window.device.model === 'iPad6,7'  ||  // iPad Pro (12.9-inch)
-      // window.device.model === 'iPad6,8'  ||  // iPad Pro (12.9-inch)
-      // window.device.model === 'iPad6,3'  ||  // iPad Pro (9.7-inch)
-      // window.device.model === 'iPad6,4'  ||  // iPad Pro (9.7-inch)
-      // window.device.model === 'iPad6,11' ||  // iPad (5th generation)
-      // window.device.model === 'iPad6,12' ||  // iPad (5th generation)
-      // window.device.model === 'iPad7,1'  ||  // iPad Pro (12.9-inch) (2nd generation)
-      // window.device.model === 'iPad7,2'  ||  // iPad Pro (12.9-inch) (2nd generation)
-      // window.device.model === 'iPad7,3'  ||  // iPad Pro (10.5-inch)
-      // window.device.model === 'iPad7,4'  ||  // iPad Pro (10.5-inch)
-      // window.device.model === 'iPad7,5 ' ||  // iPad (6th generation)
-      // window.device.model === 'iPad7,6 ' ||  // iPad (6th generation)
-      // window.device.model === 'iPad8,1'  ||  // iPad Pro (11-inch)
-      // window.device.model === 'iPad8,2'  ||  // iPad Pro (11-inch)
-      // window.device.model === 'iPad8,3'  ||  // iPad Pro (11-inch)
-      // window.device.model === 'iPad8,4'  ||  // iPad Pro (11-inch)
-      // window.device.model === 'iPad8,5'  ||  // iPad Pro (11-inch)
-      // window.device.model === 'iPad8,6'  ||  // iPad Pro (11-inch)
-      // window.device.model === 'iPad8,5'  ||  // iPad Pro (12.9-inch) (3rd generation)
-      // window.device.model === 'iPad8,7'  ||  // iPad Pro (12.9-inch) (3rd generation)
-      // window.device.model === 'iPad8,8'  ||  // iPad Pro (12.9-inch) (3rd generation)
-      // window.device.model === 'iPad11,3' ||  // iPad Air (3rd generation)
-      // window.device.model === 'iPad11,4' ||  // iPad Air (3rd generation)
-      // window.device.model === 'iPad4,7'  ||  // iPad mini 3
-      // window.device.model === 'iPad4,8'  ||  // iPad mini 3
-      // window.device.model === 'iPad4,9'  ||  // iPad mini 3
-      // window.device.model === 'iPad5,1'  ||  // iPad mini 4
-      // window.device.model === 'iPad5,2'  ||  // iPad mini 4
-      // window.device.model === 'iPad11,1' ||  // iPad mini (5th generation)
-      // window.device.model === 'iPad11,2')) { // iPad mini (5th generation)
       logMatch('iPad', true);
       return true;
     } else {

--- a/src/sass/components/_friends.scss
+++ b/src/sass/components/_friends.scss
@@ -1,4 +1,5 @@
 $friends-padding-top: 50px;
+$friends-cordova-padding-top: 84px;
 
 .friends {
   // ===========================================
@@ -33,6 +34,20 @@ $friends-padding-top: 50px;
       padding-top: $space-none;
     }
   }
+}
+
+// friendsfallback 1/27 steve
+.friends-heading-cordova {
+  width: 100%;
+  background-color: $white;
+  border-bottom: 1px solid #aaa;
+  overflow: hidden;
+  position: fixed;
+  z-index: 1;
+  left: $space-none;
+  padding-top: $friends-cordova-padding-top;
+  transition: all 100ms ease-in-out 0s;
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, .2), 0 4px 5px 0 rgba(0, 0, 0, .14), 0 1px 10px 0 rgba(0, 0, 0, .12);
 }
 
 .invite-inputs {


### PR DESCRIPTION
There still are some minor visual glitches on the login sequence: the dialogs bounce around a little with data entry, and sometimes the send button has to be pressed twice.  But I did not want to wait, and get too far diverged from develop.
Maybe it's just the material IO dialog, but when the dialog uses a component that has an action that updates the store, it also updates all the stores for the underlying page. This is a problem because if the underlying page does a historyPush then you lose the dialog. Sometimes this works out fine by accident, but if there were some set up or take down that you needed to do in the dialog and it closes abruptly, the cleanup doesn't happen.  In case of Cordova, the bottom menu might not be restored when you come back, and other bad things can happen. There's also a problem where you can have top dialog doing a dispatch and the bottom dialog could be doing a dispatch at the same time during a store update -- then you get a "dispatch within a dispatch" error that often crashes the dialog.
Because you can't have two dispatches going at once, and it's not safe to set state to flag this condition, and you have to use the signInDialogGlobalState object to set a boolean, and then unfortunately go into all of the individual classes that would be responding to store updates and prevent them from udating state by using that boolean.
This problem is made many times worse by having actions that trigger other actions, since you have to block the cascading actions, that were intended for some other situation, and that have nothing to do with what you were doing in the dialog.  We really shouldn't have those cascading actions, they seemed easier at the time ,but they cause a lot of very difficult to debug troubles for others.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
