### PR TITLE
strip candidate detail text of html

### DIFF
--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -20,7 +20,11 @@ import ShowMoreFooter from '../Navigation/ShowMoreFooter';
 import SupportStore from '../../stores/SupportStore';
 import TopCommentByBallotItem from '../Widgets/TopCommentByBallotItem';
 import VoterGuideStore from '../../stores/VoterGuideStore';
-import { abbreviateNumber, numberWithCommas } from '../../utils/textFormat';
+import {
+  abbreviateNumber,
+  numberWithCommas,
+  stripHtmlFromString,
+} from '../../utils/textFormat';
 
 // This is related to /js/components/VoterGuide/OrganizationVoterGuideCandidateItem.jsx
 class CandidateItem extends Component {
@@ -108,6 +112,7 @@ class CandidateItem extends Component {
       const twitterDescriptionText = twitterDescription && twitterDescription.length ? `${twitterDescription} ` : '';
       const ballotpediaCandidateSummary = candidate.ballotpedia_candidate_summary;
       let ballotpediaCandidateSummaryText = ballotpediaCandidateSummary && ballotpediaCandidateSummary.length ? ballotpediaCandidateSummary : '';
+      ballotpediaCandidateSummaryText = stripHtmlFromString(ballotpediaCandidateSummaryText);
       ballotpediaCandidateSummaryText = ballotpediaCandidateSummaryText.split(/<[^<>]*>/).join(''); // Strip away any HTML tags
       const candidateText = twitterDescriptionText + ballotpediaCandidateSummaryText;
       const voterOpposesBallotItem = SupportStore.getVoterOpposesByBallotItemWeVoteId(candidateWeVoteId);
@@ -228,6 +233,7 @@ class CandidateItem extends Component {
       const twitterDescriptionText = twitterDescription && twitterDescription.length ? `${twitterDescription} ` : '';
       const ballotpediaCandidateSummary = candidate.ballotpedia_candidate_summary;
       let ballotpediaCandidateSummaryText = ballotpediaCandidateSummary && ballotpediaCandidateSummary.length ? ballotpediaCandidateSummary : '';
+      ballotpediaCandidateSummaryText = stripHtmlFromString(ballotpediaCandidateSummaryText);
       ballotpediaCandidateSummaryText = ballotpediaCandidateSummaryText.split(/<[^<>]*>/).join(''); // Strip away any HTML tags
       const candidateText = twitterDescriptionText + ballotpediaCandidateSummaryText;
       const allCachedPositionsForThisCandidate = CandidateStore.getAllCachedPositionsByCandidateWeVoteId(candidateWeVoteId);

--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -113,7 +113,6 @@ class CandidateItem extends Component {
       const ballotpediaCandidateSummary = candidate.ballotpedia_candidate_summary;
       let ballotpediaCandidateSummaryText = ballotpediaCandidateSummary && ballotpediaCandidateSummary.length ? ballotpediaCandidateSummary : '';
       ballotpediaCandidateSummaryText = stripHtmlFromString(ballotpediaCandidateSummaryText);
-      ballotpediaCandidateSummaryText = ballotpediaCandidateSummaryText.split(/<[^<>]*>/).join(''); // Strip away any HTML tags
       const candidateText = twitterDescriptionText + ballotpediaCandidateSummaryText;
       const voterOpposesBallotItem = SupportStore.getVoterOpposesByBallotItemWeVoteId(candidateWeVoteId);
       const voterSupportsBallotItem = SupportStore.getVoterSupportsByBallotItemWeVoteId(candidateWeVoteId);
@@ -234,7 +233,6 @@ class CandidateItem extends Component {
       const ballotpediaCandidateSummary = candidate.ballotpedia_candidate_summary;
       let ballotpediaCandidateSummaryText = ballotpediaCandidateSummary && ballotpediaCandidateSummary.length ? ballotpediaCandidateSummary : '';
       ballotpediaCandidateSummaryText = stripHtmlFromString(ballotpediaCandidateSummaryText);
-      ballotpediaCandidateSummaryText = ballotpediaCandidateSummaryText.split(/<[^<>]*>/).join(''); // Strip away any HTML tags
       const candidateText = twitterDescriptionText + ballotpediaCandidateSummaryText;
       const allCachedPositionsForThisCandidate = CandidateStore.getAllCachedPositionsByCandidateWeVoteId(candidateWeVoteId);
       const allCachedPositionsForThisCandidateLength = allCachedPositionsForThisCandidate.length || 0;

--- a/src/js/utils/textFormat.js
+++ b/src/js/utils/textFormat.js
@@ -344,6 +344,7 @@ export function stripHtmlFromString (rawString) {
   }
   let strippedString = rawString.replace(/&nbsp;/gi, ' ');
   strippedString = strippedString.replace(/<br>/gi, ' ');
+  strippedString = strippedString.split(/<[^<>]*>/).join(''); // Strip away any HTML tags
   return strippedString;
 }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
https://github.com/wevote/WebApp/issues/3086
### Changes included this pull request?
Added stripHtmlFromString to candidate detail text coming back from ballotpedia. 