### PR TITLE
Android update, headers and hiding of footer menu for keyboard

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { getApplicationViewBooleans, polyfillObjectEntries, setZenDeskHelpVisibility } from './utils/applicationUtils';
 import cookies from './utils/cookies';
 import {
-  getToastClass, historyPush, isCordova, isWebApp,
+  getToastClass, historyPush, isCordova, isIOS, isWebApp,
   prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard,
 } from './utils/cordovaUtils';
 import { cordovaContainerMainOverride, cordovaScrollablePaneTopPadding, cordovaVoterGuideTopPadding } from './utils/cordovaOffsets';
@@ -67,7 +67,8 @@ class Application extends Component {
       window.addEventListener('scroll', this.handleWindowScroll);
     }
 
-    if (isCordova()) {
+    if (isIOS()) {
+      // Unfortunately this event only works on iOS, but fortunately it is most needed on iOS
       window.addEventListener('keyboardWillShow', () => {
         prepareForCordovaKeyboard('ballot');
       });

--- a/src/js/components/Ballot/BallotSearch.jsx
+++ b/src/js/components/Ballot/BallotSearch.jsx
@@ -7,7 +7,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import CloseIcon from '@material-ui/icons/Close';
 import styled from 'styled-components';
 import sortBy from 'lodash-es/sortBy';
-import { isCordova } from '../../utils/cordovaUtils';
+import { blurTextFieldAndroid, focusTextFieldAndroid, isCordova } from '../../utils/cordovaUtils';
 import addVoterGuideSearchPriority from '../../utils/addVoterGuideSearchPriority';
 import ballotSearchPriority from '../../utils/ballotSearchPriority';
 
@@ -127,6 +127,8 @@ class BallotSearch extends Component {
           inputRef={(input) => { this.searchInput = input; }}
           onChange={this.handleSearch}
           value={searchValue}
+          onFocus={focusTextFieldAndroid}
+          onBlur={blurTextFieldAndroid}
           placeholder="Search"
         />
         <Closer isSearching={isSearching} showCloser={showCloser} brandBlue={theme.palette.primary.main}>

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -14,6 +14,8 @@ import SettingsAccount from '../Settings/SettingsAccount';
 import VoterStore from '../../stores/VoterStore';
 import { validatePhoneOrEmail } from '../../utils/regex-checks';
 import { renderLog } from '../../utils/logging';
+import { focusTextFieldAndroid, blurTextFieldAndroid } from '../../utils/cordovaUtils';
+
 
 class AddFriendsByEmail extends Component {
   static propTypes = {
@@ -249,6 +251,7 @@ class AddFriendsByEmail extends Component {
     return voter !== undefined ? voter.has_valid_email : false;
   }
 
+
   render () {
     renderLog('AddFriendsByEmail');  // Set LOG_RENDER_EVENTS to log all renders
     const { inSideColumn } = this.props;
@@ -338,6 +341,8 @@ class AddFriendsByEmail extends Component {
                         name="friendContactInfo"
                         value={friendContactInfo}
                         onChange={this.cacheFriendData}
+                        onFocus={focusTextFieldAndroid}
+                        onBlur={blurTextFieldAndroid}
                         placeholder="For example: name@domain.com"
                       />
                       <div className="row">
@@ -354,6 +359,8 @@ class AddFriendsByEmail extends Component {
                             name="friendFirstName"
                             value={friendFirstName}
                             onChange={this.cacheFriendData}
+                            onFocus={focusTextFieldAndroid}
+                            onBlur={blurTextFieldAndroid}
                             placeholder={isMobileScreenSize() || inSideColumn ? 'Optional' : 'Optional, but helpful!'}
                           />
                         </div>
@@ -370,6 +377,8 @@ class AddFriendsByEmail extends Component {
                             name="friendLastName"
                             value={friendLastName}
                             onChange={this.cacheFriendData}
+                            onFocus={focusTextFieldAndroid}
+                            onBlur={blurTextFieldAndroid}
                             placeholder="Optional"
                           />
                         </div>
@@ -387,6 +396,8 @@ class AddFriendsByEmail extends Component {
                             name="addFriendsMessage"
                             onChange={this.cacheAddFriendsByEmailMessage}
                             fullWidth
+                            onFocus={focusTextFieldAndroid}
+                            onBlur={blurTextFieldAndroid}
                             placeholder="Here’s how I’m figuring out this election."
                           />
                         </>

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -224,6 +224,7 @@ class HeaderBar extends Component {
   }
 
   onFriendStoreChange () {
+    // console.log('HeaderBar, onFriendStoreChange textOrEmailSignInInProcess: ' + signInModalGlobalState.get('textOrEmailSignInInProcess'));
     if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
       // console.log('HeaderBar, onFriendStoreChange');
       this.setState({
@@ -233,6 +234,8 @@ class HeaderBar extends Component {
   }
 
   onVoterStoreChange () {
+    // console.log('HeaderBar, onVoterStoreChange textOrEmailSignInInProcess: ' + signInModalGlobalState.get('textOrEmailSignInInProcess'));
+    // console.log('HeaderBar, onVoterStoreChange voter: ', VoterStore.getVoter());
     if (!signInModalGlobalState.get('textOrEmailSignInInProcess')) {
       // console.log('HeaderBar, onVoterStoreChange'};
       const voter = VoterStore.getVoter();

--- a/src/js/components/Search/SearchBar.jsx
+++ b/src/js/components/Search/SearchBar.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { cordovaDot } from '../../utils/cordovaUtils';
+import { blurTextFieldAndroid, cordovaDot, focusTextFieldAndroid } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 // Dec 2019 TODO: This is the last icon from the svg-icons package used in the Web App, all the other have been removed from git
 import removeCircleIcon from '../../../img/global/svg-icons/glyphicons-pro-halflings/glyphicons-halflings-88-remove-circle.svg';
@@ -86,6 +86,8 @@ export default class SearchBar extends Component {
           value={this.state.searchString}
           onKeyDown={this.handleKeyPress}
           onChange={this.updateResults}
+          onFocus={focusTextFieldAndroid}
+          onBlur={blurTextFieldAndroid}
         />
         <div className="search-bar-options">
           <button

--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -25,6 +25,7 @@ import VoterSessionActions from '../../actions/VoterSessionActions';
 import VoterStore from '../../stores/VoterStore';
 import VoterPhoneVerificationEntry from './VoterPhoneVerificationEntry';
 import VoterPhoneEmailCordovaEntryModal from './VoterPhoneEmailCordovaEntryModal';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 
 /* global $ */
 
@@ -168,7 +169,8 @@ export default class SettingsAccount extends Component {
   }
 
   componentWillUnmount () {
-    // console.log("SignIn ---- UN mount");
+    // console.log("SettingsAccount componentWillUnmount");
+    signInModalGlobalState.set('textOrEmailSignInInProcess', false);
     this.appStoreListener.remove();
     this.facebookStoreListener.remove();
     this.voterStoreListener.remove();

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -9,7 +9,7 @@ import Paper from '@material-ui/core/Paper';
 import Mail from '@material-ui/icons/Mail';
 import InputBase from '@material-ui/core/InputBase';
 import LoadingWheel from '../LoadingWheel';
-import { isCordova, isWebApp } from '../../utils/cordovaUtils';
+import { blurTextFieldAndroid, focusTextFieldAndroid, isCordova, isWebApp } from '../../utils/cordovaUtils';
 import isMobileScreenSize from '../../utils/isMobileScreenSize';
 import { renderLog } from '../../utils/logging';
 import OpenExternalWebSite from '../Widgets/OpenExternalWebSite';
@@ -128,6 +128,7 @@ class VoterEmailAddressEntry extends Component {
   }
 
   componentWillUnmount () {
+    // console.log('VoterEmailAddressEntry componentWillUnmount');
     this.voterStoreListener.remove();
   }
 
@@ -319,6 +320,7 @@ class VoterEmailAddressEntry extends Component {
       this.displayEmailVerificationButton();
       this.turnOtherSignInOptionsOff();
     }
+    focusTextFieldAndroid();
   };
 
   onAnimationEndCancel = () => {
@@ -454,6 +456,7 @@ class VoterEmailAddressEntry extends Component {
               value={voterEmailAddress}
               onChange={this.updateVoterEmailAddress}
               onFocus={this.onFocus}
+              onBlur={blurTextFieldAndroid}
               onKeyDown={this.onKeyDown}
               placeholder="Type email here..."
             />

--- a/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
+++ b/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
@@ -52,12 +52,12 @@ class VoterPhoneEmailCordovaEntryModal extends Component {
       console.log('VoterPhoneEmailCordovaEntryModal closeSignInModalLocal this.props valid');
       this.props.closeSignInModal();
     } catch (err) {
-      console.log('VoterPhoneVerificationEntryModal closeSignInModalLocal caught error: ', err);
+      console.log('VoterPhoneEmailCordovaEntryModal closeSignInModalLocal caught error: ', err);
     }
   }
 
   render () {
-    renderLog('VoterPhoneVerificationEntryModal');  // Set LOG_RENDER_EVENTS to log all renders
+    renderLog('VoterPhoneEmailCordovaEntryModal');  // Set LOG_RENDER_EVENTS to log all renders
     const { showDialog } = this.state;
     const { classes, isPhone } = this.props;
     const isSmallApple = isIPhone3p5in() || isIPhone4in() || isIPhone4p7in();

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -464,6 +464,7 @@ class VoterPhoneVerificationEntry extends Component {
             <ButtonWrapper>
               <CancelButtonContainer>
                 <Button
+                  id="cancelVoterPhoneSendSMS"
                   color="primary"
                   disabled={signInCodeSMSSentAndWaitingForResponse}
                   className={classes.cancelButton}

--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -9,9 +9,8 @@ import CloseIcon from '@material-ui/icons/Close';
 import Typography from '@material-ui/core/Typography';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import { renderLog } from '../../utils/logging';
-import {
-  isCordova, isIPhone3p5in, isIPhone4in, isIPhone4p7in,
-  isIPhone5p5in, isIPhone5p8in, isIPhone6p1in, isIPhone6p5in,
+import { isCordova, isAndroid, isIOS,
+  isIPhone3p5in, isIPhone4in, isIPhone4p7in, isIPhone5p5in, isIPhone5p8in, isIPhone6p1in, isIPhone6p5in,
   isWebAppHeight0to568, isWebAppHeight569to667, isWebAppHeight668to736, isWebAppHeight737to896,
   isWebApp, historyPush, restoreStylesAfterCordovaKeyboard,
 } from '../../utils/cordovaUtils';
@@ -43,7 +42,7 @@ class SignInModal extends Component {
   }
 
   componentDidUpdate () {
-    if (isCordova()) {
+    if (isIOS()) {
       // Cordova really has trouble with animations on dialogs, while the visible area is being compressed to fit the software keyboard
       // eslint-disable-next-line func-names
       $('*').each(function () {
@@ -52,13 +51,14 @@ class SignInModal extends Component {
           console.log(`SignInModal componentDidUpdate transition style removed before: ${styleWorking}`);
           const cleaned = styleWorking.replace(/transition.*?;/, '');
           $(this).attr('style', cleaned);
-          console.log(`SignInModal componentDidUpdate transition style removed after: ${cleaned}`);
         }
       });
     }
   }
 
   componentWillUnmount () {
+    // console.log('SignInModal componentWillUnmount');
+    signInModalGlobalState.set('textOrEmailSignInInProcess', false);
     this.voterStoreListener.remove();
   }
 
@@ -157,6 +157,7 @@ class SignInModal extends Component {
             [classes.emailInputWebApp737to896]: isWebAppHeight737to896() && focusedOnSingleInputToggle && focusedInputName === 'email',
             [classes.phoneInputWebApp737to896]: isWebAppHeight737to896() && focusedOnSingleInputToggle && focusedInputName === 'phone',
             [classes.signInModalDialogLarger]: (isIPhone5p5in() || isIPhone5p8in() || isIPhone6p1in() || isIPhone6p5in()) && isCordova(),
+            [classes.signInModalDialogAndroid]: isAndroid(),
           }),
           root: classes.dialogRoot,
         }}
@@ -283,6 +284,9 @@ const styles = theme => ({
     [theme.breakpoints.down('sm')]: {
       transform: 'translate(-75%, -55%)',
     },
+  },
+  signInModalDialogAndroid: {
+    transform: 'translate(-50%, -60%)',
   },
   signInModalDialogLarger: {
     bottom: 'unset',

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -237,7 +237,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.measureWild:     return '42px';
         case enums.candidate:       return '24px';
         case enums.candidateWild:   return '36px';
-        case enums.ballotSmHdrWild: return '123px';
+        case enums.ballotSmHdrWild: return '141px';
         case enums.ballotLgHdrWild: return showBallotDecisionsTabs() ? '58px' : '42px';
         case enums.ballotVote:      return isSignedIn ? '131px' : '128px';
         case enums.moreTerms:       return '32px';
@@ -312,7 +312,7 @@ export function cordovaBallotFilterTopMargin () {
       } else if (window.location.href.indexOf('/index.html#/friends') > 0) {
         return '61px';
       }
-      return '49px';
+      return '61px';
     } else if (sizeString === '--xl') {
       if (window.location.href.indexOf('/index.html#/ballot/vote') > 0) {
         return '-10px';

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -549,3 +549,14 @@ export function setGlobalScreenSize (result) {
   window.pbakondyScreenSize = result;
 }
 
+export function focusTextFieldAndroid () {
+  if (isAndroid()) {
+    prepareForCordovaKeyboard('AddFriendsByEmail');
+  }
+}
+
+export function blurTextFieldAndroid () {
+  if (isAndroid()) {
+    restoreStylesAfterCordovaKeyboard('AddFriendsByEmail');
+  }
+}


### PR DESCRIPTION
New:  For Android, prepareForCordovaKeyboard, is invoked on input field focus/blur.  For iOS it is hooked in globally in Application.jsx with a 'keyboardWillShow' event listener.
Android APK: app-debug2020-02-01.apk
