### PR TITLE
Found a fix for the candidate being too wide on its own page. When we remove expandIssuesByDefault from CandidateItem (in Candidate.jsx), the page is pushed very wide. This needs to be fixed. This started happening when we implemented the flex-based "TwoColumns".

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -25,6 +25,7 @@ import { abbreviateNumber, numberWithCommas } from '../../utils/textFormat';
 class CandidateItem extends Component {
   static propTypes = {
     candidateWeVoteId: PropTypes.string.isRequired,
+    expandIssuesByDefault: PropTypes.bool,
     hideBallotItemSupportOpposeComment: PropTypes.bool,
     hideCandidateText: PropTypes.bool,
     hideCandidateUrl: PropTypes.bool,
@@ -404,7 +405,7 @@ class CandidateItem extends Component {
 
   candidateIssuesAndCommentBlock = (candidateText, localUniqueId) => {
     const {
-      candidateWeVoteId, hideBallotItemSupportOpposeComment, hideCandidateText, hideIssuesRelatedToCandidate, hideShowMoreFooter,
+      candidateWeVoteId, expandIssuesByDefault, hideBallotItemSupportOpposeComment, hideCandidateText, hideIssuesRelatedToCandidate, hideShowMoreFooter,
       linkToBallotItemPage, showHover, showPositionStatementActionBar, showTopCommentByBallotItem, hidePositionPublicToggle, showPositionPublicToggle, inModal,
     } = this.props;
     const {
@@ -493,6 +494,7 @@ class CandidateItem extends Component {
             <IssuesByBallotItemDisplayList
               ballotItemDisplayName={ballotItemDisplayName}
               ballotItemWeVoteId={candidateWeVoteId}
+              expandIssuesByDefault={expandIssuesByDefault}
               externalUniqueId={`candidateItem-${candidateWeVoteId}`}
               placement="bottom"
             />

--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -19,6 +19,7 @@ class IssuesByBallotItemDisplayList extends Component {
     ballotItemDisplayName: PropTypes.string,
     children: PropTypes.object,
     disableMoreWrapper: PropTypes.bool,
+    expandIssuesByDefault: PropTypes.bool,
     externalUniqueId: PropTypes.string,
     handleLeaveCandidateCard: PropTypes.func,
     handleEnterCandidateCard: PropTypes.func,
@@ -32,7 +33,7 @@ class IssuesByBallotItemDisplayList extends Component {
       issuesUnderThisBallotItemVoterIsFollowingLength: 0,
       issuesUnderThisBallotItemVoterIsNotFollowingLength: 0,
       maximumNumberOfIssuesToDisplay: 26,
-      expand: false,
+      expandIssues: false,
       totalWidth: null,
       totalRemainingWidth: null,
     };
@@ -49,10 +50,11 @@ class IssuesByBallotItemDisplayList extends Component {
     const issuesUnderThisBallotItemVoterIsNotFollowing = IssueStore.getIssuesUnderThisBallotItemVoterNotFollowing(this.props.ballotItemWeVoteId) || [];
     const issuesUnderThisBallotItemVoterIsFollowingLength = issuesUnderThisBallotItemVoterIsFollowing.length;
     const issuesUnderThisBallotItemVoterIsNotFollowingLength = issuesUnderThisBallotItemVoterIsNotFollowing.length;
-    const { ballotItemDisplayName, ballotItemWeVoteId } = this.props;
+    const { ballotItemDisplayName, ballotItemWeVoteId, expandIssuesByDefault } = this.props;
     this.setState({
       ballotItemDisplayName,
       ballotItemWeVoteId,
+      expandIssues: expandIssuesByDefault,
       issuesUnderThisBallotItemVoterIsFollowing,
       issuesUnderThisBallotItemVoterIsNotFollowing,
       issuesUnderThisBallotItemVoterIsFollowingLength,
@@ -83,8 +85,8 @@ class IssuesByBallotItemDisplayList extends Component {
       // console.log('this.state.ballotItemWeVoteId: ', this.state.ballotItemWeVoteId, ', nextState.ballotItemWeVoteId', nextState.ballotItemWeVoteId);
       return true;
     }
-    if (this.state.expand !== nextState.expand) {
-      // console.log('this.state.expand: ', this.state.expand, ', nextState.expand', nextState.expand);
+    if (this.state.expandIssues !== nextState.expandIssues) {
+      // console.log('this.state.expandIssues: ', this.state.expandIssues, ', nextState.expandIssues', nextState.expandIssues);
       return true;
     }
     if (this.state.issuesUnderThisBallotItemVoterIsFollowingLength !== nextState.issuesUnderThisBallotItemVoterIsFollowingLength) {
@@ -152,8 +154,8 @@ class IssuesByBallotItemDisplayList extends Component {
   };
 
   handleExpandIssues = () => {
-    const { expand } = this.state;
-    this.setState({ expand: !expand });
+    const { expandIssues } = this.state;
+    this.setState({ expandIssues: !expandIssues });
   };
 
   handleLeaveHoverLocalArea = () => {
@@ -179,7 +181,7 @@ class IssuesByBallotItemDisplayList extends Component {
     // console.log('IssuesByBallotItemDisplayList render');
     const { externalUniqueId } = this.props;
     const {
-      ballotItemDisplayName, ballotItemWeVoteId, expand,
+      ballotItemDisplayName, ballotItemWeVoteId, expandIssues,
       issuesUnderThisBallotItemVoterIsFollowing, issuesUnderThisBallotItemVoterIsNotFollowing,
       issuesUnderThisBallotItemVoterIsFollowingLength, issuesUnderThisBallotItemVoterIsNotFollowingLength,
       maximumNumberOfIssuesToDisplay,
@@ -258,7 +260,7 @@ class IssuesByBallotItemDisplayList extends Component {
         <Issues>
           {/* Show a break-down of the current positions in your network */}
           <div ref={this.issuesList}>
-            <IssueList key={`issuesByBallotItemDisplayList-${ballotItemWeVoteId}`} expand={expand}>
+            <IssueList key={`issuesByBallotItemDisplayList-${ballotItemWeVoteId}`} expandIssues={expandIssues}>
               {/* Issues the voter is already following */}
               {issuesVoterIsFollowingHtml}
               {/* Issues the voter is not following yet */}
@@ -266,7 +268,7 @@ class IssuesByBallotItemDisplayList extends Component {
             </IssueList>
           </div>
         </Issues>
-        {(expand || this.props.disableMoreWrapper || totalRemainingWidth > 0) ? null : (
+        {(expandIssues || this.props.disableMoreWrapper || totalRemainingWidth > 0) ? null : (
           <MoreWrapper onClick={this.handleExpandIssues}>
             <MoreHorizIcon
               id="issuesByBallotItemDisplayListMoreIssuesIcon"
@@ -295,7 +297,7 @@ const Issues = styled.div`
 
 const IssueList = styled.ul`
   display: flex;
-  flex-flow: row${({ expand }) => (expand ? ' wrap' : '')};
+  flex-flow: row${({ expandIssues }) => (expandIssues ? ' wrap' : '')};
   margin-bottom: 8px;
   overflow: hidden;
   padding-inline-start: 0;

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -274,6 +274,8 @@ class Candidate extends Component {
     const voter = VoterStore.getVoter();
     const candidateAdminEditUrl = `${webAppConfig.WE_VOTE_SERVER_ROOT_URL}c/${candidate.id}/edit/?google_civic_election_id=${VoterStore.electionId()}&state_code=`;
 
+    // TODO When we remove expandIssuesByDefault from CandidateItem, the page is pushed very wide. This needs to be fixed.
+    //   This started happening when we implemented the flex-based "TwoColumns"
     return (
       <span>
         <Helmet
@@ -285,11 +287,12 @@ class Candidate extends Component {
             <CandidateStickyHeader candidate={candidate} />
           )
         }
-        <section className="card">
+        <div className="card">
           <TwoColumns>
             <LeftColumnWrapper>
               <CandidateItem
                 candidateWeVoteId={candidate.we_vote_id}
+                expandIssuesByDefault
                 hideShowMoreFooter
                 organizationWeVoteId={organizationWeVoteId}
                 linkToOfficePage
@@ -309,7 +312,7 @@ class Candidate extends Component {
               )}
             </RightColumnWrapper>
           </TwoColumns>
-        </section>
+        </div>
         { !!(allCachedPositionsForThisCandidate.length) && (
           <section className="card">
             <DelayedLoad showLoadingText waitBeforeShow={500}>
@@ -363,19 +366,15 @@ const CandidateShareWrapper = styled.div`
 `;
 
 const LeftColumnWrapper = styled.div`
-  flex-grow: 6;
 `;
 
 const RightColumnWrapper = styled.div`
-  flex-grow: 1;
   margin-right: 12px;
   margin-top: 12px;
 `;
 
 const TwoColumns = styled.div`
   display: flex;
-  justify-content: flex-start;
-  width: 100%;
 `;
 
 export default Candidate;


### PR DESCRIPTION
Found a fix for the candidate being too wide on its own page. When we remove expandIssuesByDefault from CandidateItem (in Candidate.jsx), the page is pushed very wide. This needs to be fixed. This started happening when we implemented the flex-based "TwoColumns".