### PR TITLE
Added configuration option to off "share opinions" option for 501c3 sites. Turned off autoFocus on ready page input field. All visits to root level of site now direct to Ready page. Fixed problem in settings section where the footer wasn't appearing in Tablet mode.

### DIFF
--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -82,7 +82,7 @@ import YourPage from './routes/YourPage';
 import { isWebApp } from './utils/cordovaUtils';
 
 // See /js/components/Navigation/HeaderBar.jsx for show_full_navigation cookie
-const ballotHasBeenVisited = cookies.getItem('ballot_has_been_visited');
+// const ballotHasBeenVisited = cookies.getItem('ballot_has_been_visited');
 const firstVisit = !cookies.getItem('voter_device_id');
 const { hostname } = window.location;
 const weVoteSites = ['wevote.us', 'quality.wevote.us', 'localhost', ''];   // localhost on Cordova is a ''
@@ -97,7 +97,8 @@ const routes = () => {  // eslint-disable-line arrow-body-style
       {                       // 12/4/18: Not sure why we need the following disabled
         (function redir () {  // eslint-disable-line wrap-iife
           if (isWebApp()) {
-            return ballotHasBeenVisited ? <IndexRedirect to="/ballot" /> : <IndexRedirect to="/ready" />;
+            // return ballotHasBeenVisited ? <IndexRedirect to="/ballot" /> : <IndexRedirect to="/ready" />;
+            return <IndexRedirect to="/ready" />;
           } else {
             return firstVisit ? <IndexRedirect to="/wevoteintro/network" /> : <IndexRedirect to="/ballot" />;
           }

--- a/src/js/actions/OrganizationActions.js
+++ b/src/js/actions/OrganizationActions.js
@@ -156,6 +156,14 @@ export default {
       });
   },
 
+  organizationPreventSharingOpinions (organizationWeVoteId, organizationPreventSharingOpinions) {
+    Dispatcher.loadEndpoint('organizationSave',
+      {
+        chosen_prevent_sharing_opinions: organizationPreventSharingOpinions,
+        organization_we_vote_id: organizationWeVoteId,
+      });
+  },
+
   organizationNameSave (organizationWeVoteId, organizationName) {
     Dispatcher.loadEndpoint('organizationSave',
       {

--- a/src/js/components/Ready/EditAddressOneHorizontalRow.jsx
+++ b/src/js/components/Ready/EditAddressOneHorizontalRow.jsx
@@ -7,8 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import InputBase from '@material-ui/core/InputBase';
 import BallotStore from '../../stores/BallotStore';
-// import BallotActions from '../../actions/BallotActions';
-import { historyPush, isCordova, prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
+import { historyPush, prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import VoterActions from '../../actions/VoterActions';
 import VoterStore from '../../stores/VoterStore';
@@ -17,7 +16,6 @@ import cookies from '../../utils/cookies';
 class EditAddressOneHorizontalRow extends Component {
   static propTypes = {
     saveUrl: PropTypes.string,
-    disableAutoFocus: PropTypes.bool,
     classes: PropTypes.object,
   };
 
@@ -187,7 +185,6 @@ class EditAddressOneHorizontalRow extends Component {
                 inputProps={{
                   onChange: this.updateVoterAddress,
                   onKeyDown: this.handleKeyPress,
-                  autoFocus: (!isCordova() && !this.props.disableAutoFocus),
                 }}
                 id="editAddressOneHorizontalRowTextForMapSearch"
               />

--- a/src/js/components/Settings/SettingsSharing.jsx
+++ b/src/js/components/Settings/SettingsSharing.jsx
@@ -31,13 +31,14 @@ class SettingsSharing extends Component {
       chosenFeaturePackage: 'FREE',
       chosenFaviconFromFileReader: null,
       chosenLogoFromFileReader: null,
+      chosenPreventSharingOptions: false,
+      chosenSocialShareDescription: '',
+      chosenSocialShareDescriptionChangedLocally: false,
+      chosenSocialShareDescriptionSavedValue: '',
       chosenSocialShareMasterImageFromFileReader: null,
       hideLogo: false,
       organization: {},
       organizationWeVoteId: '',
-      chosenSocialShareDescription: '',
-      chosenSocialShareDescriptionChangedLocally: false,
-      chosenSocialShareDescriptionSavedValue: '',
       uploadImageType: 'headerLogo',
       voter: {},
       voterFeaturePackageExceedsOrEqualsEnterprise: false,
@@ -76,6 +77,7 @@ class SettingsSharing extends Component {
       const voterFeaturePackageExceedsOrEqualsEnterprise = voterFeaturePackageExceedsOrEqualsRequired(chosenFeaturePackage, 'ENTERPRISE');
       this.setState({
         chosenFeaturePackage,
+        chosenPreventSharingOptions: organization.chosen_prevent_sharing_opinions || false,
         chosenSocialShareDescriptionSavedValue,
         hideLogo: organization.chosen_hide_we_vote_logo || false,
         organization,
@@ -126,6 +128,16 @@ class SettingsSharing extends Component {
     OrganizationActions.organizationChosenHideWeVoteLogoSave(organizationWeVoteId, !hideLogo);
     this.setState({
       hideLogo: !hideLogo,
+    });
+    event.preventDefault();
+  };
+
+  handleTogglePreventSharingOpinions = (event) => {
+    const { chosenPreventSharingOptions, organizationWeVoteId } = this.state;
+    // console.log('chosenPreventSharingOptions', !chosenPreventSharingOptions);
+    OrganizationActions.organizationPreventSharingOpinions(organizationWeVoteId, !chosenPreventSharingOptions);
+    this.setState({
+      chosenPreventSharingOptions: !chosenPreventSharingOptions,
     });
     event.preventDefault();
   };
@@ -244,6 +256,7 @@ class SettingsSharing extends Component {
       chosenFaviconFromFileReader,
       chosenFeaturePackage,
       chosenLogoFromFileReader,
+      chosenPreventSharingOptions,
       chosenSocialShareDescription,
       chosenSocialShareDescriptionChangedLocally,
       chosenSocialShareMasterImageFromFileReader,
@@ -336,6 +349,7 @@ class SettingsSharing extends Component {
                 <Button
                   color="primary"
                   classes={{ root: classes.uploadButton }}
+                  id="uploadHeaderLogo"
                   variant="contained"
                   onClick={this.handleUploadHeaderLogo}
                 >
@@ -346,6 +360,7 @@ class SettingsSharing extends Component {
                     <Button
                       classes={{ root: classes.uploadButton }}
                       color="primary"
+                      id="organizationChosenLogoDelete"
                       variant="outlined"
                       onClick={() => this.organizationChosenLogoDelete()}
                     >
@@ -492,6 +507,25 @@ class SettingsSharing extends Component {
                     )}
                   </PremiumableButton>
                 </Actions>
+              </SharingColumn>
+            </SharingRow>
+            <SharingRow>
+              <SharingColumn>
+                <InputBoxLabel>Prohibit Sharing With Opinions</InputBoxLabel>
+                <DescriptionText>
+                  Turn off the ability for voters to share their opinions from the &quot;Share&quot; buttons.
+                  {' '}
+                  If you are a 501(c)(3) nonprofit organization, this option must be turned on because the IRS does not allow you to provide voters with a way to share their opinions with other voters from a website you manage.
+                </DescriptionText>
+              </SharingColumn>
+              <SharingColumn alignRight>
+                <Switch
+                  color="primary"
+                  checked={chosenPreventSharingOptions}
+                  onChange={this.handleTogglePreventSharingOpinions}
+                  value="chosenPreventSharingOptions"
+                  inputProps={{ 'aria-label': 'Prevent sharing opinions switch' }}
+                />
               </SharingColumn>
             </SharingRow>
           </CardMain>

--- a/src/js/components/Settings/SettingsSharing.jsx
+++ b/src/js/components/Settings/SettingsSharing.jsx
@@ -388,8 +388,9 @@ class SettingsSharing extends Component {
               <SharingColumn alignRight>
                 <PremiumableButton
                   classes={{ root: voterFeaturePackageExceedsOrEqualsEnterprise ? classes.uploadButton : '' }}
-                  premium={voterFeaturePackageExceedsOrEqualsEnterprise ? 1 : 0}
+                  id="handleUploadFavicon"
                   onClick={voterFeaturePackageExceedsOrEqualsEnterprise ? this.handleUploadFavicon : () => this.openPaidAccountUpgradeModal('enterprise')}
+                  premium={voterFeaturePackageExceedsOrEqualsEnterprise ? 1 : 0}
                 >
                   {voterFeaturePackageExceedsOrEqualsEnterprise ? (
                     'Upload'
@@ -409,6 +410,7 @@ class SettingsSharing extends Component {
                     <Button
                       classes={{ root: classes.uploadButton }}
                       color="primary"
+                      id="organizationChosenFaviconDelete"
                       variant="outlined"
                       onClick={() => this.organizationChosenFaviconDelete()}
                     >
@@ -436,6 +438,7 @@ class SettingsSharing extends Component {
               <SharingColumn alignRight>
                 <PremiumableButton
                   classes={{ root: voterFeaturePackageExceedsOrEqualsEnterprise ? classes.uploadButton : '' }}
+                  id="handleUploadShareImage"
                   premium={voterFeaturePackageExceedsOrEqualsEnterprise ? 1 : 0}
                   onClick={voterFeaturePackageExceedsOrEqualsEnterprise ? this.handleUploadShareImage : () => this.openPaidAccountUpgradeModal('enterprise')}
                 >
@@ -457,6 +460,7 @@ class SettingsSharing extends Component {
                     <Button
                       classes={{ root: classes.uploadButton }}
                       color="primary"
+                      id="organizationChosenSocialShareMasterImageDelete"
                       variant="outlined"
                       onClick={() => this.organizationChosenSocialShareMasterImageDelete()}
                     >
@@ -483,6 +487,7 @@ class SettingsSharing extends Component {
                     color="primary"
                     classes={{ root: classes.button }}
                     disabled={!chosenSocialShareDescriptionChangedLocally}
+                    id="cancelChosenSocialShareDescriptionButton"
                     onClick={this.onCancelChosenSocialShareDescriptionButton}
                   >
                     Cancel
@@ -490,6 +495,7 @@ class SettingsSharing extends Component {
                   <PremiumableButton
                     classes={{ root: voterFeaturePackageExceedsOrEqualsEnterprise ? classes.uploadButton : '' }}
                     disabled={voterFeaturePackageExceedsOrEqualsEnterprise ? !chosenSocialShareDescriptionChangedLocally : false}
+                    id="onSaveChosenSocialShareDescriptionButton"
                     premium={voterFeaturePackageExceedsOrEqualsEnterprise ? 1 : 0}
                     onClick={voterFeaturePackageExceedsOrEqualsEnterprise ? this.onSaveChosenSocialShareDescriptionButton : () => this.openPaidAccountUpgradeModal('enterprise')}
                   >
@@ -522,6 +528,7 @@ class SettingsSharing extends Component {
                 <Switch
                   color="primary"
                   checked={chosenPreventSharingOptions}
+                  id="chosenPreventSharingOptions"
                   onChange={this.handleTogglePreventSharingOpinions}
                   value="chosenPreventSharingOptions"
                   inputProps={{ 'aria-label': 'Prevent sharing opinions switch' }}

--- a/src/js/components/Settings/SettingsSharing.jsx
+++ b/src/js/components/Settings/SettingsSharing.jsx
@@ -31,7 +31,7 @@ class SettingsSharing extends Component {
       chosenFeaturePackage: 'FREE',
       chosenFaviconFromFileReader: null,
       chosenLogoFromFileReader: null,
-      chosenPreventSharingOptions: false,
+      chosenPreventSharingOpinions: false,
       chosenSocialShareDescription: '',
       chosenSocialShareDescriptionChangedLocally: false,
       chosenSocialShareDescriptionSavedValue: '',
@@ -77,7 +77,7 @@ class SettingsSharing extends Component {
       const voterFeaturePackageExceedsOrEqualsEnterprise = voterFeaturePackageExceedsOrEqualsRequired(chosenFeaturePackage, 'ENTERPRISE');
       this.setState({
         chosenFeaturePackage,
-        chosenPreventSharingOptions: organization.chosen_prevent_sharing_opinions || false,
+        chosenPreventSharingOpinions: organization.chosen_prevent_sharing_opinions || false,
         chosenSocialShareDescriptionSavedValue,
         hideLogo: organization.chosen_hide_we_vote_logo || false,
         organization,
@@ -133,11 +133,11 @@ class SettingsSharing extends Component {
   };
 
   handleTogglePreventSharingOpinions = (event) => {
-    const { chosenPreventSharingOptions, organizationWeVoteId } = this.state;
-    // console.log('chosenPreventSharingOptions', !chosenPreventSharingOptions);
-    OrganizationActions.organizationPreventSharingOpinions(organizationWeVoteId, !chosenPreventSharingOptions);
+    const { chosenPreventSharingOpinions, organizationWeVoteId } = this.state;
+    // console.log('chosenPreventSharingOpinions', !chosenPreventSharingOpinions);
+    OrganizationActions.organizationPreventSharingOpinions(organizationWeVoteId, !chosenPreventSharingOpinions);
     this.setState({
-      chosenPreventSharingOptions: !chosenPreventSharingOptions,
+      chosenPreventSharingOpinions: !chosenPreventSharingOpinions,
     });
     event.preventDefault();
   };
@@ -256,7 +256,7 @@ class SettingsSharing extends Component {
       chosenFaviconFromFileReader,
       chosenFeaturePackage,
       chosenLogoFromFileReader,
-      chosenPreventSharingOptions,
+      chosenPreventSharingOpinions,
       chosenSocialShareDescription,
       chosenSocialShareDescriptionChangedLocally,
       chosenSocialShareMasterImageFromFileReader,
@@ -527,10 +527,10 @@ class SettingsSharing extends Component {
               <SharingColumn alignRight>
                 <Switch
                   color="primary"
-                  checked={chosenPreventSharingOptions}
-                  id="chosenPreventSharingOptions"
+                  checked={chosenPreventSharingOpinions}
+                  id="chosenPreventSharingOpinions"
                   onChange={this.handleTogglePreventSharingOpinions}
-                  value="chosenPreventSharingOptions"
+                  value="chosenPreventSharingOpinions"
                   inputProps={{ 'aria-label': 'Prevent sharing opinions switch' }}
                 />
               </SharingColumn>

--- a/src/js/components/Share/ShareButtonDesktopTablet.jsx
+++ b/src/js/components/Share/ShareButtonDesktopTablet.jsx
@@ -24,7 +24,7 @@ class ShareButtonDesktopTablet extends Component {
     super(props);
     this.state = {
       anchorEl: null,
-      chosenPreventSharingOptions: false,
+      chosenPreventSharingOpinions: false,
       openShareMenu: false,
     };
     this.handleShareButtonClick = this.handleShareButtonClick.bind(this);
@@ -33,9 +33,9 @@ class ShareButtonDesktopTablet extends Component {
 
   componentDidMount () {
     this.appStoreListener = AppStore.addListener(this.onAppStoreChange.bind(this));
-    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    const chosenPreventSharingOpinions = AppStore.getChosenPreventSharingOpinions();
     this.setState({
-      chosenPreventSharingOptions,
+      chosenPreventSharingOpinions,
     });
   }
 
@@ -44,9 +44,9 @@ class ShareButtonDesktopTablet extends Component {
   }
 
   onAppStoreChange () {
-    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    const chosenPreventSharingOpinions = AppStore.getChosenPreventSharingOpinions();
     this.setState({
-      chosenPreventSharingOptions,
+      chosenPreventSharingOpinions,
     });
   }
 
@@ -109,7 +109,7 @@ class ShareButtonDesktopTablet extends Component {
 
   render () {
     const { candidateShare, classes, measureShare, officeShare } = this.props;
-    const { anchorEl, chosenPreventSharingOptions, openShareMenu } = this.state;
+    const { anchorEl, chosenPreventSharingOpinions, openShareMenu } = this.state;
 
     let shareButtonClasses;
     let shareMenuTextDefault;
@@ -192,7 +192,7 @@ class ShareButtonDesktopTablet extends Component {
             </MenuFlex>
           </MenuItem>
           <MenuSeparator />
-          {chosenPreventSharingOptions ? null : (
+          {chosenPreventSharingOpinions ? null : (
             <MenuItem className={classes.menuItem} onClick={() => this.openShareModal(true)}>
               <MenuFlex>
                 <MenuIcon>

--- a/src/js/components/Share/ShareButtonDesktopTablet.jsx
+++ b/src/js/components/Share/ShareButtonDesktopTablet.jsx
@@ -7,6 +7,7 @@ import { Menu, MenuItem } from '@material-ui/core/esm'; // , Tooltip
 import Reply from '@material-ui/icons/Reply';
 import { withStyles } from '@material-ui/core/styles';
 import AppActions from '../../actions/AppActions';
+import AppStore from '../../stores/AppStore';
 import { historyPush } from '../../utils/cordovaUtils';
 import ShareActions from '../../actions/ShareActions';
 import { stringContains } from '../../utils/textFormat';
@@ -22,11 +23,31 @@ class ShareButtonDesktopTablet extends Component {
   constructor (props) {
     super(props);
     this.state = {
-      openShareMenu: false,
       anchorEl: null,
+      chosenPreventSharingOptions: false,
+      openShareMenu: false,
     };
     this.handleShareButtonClick = this.handleShareButtonClick.bind(this);
     this.handleCloseMenu = this.handleCloseMenu.bind(this);
+  }
+
+  componentDidMount () {
+    this.appStoreListener = AppStore.addListener(this.onAppStoreChange.bind(this));
+    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    this.setState({
+      chosenPreventSharingOptions,
+    });
+  }
+
+  componentWillUnmount () {
+    this.appStoreListener.remove();
+  }
+
+  onAppStoreChange () {
+    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    this.setState({
+      chosenPreventSharingOptions,
+    });
   }
 
   handleShareButtonClick (event) {
@@ -88,7 +109,7 @@ class ShareButtonDesktopTablet extends Component {
 
   render () {
     const { candidateShare, classes, measureShare, officeShare } = this.props;
-    const { anchorEl } = this.state;
+    const { anchorEl, chosenPreventSharingOptions, openShareMenu } = this.state;
 
     let shareButtonClasses;
     let shareMenuTextDefault;
@@ -111,7 +132,6 @@ class ShareButtonDesktopTablet extends Component {
       shareMenuTextDefault = 'Ballot';
       shareMenuTextAllOpinions = 'Ballot + Your Opinions';
     }
-    const featureStillInDevelopment = false;
     return (
       <>
         <Button
@@ -142,7 +162,7 @@ class ShareButtonDesktopTablet extends Component {
           elevation={2}
           getContentAnchorEl={null}
           onClose={this.handleCloseMenu}
-          open={this.state.openShareMenu}
+          open={openShareMenu}
           transformOrigin={{
             horizontal: 'right',
             vertical: 'top',
@@ -172,7 +192,7 @@ class ShareButtonDesktopTablet extends Component {
             </MenuFlex>
           </MenuItem>
           <MenuSeparator />
-          {featureStillInDevelopment ? null : (
+          {chosenPreventSharingOptions ? null : (
             <MenuItem className={classes.menuItem} onClick={() => this.openShareModal(true)}>
               <MenuFlex>
                 <MenuIcon>

--- a/src/js/components/Share/ShareButtonFooter.jsx
+++ b/src/js/components/Share/ShareButtonFooter.jsx
@@ -38,7 +38,7 @@ class ShareButtonFooter extends Component {
     this.state = {
       allOpinions: false,
       candidateShare: false,
-      chosenPreventSharingOptions: false,
+      chosenPreventSharingOpinions: false,
       currentFullUrlToShare: '',
       hideShareButtonFooter: false,
       measureShare: false,
@@ -61,7 +61,7 @@ class ShareButtonFooter extends Component {
     const showingOneCompleteYourProfileModal = AppStore.showingOneCompleteYourProfileModal();
     const showShareModal = AppStore.showShareModal();
     const showSignInModal = AppStore.showSignInModal();
-    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    const chosenPreventSharingOpinions = AppStore.getChosenPreventSharingOpinions();
     const currentFullUrl = window.location.href || '';
     const currentFullUrlToShare = currentFullUrl.replace('/modal/share', '');
     const candidateShare = pathname.startsWith('/candidate');
@@ -85,7 +85,7 @@ class ShareButtonFooter extends Component {
     const voterIsSignedIn = voter.is_signed_in;
     this.setState({
       candidateShare,
-      chosenPreventSharingOptions,
+      chosenPreventSharingOpinions,
       currentFullUrlToShare,
       measureShare,
       officeShare,
@@ -106,7 +106,7 @@ class ShareButtonFooter extends Component {
 
   onAppStoreChange () {
     const { openShareButtonDrawer } = this.state;
-    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    const chosenPreventSharingOpinions = AppStore.getChosenPreventSharingOpinions();
     const scrolledDown = AppStore.getScrolledDown();
     const hideShareButtonFooter = scrolledDown && !openShareButtonDrawer;
     // console.log('scrolledDown:', scrolledDown, ', hideShareButtonFooter:', hideShareButtonFooter);
@@ -114,7 +114,7 @@ class ShareButtonFooter extends Component {
     const showShareModal = AppStore.showShareModal();
     const showSignInModal = AppStore.showSignInModal();
     this.setState({
-      chosenPreventSharingOptions,
+      chosenPreventSharingOpinions,
       hideShareButtonFooter,
       showingOneCompleteYourProfileModal,
       showShareModal,
@@ -306,7 +306,7 @@ class ShareButtonFooter extends Component {
     const { classes, pathname } = this.props;
     const {
       allOpinions,
-      candidateShare, chosenPreventSharingOptions, currentFullUrlToShare,
+      candidateShare, chosenPreventSharingOpinions, currentFullUrlToShare,
       hideShareButtonFooter, measureShare, officeShare, openShareButtonDrawer,
       shareFooterStep, showingOneCompleteYourProfileModal, showShareButton,
       showShareModal, showSignInModal,
@@ -495,7 +495,7 @@ class ShareButtonFooter extends Component {
                           {' '}
                           Your opinions are NOT included.
                           {' '}
-                          {!chosenPreventSharingOptions && (
+                          {!chosenPreventSharingOpinions && (
                             <span className="u-link-color u-underline u-cursor--pointer" onClick={() => this.includeOpinions(shareFooterStep)}>
                               Include your opinions.
                             </span>
@@ -634,7 +634,7 @@ class ShareButtonFooter extends Component {
                         </MenuText>
                       </MenuFlex>
                     </MenuItem>
-                    {!chosenPreventSharingOptions && (
+                    {!chosenPreventSharingOpinions && (
                       <>
                         <MenuSeparator />
                         <MenuItem className={classes.menuItem} onClick={() => this.openShareOptions(true)}>

--- a/src/js/components/Share/ShareButtonFooter.jsx
+++ b/src/js/components/Share/ShareButtonFooter.jsx
@@ -38,6 +38,7 @@ class ShareButtonFooter extends Component {
     this.state = {
       allOpinions: false,
       candidateShare: false,
+      chosenPreventSharingOptions: false,
       currentFullUrlToShare: '',
       hideShareButtonFooter: false,
       measureShare: false,
@@ -60,6 +61,7 @@ class ShareButtonFooter extends Component {
     const showingOneCompleteYourProfileModal = AppStore.showingOneCompleteYourProfileModal();
     const showShareModal = AppStore.showShareModal();
     const showSignInModal = AppStore.showSignInModal();
+    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
     const currentFullUrl = window.location.href || '';
     const currentFullUrlToShare = currentFullUrl.replace('/modal/share', '');
     const candidateShare = pathname.startsWith('/candidate');
@@ -83,6 +85,7 @@ class ShareButtonFooter extends Component {
     const voterIsSignedIn = voter.is_signed_in;
     this.setState({
       candidateShare,
+      chosenPreventSharingOptions,
       currentFullUrlToShare,
       measureShare,
       officeShare,
@@ -103,6 +106,7 @@ class ShareButtonFooter extends Component {
 
   onAppStoreChange () {
     const { openShareButtonDrawer } = this.state;
+    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
     const scrolledDown = AppStore.getScrolledDown();
     const hideShareButtonFooter = scrolledDown && !openShareButtonDrawer;
     // console.log('scrolledDown:', scrolledDown, ', hideShareButtonFooter:', hideShareButtonFooter);
@@ -110,6 +114,7 @@ class ShareButtonFooter extends Component {
     const showShareModal = AppStore.showShareModal();
     const showSignInModal = AppStore.showSignInModal();
     this.setState({
+      chosenPreventSharingOptions,
       hideShareButtonFooter,
       showingOneCompleteYourProfileModal,
       showShareModal,
@@ -301,9 +306,9 @@ class ShareButtonFooter extends Component {
     const { classes, pathname } = this.props;
     const {
       allOpinions,
-      candidateShare, currentFullUrlToShare,
-      hideShareButtonFooter, measureShare, officeShare, openShareButtonDrawer, shareFooterStep,
-      showingOneCompleteYourProfileModal, showShareButton,
+      candidateShare, chosenPreventSharingOptions, currentFullUrlToShare,
+      hideShareButtonFooter, measureShare, officeShare, openShareButtonDrawer,
+      shareFooterStep, showingOneCompleteYourProfileModal, showShareButton,
       showShareModal, showSignInModal,
       urlWithSharedItemCode, urlWithSharedItemCodeAllOpinions,
     } = this.state;
@@ -490,9 +495,11 @@ class ShareButtonFooter extends Component {
                           {' '}
                           Your opinions are NOT included.
                           {' '}
-                          <span className="u-link-color u-underline u-cursor--pointer" onClick={() => this.includeOpinions(shareFooterStep)}>
-                            Include your opinions.
-                          </span>
+                          {!chosenPreventSharingOptions && (
+                            <span className="u-link-color u-underline u-cursor--pointer" onClick={() => this.includeOpinions(shareFooterStep)}>
+                              Include your opinions.
+                            </span>
+                          )}
                         </>
                       )
                       }
@@ -627,17 +634,21 @@ class ShareButtonFooter extends Component {
                         </MenuText>
                       </MenuFlex>
                     </MenuItem>
-                    <MenuSeparator />
-                    <MenuItem className={classes.menuItem} onClick={() => this.openShareOptions(true)}>
-                      <MenuFlex>
-                        <MenuIcon>
-                          <Comment />
-                        </MenuIcon>
-                        <MenuText>
-                          {shareMenuTextAllOpinions}
-                        </MenuText>
-                      </MenuFlex>
-                    </MenuItem>
+                    {!chosenPreventSharingOptions && (
+                      <>
+                        <MenuSeparator />
+                        <MenuItem className={classes.menuItem} onClick={() => this.openShareOptions(true)}>
+                          <MenuFlex>
+                            <MenuIcon>
+                              <Comment />
+                            </MenuIcon>
+                            <MenuText>
+                              {shareMenuTextAllOpinions}
+                            </MenuText>
+                          </MenuFlex>
+                        </MenuItem>
+                      </>
+                    )}
                   </MenuItemsWrapper>
                   <Button className={classes.cancelButton} fullWidth onClick={this.handleCloseShareButtonDrawer} variant="outlined" color="primary">
                     Cancel

--- a/src/js/components/Share/ShareModal.jsx
+++ b/src/js/components/Share/ShareModal.jsx
@@ -45,7 +45,7 @@ class ShareModal extends Component {
     super(props);
     this.state = {
       pathname: '',
-      chosenPreventSharingOptions: false,
+      chosenPreventSharingOpinions: false,
       currentFullUrlToShare: '',
       currentFriendsList: [],
       // friendsToShareWith: [],
@@ -70,7 +70,7 @@ class ShareModal extends Component {
     FriendActions.currentFriends();
     this.shareStoreListener = ShareStore.addListener(this.onShareStoreChange.bind(this));
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
-    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    const chosenPreventSharingOpinions = AppStore.getChosenPreventSharingOpinions();
     const currentFullUrl = window.location.href || '';
     const currentFullUrlToShare = currentFullUrl.replace('/modal/share', '').toLowerCase();
     const urlWithSharedItemCode = ShareStore.getUrlWithSharedItemCodeByFullUrl(currentFullUrlToShare);
@@ -80,7 +80,7 @@ class ShareModal extends Component {
       ShareActions.sharedItemSave(currentFullUrlToShare);
     }
     this.setState({
-      chosenPreventSharingOptions,
+      chosenPreventSharingOpinions,
       currentFriendsList: FriendStore.currentFriends(),
       currentFullUrlToShare,
       pathname: this.props.pathname,
@@ -100,9 +100,9 @@ class ShareModal extends Component {
   }
 
   onAppStoreChange () {
-    const chosenPreventSharingOptions = AppStore.getChosenPreventSharingOpinions();
+    const chosenPreventSharingOpinions = AppStore.getChosenPreventSharingOpinions();
     this.setState({
-      chosenPreventSharingOptions,
+      chosenPreventSharingOpinions,
     });
   }
 
@@ -190,7 +190,7 @@ class ShareModal extends Component {
     // console.log('ShareModal render');
     const { classes } = this.props;
     const {
-      chosenPreventSharingOptions, currentFullUrlToShare, shareModalStep,
+      chosenPreventSharingOpinions, currentFullUrlToShare, shareModalStep,
       urlWithSharedItemCode, urlWithSharedItemCodeAllOpinions,
       voterIsSignedIn,
     } = this.state;
@@ -316,7 +316,7 @@ class ShareModal extends Component {
                     {' '}
                     Your opinions are NOT included.
                     {' '}
-                    {!chosenPreventSharingOptions && (
+                    {!chosenPreventSharingOpinions && (
                       <span className="u-link-color u-underline u-cursor--pointer" onClick={() => this.includeOpinions(shareModalStep)}>
                         Include your opinions.
                       </span>

--- a/src/js/routes/HowItWorks.jsx
+++ b/src/js/routes/HowItWorks.jsx
@@ -121,6 +121,7 @@ class HowItWorks extends Component {
           index: 4,
         },
       },
+      howItWorksWatched: false,
       selectedCategoryIndex: 0,
       selectedStepIndex: 0,
       voter: {},
@@ -161,6 +162,10 @@ class HowItWorks extends Component {
         selectedStepIndex: 0,
       });
     }
+    const howItWorksWatched = VoterStore.getInterfaceFlagState(VoterConstants.HOW_IT_WORKS_WATCHED);
+    this.setState({
+      howItWorksWatched,
+    });
   }
 
   componentWillReceiveProps (nextProps) {
@@ -195,6 +200,10 @@ class HowItWorks extends Component {
         selectedStepIndex: 0,
       });
     }
+    const howItWorksWatched = VoterStore.getInterfaceFlagState(VoterConstants.HOW_IT_WORKS_WATCHED);
+    this.setState({
+      howItWorksWatched,
+    });
   }
 
   componentWillUnmount () {
@@ -208,6 +217,13 @@ class HowItWorks extends Component {
   }
 
   handleChangeSlide = (selectedStepIndex) => {
+    const { howItWorksWatched } = this.state;
+    const minimumStepIndexForCompletion = 2;
+    if (!howItWorksWatched && selectedStepIndex >= minimumStepIndexForCompletion) {
+      // Mark this so we know to show 'How it Works' as completed
+      VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.HOW_IT_WORKS_WATCHED);
+      this.setState({ howItWorksWatched: true });
+    }
     this.setState({ selectedStepIndex });
   };
 
@@ -235,14 +251,16 @@ class HowItWorks extends Component {
   };
 
   howItWorksGetStarted () {
-    const { getStartedMode, getStartedUrl, voter } = this.state;
+    const { getStartedMode, getStartedUrl, howItWorksWatched, voter } = this.state;
     let isSignedIn = false;
     if (voter) {
       ({ is_signed_in: isSignedIn } = voter);
       isSignedIn = isSignedIn === undefined || isSignedIn === null ? false : isSignedIn;
     }
-    // Mark this so we know to show 'How it Works' as completed
-    VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.HOW_IT_WORKS_WATCHED);
+    if (!howItWorksWatched) {
+      // Mark this so we know to show 'How it Works' as completed
+      VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.HOW_IT_WORKS_WATCHED);
+    }
     if (isSignedIn) {
       historyPush(getStartedUrl);
       AppActions.setShowHowItWorksModal(false);

--- a/src/js/stores/AppStore.js
+++ b/src/js/stores/AppStore.js
@@ -12,6 +12,7 @@ import { stringContains } from '../utils/textFormat';
 class AppStore extends ReduceStore {
   getInitialState () {
     return {
+      chosenPreventSharingOpinions: false,
       chosenReadyIntroductionText: '',
       chosenReadyIntroductionTitle: '',
       chosenSiteLogoUrl: '',
@@ -41,6 +42,10 @@ class AppStore extends ReduceStore {
       storeSignInStartFullUrl: false,
       voterExternalIdHasBeenSavedOnce: {}, // Dict with externalVoterId and membershipOrganizationWeVoteId as keys, and true/false as value
     };
+  }
+
+  getChosenPreventSharingOpinions () {
+    return this.getState().chosenPreventSharingOpinions;
   }
 
   getChosenReadyIntroductionText () {
@@ -204,6 +209,7 @@ class AppStore extends ReduceStore {
   reduce (state, action) {
     let apiStatus;
     let apiSuccess;
+    let chosenPreventSharingOpinions;
     let chosenReadyIntroductionText;
     let chosenReadyIntroductionTitle;
     let chosenSiteLogoUrl;
@@ -264,6 +270,7 @@ class AppStore extends ReduceStore {
           organization_we_vote_id: siteOwnerOrganizationWeVoteId,
           chosen_hide_we_vote_logo: hideWeVoteLogo,
           chosen_logo_url_https: chosenSiteLogoUrl,
+          chosen_prevent_sharing_opinions: chosenPreventSharingOpinions,
           chosen_ready_introduction_text: chosenReadyIntroductionText,
           chosen_ready_introduction_title: chosenReadyIntroductionTitle,
         } = action.res);
@@ -309,6 +316,7 @@ class AppStore extends ReduceStore {
             ...state,
             apiStatus,
             apiSuccess,
+            chosenPreventSharingOpinions,
             chosenReadyIntroductionText,
             chosenReadyIntroductionTitle,
             chosenSiteLogoUrl,

--- a/src/js/utils/applicationUtils.js
+++ b/src/js/utils/applicationUtils.js
@@ -169,14 +169,7 @@ export function getApplicationViewBooleans (pathname) {
       (pathnameLowerCase === '/welcome') ||
       pathnameLowerCase.startsWith('/value/') ||
       pathnameLowerCase.startsWith('/values/') ||
-      pathnameLowerCase.startsWith('/settings/account') ||
-      pathnameLowerCase.startsWith('/settings/domain') ||
-      pathnameLowerCase.startsWith('/settings/notifications') ||
       stringContains('/settings/positions', pathnameLowerCase) ||
-      pathnameLowerCase.startsWith('/settings/profile') ||
-      pathnameLowerCase.startsWith('/settings/sharing') ||
-      pathnameLowerCase.startsWith('/settings/subscription') ||
-      pathnameLowerCase.startsWith('/settings/tools') ||
       pathnameLowerCase.startsWith('/settings/voterguidelist') ||
       pathnameLowerCase.startsWith('/settings/voterguidesmenu')
   ) {
@@ -192,6 +185,14 @@ export function getApplicationViewBooleans (pathname) {
       (pathnameLowerCase === '/more/terms') ||
       pathnameLowerCase.startsWith('/office') || // Show Footer if back to not specified above
       pathnameLowerCase.startsWith('/values') ||
+      pathnameLowerCase.startsWith('/settings/account') ||
+      pathnameLowerCase.startsWith('/settings/domain') ||
+      pathnameLowerCase.startsWith('/settings/notifications') ||
+      pathnameLowerCase.startsWith('/settings/profile') ||
+      pathnameLowerCase.startsWith('/settings/sharing') ||
+      pathnameLowerCase.startsWith('/settings/subscription') ||
+      pathnameLowerCase.startsWith('/settings/text') ||
+      pathnameLowerCase.startsWith('/settings/tools') ||
       pathnameLowerCase.startsWith('/settings')) {
     // We want to SHOW the footer bar on the above path patterns
     showFooterBar = true;


### PR DESCRIPTION
Added configuration option to off "share opinions" option for 501c3 sites. Turned off autoFocus on ready page input field. All visits to root level of site now direct to Ready page. Fixed problem in settings section where the footer wasn't appearing in Tablet mode.