### PR TITLE
Share is now working correctly on Android Tablets

### DIFF
--- a/src/js/components/Activity/ActivityPostAdd.jsx
+++ b/src/js/components/Activity/ActivityPostAdd.jsx
@@ -7,6 +7,7 @@ import { renderLog } from '../../utils/logging';
 import ActivityPostModal from './ActivityPostModal';
 import stockAvatar from '../../../img/global/icons/avatar-generic.png';
 import VoterStore from '../../stores/VoterStore';
+import { isCordova } from '../../utils/cordovaUtils';
 
 class ActivityPostAdd extends Component {
   static propTypes = {
@@ -112,9 +113,12 @@ class ActivityPostAdd extends Component {
 
     // console.log('ActivityPostAdd');
     // console.log('editMode:', editMode);
+
+    const unsetSideMarginsIfCordova = isCordova() ? { margin: 0 } : {};
+
     return (
-      <Card className="card">
-        <AddTidbitTitle>
+      <Card className="card" style={unsetSideMarginsIfCordova}>
+        <AddTidbitTitle style={unsetSideMarginsIfCordova}>
           Create Post
         </AddTidbitTitle>
         <CardNewsWrapper>

--- a/src/js/components/Apple/AppleSignIn.jsx
+++ b/src/js/components/Apple/AppleSignIn.jsx
@@ -141,6 +141,7 @@ class AppleSignIn extends Component {
     const isWeb = isWebApp();
     const { signedIn } = this.props;
     let enabled = true;
+    const tinyScreen = isWeb && window.innerWidth < 300;  // Galaxy fold, folded
 
     if (isAndroid()) {
       // console.log('Sign in with Apple is not available on Android');
@@ -165,6 +166,7 @@ class AppleSignIn extends Component {
         <AppleSignInContainer enabled={enabled}>
           <AppleSignInButton type="submit"
                              isWeb={isWeb}
+                             tinyScreen={tinyScreen}
                              onClick={() => this.signInClicked(enabled)}
           >
             <AppleLogo signedIn={signedIn} enabled={enabled} />
@@ -209,6 +211,10 @@ export function AppleLogo (parameters) {
   );
 }
 
+/*
+Note, May 21, 2020: Before making changes to these styles, be sure you are compliant with
+https://developer.apple.com/design/resources/ or we risk getting rejected by Apple
+*/
 const AppleLogoSvg = styled.svg`
   position: absolute;
   left: ${({ signedIn }) => (signedIn ? '29%' : '5%')};
@@ -217,17 +223,25 @@ const AppleLogoSvg = styled.svg`
   color: ${({ enabled }) => (enabled ? '#fff' : 'grey')};
 `;
 
+/*
+Note, May 21, 2020: Before making changes to these styles, be sure you are compliant with
+https://developer.apple.com/design/resources/ or we risk getting rejected by Apple
+*/
 const AppleSignInText = styled.span`
-  font-size: 12pt;
-  padding: none;
+  font-size: 18px;
+  padding: 0;
   border: none;
   color: ${({ enabled }) => (enabled ? '#fff' : 'grey')};
 `;
 
+/*
+Note, May 21, 2020: Before making changes to these styles, be sure you are compliant with
+https://developer.apple.com/design/resources/ or we risk getting rejected by Apple
+*/
 const AppleSignInButton = styled.button`
   margin-top: ${({ isWeb }) => (isWeb ? '8px' : '10px')};
   border: none;
-  padding-left: 40px;
+  padding-left: ${({ tinyScreen }) => (tinyScreen ? '20px' : '40px')};
   background-color: #000;
   color: #fff;
 `;
@@ -253,6 +267,10 @@ const AppleSignInContainer  = styled.div`
   width: 100%;
 `;
 
+/*
+Note, May 21, 2020: Before making changes to these styles, be sure you are compliant with
+https://developer.apple.com/design/resources/ or we risk getting rejected by Apple
+*/
 const AppleSignedInContainer  = styled.div`
   background-color: #000;
   border-color: #000;

--- a/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
+++ b/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
@@ -397,7 +397,7 @@ class SettingsWidgetFirstLastName extends Component {
                       color="primary"
                       id={`firstLastSaveButton-${externalUniqueId}`}
                       onClick={this.saveNameCordova}
-                      variant="outlined"
+                      variant="contained"
                       fullWidth
                     >
                       Save

--- a/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
+++ b/src/js/components/Settings/VoterPhoneEmailCordovaEntryModal.jsx
@@ -16,7 +16,7 @@ class VoterPhoneEmailCordovaEntryModal extends Component {
   static propTypes = {
     classes: PropTypes.object,
     closeSignInModal: PropTypes.func,
-    toggleOtherSignInOptions: PropTypes.func,
+    // toggleOtherSignInOptions: PropTypes.func,
     isPhone: PropTypes.bool,
     hideDialogForCordova: PropTypes.func,
   };

--- a/src/js/components/Share/ShareModal.jsx
+++ b/src/js/components/Share/ShareModal.jsx
@@ -14,17 +14,18 @@ import {
 import AnalyticsActions from '../../actions/AnalyticsActions';
 import AppActions from '../../actions/AppActions';
 import AppStore from '../../stores/AppStore';
-import { cordovaDot, hasIPhoneNotch } from '../../utils/cordovaUtils';
 import FriendActions from '../../actions/FriendActions';
-import FriendsShareList from '../Friends/FriendsShareList';
 import FriendStore from '../../stores/FriendStore';
+import FriendsShareList from '../Friends/FriendsShareList';
 import MessageCard from '../Widgets/MessageCard';
-import { renderLog } from '../../utils/logging';
-import { stringContains } from '../../utils/textFormat';
 import ShareActions from '../../actions/ShareActions';
 import ShareModalOption from './ShareModalOption';
 import ShareStore from '../../stores/ShareStore';
 import VoterStore from '../../stores/VoterStore';
+import { androidFacebookClickHandler, androidTwitterClickHandler } from './shareButtonCommon';
+import { cordovaDot, hasIPhoneNotch, isAndroid } from '../../utils/cordovaUtils';
+import { renderLog } from '../../utils/logging';
+import { stringContains } from '../../utils/textFormat';
 
 class ShareModal extends Component {
   static propTypes = {
@@ -376,44 +377,58 @@ class ShareModal extends Component {
                   />
                 )}
                 <Wrapper>
-                  <FacebookShareButton
-                    className="no-decoration"
-                    id="shareModalFacebookButton"
-                    onClick={this.saveActionShareButtonFacebook}
-                    quote={titleText}
-                    url={`${linkToBeSharedUrlEncoded}`}
-                    windowWidth={750}
-                    windowHeight={600}
+                  <div id="androidFacebook"
+                       onClick={() => isAndroid() &&
+                         androidFacebookClickHandler(`${linkToBeSharedUrlEncoded}&t=WeVote`)}
                   >
-                    <FacebookIcon
-                      bgStyle={{ background: '#3b5998' }}
-                      round="True"
-                      size={68}
-                    />
-                    <Text>
-                      Facebook
-                    </Text>
-                  </FacebookShareButton>
+                    <FacebookShareButton
+                      className="no-decoration"
+                      id="shareModalFacebookButton"
+                      onClick={this.saveActionShareButtonFacebook}
+                      quote={titleText}
+                      url={`${linkToBeSharedUrlEncoded}`}
+                      windowWidth={750}
+                      windowHeight={600}
+                      disabled={isAndroid()}
+                      disabledStyle={isAndroid() ? { opacity: 1 } : {}}
+                    >
+                      <FacebookIcon
+                        bgStyle={{ background: '#3b5998' }}
+                        round="True"
+                        size={68}
+                      />
+                      <Text>
+                        Facebook
+                      </Text>
+                    </FacebookShareButton>
+                  </div>
                 </Wrapper>
                 <Wrapper>
-                  <TwitterShareButton
-                    className="no-decoration"
-                    id="shareModalTwitterButton"
-                    onClick={this.saveActionShareButtonTwitter}
-                    title={titleText}
-                    url={`${linkToBeSharedUrlEncoded}`}
-                    windowWidth={750}
-                    windowHeight={600}
+                  <div id="androidTwitter"
+                       onClick={() => isAndroid() &&
+                         androidTwitterClickHandler(linkToBeSharedUrlEncoded)}
                   >
-                    <TwitterIcon
-                      bgStyle={{ background: '#38A1F3' }}
-                      round="True"
-                      size={68}
-                    />
-                    <Text>
-                      Twitter
-                    </Text>
-                  </TwitterShareButton>
+                    <TwitterShareButton
+                      className="no-decoration"
+                      id="shareModalTwitterButton"
+                      onClick={this.saveActionShareButtonTwitter}
+                      title={titleText}
+                      url={`${linkToBeSharedUrlEncoded}`}
+                      windowWidth={750}
+                      windowHeight={600}
+                      disabled={isAndroid()}
+                      disabledStyle={isAndroid() ? { opacity: 1 } : {}}
+                    >
+                      <TwitterIcon
+                        bgStyle={{ background: '#38A1F3' }}
+                        round="True"
+                        size={68}
+                      />
+                      <Text>
+                        Twitter
+                      </Text>
+                    </TwitterShareButton>
+                  </div>
                 </Wrapper>
                 <Wrapper>
                   {/* The EmailShareButton works in Cordova, but ONLY if an email client is configured, so it doesn't work in a simulator */}

--- a/src/js/components/Share/ShareModalOption.jsx
+++ b/src/js/components/Share/ShareModalOption.jsx
@@ -44,7 +44,7 @@ class ShareModalOption extends Component {
   render () {
     renderLog('ShareModalOption');  // Set LOG_RENDER_EVENTS to log all renders
     const { backgroundColor, copyLink, icon, link, noLink, title, uniqueExternalId } = this.props;
-    const linkToBeShared = link.replace('https://file:/', 'https://wevote.us/');
+    const linkToBeShared = link.replace(/https:\/\/file:.*?\/|https:\/\/localhost.*?\//, 'https://wevote.us/');
     console.log('ShareModalOption copyLink:', copyLink, ', noLink:', noLink, 'link:', link, ', linkToBeShared:', linkToBeShared);
     return (
       <Wrapper>

--- a/src/js/components/Share/shareButtonCommon.jsx
+++ b/src/js/components/Share/shareButtonCommon.jsx
@@ -1,0 +1,17 @@
+import { cordovaOpenSafariView } from '../../utils/cordovaUtils';
+
+export function androidFacebookClickHandler (linkToBeShared) {
+  // react-share in Cordova for Android, navigates to the URL instead of opening a "tab" with a return 'X' button
+  // https://m.facebook.com/sharer/sharer.php?u=https%253A%252F%252Fwevote.us%252F-0i8mao%26t%3DWeVote&quote=This+is+a+website+I+am+using+to+get+ready+to+vote.
+  const fbURL = `https://m.facebook.com/sharer/sharer.php?u=${linkToBeShared}&quote=This+is+a+website+I+am+using+to+get+ready+to+vote.`;
+  console.log(`androidFacebookClickHandler clicked ~~~~~~~~~~~~~~~~ url : ${fbURL}`);
+  cordovaOpenSafariView(fbURL, null, 50);
+}
+
+export function androidTwitterClickHandler (linkToBeShared) {
+  // react-share in Cordova for Android, navigates to the URL instead of opening a "tab" with a return 'X' button
+  // https://twitter.com/share?url=https%3A%2F%2Fwevote.us%2F-0i8mao&text=This%20is%20a%20website%20I%20am%20using%20to%20get%20ready%20to%20vote.
+  const twitURL = `https://twitter.com/share?url=${linkToBeShared}&text=This%20is%20a%20website%20I%20am%20using%20to%20get%20ready%20to%20vote.`;
+  console.log(`androidTwitterClickHandler clicked ~~~~~~~~~~~~~~~~ url : ${twitURL}`);
+  cordovaOpenSafariView(twitURL, null, 50);
+}

--- a/src/js/routes/Activity/News.jsx
+++ b/src/js/routes/Activity/News.jsx
@@ -184,6 +184,7 @@ class News extends Component {
       marginRight: 0,
       marginLeft: 0,
     } : {};
+    const reduceConstraintsIfCordova = isCordova() ? { margin: '5px 0' } : {};
     const expandSideMarginsIfCordova = isCordova() ? { marginRight: 23, marginLeft: 23 } : {};
 
     return (
@@ -193,7 +194,7 @@ class News extends Component {
         <div className="row" style={unsetSomeRowStylesIfCordova}>
           <div className="col-sm-12 col-md-8" style={unsetSomeRowStylesIfCordova}>
             <>
-              <ActivityPostAddWrapper>
+              <ActivityPostAddWrapper style={reduceConstraintsIfCordova}>
                 <ActivityPostAdd />
               </ActivityPostAddWrapper>
               {activityTidbitsList.map((oneActivityTidbit) => {

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -135,6 +135,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.ready:                 return '7px';
         case enums.settingsAccount:       return '84px';
         case enums.settingsHamburger:     return '81px';
+        case enums.settingsNotifications: return '79px';
         case enums.settingsSubscription:  return '90px';
         case enums.settingsVoterGuideLst: return '98px';
         case enums.settingsWild:          return '63px';
@@ -158,6 +159,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.ballotLgHdrWild:       return showBallotDecisionsTabs() ? '58px' : '42px';
         case enums.moreAbout:             return '22px';
         case enums.settingsAccount:       return '81px';
+        case enums.settingsNotifications: return '82px';
         case enums.moreTerms:             return '60px';
         // case enums.voterGuideWild: return 'YYx'; // See cordovaVoterGuideTopPadding instead
         case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
@@ -182,6 +184,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.moreAbout:             return '51px';
         case enums.moreTerms:             return '44px';
         case enums.moreTools:             return '44px';
+        case enums.news:                  return '19px';
         case enums.officeWild:            return '94px';
         case enums.opinions:              return '14px';
         case enums.ready:                 return '24px';
@@ -486,7 +489,10 @@ export function cordovaVoterGuideTopPadding () {
     } else if (hasIPhoneNotch()) {
       return '28px';
     } else if (isIPad()) {
-      return '0px';
+      switch (pageEnumeration()) {
+        case enums.news:             return '19px';
+        default:                     return '0px';
+      }
     }
   } else if (isAndroid()) {
     return '0px';
@@ -622,6 +628,7 @@ export function cordovaTopHeaderTopMargin () {
           case enums.ballotVote:      style.marginTop = '16px'; break;
           case enums.settingsAccount:       style.marginTop = '31px'; break;
           case enums.settingsSubscription:  style.marginTop = '34px'; break;
+          case enums.settingsNotifications: style.marginTop = '36px'; break;
           case enums.settingsWild:          style.marginTop = '38px'; break;
           case enums.voterGuideCreatorWild: style.marginTop = '38px'; break; // $headroom-wrapper-webapp-voter-guide-creator
           case enums.voterGuideWild:   style.marginTop = '38px'; break; // Any page with btcand or btmeas

--- a/src/js/utilsApi/cordovaUtilsPageEnumeration.js
+++ b/src/js/utilsApi/cordovaUtilsPageEnumeration.js
@@ -30,6 +30,7 @@ export const enums = {
   voterGuideWild: 204,
   ready: 205,
   twitterSignIn: 206,
+  news: 207,
   defaultVal: 1000,
 };
 
@@ -51,6 +52,8 @@ export function pageEnumeration () {
     return enums.settingsHamburger;
   } else if (href.indexOf('/index.html#/settings/tools') > 0) {
     return enums.moreTools;
+  } else if (href.indexOf('/index.html#/settings/notifications') > 0) {
+    return enums.settingsNotifications;
   } else if (href.indexOf('/index.html#/settings/subscription') > 0) {
     return enums.settingsSubscription;
   } else if (href.indexOf('/index.html#/settings/voterguidelist') > 0) {
@@ -105,6 +108,8 @@ export function pageEnumeration () {
     return enums.welcomeWild;
   } else if (href.indexOf('/index.html#/twitter_sign_in') > 0) {
     return enums.twitterSignIn;
+  } else if (href.indexOf('/index.html#/news') > 0) {
+    return enums.news;
   }
   return enums.defaultVal;
 }


### PR DESCRIPTION
More fixes to News.jsx to stop horizontal scrolling in Cordova phone sized screens.
A fix to the AppleSignIn.jsx button for tiny (Galaxy Fold, Folded = 280 pixel wide) screens.
Change the save button under Cordova on SettingsWidgetFirstLastName.jsx
New shareButtonCommon.jsx for common code for ShareButtonFooter.jsx and ShareModal.jsx, which
allows Android specific external URL opening when in Tablet size screens.
Support for a unique top header offset for News.jsx, which is a relatively new page.
