### PR TITLE
Turned the "Address & Elections" button back on on the Ballot page, and added it to the Ready page too. Added "Enter full address for correct ballot" text in mobile mode. Fixed bug reported by voter where the last character wasn't getting include with onPaste in SettingsVerifySecretCode. Added notice to "Choose or Oppose" modal after sign in. Made it so people can remove their support or opposition of candidate or measure in Endorsements popover, based on user testing.

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -87,6 +87,15 @@ class Application extends Component {
     //     stringContains('/ballot', pathname.toLowerCase().slice(0, 7)))) {
     //   AppActions.setShowEditAddressButton(true);
     // }
+    if (stringContains('/ballot', pathname.toLowerCase().slice(0, 7)) ||
+        stringContains('/ready', pathname.toLowerCase().slice(0, 7))) {
+      if (!AppStore.showEditAddressButton()) {
+        AppActions.setShowEditAddressButton(true);
+      }
+    } else if (AppStore.showEditAddressButton()) {
+      AppActions.setShowEditAddressButton(false);
+    }
+
     if (isWebApp() && String(lastZenDeskVisibilityPathName) !== String(pathname)) {
       // console.log('lastZenDeskVisibilityPathName:', lastZenDeskVisibilityPathName, ', pathname:', pathname);
       setZenDeskHelpVisibility(pathname);

--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -42,6 +42,7 @@ const routes = () => {  // eslint-disable-line arrow-body-style
           <Route path="/welcome" component={isNotWeVoteMarketingSite ? componentLoader('ReadyRedirect') : props => <WelcomeForVoters {...props} pathname="/welcome" />} />
           <Route path="/news" component={componentLoader('News')} />
           <Route path="/ready" component={componentLoader('Ready')} />
+          <Route path="/ready/election/:google_civic_election_id" component={componentLoader('Ready')} />
           <Route path="/register" component={componentLoader('Register')} />
           <Route path="/ballot" component={componentLoader('Ballot')} />
           <Route path="/ballot?voter_refresh_timer_on=:voter_refresh_timer_on" component={componentLoader('Ballot')} />

--- a/src/js/components/Ballot/SelectBallotModal.jsx
+++ b/src/js/components/Ballot/SelectBallotModal.jsx
@@ -41,7 +41,6 @@ class SelectBallotModal extends Component {
     super(props);
     this.state = {
       editingAddress: false,
-      pathname: undefined,
       selectedState: 'all',
       upcoming: true,
       prior: false,
@@ -51,17 +50,9 @@ class SelectBallotModal extends Component {
   }
 
   componentDidMount () {
-    this.setState({
-      pathname: this.props.pathname,
-    });
     AnalyticsActions.saveActionSelectBallotModal(VoterStore.electionId());
   }
 
-  componentWillReceiveProps (nextProps) {
-    this.setState({
-      pathname: nextProps.pathname,
-    });
-  }
   //
   // shouldComponentUpdate (nextProps, nextState) {
   //   // This lifecycle method tells the component to NOT render if componentWillReceiveProps didn't see any changes
@@ -111,9 +102,9 @@ class SelectBallotModal extends Component {
 
   render () {
     renderLog('SelectBallotModal');  // Set LOG_RENDER_EVENTS to log all renders
-    const { classes, hideAddressEdit, hideElections } = this.props;
+    const { classes, hideAddressEdit, hideElections, pathname } = this.props;
     const { editingAddress } = this.state;
-    const ballotBaseUrl = calculateBallotBaseUrl(this.props.ballotBaseUrl, this.props.pathname);
+    const ballotBaseUrl = calculateBallotBaseUrl(this.props.ballotBaseUrl, pathname);
 
     const voterAddressObject = VoterStore.getAddressObject();
     let dialogTitleText = 'Address & Elections';
@@ -126,7 +117,7 @@ class SelectBallotModal extends Component {
       <Dialog
         classes={{ paper: classes.dialogPaper }}
         open={this.props.show}
-        onClose={() => { this.props.toggleFunction(this.state.pathname); }}
+        onClose={() => { this.props.toggleFunction(pathname); }}
       >
         <DialogTitle>
           <Title>
@@ -148,8 +139,9 @@ class SelectBallotModal extends Component {
                 <EditAddressInPlaceWrapperMobile>
                   <EditAddressInPlace
                     address={voterAddressObject}
+                    ballotBaseUrl={ballotBaseUrl}
                     defaultIsEditingAddress={editingAddress}
-                    pathname={this.state.pathname}
+                    pathname={pathname}
                     toggleFunction={this.props.toggleFunction}
                     toggleEditingAddress={this.toggleEditingAddress}
                   />
@@ -166,8 +158,9 @@ class SelectBallotModal extends Component {
                 {!hideAddressEdit && (
                   <EditAddressInPlace
                     address={voterAddressObject}
+                    ballotBaseUrl={ballotBaseUrl}
                     defaultIsEditingAddress={editingAddress}
-                    pathname={this.state.pathname}
+                    pathname={pathname}
                     toggleFunction={this.props.toggleFunction}
                     toggleEditingAddress={this.toggleEditingAddress}
                   />

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -431,11 +431,11 @@ class HeaderBar extends Component {
     } = this.state;
 
     // console.log('Header Bar, showSignInModal ', showSignInModal);
-    const ballotBaseUrl = '/ballot';
+    const ballotBaseUrl = stringContains('/ready', pathname.toLowerCase().slice(0, 7)) ? '/ready' : '/ballot';
     const numberOfIncomingFriendRequests = friendInvitationsSentToMe.length || 0;
     const showFullNavigation = true;
     const weVoteBrandingOff = this.state.we_vote_branding_off;
-    const showingBallot = stringContains(ballotBaseUrl, pathname.toLowerCase().slice(0, 7));
+    const showingBallot = stringContains('/ballot', pathname.toLowerCase().slice(0, 7));
     const showingFriendsTabs = displayFriendsTabs();
     const voterPhotoUrlMedium = voterPhoto(voter);
     const editAddressButtonHtml = (
@@ -629,7 +629,7 @@ class HeaderBar extends Component {
         )}
         {showSelectBallotModal && (
           <SelectBallotModal
-            ballotBaseUrl="/ballot"
+            ballotBaseUrl={ballotBaseUrl}
             hideAddressEdit={showSelectBallotModalHideAddress}
             hideElections={showSelectBallotModalHideElections}
             location={location}

--- a/src/js/components/Ready/EditAddressOneHorizontalRow.jsx
+++ b/src/js/components/Ready/EditAddressOneHorizontalRow.jsx
@@ -161,68 +161,62 @@ class EditAddressOneHorizontalRow extends Component {
     const { textForMapSearch } = this.state;
 
     return (
-      <Wrapper>
-        <AddressLabel className="u-show-desktop-tablet">
-          {(textForMapSearch) ? (
-            <>
-              <span className="u-show-tablet">
-                Your correct location?
-              </span>
-              <span className="u-show-desktop">
-                Do we have your location correct?
-              </span>
-            </>
-          ) : (
-            <>
-              <span className="u-show-tablet">
-                Enter full address for correct ballot
-              </span>
-              <span className="u-show-desktop">
-                Enter your full address to see correct ballot
-              </span>
-            </>
-          )}
-        </AddressLabel>
-        <form onSubmit={this.voterAddressSave}>
-          <InternalFormWrapper>
-            <Paper className={classes.paperInputForm} elevation={2}>
-              <EditLocation className="ion-input-icon" />
-              <InputBase
-                className={classes.inputBase}
-                name="address"
-                aria-label="Address"
-                placeholder="Full address and ZIP..."
-                value={textForMapSearch}
-                inputRef={(autocomplete) => { this.autoComplete = autocomplete; }}
-                inputProps={{
-                  onBlur: this.saveAddressToApiServer,
-                  onChange: this.updateVoterAddress,
-                  onKeyDown: this.handleKeyPress,
-                }}
-                id="editAddressOneHorizontalRowTextForMapSearch"
-              />
-            </Paper>
-            <Button
-              classes={{ root: classes.saveButton }}
-              color="primary"
-              fullWidth
-              id="editAddressOneHorizontalRowSaveButton"
-              onClick={this.voterAddressSave}
-              variant="contained"
-            >
-              {(textForMapSearch) ? (
-                <>
-                  Confirm
-                </>
-              ) : (
-                <>
-                  Save
-                </>
-              )}
-            </Button>
-          </InternalFormWrapper>
-        </form>
-      </Wrapper>
+      <OuterWrapper>
+        <InnerWrapper className="u-show-mobile">
+          <AddressLabelMobile>
+            Enter full address for correct ballot
+          </AddressLabelMobile>
+        </InnerWrapper>
+        <InnerWrapper>
+          <AddressLabel>
+            <span className="u-show-tablet">
+              Enter full address for correct ballot
+            </span>
+            <span className="u-show-desktop">
+              Enter your full address to see correct ballot
+            </span>
+          </AddressLabel>
+          <form onSubmit={this.voterAddressSave}>
+            <InternalFormWrapper>
+              <Paper className={classes.paperInputForm} elevation={2}>
+                <EditLocation className="ion-input-icon" />
+                <InputBase
+                  className={classes.inputBase}
+                  name="address"
+                  aria-label="Address"
+                  placeholder="Full address and ZIP..."
+                  value={textForMapSearch}
+                  inputRef={(autocomplete) => { this.autoComplete = autocomplete; }}
+                  inputProps={{
+                    onBlur: this.saveAddressToApiServer,
+                    onChange: this.updateVoterAddress,
+                    onKeyDown: this.handleKeyPress,
+                  }}
+                  id="editAddressOneHorizontalRowTextForMapSearch"
+                />
+              </Paper>
+              <Button
+                classes={{ root: classes.saveButton }}
+                color="primary"
+                fullWidth
+                id="editAddressOneHorizontalRowSaveButton"
+                onClick={this.voterAddressSave}
+                variant="contained"
+              >
+                {(textForMapSearch) ? (
+                  <>
+                    Update
+                  </>
+                ) : (
+                  <>
+                    Save
+                  </>
+                )}
+              </Button>
+            </InternalFormWrapper>
+          </form>
+        </InnerWrapper>
+      </OuterWrapper>
     );
   }
 }
@@ -231,17 +225,25 @@ const AddressLabel = styled.div`
   font-weight: 600;
   margin-right: 12px;
 `;
+
+const AddressLabelMobile = styled.div`
+  font-weight: 600;
+`;
+
 const InternalFormWrapper = styled.div`
   display: flex;
   justify-content: center;
 `;
 
-const Wrapper = styled.div`
+const OuterWrapper = styled.div`
+  margin-bottom: 8px !important;
+  width: 100%;
+`;
+
+const InnerWrapper = styled.div`
   align-items: center;
   display: flex;
   justify-content: center;
-  margin-bottom: 8px !important;
-  width: 100%;
 `;
 
 const styles = theme => ({

--- a/src/js/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/components/Settings/SettingsVerifySecretCode.jsx
@@ -311,7 +311,8 @@ class SettingsVerifySecretCode extends Component {
         digit5: allDigits[4],
         digit6: allDigits[5],
       });
-      document.getElementById('digit6').focus();
+      document.getElementById('digit1').blur(); // If we leave the focus, the box doesn't fill
+      // document.getElementById('digit6').focus(); // If we focus, it clears the box
       this.setState({
         errorToDisplay: false,
         errorMessageToDisplay: '',

--- a/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
@@ -16,6 +16,8 @@ import { stringContains } from '../../utils/textFormat';
 import StickyPopover from '../Ballot/StickyPopover';
 import { getPositionSummaryListForBallotItem, getPositionListSummaryIncomingDataStats } from '../../utils/positionFunctions';
 import PositionSummaryListForPopover from './PositionSummaryListForPopover';
+import SupportActions from '../../actions/SupportActions';
+import { openSnackbar } from './SnackNotifier';
 
 class BallotItemSupportOpposeCountDisplay extends Component {
   static closePositionsPopover () {
@@ -65,6 +67,8 @@ class BallotItemSupportOpposeCountDisplay extends Component {
       voterSupportsBallotItem: false,
     };
     this.goToBallotItemLinkLocal = this.goToBallotItemLinkLocal.bind(this);
+    this.stopOpposingItem = this.stopOpposingItem.bind(this);
+    this.stopSupportingItem = this.stopSupportingItem.bind(this);
   }
 
   componentDidMount () {
@@ -421,6 +425,29 @@ class BallotItemSupportOpposeCountDisplay extends Component {
     }
   };
 
+  stopOpposingItem () {
+    const { ballotItemWeVoteId } = this.props;
+    const isMeasure = stringContains('meas', ballotItemWeVoteId);
+    let kindOfBallotItem = 'CANDIDATE';
+    if (isMeasure) {
+      kindOfBallotItem = 'MEASURE';
+    }
+    // console.log('ItemActionBar, stopOpposingItem, transitioning:', this.state.transitioning);
+    SupportActions.voterStopOpposingSave(ballotItemWeVoteId, kindOfBallotItem);
+    openSnackbar({ message: 'Opposition removed!' });
+  }
+
+  stopSupportingItem () {
+    const { ballotItemWeVoteId } = this.props;
+    const isMeasure = stringContains('meas', ballotItemWeVoteId);
+    let kindOfBallotItem = 'CANDIDATE';
+    if (isMeasure) {
+      kindOfBallotItem = 'MEASURE';
+    }
+    SupportActions.voterStopSupportingSave(ballotItemWeVoteId, kindOfBallotItem);
+    openSnackbar({ message: 'Support removed!' });
+  }
+
   componentDidCatch (error, info) {
     // We should get this information to Splunk!
     console.error('BallotItemSupportOpposeCountDisplay caught error: ', `${error} with info: `, info);
@@ -496,7 +523,12 @@ class BallotItemSupportOpposeCountDisplay extends Component {
               {voterSupportsBallotItem && (
                 <YourOpinion>
                   <DecidedIconWrapper>
-                    <NetworkScoreSmall className={classes.voterSupports} voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative} voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}>
+                    <NetworkScoreSmall
+                      className={classes.voterSupports}
+                      onClick={this.stopSupportingItem}
+                      voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                      voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                    >
                       <Done classes={{ root: classes.decidedIconSmall }} />
                     </NetworkScoreSmall>
                   </DecidedIconWrapper>
@@ -513,7 +545,12 @@ class BallotItemSupportOpposeCountDisplay extends Component {
               {voterOpposesBallotItem && (
                 <YourOpinion>
                   <DecidedIconWrapper>
-                    <NetworkScoreSmall className={classes.voterOpposes} voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative} voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}>
+                    <NetworkScoreSmall
+                      className={classes.voterOpposes}
+                      onClick={this.stopOpposingItem}
+                      voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                      voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                    >
                       <NotInterested classes={{ root: classes.decidedIconSmall }} />
                     </NetworkScoreSmall>
                   </DecidedIconWrapper>
@@ -703,7 +740,12 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             {voterSupportsBallotItem && (
               <YourOpinion>
                 <DecidedIconWrapper>
-                  <NetworkScoreSmall className={classes.voterSupports} voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative} voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}>
+                  <NetworkScoreSmall
+                    className={classes.voterSupports}
+                    onClick={this.stopSupportingItem}
+                    voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                    voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                  >
                     <Done classes={{ root: classes.decidedIconSmall }} />
                   </NetworkScoreSmall>
                 </DecidedIconWrapper>
@@ -721,7 +763,12 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             {voterOpposesBallotItem && (
               <YourOpinion>
                 <DecidedIconWrapper>
-                  <NetworkScoreSmall className={classes.voterOpposes} voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative} voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}>
+                  <NetworkScoreSmall
+                    className={classes.voterOpposes}
+                    onClick={this.stopOpposingItem}
+                    voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                    voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                  >
                     <NotInterested classes={{ root: classes.decidedIconSmall }} />
                   </NetworkScoreSmall>
                 </DecidedIconWrapper>

--- a/src/js/components/Widgets/ItemActionBar/ChooseOrOppose.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ChooseOrOppose.jsx
@@ -7,6 +7,7 @@ import { withStyles } from '@material-ui/core/styles';
 import PositionPublicToggle from '../PositionPublicToggle';
 import Slides from './Slides';
 import SettingsAccount from '../../Settings/SettingsAccount';
+import VoterStore from '../../../stores/VoterStore';
 
 class ChooseOrOppose extends Component {
   static propTypes = {
@@ -17,8 +18,35 @@ class ChooseOrOppose extends Component {
     inModal: PropTypes.bool,
   };
 
+  constructor (props) {
+    super(props);
+    this.state = {
+      voterIsSignedIn: false,
+    };
+  }
+
+  componentDidMount () {
+    this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
+    const voterIsSignedIn = VoterStore.getVoterIsSignedIn();
+    this.setState({
+      voterIsSignedIn,
+    });
+  }
+
+  componentWillUnmount () {
+    this.voterStoreListener.remove();
+  }
+
+  onVoterStoreChange () {
+    const voterIsSignedIn = VoterStore.getVoterIsSignedIn();
+    this.setState({
+      voterIsSignedIn,
+    });
+  }
+
   getSlides = () => {
     const { ballotItemType } = this.props;
+    const { voterIsSignedIn } = this.state;
     const slides = [
       (
         <React.Fragment>
@@ -45,12 +73,20 @@ class ChooseOrOppose extends Component {
         </React.Fragment>
       ),
       (
-        <SettingsAccount
-          pleaseSignInTitle="Sign in to save your choices!"
-          pleaseSignInSubTitle=""
-          toggleSignInModal={this.props.onClose}
-          inModal
-        />
+        <>
+          {voterIsSignedIn ? (
+            <div>
+              Thank you for signing in!
+            </div>
+          ) : (
+            <SettingsAccount
+              pleaseSignInTitle="Sign in to save your choices!"
+              pleaseSignInSubTitle=""
+              toggleSignInModal={this.props.onClose}
+              inModal
+            />
+          )}
+        </>
       ),
     ];
     return slides;
@@ -58,6 +94,7 @@ class ChooseOrOppose extends Component {
 
   render () {
     const { classes } = this.props;
+    const { voterIsSignedIn } = this.state;
     return (
       <React.Fragment>
         <DialogTitle classes={{ root: classes.dialogTitle }}>
@@ -73,7 +110,11 @@ class ChooseOrOppose extends Component {
         </DialogTitle>
         <HorizontalLine />
         <DialogContent classes={{ root: classes.dialogContent }}>
-          <Slides slides={this.getSlides()} onClose={this.props.onClose} />
+          <Slides
+            onClose={this.props.onClose}
+            slides={this.getSlides()}
+            voterIsSignedIn={voterIsSignedIn}
+          />
         </DialogContent>
       </React.Fragment>
     );

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -551,6 +551,7 @@ class ItemActionBar extends PureComponent {
     }
 
     const supportOpposeModalHasBeenShown = VoterStore.getInterfaceFlagState(VoterConstants.SUPPORT_OPPOSE_MODAL_SHOWN);
+    // const supportOpposeModalHasBeenShown = false; // For testing
     if (!supportOpposeModalHasBeenShown) {
       this.toggleSupportOrOpposeHelpModal();
       VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.SUPPORT_OPPOSE_MODAL_SHOWN);
@@ -584,7 +585,11 @@ class ItemActionBar extends PureComponent {
     renderLog('ItemActionBar ItemActionBar.jsx');  // Set LOG_RENDER_EVENTS to log all renders
     // console.log('ItemActionBar render');
     const { buttonsOnly, commentButtonHide, commentButtonHideInMobile, classes } = this.props;
-    const { ballotItemType, ballotItemWeVoteId, isOpposeAPIState, isSupportAPIState, numberOfOpposePositionsForScore, numberOfSupportPositionsForScore, showSupportOrOpposeHelpModal, voterPositionIsPublic } = this.state;
+    const {
+      ballotItemType, ballotItemWeVoteId, isOpposeAPIState, isSupportAPIState,
+      numberOfOpposePositionsForScore, numberOfSupportPositionsForScore,
+      showSupportOrOpposeHelpModal, voterPositionIsPublic,
+    } = this.state;
 
     if (numberOfSupportPositionsForScore === undefined ||
       numberOfOpposePositionsForScore === undefined ||

--- a/src/js/components/Widgets/ItemActionBar/Slides.jsx
+++ b/src/js/components/Widgets/ItemActionBar/Slides.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Button } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
-import VoterStore from '../../../stores/VoterStore';
 
 class Slides extends Component {
   static propTypes = {
+    classes: PropTypes.object,
     slides: PropTypes.array,
     startIndex: PropTypes.number,
-    classes: PropTypes.object,
     onClose: PropTypes.func,
+    voterIsSignedIn: PropTypes.bool,
   }
 
   constructor (props) {
@@ -29,10 +29,9 @@ class Slides extends Component {
   }
 
   render () {
-    const { classes } = this.props;
+    const { classes, voterIsSignedIn } = this.props;
     const { currentIndex } = this.state;
     const numberOfButtons = currentIndex > 0 && currentIndex < this.props.slides.length ? 2 : 1;
-    const voterIsSignedIn = VoterStore.getVoterIsSignedIn();
     let activeButtons;
     switch (currentIndex) {
       default:
@@ -107,7 +106,7 @@ class Slides extends Component {
               color="primary"
               onClick={this.props.onClose}
             >
-              Sign In Later
+              {voterIsSignedIn ? 'Close' : 'Sign In Later'}
             </Button>
           </Options>
         );

--- a/src/js/utils/textFormat.js
+++ b/src/js/utils/textFormat.js
@@ -47,7 +47,9 @@ export function calculateBallotBaseUrl (incomingBallotBaseUrl, incomingPathname)
   const incomingPathnameExists = incomingPathname && incomingPathname !== '';
   const ballotBaseUrlEmpty = !incomingBallotBaseUrl || incomingBallotBaseUrl === '';
   let ballotBaseUrl = '';
-  if (incomingPathnameExists && ballotBaseUrlEmpty) {
+  if (incomingBallotBaseUrl === '/ready') {
+    ballotBaseUrl = '/ready';
+  } else if (incomingPathnameExists && ballotBaseUrlEmpty) {
     // console.log("incomingPathname:", incomingPathname);
     // Strip off everything after these path strings "/ballot" "/positions" "/followers" "/followed"
     const temp1 = incomingPathname.toLowerCase().split('/ballot')[0];


### PR DESCRIPTION
Turned the "Address & Elections" button back on on the Ballot page, and added it to the Ready page too. Added "Enter full address for correct ballot" text in mobile mode. Fixed bug reported by voter where the last character wasn't getting include with onPaste in SettingsVerifySecretCode. Added notice to "Choose or Oppose" modal after sign in. Made it so people can remove their support or opposition of candidate or measure in Endorsements popover, based on user testing.