### PR TITLE
Turning off the Apple Sign in button when focus is in the email or SMS input field. Made the Phone and SMS links ('Make Primary', 'Delete', 'Send Verification Again', 'sign out') look like links, and fixed bug with Send Verification Again. Moved the "Sign in with Apple" button above the "Currently Signed In" header (still needs work).

### DIFF
--- a/src/js/components/Activity/ActivityTidbitItem.jsx
+++ b/src/js/components/Activity/ActivityTidbitItem.jsx
@@ -189,6 +189,7 @@ const ActivityPostEditWrapper = styled.div`
 `;
 
 const ActivityPostWrapper = styled.div`
+  font-size: 18px;
 `;
 
 const ActivitySpeakerCardWrapper = styled.div`

--- a/src/js/components/Apple/AppleSignIn.jsx
+++ b/src/js/components/Apple/AppleSignIn.jsx
@@ -218,7 +218,7 @@ const AppleLogoSvg = styled.svg`
 `;
 
 const AppleSignInText = styled.span`
-  font-size: 14pt;
+  font-size: 12pt;
   padding: none;
   border: none;
   color: ${({ enabled }) => (enabled ? '#fff' : 'grey')};

--- a/src/js/components/Settings/SettingsAccount.jsx
+++ b/src/js/components/Settings/SettingsAccount.jsx
@@ -9,8 +9,7 @@ import AppActions from '../../actions/AppActions';
 import AppleSignIn from '../Apple/AppleSignIn';
 import AppStore from '../../stores/AppStore';
 import BrowserPushMessage from '../Widgets/BrowserPushMessage';
