### PR TITLE
ballotpedia button shows on measures page

### DIFF
--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -280,8 +280,8 @@ class Measure extends Component {
               <MeasureShareWrapper>
                 <ShareButtonDesktopTablet measureShare />
               </MeasureShareWrapper>
-              {measure.ballotpedia_measure_url && (
-                <ViewOnBallotpedia externalLinkUrl={measure.ballotpedia_measure_url} />
+              {measure.measure_url && (
+                <ViewOnBallotpedia externalLinkUrl={measure.measure_url} />
               )}
               {measureName && (
                 <SearchOnGoogle googleQuery={`${measureName}`} />


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
https://github.com/wevote/WebApp/issues/3096

### Changes included this pull request?
Ballotpedia button added to Measure pages