### PR TITLE
[Issue #2944] removed else-if logic for zero-padding time

### DIFF
--- a/src/js/components/Ready/ElectionCountdown.jsx
+++ b/src/js/components/Ready/ElectionCountdown.jsx
@@ -59,14 +59,14 @@ class ElectionCountdown extends React.Component {
       let minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
       let seconds = Math.floor((distance % (1000 * 60)) / 1000);
 
-      const numbersToAddZeroTo = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-
       days = `${days}`;
-      if (numbersToAddZeroTo.includes(hours)) {
+      if (hours < 10) {
         hours = `0${hours}`;
-      } else if (numbersToAddZeroTo.includes(minutes)) {
+      }
+      if (minutes < 10) {
         minutes = `0${minutes}`;
-      } else if (numbersToAddZeroTo.includes(seconds)) {
+      }
+      if (seconds < 10) {
         seconds = `0${seconds}`;
       }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

Issue #2944 

### Changes included this pull request?

All three (hours, minutes, seconds) need to test for a zero prefix. Also removed the `array.includes()` test in favor of the numerical test `n < 10`
