### PR TITLE
Open share modal after signing in

### DIFF
--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -117,6 +117,7 @@ const routes = () => {  // eslint-disable-line arrow-body-style
       </Route>
       <Route path="/ballot/vote" component={Vote} />
       <Route path="/ballot/:ballot_location_shortcut" component={Ballot} />
+      <Route path="/ballot/modal/:modal_to_show" component={Ballot} />
       <Route path="/ballot/id/:ballot_returned_we_vote_id" component={Ballot} />
       <Route path="/ballot/election/:google_civic_election_id" component={Ballot} />
 

--- a/src/js/components/Ballot/BallotShareButton.jsx
+++ b/src/js/components/Ballot/BallotShareButton.jsx
@@ -7,6 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Reply from '@material-ui/icons/Reply';
 import styled from 'styled-components';
 import AppActions from '../../actions/AppActions';
+import { historyPush } from '../../utils/cordovaUtils';
 
 class BallotShareButton extends Component {
   static propTypes = {
@@ -39,8 +40,9 @@ class BallotShareButton extends Component {
 
   openShareModal () {
     // console.log('SettingsDomain openPaidAccountUpgradeModal');
+    historyPush('/ballot/modal/share');
     AppActions.setShareModalStep('options');
-    AppActions.setShowShareModal(true);
+    // AppActions.setShowShareModal(true);
   }
 
   render () {

--- a/src/js/components/Ballot/BallotShareButtonFooter.jsx
+++ b/src/js/components/Ballot/BallotShareButtonFooter.jsx
@@ -11,6 +11,7 @@ import { getApplicationViewBooleans } from '../../utils/applicationUtils';
 import AppActions from '../../actions/AppActions';
 import AppStore from '../../stores/AppStore';
 import ShareModalOption from './ShareModalOption';
+import { historyPush } from '../../utils/cordovaUtils';
 
 class BallotShareButtonFooter extends Component {
   static propTypes = {
@@ -64,7 +65,8 @@ class BallotShareButtonFooter extends Component {
 
   openShareModal (step) {
     this.handleClose();
-    AppActions.setShowShareModal(true);
+    // AppActions.setShowShareModal(true);
+    historyPush('/ballot/modal/share');
     AppActions.setShareModalStep(step);
   }
 

--- a/src/js/components/Ballot/ShareModal.jsx
+++ b/src/js/components/Ballot/ShareModal.jsx
@@ -11,7 +11,7 @@ import Mail from '@material-ui/icons/Mail';
 import FileCopyOutlinedIcon from '@material-ui/icons/FileCopyOutlined';
 import ArrowBackIos from '@material-ui/icons/ArrowBackIos';
 import { Button, Tooltip } from '@material-ui/core';
-import { hasIPhoneNotch } from '../../utils/cordovaUtils';
+import { hasIPhoneNotch, historyPush } from '../../utils/cordovaUtils';
 import FriendActions from '../../actions/FriendActions';
 import FriendStore from '../../stores/FriendStore';
 import MessageCard from '../Widgets/MessageCard';
@@ -19,6 +19,8 @@ import { renderLog } from '../../utils/logging';
 import ShareModalOption from './ShareModalOption';
 import SettingsAccount from '../Settings/SettingsAccount';
 import FriendsShareList from '../Friends/FriendsShareList';
+import AppActions from '../../actions/AppActions';
+import cookies from '../../utils/cookies';
 
 class ShareModal extends Component {
   static propTypes = {
@@ -127,7 +129,20 @@ class ShareModal extends Component {
           <DialogContent classes={{ root: classes.dialogContent }}>
             <div className="full-width">
               <Flex>
-                <ShareModalOption noLink onClickFunction={() => this.setStep('friends')} background="#2E3C5D" icon={<img src="../../../img/global/svg-icons/we-vote-icon-square-color.svg" />} title="We Vote Friends" />
+                <ShareModalOption
+                  noLink
+                  onClickFunction={() => {
+                    if (!this.props.isSignedIn) {
+                      AppActions.setShowSignInModal(true);
+                      this.setStep('friends');
+                    } else {
+                      this.setStep('friends');
+                    }
+                  }}
+                  background="#2E3C5D"
+                  icon={<img src="../../../img/global/svg-icons/we-vote-icon-square-color.svg" />}
+                  title="We Vote Friends"
+                />
                 <ShareModalOption link="https://www.facebook.com/sharer/sharer.php?u=wevote.us&t=WeVote" target="_blank" background="#3b5998" icon={<i className="fab fa-facebook-f" />} title="Facebook" />
                 <ShareModalOption link={`https://twitter.com/share?text=Check out this cool ballot tool at https://wevote.us${window.location.pathname}!`} background="#38A1F3" icon={<i className="fab fa-twitter" />} title="Twitter" />
                 <ShareModalOption link="mailto:" background="#2E3C5D" icon={<Mail />} title="Email" />
@@ -138,28 +153,33 @@ class ShareModal extends Component {
         </Dialog>
       );
     } else if (this.state.step === 'friends' && !this.props.isSignedIn) {
-      shareModalHtml = (
-        <Dialog
-          classes={{ paper: classes.dialogPaper }}
-          open={this.props.show}
-          onClose={() => { this.props.toggleFunction(this.state.pathname); }}
-        >
-          <ModalTitleArea onSignInSlide>
-            <Title onSignInSlide bold>Sign In</Title>
-            <IconButton
-              aria-label="Close"
-              className={classes.closeButtonAbsolute}
-              onClick={this.closeShareModal}
-              id="profileCloseShareModal"
-            >
-              <CloseIcon />
-            </IconButton>
-          </ModalTitleArea>
-          <DialogContent classes={{ root: classes.dialogContent }}>
-            <SettingsAccount inShareModal inModal pleaseSignInTitle="Sign in to share with your friends" />
-          </DialogContent>
-        </Dialog>
-      );
+      // historyPush('/ballot/modal/share');
+      // AppActions.setShowSignInModal(true);
+
+
+      // cookies.setItem('sign_in_start_full_url', signInStartFullUrl, 86400, '/', 'wevote.us');
+      // shareModalHtml = (
+      //   <Dialog
+      //     classes={{ paper: classes.dialogPaper }}
+      //     open={this.props.show}
+      //     onClose={() => { this.props.toggleFunction(this.state.pathname); }}
+      //   >
+      //     <ModalTitleArea onSignInSlide>
+      //       <Title onSignInSlide bold>Sign In</Title>
+      //       <IconButton
+      //         aria-label="Close"
+      //         className={classes.closeButtonAbsolute}
+      //         onClick={this.closeShareModal}
+      //         id="profileCloseShareModal"
+      //       >
+      //         <CloseIcon />
+      //       </IconButton>
+      //     </ModalTitleArea>
+      //     <DialogContent classes={{ root: classes.dialogContent }}>
+      //       <SettingsAccount inShareModal inModal pleaseSignInTitle="Sign in to share with your friends" />
+      //     </DialogContent>
+      //   </Dialog>
+      // );
     } else if (this.state.step === 'friends' && this.props.isSignedIn && this.state.currentFriendsList.length > 0) {
       shareModalHtml = (
         <Dialog

--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -88,6 +88,11 @@ export default class SettingsAccount extends Component {
     const getStartedMode = AppStore.getStartedMode();
     AnalyticsActions.saveActionAccountPage(VoterStore.electionId());
     const { origin } = window.location;
+
+    // if (window.location.pathname === '/ballot/modal/share') {
+
+    // }
+
     if (this.props.pleaseSignInTitle || this.props.pleaseSignInSubTitle) {
       AppActions.storeSignInStartFullUrl();
       this.setState({

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -852,6 +852,12 @@ class Ballot extends Component {
     // console.log(ballotWithAllItems);
     const textForMapSearch = VoterStore.getTextForMapSearch();
 
+    const modalToOpen = this.props.params.modal_to_show || '';
+
+    if (modalToOpen === 'share') {
+      AppActions.setShowShareModal(true);
+    }
+
     if (!ballotWithItemsFromCompletionFilterType) {
       return (
         <DelayedLoad showLoadingText waitBeforeShow={2000}>


### PR DESCRIPTION
### Changes included this pull request?

The sign-in modal now opens if you are not signed in and you click on the "We Vote Friends" option in the share modal. The share modal is then re-opened upon successfully signing in.