-import { historyPush, isCordova, isIPhone4in, isIPhone4p7in, isWebApp,
-  restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
+import { historyPush, isCordova, isIPhone4in, isIPhone4p7in, restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
 import FacebookActions from '../../actions/FacebookActions';
 import FacebookStore from '../../stores/FacebookStore';
 import FacebookSignIn from '../Facebook/FacebookSignIn';
@@ -45,6 +44,7 @@ export default class SettingsAccount extends Component {
     super(props);
     this.state = {
       facebookAuthResponse: {},
+      hideAppleSignInButton: false,
       hideCurrentlySignedInHeader: false,
       hideDialogForCordova: false,
       hideFacebookSignInButton: false,
@@ -227,8 +227,12 @@ export default class SettingsAccount extends Component {
   };
 
   toggleNonEmailSignInOptions = () => {
-    const { hideCurrentlySignedInHeader, hideFacebookSignInButton, hideTwitterSignInButton, hideVoterPhoneEntry } = this.state;
+    const {
+      hideAppleSignInButton, hideCurrentlySignedInHeader, hideFacebookSignInButton,
+      hideTwitterSignInButton, hideVoterPhoneEntry,
+    } = this.state;
     this.setState({
+      hideAppleSignInButton: !hideAppleSignInButton,
       hideCurrentlySignedInHeader: !hideCurrentlySignedInHeader,
       hideFacebookSignInButton: !hideFacebookSignInButton,
       hideTwitterSignInButton: !hideTwitterSignInButton,
@@ -239,8 +243,12 @@ export default class SettingsAccount extends Component {
   };
 
   toggleNonPhoneSignInOptions = () => {
-    const { hideCurrentlySignedInHeader, hideFacebookSignInButton, hideTwitterSignInButton, hideVoterEmailAddressEntry } = this.state;
+    const {
+      hideAppleSignInButton, hideCurrentlySignedInHeader, hideFacebookSignInButton,
+      hideTwitterSignInButton, hideVoterEmailAddressEntry,
+    } = this.state;
     this.setState({
+      hideAppleSignInButton: !hideAppleSignInButton,
       hideCurrentlySignedInHeader: !hideCurrentlySignedInHeader,
       hideFacebookSignInButton: !hideFacebookSignInButton,
       hideTwitterSignInButton: !hideTwitterSignInButton,
@@ -307,7 +315,8 @@ export default class SettingsAccount extends Component {
     renderLog('SettingsAccount');  // Set LOG_RENDER_EVENTS to log all renders
     const { inModal, externalUniqueId } = this.props;
     const {
-      facebookAuthResponse, hideCurrentlySignedInHeader, hideFacebookSignInButton, hideTwitterSignInButton,
+      facebookAuthResponse, hideCurrentlySignedInHeader,
+      hideAppleSignInButton, hideFacebookSignInButton, hideTwitterSignInButton,
       hideVoterEmailAddressEntry, hideVoterPhoneEntry, isOnWeVoteRootUrl, isOnWeVoteSubdomainUrl,
       isOnFacebookSupportedDomainUrl, pleaseSignInTitle, pleaseSignInSubTitle, voter, hideDialogForCordova,
     } = this.state;
@@ -411,6 +420,9 @@ export default class SettingsAccount extends Component {
               </>
             ) : null
             }
+            {!hideAppleSignInButton && (
+              <AppleSignIn signedIn={voterIsSignedInWithApple} closeSignInModal={this.localCloseSignInModal} />
+            )}
             {voterIsSignedIn && !hideDialogForCordova ? (
               <div className="u-stack--md">
                 {!hideCurrentlySignedInHeader && (
@@ -418,7 +430,12 @@ export default class SettingsAccount extends Component {
                     <span className="h3 voterIsSignedIn">Currently Signed In</span>
                     <span className="u-margin-left--sm" />
                     <span className="account-edit-action" onKeyDown={this.twitterLogOutOnKeyDown.bind(this)}>
-                      <span className="pull-right" onClick={this.signOut.bind(this)}>sign out</span>
+                      <span
+                        className="pull-right u-link-color u-cursor--pointer"
+                        onClick={this.signOut.bind(this)}
+                      >
+                        sign out
+                      </span>
                     </span>
                   </div>
                 )}
@@ -484,34 +501,31 @@ export default class SettingsAccount extends Component {
               </div>
             ) : null
             }
-            <AppleSignIn signedIn={voterIsSignedInWithApple} closeSignInModal={this.localCloseSignInModal} />
-            {!hideVoterPhoneEntry && isWebApp() && (
+            {!hideVoterPhoneEntry && (
               <VoterPhoneVerificationEntry
                 closeSignInModal={this.localCloseSignInModal}
-                inModal={inModal}
+                hideSignInWithPhoneForm={isCordova()}
                 toggleOtherSignInOptions={this.toggleNonPhoneSignInOptions}
               />
             )}
             {!hideVoterPhoneEntry && isCordova() && (
               <VoterPhoneEmailCordovaEntryModal
                 closeSignInModal={this.localCloseSignInModal}
-                inModal={inModal}
                 toggleOtherSignInOptions={this.toggleNonPhoneSignInOptions}
                 isPhone
                 hideDialogForCordova={this.hideDialogForCordovaLocal}
               />
             )}
-            {!hideVoterEmailAddressEntry && isWebApp() && (
+            {!hideVoterEmailAddressEntry && (
               <VoterEmailAddressEntry
                 closeSignInModal={this.localCloseSignInModal}
-                inModal={inModal}
+                hideSignInWithEmailForm={isCordova()}
                 toggleOtherSignInOptions={this.toggleNonEmailSignInOptions}
               />
             )}
             {!hideVoterEmailAddressEntry && isCordova() && (
               <VoterPhoneEmailCordovaEntryModal
                 closeSignInModal={this.localCloseSignInModal}
-                inModal={inModal}
                 toggleOtherSignInOptions={this.toggleNonPhoneSignInOptions}
                 isPhone={false}
                 hideDialogForCordova={this.hideDialogForCordovaLocal}
@@ -566,7 +580,7 @@ export default class SettingsAccount extends Component {
 
 const Main = styled.div`
   margin-top: ${({ inModal }) => (inModal ? '-16px' : '0')};
-  padding: 16px;
+  padding: ${({ inModal }) => (inModal ? '0' : '16px')};
   text-align: center;
   padding-top: 0;
   width: 100%;

--- a/src/js/components/Settings/SettingsNotifications.jsx
+++ b/src/js/components/Settings/SettingsNotifications.jsx
@@ -451,7 +451,7 @@ class SettingsNotifications extends Component {
                 </Table>
               </TableContainer>
             </NotificationsTableWrapper>
-            <VoterEmailAddressEntry hideSignInWithEmail={!addEmailInterfaceOpen} />
+            <VoterEmailAddressEntry hideSignInWithEmailForm={!addEmailInterfaceOpen} />
             {!addEmailInterfaceOpen && (
               <AddNewEmailWrapper>
                 <div className="u-cursor--pointer u-link-color" onClick={this.openAddEmailInterface}>

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -19,10 +19,11 @@ import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 
 class VoterEmailAddressEntry extends Component {
   static propTypes = {
+    cancelShouldCloseModal: PropTypes.bool,
     classes: PropTypes.object,
     closeSignInModal: PropTypes.func,
-    hideSignInWithEmail: PropTypes.bool,
-    inModal: PropTypes.bool,
+    hideEverythingButSignInWithEmailForm: PropTypes.bool,
+    hideSignInWithEmailForm: PropTypes.bool,
     toggleOtherSignInOptions: PropTypes.func,
   };
 
@@ -64,55 +65,6 @@ class VoterEmailAddressEntry extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     VoterActions.voterEmailAddressRetrieve();
   }
-
-  // shouldComponentUpdate (nextProps, nextState) {
-  //   if (JSON.stringify(this.state.emailAddressStatus) !== JSON.stringify(nextState.emailAddressStatus)) {
-  //     // console.log('this.state.emailAddressStatus', this.state.emailAddressStatus, ', nextState.emailAddressStatus', nextState.emailAddressStatus);
-  //     return true;
-  //   }
-  //   if (this.state.disableEmailVerificationButton !== nextState.disableEmailVerificationButton) {
-  //     // console.log('this.state.disableEmailVerificationButton', this.state.disableEmailVerificationButton, ', nextState.disableEmailVerificationButton', nextState.disableEmailVerificationButton);
-  //     return true;
-  //   }
-  //   if (this.state.displayEmailVerificationButton !== nextState.displayEmailVerificationButton) {
-  //     // console.log('this.state.displayEmailVerificationButton', this.state.displayEmailVerificationButton, ', nextState.displayEmailVerificationButton', nextState.displayEmailVerificationButton);
-  //     return true;
-  //   }
-  //   if (this.state.loading !== nextState.loading) {
-  //     // console.log('this.state.loading', this.state.loading, ', nextState.loading', nextState.loading);
-  //     return true;
-  //   }
-  //   if (this.state.secretCodeSystemLocked !== nextState.secretCodeSystemLocked) {
-  //     // console.log('this.state.secretCodeSystemLocked', this.state.secretCodeSystemLocked, ', nextState.secretCodeSystemLocked', nextState.secretCodeSystemLocked);
-  //     return true;
-  //   }
-  //   if (this.state.showError !== nextState.showError) {
-  //     // console.log('this.state.showError', this.state.showError, ', nextState.showError', nextState.showError);
-  //     return true;
-  //   }
-  //   if (this.state.showVerifyModal !== nextState.showVerifyModal) {
-  //     // console.log('this.state.showVerifyModal', this.state.showVerifyModal, ', nextState.showVerifyModal', nextState.showVerifyModal);
-  //     return true;
-  //   }
-  //   if (this.state.signInCodeEmailSentAndWaitingForResponse !== nextState.signInCodeEmailSentAndWaitingForResponse) {
-  //     // console.log('this.state.signInCodeEmailSentAndWaitingForResponse', this.state.signInCodeEmailSentAndWaitingForResponse, ', nextState.signInCodeEmailSentAndWaitingForResponse', nextState.signInCodeEmailSentAndWaitingForResponse);
-  //     return true;
-  //   }
-  //   if (this.state.voterEmailAddress !== nextState.voterEmailAddress) {
-  //     // console.log('this.state.voterEmailAddress', this.state.voterEmailAddress, ', nextState.voterEmailAddress', nextState.voterEmailAddress);
-  //     return true;
-  //   }
-  //   if (this.state.voterEmailAddressListCount !== nextState.voterEmailAddressListCount) {
-  //     // console.log('this.state.voterEmailAddressListCount', this.state.voterEmailAddressListCount, ', nextState.voterEmailAddressListCount', nextState.voterEmailAddressListCount);
-  //     return true;
-  //   }
-  //   if (this.state.voterEmailAddressesVerifiedCount !== nextState.voterEmailAddressesVerifiedCount) {
-  //     // console.log('this.state.voterEmailAddressesVerifiedCount', this.state.voterEmailAddressesVerifiedCount, ', nextState.voterEmailAddressesVerifiedCount', nextState.voterEmailAddressesVerifiedCount);
-  //     return true;
-  //   }
-  //   // console.log('shouldComponentUpdate false');
-  //   return false;
-  // }
 
   componentDidUpdate () {
     const { movedInitialFocus } = this.state;
@@ -304,8 +256,8 @@ class VoterEmailAddressEntry extends Component {
 
   onCancel = () => {
     // console.log('VoterEmailAddressEntry onCancel');
-    const { inModal } = this.props;
-    if (inModal) {
+    const { cancelShouldCloseModal } = this.props;
+    if (cancelShouldCloseModal) {
       this.closeSignInModal();
     } else {
       // There are Modal display problems that don't seem to be resolvable that prevents us from returning to the full SettingsAccount modal
@@ -367,7 +319,7 @@ class VoterEmailAddressEntry extends Component {
       return LoadingWheel;
     }
 
-    const { classes, hideSignInWithEmail } = this.props;
+    const { classes, hideEverythingButSignInWithEmailForm, hideSignInWithEmailForm } = this.props;
     const {
       disableEmailVerificationButton, displayEmailVerificationButton, emailAddressStatus, hideExistingEmailAddresses,
       secretCodeSystemLocked, showVerifyModal, signInCodeEmailSentAndWaitingForResponse,
@@ -440,7 +392,7 @@ class VoterEmailAddressEntry extends Component {
       //   "You'll receive a magic link in the email on this phone. Click that link to verify this new email.";
     }
 
-    const enterEmailHtml = (
+    const enterEmailHtml = hideSignInWithEmailForm ? null : (
       <div>
         <div className="u-stack--sm u-tl">
           <strong>
@@ -536,20 +488,22 @@ class VoterEmailAddressEntry extends Component {
               <span>
                 <span>&nbsp;&nbsp;&nbsp;</span>
                 <span>
-                  <a // eslint-disable-line
+                  <span
+                    className="u-link-color u-cursor--pointer"
                     onClick={this.setAsPrimaryEmailAddress.bind(this, voterEmailAddressFromList.email_we_vote_id)}
                   >
                     Make Primary
-                  </a>
+                  </span>
                   &nbsp;&nbsp;&nbsp;
                 </span>
                 <span>&nbsp;&nbsp;&nbsp;</span>
                 {allowRemoveEmail && (
-                  <a // eslint-disable-line
+                  <span
+                    className="u-link-color u-cursor--pointer"
                     onClick={this.removeVoterEmailAddress.bind(this, voterEmailAddressFromList.email_we_vote_id)}
                   >
                     <Delete />
-                  </a>
+                  </span>
                 )}
               </span>
             )}
@@ -576,20 +530,22 @@ class VoterEmailAddressEntry extends Component {
               <span>&nbsp;&nbsp;&nbsp;</span>
               {voterEmailAddressFromList.email_ownership_is_verified ?
                 null : (
-                  <a // eslint-disable-line
+                  <span
+                    className="u-link-color u-cursor--pointer"
                     onClick={() => this.reSendSignInCodeEmail(voterEmailAddressFromList.normalized_email_address)}
                   >
                     Send Verification Again
-                  </a>
+                  </span>
                 )}
 
               <span>&nbsp;&nbsp;&nbsp;</span>
               {allowRemoveEmail && (
-                <a // eslint-disable-line
+                <span
+                  className="u-link-color u-cursor--pointer"
                   onClick={this.removeVoterEmailAddress.bind(this, voterEmailAddressFromList.email_we_vote_id)}
                 >
                   <Delete />
-                </a>
+                </span>
               )}
             </div>
           </div>
@@ -601,9 +557,13 @@ class VoterEmailAddressEntry extends Component {
 
     return (
       <Wrapper isWeb={isWebApp()}>
-        {!hideExistingEmailAddresses ? (
+        {(hideEverythingButSignInWithEmailForm || hideExistingEmailAddresses) ? (
+          <span>
+            {emailAddressStatusHtml}
+          </span>
+        ) : (
           <div>
-            {verifiedEmailsFound && !this.props.inModal ? (
+            {verifiedEmailsFound ? (
               <EmailSection isWeb={isWebApp()}>
                 <span className="h3">
                   Your Email
@@ -617,19 +577,15 @@ class VoterEmailAddressEntry extends Component {
                 {emailAddressStatusHtml}
               </span>
             )}
-            {unverifiedEmailsFound && !this.props.inModal && (
+            {unverifiedEmailsFound && (
               <EmailSection isWeb={isWebApp()}>
                 <span className="h3">Emails to Verify</span>
                 {toVerifyEmailListHtml}
               </EmailSection>
             )}
           </div>
-        ) : (
-          <span>
-            {emailAddressStatusHtml}
-          </span>
         )}
-        {!hideSignInWithEmail && (
+        {!hideSignInWithEmailForm && (
           <EmailSection isWeb={isWebApp()}>
             {enterEmailHtml}
           </EmailSection>

--- a/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
+++ b/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
@@ -16,8 +16,7 @@ class VoterPhoneEmailCordovaEntryModal extends Component {
   static propTypes = {
     classes: PropTypes.object,
     closeSignInModal: PropTypes.func,
-    // inModal: PropTypes.bool,
-    // toggleOtherSignInOptions: PropTypes.func,
+    toggleOtherSignInOptions: PropTypes.func,
     isPhone: PropTypes.bool,
     hideDialogForCordova: PropTypes.func,
   };
@@ -90,15 +89,15 @@ class VoterPhoneEmailCordovaEntryModal extends Component {
           <DialogContent id="textOrEmailEntryContent" style={{ paddingTop: `${isCordova() ? 'unset' : 'undefined'}`, bottom: `${isCordova() ? 'unset' : 'undefined'}` }}>
             {isPhone ? (
               <VoterPhoneVerificationEntry
+                cancelShouldCloseModal
                 closeSignInModal={this.closeSignInModalLocal}
-                inModal
-                // toggleOtherSignInOptions={this.props.toggleNonPhoneSignInOptions}
+                hideEverythingButSignInWithPhoneForm
               />
             ) : (
               <VoterEmailAddressEntry
+                cancelShouldCloseModal
                 closeSignInModal={this.closeSignInModalLocal}
-                inModal
-                // toggleOtherSignInOptions={this.props.toggleNonEmailSignInOptions}
+                hideEverythingButSignInWithEmailForm
               />
             )}
           </DialogContent>

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -12,9 +12,9 @@ import LoadingWheel from '../LoadingWheel';
 import { renderLog } from '../../utils/logging';
 import OpenExternalWebSite from '../Widgets/OpenExternalWebSite';
 import SettingsVerifySecretCode from './SettingsVerifySecretCode';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 import VoterActions from '../../actions/VoterActions';
 import VoterStore from '../../stores/VoterStore';
-import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 
 /* global $ */
 
@@ -22,7 +22,9 @@ class VoterPhoneVerificationEntry extends Component {
   static propTypes = {
     classes: PropTypes.object,
     closeSignInModal: PropTypes.func,
-    inModal: PropTypes.bool,
+    hideEverythingButSignInWithPhoneForm: PropTypes.bool,
+    hideSignInWithPhoneForm: PropTypes.bool,
+    cancelShouldCloseModal: PropTypes.bool,
     toggleOtherSignInOptions: PropTypes.func,
   };
 
@@ -63,59 +65,6 @@ class VoterPhoneVerificationEntry extends Component {
     }
   }
 
-  // shouldComponentUpdate (nextProps, nextState) {
-  //   if (JSON.stringify(this.state.smsPhoneNumberStatus) !== JSON.stringify(nextState.smsPhoneNumberStatus)) {
-  //     // console.log('this.state.smsPhoneNumberStatus', this.state.smsPhoneNumberStatus, ', nextState.smsPhoneNumberStatus', nextState.smsPhoneNumberStatus);
-  //     return true;
-  //   }
-  //   if (this.state.disablePhoneVerificationButton !== nextState.disablePhoneVerificationButton) {
-  //     // console.log('this.state.disablePhoneVerificationButton', this.state.disablePhoneVerificationButton, ', nextState.disablePhoneVerificationButton', nextState.disablePhoneVerificationButton);
-  //     return true;
-  //   }
-  //   if (this.state.displayPhoneVerificationButton !== nextState.displayPhoneVerificationButton) {
-  //     // console.log('this.state.displayPhoneVerificationButton', this.state.displayPhoneVerificationButton, ', nextState.displayPhoneVerificationButton', nextState.displayPhoneVerificationButton);
-  //     return true;
-  //   }
-  //   if (this.state.hideExistingPhoneNumbers !== nextState.hideExistingPhoneNumbers) {
-  //     // console.log('this.state.hideExistingPhoneNumbers', this.state.hideExistingPhoneNumbers, ', nextState.hideExistingPhoneNumbers', nextState.hideExistingPhoneNumbers);
-  //     return true;
-  //   }
-  //   if (this.state.loading !== nextState.loading) {
-  //     // console.log('this.state.loading', this.state.loading, ', nextState.loading', nextState.loading);
-  //     return true;
-  //   }
-  //   if (this.state.secretCodeSystemLocked !== nextState.secretCodeSystemLocked) {
-  //     // console.log('this.state.secretCodeSystemLocked', this.state.secretCodeSystemLocked, ', nextState.secretCodeSystemLocked', nextState.secretCodeSystemLocked);
-  //     return true;
-  //   }
-  //   if (this.state.showError !== nextState.showError) {
-  //     // console.log('this.state.showError', this.state.showError, ', nextState.showError', nextState.showError);
-  //     return true;
-  //   }
-  //   if (this.state.showVerifyModal !== nextState.showVerifyModal) {
-  //     // console.log('this.state.showVerifyModal', this.state.showVerifyModal, ', nextState.showVerifyModal', nextState.showVerifyModal);
-  //     return true;
-  //   }
-  //   if (this.state.signInCodeSMSSentAndWaitingForResponse !== nextState.signInCodeSMSSentAndWaitingForResponse) {
-  //     // console.log('this.state.signInCodeSMSSentAndWaitingForResponse', this.state.signInCodeSMSSentAndWaitingForResponse, ', nextState.signInCodeSMSSentAndWaitingForResponse', nextState.signInCodeSMSSentAndWaitingForResponse);
-  //     return true;
-  //   }
-  //   if (this.state.smsPhoneNumberListCount !== nextState.smsPhoneNumberListCount) {
-  //     // console.log('this.state.smsPhoneNumberListCount', this.state.smsPhoneNumberListCount, ', nextState.smsPhoneNumberListCount', nextState.smsPhoneNumberListCount);
-  //     return true;
-  //   }
-  //   if (this.state.voterSMSPhoneNumber !== nextState.voterSMSPhoneNumber) {
-  //     // console.log('this.state.voterSMSPhoneNumber', this.state.voterSMSPhoneNumber, ', nextState.voterSMSPhoneNumber', nextState.voterSMSPhoneNumber);
-  //     return true;
-  //   }
-  //   if (this.state.voterSMSPhoneNumbersVerifiedCount !== nextState.voterSMSPhoneNumbersVerifiedCount) {
-  //     // console.log('this.state.voterSMSPhoneNumbersVerifiedCount', this.state.voterSMSPhoneNumbersVerifiedCount, ', nextState.voterSMSPhoneNumbersVerifiedCount', nextState.voterSMSPhoneNumbersVerifiedCount);
-  //     return true;
-  //   }
-  //   // console.log('shouldComponentUpdate false');
-  //   return false;
-  // }
-
   componentWillUnmount () {
     this.voterStoreListener.remove();
   }
@@ -132,13 +81,7 @@ class VoterPhoneVerificationEntry extends Component {
       signed_in_with_sms_phone_number: signedInWithSmsPhoneNumber,
     } = voter;
     // console.log(`VoterEmailAddressEntry onVoterStoreChange isSignedIn: ${isSignedIn}, signedInWithSmsPhoneNumber: ${signedInWithSmsPhoneNumber}`);
-    if (signedInWithSmsPhoneNumber) {
-      // console.log('VoterEmailAddressEntry onVoterStoreChange signedInWithSmsPhoneNumber so doing a fallback close ===================');
-      this.closeSignInModal();
-      this.setState({
-        smsPhoneNumberStatus,
-      });
-    } else if (secretCodeVerified) {
+    if (secretCodeVerified) {
       this.setState({
         displayPhoneVerificationButton: false,
         showVerifyModal: false,
@@ -160,6 +103,12 @@ class VoterPhoneVerificationEntry extends Component {
         smsPhoneNumberStatus,
         showVerifyModal: false,
         signInCodeSMSSentAndWaitingForResponse: false,
+      });
+    } else if (signedInWithSmsPhoneNumber) {
+      // console.log('VoterEmailAddressEntry onVoterStoreChange signedInWithSmsPhoneNumber so doing a fallback close ===================');
+      this.closeSignInModal();
+      this.setState({
+        smsPhoneNumberStatus,
       });
     } else {
       this.setState({
@@ -274,8 +223,8 @@ class VoterPhoneVerificationEntry extends Component {
 
   onCancel = () => {
     // console.log('VoterPhoneVerificationEntry onCancel');
-    const { inModal } = this.props;
-    if (inModal) {
+    const { cancelShouldCloseModal } = this.props;
+    if (cancelShouldCloseModal) {
       this.closeSignInModal();
     } else {
       // There are Modal display problems that don't seem to be resolvable that prevents us from returning to the full SettingsAccount modal
@@ -372,7 +321,7 @@ class VoterPhoneVerificationEntry extends Component {
       return LoadingWheel;
     }
 
-    const { classes } = this.props;
+    const { classes, hideEverythingButSignInWithPhoneForm, hideSignInWithPhoneForm } = this.props;
     const {
       disablePhoneVerificationButton, displayPhoneVerificationButton, hideExistingPhoneNumbers,
       secretCodeSystemLocked, showError, showVerifyModal, signInCodeSMSSentAndWaitingForResponse,
@@ -438,7 +387,7 @@ class VoterPhoneVerificationEntry extends Component {
       enterSMSPhoneNumberTitle = 'Add New Phone Number';
     }
 
-    const enterSMSPhoneNumberHtml = (
+    const enterSMSPhoneNumberHtml = hideSignInWithPhoneForm ? null : (
       <div>
         <div className="u-stack--sm u-tl">
           <strong>
@@ -538,20 +487,22 @@ class VoterPhoneVerificationEntry extends Component {
               <span>
                 <span>&nbsp;&nbsp;&nbsp;</span>
                 <span>
-                  <a // eslint-disable-line
+                  <span
+                    className="u-link-color u-cursor--pointer"
                     onClick={this.setAsPrimarySMSPhoneNumber.bind(this, voterSMSPhoneNumberFromList.sms_we_vote_id)}
                   >
                     Make Primary
-                  </a>
+                  </span>
                   &nbsp;&nbsp;&nbsp;
                 </span>
                 <span>&nbsp;&nbsp;&nbsp;</span>
                 {allowRemoveSMSPhoneNumber && (
-                  <a // eslint-disable-line
+                  <span
+                    className="u-link-color u-cursor--pointer"
                     onClick={this.removeVoterSMSPhoneNumber.bind(this, voterSMSPhoneNumberFromList.sms_we_vote_id)}
                   >
                     <Delete />
-                  </a>
+                  </span>
                 )}
               </span>
             )}
@@ -578,20 +529,22 @@ class VoterPhoneVerificationEntry extends Component {
               <span>&nbsp;&nbsp;&nbsp;</span>
               {voterSMSPhoneNumberFromList.sms_ownership_is_verified ?
                 null : (
-                  <a // eslint-disable-line
+                  <span
+                    className="u-link-color u-cursor--pointer"
                     onClick={() => this.reSendSignInCodeSMS(voterSMSPhoneNumberFromList.normalized_sms_phone_number)}
                   >
                     Send Verification Again
-                  </a>
+                  </span>
                 )}
 
               <span>&nbsp;&nbsp;&nbsp;</span>
               {allowRemoveSMSPhoneNumber && (
-                <a // eslint-disable-line
+                <span
+                  className="u-link-color u-cursor--pointer"
                   onClick={this.removeVoterSMSPhoneNumber.bind(this, voterSMSPhoneNumberFromList.sms_we_vote_id)}
                 >
                   <Delete />
-                </a>
+                </span>
               )}
             </div>
           </div>
@@ -603,9 +556,13 @@ class VoterPhoneVerificationEntry extends Component {
 
     return (
       <Wrapper isWeb={isWebApp()} id="voterPhoneEntryWrapper">
-        {!hideExistingPhoneNumbers ? (
+        {(hideEverythingButSignInWithPhoneForm || hideExistingPhoneNumbers) ? (
+          <span>
+            {smsPhoneNumberStatusHtml}
+          </span>
+        ) : (
           <div>
-            {verifiedSMSFound && !this.props.inModal ? (
+            {verifiedSMSFound ? (
               <PhoneNumberSection isWeb={isWebApp()}>
                 <span className="h3">
                   Your Phone Number
@@ -619,21 +576,19 @@ class VoterPhoneVerificationEntry extends Component {
                 {smsPhoneNumberStatusHtml}
               </span>
             )}
-            {unverifiedSMSFound && !this.props.inModal && (
+            {unverifiedSMSFound && (
               <PhoneNumberSection isWeb={isWebApp()}>
                 <span className="h3">Phone Numbers to Verify</span>
                 {toVerifySMSListHtml}
               </PhoneNumberSection>
             )}
           </div>
-        ) : (
-          <span>
-            {smsPhoneNumberStatusHtml}
-          </span>
         )}
-        <PhoneNumberSection isWeb={isWebApp()}>
-          {enterSMSPhoneNumberHtml}
-        </PhoneNumberSection>
+        {!hideSignInWithPhoneForm && (
+          <PhoneNumberSection isWeb={isWebApp()}>
+            {enterSMSPhoneNumberHtml}
+          </PhoneNumberSection>
+        )}
         {showVerifyModal && (
           <SettingsVerifySecretCode
             show={showVerifyModal}


### PR DESCRIPTION
Turning off the Apple Sign in button when focus is in the email or SMS input field. Made the Phone and SMS links ('Make Primary', 'Delete', 'Send Verification Again', 'sign out') look like links, and fixed bug with Send Verification Again. Moved the "Sign in with Apple" button above the "Currently Signed In" header (still needs work).