### PR TITLE
new supporter icon fix

### DIFF
--- a/src/js/components/Widgets/BallotItemVoterGuideSupportOpposeDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemVoterGuideSupportOpposeDisplay.jsx
@@ -225,10 +225,8 @@ const styles = theme => ({
 });
 
 const FriendsOnlyIndicatorWrapper = styled.div`
-  margin-top: -3px;
-  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
-    margin-top: -2px !important;
-  }
+  margin-top: 0px !important;
+  display: flex;
 `;
 
 const Wrapper = styled.div`
@@ -343,25 +341,19 @@ const OverlayImage = styled.div`
 `;
 
 const OrganizationIconWrapper = styled.div`
-  margin-top: -3px !important;
+  margin-top: 0px !important;
   padding: 0 !important;
   width: 22px;
-  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
-    margin-top: -2px !important;
-  }
+  display: flex;
 `;
 
 const TinyImageSpacer = styled.div`
   background: white;
   border-radius: 3px;
   margin: 0px !important;
-  margin-top: 3px !important; // Override setting in OrganizationIconWrapper
   padding: 0px !important;
   width: 16px;
   height: 16px;
-  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
-    margin-top: 2px !important; // Override setting in OrganizationIconWrapper
-  }
 `;
 
 export default withTheme(withStyles(styles)(BallotItemVoterGuideSupportOpposeDisplay));

--- a/src/js/components/Widgets/FriendsOnlyIndicator.jsx
+++ b/src/js/components/Widgets/FriendsOnlyIndicator.jsx
@@ -29,10 +29,10 @@ export default class FriendsOnlyIndicator extends Component {
     let visibilityIcon = '';
     if (isFriendsOnly) {
       labelText = 'This position is only visible to We Vote friends.';
-      visibilityIcon = <ReactSVG src={cordovaDot(groupIcon)} svgStyle={{ backgroundColor: '#fff', borderRadius: '3px', fill: '#555', width: '16px', height: '16px'  }} alt="Visible to Friends Only" />;
+      visibilityIcon = <ReactSVG src={cordovaDot(groupIcon)} svgStyle={{ backgroundColor: '#fff', borderRadius: '3px', fill: '#555', width: '16px', height: '16px', display: 'flex', verticalAlign: 'unset'  }} alt="Visible to Friends Only" />;
     } else {
       labelText = 'This position is visible to the public.';
-      visibilityIcon = <ReactSVG src={cordovaDot(publicIcon)} svgStyle={{ backgroundColor: '#fff', borderRadius: '3px', fill: '#555', width: '16px', height: '16px' }} alt="Visible to Public" />;
+      visibilityIcon = <ReactSVG src={cordovaDot(publicIcon)} svgStyle={{ backgroundColor: '#fff', borderRadius: '3px', fill: '#555', width: '16px', height: '16px', display: 'flex', verticalAlign: 'unset' }} alt="Visible to Public" />;
     }
 
     const tooltip = <Tooltip id="tooltip">{labelText}</Tooltip>;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
https://github.com/wevote/WebApp/issues/3128
### Changes included this pull request?
Aligning endorser image and endorsement privacy level on news page.  Got rid of top padding, added flex display