### PR TITLE
Issue2879

### DIFF
--- a/src/js/components/Widgets/PositionSummaryListForPopover.jsx
+++ b/src/js/components/Widgets/PositionSummaryListForPopover.jsx
@@ -158,15 +158,28 @@ class PositionSummaryListForPopover extends Component {
             >
               <OrganizationPopoverWrapper>
                 {!!(positionSummary.issuesInCommonBetweenOrganizationAndVoter && positionSummary.issuesInCommonBetweenOrganizationAndVoter.length) && (
+                  // Limits the number of displayed Issue icons
+                  // The popover isn't big enough to accommodate more than 4 icons without making them too small!
                   <VoterAndOrganizationShareTheseIssuesWrapper>
-                    {positionSummary.issuesInCommonBetweenOrganizationAndVoter.map(issue => (
-                      <IssueIcon key={`issueInScore-${issue.issue_we_vote_id}`}>
-                        <ReactSVG
+                    {(positionSummary.issuesInCommonBetweenOrganizationAndVoter.length > 4) ? (
+                      positionSummary.issuesInCommonBetweenOrganizationAndVoter.slice(0, 3).map(issue => (
+                        <IssueIcon key={`issueInScore-${issue.issue_we_vote_id}`}>
+                          <ReactSVG
                           src={cordovaDot(`/img/global/svg-icons/issues/${issue.issue_icon_local_path}.svg`)}
                           svgStyle={{ fill: '#555', padding: '1px 1px 1px 0px' }}
-                        />
-                      </IssueIcon>
-                    ))}
+                          />
+                        </IssueIcon>
+                      ))
+                    ) : (
+                      positionSummary.issuesInCommonBetweenOrganizationAndVoter.map(issue => (
+                        <IssueIcon key={`issueInScore-${issue.issue_we_vote_id}`}>
+                          <ReactSVG
+                            src={cordovaDot(`/img/global/svg-icons/issues/${issue.issue_icon_local_path}.svg`)}
+                            svgStyle={{ fill: '#555', padding: '1px 1px 1px 0px' }}
+                          />
+                        </IssueIcon>
+                      ))
+                    )}
                   </VoterAndOrganizationShareTheseIssuesWrapper>
                 )}
                 {positionSummary.voterIsFriendsWithThisOrganization ? (

--- a/src/js/components/Widgets/PositionSummaryListForPopover.jsx
+++ b/src/js/components/Widgets/PositionSummaryListForPopover.jsx
@@ -182,6 +182,7 @@ class PositionSummaryListForPopover extends Component {
                     )}
                   </VoterAndOrganizationShareTheseIssuesWrapper>
                 )}
+                {(positionSummary.issuesInCommonBetweenOrganizationAndVoter.length > 4) ? ('...') : null}
                 {positionSummary.voterIsFriendsWithThisOrganization ? (
                   <FollowingWrapper>
                     {/* <CheckCircle className="friends-icon" /> */}


### PR DESCRIPTION
Goal: Limit the number of issue icons displayed on a popover on a specific candidate/measure page

- I added a conditional that should limit the number of displayed issue icons --> it does so by determining the length of the container (array in this case) that the issues were encapsulated in. Logic: If that length is greater than 4, use only the first 3 entries (issues) of the container
- Moreover, I also used this logic to add in a '...' string whenever that conditions mentioned above are met
