### PR TITLE
[#2841] Delayed sequential render of issues chips

### DIFF
--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -293,7 +293,6 @@ class Candidate extends Component {
             <LeftColumnWrapper>
               <CandidateItem
                 candidateWeVoteId={candidate.we_vote_id}
-                expandIssuesByDefault
                 hideShowMoreFooter
                 organizationWeVoteId={organizationWeVoteId}
                 linkToOfficePage


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#2841 
### Changes included this pull request?
This will render the issue chips sequentially with a delay. This allows us to stop rendering when we know the next chip will overflow, or to backtrack (remove the last rendered chip) if there is an overflow.

This solution seems to work for all screen sizes, but is not responsive.