### PR TITLE
changing max-width style to include firefox

### DIFF
--- a/src/sass/components/_navigator.scss
+++ b/src/sass/components/_navigator.scss
@@ -286,7 +286,7 @@ $pop-up-menu-cordova-padding: 10px;
     background: #fff;
     overflow: hidden;
     display: inline;
-    max-width: fit-content;
+    max-width: max-content;
     @include breakpoints(max mid-small) {
       margin-top: $space-xs;
       margin-bottom: $space-xs;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
squished avatar on firefox
### Changes included this pull request?
avatar width fit-content switched to max content, which is compatible with firefox