### PR TITLE
Split out the contents of PersonalizedScoreIntroModal so we can use this training tool separate from the modal. Made changes to onboarding based on user testing. Renamed the "News" section to "Discuss". Made the "Enter street address" more explicit. Fixed problem where "Decide on Candidates" was taking voters to the "All" filter, which often has measures at the top.

### DIFF
--- a/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
+++ b/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
@@ -1,0 +1,482 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Button } from '@material-ui/core';
+import { withStyles, withTheme } from '@material-ui/core/styles';
+import { renderLog } from '../../utils/logging';
+import CandidateItem from '../Ballot/CandidateItem';
+import { hideZenDeskHelpVisibility, setZenDeskHelpVisibility } from '../../utils/applicationUtils';
+import VoterActions from '../../actions/VoterActions';
+import VoterConstants from '../../constants/VoterConstants';
+
+class PersonalizedScoreIntroBody extends Component {
+  static propTypes = {
+    classes: PropTypes.object,
+    inModal: PropTypes.bool,
+    pathname: PropTypes.string,
+    show: PropTypes.bool,
+    toggleFunction: PropTypes.func.isRequired,
+  };
+
+  constructor (props) {
+    super(props);
+    this.state = {
+      previousStep: false,
+      currentStep: 1,
+      nextStep: 2,
+      actionButtonText: '',
+      controlAdviserMaterialUIPopoverFromProp: false,
+      explanationTextTopPlain: null,
+      explanationTextTopBlue: null,
+      explanationTextBottomPlain: null,
+      explanationTextBottomBlue: null,
+      openAdviserMaterialUIPopover: false,
+      openSupportOpposeCountDisplayModal: false,
+      pathname: '',
+      supportOpposeCountDisplayModalTutorialOn: true,
+      supportOpposeCountDisplayModalTutorialText: null,
+      showPersonalizedScoreDownArrow: false,
+      showPersonalizedScoreUpArrow: false,
+      showPersonalizedScoreIntroCompletedButton: false,
+      personalizedScoreSteps: {
+        1: {
+          previousStep: false,
+          currentStep: 1,
+          nextStep: 2,
+          actionButtonText: 'Say What?!?',
+          closeSupportOpposeCountDisplayModal: true,
+          controlAdviserMaterialUIPopoverFromProp: false,
+          explanationTextTopPlain: null,
+          explanationTextTopBlue: <>A Personalized Score is the number of people who support a candidate.</>,
+          explanationTextBottomPlain: <>(We&apos;ll explain! Click the button below to continue.)</>,
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: false,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: null,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: false,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        2: {
+          previousStep: 1,
+          currentStep: 2,
+          nextStep: 3,
+          actionButtonText: 'Next >',
+          closeSupportOpposeCountDisplayModal: true,
+          controlAdviserMaterialUIPopoverFromProp: false,
+          explanationTextTopPlain: null,
+          explanationTextTopBlue: <>In this example, you have a Personalized Score of &quot;+3&quot; for the historical candidate &quot;Alexander Hamilton&quot;.</>,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: false,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: null,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: true,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        3: {
+          previousStep: 2,
+          currentStep: 3,
+          nextStep: 4,
+          actionButtonText: 'Tell Me!',
+          closeSupportOpposeCountDisplayModal: true,
+          explanationTextTopPlain: <>But how is the +3 calculated?</>,
+          explanationTextTopBlue: null,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: false,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: null,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: true,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        4: {
+          previousStep: 3,
+          currentStep: 4,
+          nextStep: 5,
+          actionButtonText: 'I\'ll Pretend',
+          closeSupportOpposeCountDisplayModal: true,
+          controlAdviserMaterialUIPopoverFromProp: false,
+          explanationTextTopPlain: <>But how is the +3 calculated?</>,
+          explanationTextTopBlue: null,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: <>In this example, we pretend you are following 3 advisers.</>,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: false,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: null,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: true,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        5: {
+          previousStep: 4,
+          currentStep: 5,
+          nextStep: 6,
+          actionButtonText: 'Next >',
+          closeSupportOpposeCountDisplayModal: true,
+          controlAdviserMaterialUIPopoverFromProp: false,
+          explanationTextTopPlain: <>But how is the +3 calculated?</>,
+          explanationTextTopBlue: null,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: <>Out of those people, we count the number who support Alexander Hamilton. We pretend all 3 support him.</>,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: false,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: null,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: true,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        6: {
+          previousStep: 5,
+          currentStep: 6,
+          nextStep: 7,
+          actionButtonText: 'Show',
+          closeSupportOpposeCountDisplayModal: true,
+          controlAdviserMaterialUIPopoverFromProp: false,
+          explanationTextTopPlain: null,
+          explanationTextTopBlue: <>So, your Personalized Score is the number of people who support Alexander Hamilton, from among the people you follow.</>,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: false,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: null,
+          showPersonalizedScoreDownArrow: true,
+          showPersonalizedScoreUpArrow: false,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        7: {
+          previousStep: 6,
+          currentStep: 7,
+          nextStep: 8,
+          actionButtonText: 'Next >',
+          closeSupportOpposeCountDisplayModal: false,
+          controlAdviserMaterialUIPopoverFromProp: true,
+          explanationTextTopPlain: null,
+          explanationTextTopBlue: null,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: true,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: <>These are the people and groups who support Alexander Hamilton.</>,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: false,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        8: {
+          previousStep: 7,
+          currentStep: 8,
+          nextStep: 9,
+          actionButtonText: 'Next >',
+          closeSupportOpposeCountDisplayModal: false,
+          controlAdviserMaterialUIPopoverFromProp: true,
+          explanationTextTopPlain: null,
+          explanationTextTopBlue: null,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: true,
+          openSupportOpposeCountDisplayModal: true,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: <>You can click on any adviser to see why they are part of your Personalized Score.</>,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: false,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        9: {
+          previousStep: 8,
+          currentStep: 9,
+          nextStep: 10,
+          actionButtonText: 'Got It!',
+          closeSupportOpposeCountDisplayModal: false,
+          controlAdviserMaterialUIPopoverFromProp: true,
+          explanationTextTopPlain: null,
+          explanationTextTopBlue: null,
+          explanationTextBottomPlain: null,
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: true,
+          supportOpposeCountDisplayModalTutorialOn: true,
+          supportOpposeCountDisplayModalTutorialText: <>Click the +3 any time to see your Personalized Score explained.</>,
+          showPersonalizedScoreDownArrow: true,
+          showPersonalizedScoreUpArrow: false,
+          showPersonalizedScoreIntroCompletedButton: false,
+        },
+        10: {
+          previousStep: 9,
+          currentStep: 10,
+          nextStep: false,
+          actionButtonText: 'All Done!',
+          closeSupportOpposeCountDisplayModal: true,
+          controlAdviserMaterialUIPopoverFromProp: false,
+          explanationTextTopPlain: null,
+          explanationTextTopBlue: <>Success! Now you know what a personalized score is:</>,
+          explanationTextBottomPlain: (
+            <>
+              A
+              {' '}
+              <strong>
+                Personalized Score
+              </strong>
+              {' '}
+              is the number of friends, public figures or groups who support one candidate, from among the people you follow.
+            </>
+          ),
+          explanationTextBottomBlue: null,
+          openAdviserMaterialUIPopover: false,
+          openSupportOpposeCountDisplayModal: false,
+          supportOpposeCountDisplayModalTutorialOn: false,
+          supportOpposeCountDisplayModalTutorialText: null,
+          showPersonalizedScoreDownArrow: false,
+          showPersonalizedScoreUpArrow: false,
+          showPersonalizedScoreIntroCompletedButton: true,
+        },
+      },
+    };
+  }
+
+  componentDidMount () {
+    // Step 1 settings
+    const { personalizedScoreSteps } = this.state;
+    this.setState(personalizedScoreSteps[1]);
+    this.setState({
+      pathname: this.props.pathname,
+    });
+    if (this.props.show) {
+      hideZenDeskHelpVisibility();
+    }
+  }
+
+  componentWillReceiveProps (nextProps) {
+    if (nextProps.show) {
+      hideZenDeskHelpVisibility();
+    } else {
+      setZenDeskHelpVisibility(this.props.pathname);
+    }
+  }
+
+  componentWillUnmount () {
+    setZenDeskHelpVisibility(this.props.pathname);
+  }
+
+  closeThisModal = () => {
+    setZenDeskHelpVisibility(this.props.pathname);
+    const { currentStep } = this.state;
+    const currentStepCompletedThreshold = 8;
+    if (currentStep >= currentStepCompletedThreshold) {
+      // console.log('currentStepCompletedThreshold passed');
+      VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
+    }
+    this.props.toggleFunction(this.state.pathname);
+  };
+
+  personalizedScoreIntroCompleted = () => {
+    // Mark this so we know to show 'How it Works' as completed
+    VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
+    this.props.toggleFunction(this.state.pathname);
+  };
+
+  clickNextStepButton = () => {
+    const {
+      nextStep, personalizedScoreSteps,
+    } = this.state;
+    // console.log('clickNextStepButton, nextStep:', nextStep);
+    if (nextStep) {
+      this.setState(personalizedScoreSteps[nextStep]);
+    }
+  };
+
+  clickPreviousStepButton = () => {
+    const {
+      previousStep, personalizedScoreSteps,
+    } = this.state;
+    // console.log('clickPreviousStepButton, previousStep:', previousStep);
+    if (previousStep) {
+      this.setState(personalizedScoreSteps[previousStep]);
+    }
+  };
+
+  render () {
+    renderLog('PersonalizedScoreIntroBody');  // Set LOG_RENDER_EVENTS to log all renders
+    const { classes, inModal } = this.props;
+    const {
+      actionButtonText, closeSupportOpposeCountDisplayModal, controlAdviserMaterialUIPopoverFromProp,
+      explanationTextBottomBlue, explanationTextBottomPlain,
+      explanationTextTopBlue, explanationTextTopPlain, showPersonalizedScoreIntroCompletedButton,
+      nextStep, openAdviserMaterialUIPopover, openSupportOpposeCountDisplayModal,
+      supportOpposeCountDisplayModalTutorialOn, supportOpposeCountDisplayModalTutorialText,
+      previousStep,
+      showPersonalizedScoreDownArrow, showPersonalizedScoreUpArrow,
+    } = this.state;
+
+    return (
+      <>
+        <PersonalizedScoreIntroBodyWrapper>
+          <div className="full-width">
+            <ScrollableContentWrapper>
+              <CandidateItemOuterWrapper>
+                <CandidateItem
+                  candidateWeVoteId="candidateAlexanderHamilton"
+                  closeSupportOpposeCountDisplayModal={closeSupportOpposeCountDisplayModal}
+                  controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
+                  hideBallotItemSupportOpposeComment
+                  hideCandidateText
+                  hideCandidateUrl
+                  hideIssuesRelatedToCandidate
+                  hideShowMoreFooter
+                  openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
+                  openSupportOpposeCountDisplayModal={openSupportOpposeCountDisplayModal}
+                  supportOpposeCountDisplayModalTutorialOn={supportOpposeCountDisplayModalTutorialOn}
+                  supportOpposeCountDisplayModalTutorialText={supportOpposeCountDisplayModalTutorialText}
+                  showDownArrow={showPersonalizedScoreDownArrow}
+                  showUpArrow={showPersonalizedScoreUpArrow}
+                  showLargeImage
+                  showOfficeName
+                />
+              </CandidateItemOuterWrapper>
+              <ExplanationTextTop>
+                {explanationTextTopBlue && (
+                  <div
+                    style={{
+                      color: '#2e3c5d',
+                      fontSize: '18px',
+                      fontWeight: 600,
+                      margin: '6px 0 0 0',
+                    }}
+                  >
+                    {explanationTextTopBlue}
+                  </div>
+                )}
+                {explanationTextTopPlain && (
+                  <div
+                    style={{
+                      fontSize: '16px',
+                      fontWeight: 200,
+                      margin: '6px 0 0 0',
+                    }}
+                  >
+                    {explanationTextTopPlain}
+                  </div>
+                )}
+              </ExplanationTextTop>
+              <ExplanationTextBottom>
+                {explanationTextBottomBlue && (
+                  <div
+                    style={{
+                      color: '#2e3c5d',
+                      fontSize: '18px',
+                      fontWeight: 600,
+                      margin: '6px 0 0 0',
+                    }}
+                  >
+                    {explanationTextBottomBlue}
+                  </div>
+                )}
+                {explanationTextBottomPlain && (
+                  <div
+                    style={{
+                      fontSize: '16px',
+                      fontWeight: 200,
+                      margin: '6px 0 0 0',
+                    }}
+                  >
+                    {explanationTextBottomPlain}
+                  </div>
+                )}
+              </ExplanationTextBottom>
+            </ScrollableContentWrapper>
+            <ContinueButtonWrapper inModal={inModal}>
+              <TwoButtonsWrapper inModal={inModal}>
+                <OneButtonWrapper inModal={inModal}>
+                  <Button
+                    classes={{ root: classes.backButtonRoot }}
+                    color="primary"
+                    disabled={!(previousStep)}
+                    fullWidth
+                    id="personalizedScoreIntroModalBackButton"
+                    onClick={this.clickPreviousStepButton}
+                    variant="outlined"
+                  >
+                    Back
+                  </Button>
+                </OneButtonWrapper>
+                <OneButtonWrapper inModal={inModal}>
+                  <Button
+                    classes={{ root: classes.nextButtonRoot }}
+                    color="primary"
+                    id="personalizedScoreIntroModalNextButton"
+                    disabled={!(nextStep || (showPersonalizedScoreIntroCompletedButton && inModal))}
+                    variant="contained"
+                    onClick={showPersonalizedScoreIntroCompletedButton ? this.personalizedScoreIntroCompleted : this.clickNextStepButton}
+                  >
+                    <span className="u-no-break">{actionButtonText}</span>
+                  </Button>
+                </OneButtonWrapper>
+              </TwoButtonsWrapper>
+            </ContinueButtonWrapper>
+          </div>
+        </PersonalizedScoreIntroBodyWrapper>
+      </>
+    );
+  }
+}
+const styles = () => ({
+  backButtonRoot: {
+    width: '85%',
+  },
+  nextButtonRoot: {
+    width: '90%',
+  },
+});
+
+const CandidateItemOuterWrapper = styled.div`
+`;
+
+const ContinueButtonWrapper = styled.div`
+  align-items: center;
+  background: #fff;
+  border-top: 1px solid #eee;
+  ${({ inModal }) => (inModal ? 'bottom: 0;' : '')}
+  display: flex;
+  justify-content: space-between;
+  ${({ inModal }) => (inModal ? 'margin: 0 !important;' : '')}
+  ${({ inModal }) => (inModal ? 'position: absolute;' : '')}
+  ${({ inModal }) => (inModal ? 'width: 90%;' : '')}
+  height: 50px;
+`;
+
+const ExplanationTextBottom = styled.div`
+`;
+
+const ExplanationTextTop = styled.div`
+`;
+
+const OneButtonWrapper = styled.div`
+  ${({ inModal }) => (inModal ? 'width: 90%;' : '')}
+`;
+
+const PersonalizedScoreIntroBodyWrapper = styled.div`
+`;
+
+const ScrollableContentWrapper = styled.div`
+  padding-bottom: 60px;
+  overflow-y: auto;
+`;
+
+const TwoButtonsWrapper = styled.div`
+  align-items: center;
+  display: flex;
+  ${({ inModal }) => (inModal ? 'justify-content: space-between;' : 'justify-content: center;')}
+  margin: 0;
+  padding: 4px 0 0 0;
+  width: 100%;
+`;
+
+export default withTheme(withStyles(styles)(PersonalizedScoreIntroBody));

--- a/src/js/components/CompleteYourProfile/PersonalizedScoreIntroModal.jsx
+++ b/src/js/components/CompleteYourProfile/PersonalizedScoreIntroModal.jsx
@@ -2,12 +2,12 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Close } from '@material-ui/icons';
-import { Dialog, DialogContent, IconButton, Button } from '@material-ui/core';
+import { Dialog, DialogContent, IconButton } from '@material-ui/core';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import { hasIPhoneNotch } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
-import CandidateItem from '../Ballot/CandidateItem';
 import { hideZenDeskHelpVisibility, setZenDeskHelpVisibility } from '../../utils/applicationUtils';
+import PersonalizedScoreIntroBody from './PersonalizedScoreIntroBody';
 import VoterActions from '../../actions/VoterActions';
 import VoterConstants from '../../constants/VoterConstants';
 
@@ -21,235 +21,10 @@ class PersonalizedScoreIntroModal extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {
-      previousStep: false,
-      currentStep: 1,
-      nextStep: 2,
-      actionButtonText: '',
-      controlAdviserMaterialUIPopoverFromProp: false,
-      explanationTextTopPlain: null,
-      explanationTextTopBlue: null,
-      explanationTextBottomPlain: null,
-      explanationTextBottomBlue: null,
-      openAdviserMaterialUIPopover: false,
-      openSupportOpposeCountDisplayModal: false,
-      pathname: '',
-      supportOpposeCountDisplayModalTutorialOn: true,
-      supportOpposeCountDisplayModalTutorialText: null,
-      showPersonalizedScoreDownArrow: false,
-      showPersonalizedScoreUpArrow: false,
-      showPersonalizedScoreIntroCompletedButton: false,
-      personalizedScoreSteps: {
-        1: {
-          previousStep: false,
-          currentStep: 1,
-          nextStep: 2,
-          actionButtonText: 'Say What?!?',
-          closeSupportOpposeCountDisplayModal: true,
-          controlAdviserMaterialUIPopoverFromProp: false,
-          explanationTextTopPlain: null,
-          explanationTextTopBlue: <>A Personalized Score is the number of people who support a candidate.</>,
-          explanationTextBottomPlain: <>(We&apos;ll explain! Click the button below to continue.)</>,
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: false,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: null,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: false,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        2: {
-          previousStep: 1,
-          currentStep: 2,
-          nextStep: 3,
-          actionButtonText: 'Next >',
-          closeSupportOpposeCountDisplayModal: true,
-          controlAdviserMaterialUIPopoverFromProp: false,
-          explanationTextTopPlain: null,
-          explanationTextTopBlue: <>In this example, you have a Personalized Score of &quot;+3&quot; for the historical candidate &quot;Alexander Hamilton&quot;.</>,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: false,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: null,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: true,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        3: {
-          previousStep: 2,
-          currentStep: 3,
-          nextStep: 4,
-          actionButtonText: 'Tell Me!',
-          closeSupportOpposeCountDisplayModal: true,
-          explanationTextTopPlain: <>But how is the +3 calculated?</>,
-          explanationTextTopBlue: null,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: false,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: null,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: true,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        4: {
-          previousStep: 3,
-          currentStep: 4,
-          nextStep: 5,
-          actionButtonText: 'I\'ll Pretend',
-          closeSupportOpposeCountDisplayModal: true,
-          controlAdviserMaterialUIPopoverFromProp: false,
-          explanationTextTopPlain: <>But how is the +3 calculated?</>,
-          explanationTextTopBlue: null,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: <>In this example, we pretend you are following 3 advisers.</>,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: false,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: null,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: true,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        5: {
-          previousStep: 4,
-          currentStep: 5,
-          nextStep: 6,
-          actionButtonText: 'Next >',
-          closeSupportOpposeCountDisplayModal: true,
-          controlAdviserMaterialUIPopoverFromProp: false,
-          explanationTextTopPlain: <>But how is the +3 calculated?</>,
-          explanationTextTopBlue: null,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: <>Out of those people, we count the number who support Alexander Hamilton. We pretend all 3 support him.</>,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: false,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: null,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: true,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        6: {
-          previousStep: 5,
-          currentStep: 6,
-          nextStep: 7,
-          actionButtonText: 'Show',
-          closeSupportOpposeCountDisplayModal: true,
-          controlAdviserMaterialUIPopoverFromProp: false,
-          explanationTextTopPlain: null,
-          explanationTextTopBlue: <>So, your Personalized Score is the number of people who support Alexander Hamilton, from among the people you follow.</>,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: false,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: null,
-          showPersonalizedScoreDownArrow: true,
-          showPersonalizedScoreUpArrow: false,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        7: {
-          previousStep: 6,
-          currentStep: 7,
-          nextStep: 8,
-          actionButtonText: 'Next >',
-          closeSupportOpposeCountDisplayModal: false,
-          controlAdviserMaterialUIPopoverFromProp: true,
-          explanationTextTopPlain: null,
-          explanationTextTopBlue: null,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: true,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: <>These are the people and groups who support Alexander Hamilton.</>,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: false,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        8: {
-          previousStep: 7,
-          currentStep: 8,
-          nextStep: 9,
-          actionButtonText: 'Next >',
-          closeSupportOpposeCountDisplayModal: false,
-          controlAdviserMaterialUIPopoverFromProp: true,
-          explanationTextTopPlain: null,
-          explanationTextTopBlue: null,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: true,
-          openSupportOpposeCountDisplayModal: true,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: <>You can click on any adviser to see why they are part of your Personalized Score.</>,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: false,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        9: {
-          previousStep: 8,
-          currentStep: 9,
-          nextStep: 10,
-          actionButtonText: 'Got It!',
-          closeSupportOpposeCountDisplayModal: false,
-          controlAdviserMaterialUIPopoverFromProp: true,
-          explanationTextTopPlain: null,
-          explanationTextTopBlue: null,
-          explanationTextBottomPlain: null,
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: true,
-          supportOpposeCountDisplayModalTutorialOn: true,
-          supportOpposeCountDisplayModalTutorialText: <>Click the +3 any time to see your Personalized Score explained.</>,
-          showPersonalizedScoreDownArrow: true,
-          showPersonalizedScoreUpArrow: false,
-          showPersonalizedScoreIntroCompletedButton: false,
-        },
-        10: {
-          previousStep: 9,
-          currentStep: 10,
-          nextStep: false,
-          actionButtonText: 'All Done!',
-          closeSupportOpposeCountDisplayModal: true,
-          controlAdviserMaterialUIPopoverFromProp: false,
-          explanationTextTopPlain: null,
-          explanationTextTopBlue: <>Success! Now you know what a personalized score is:</>,
-          explanationTextBottomPlain: (
-            <>
-              A
-              {' '}
-              <strong>
-                Personalized Score
-              </strong>
-              {' '}
-              is the number of friends, public figures or groups who support one candidate, from among the people you follow.
-            </>
-          ),
-          explanationTextBottomBlue: null,
-          openAdviserMaterialUIPopover: false,
-          openSupportOpposeCountDisplayModal: false,
-          supportOpposeCountDisplayModalTutorialOn: false,
-          supportOpposeCountDisplayModalTutorialText: null,
-          showPersonalizedScoreDownArrow: false,
-          showPersonalizedScoreUpArrow: false,
-          showPersonalizedScoreIntroCompletedButton: true,
-        },
-      },
-    };
+    this.state = {};
   }
 
   componentDidMount () {
-    // Step 1 settings
-    const { personalizedScoreSteps } = this.state;
-    this.setState(personalizedScoreSteps[1]);
-    this.setState({
-      pathname: this.props.pathname,
-    });
     if (this.props.show) {
       hideZenDeskHelpVisibility();
     }
@@ -264,63 +39,40 @@ class PersonalizedScoreIntroModal extends Component {
   }
 
   componentWillUnmount () {
-    setZenDeskHelpVisibility(this.props.pathname);
+    const { pathname } = this.props;
+    setZenDeskHelpVisibility(pathname);
   }
 
   closeThisModal = () => {
-    setZenDeskHelpVisibility(this.props.pathname);
+    const { pathname } = this.props;
+    setZenDeskHelpVisibility(pathname);
     const { currentStep } = this.state;
     const currentStepCompletedThreshold = 8;
     if (currentStep >= currentStepCompletedThreshold) {
       // console.log('currentStepCompletedThreshold passed');
       VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
     }
-    this.props.toggleFunction(this.state.pathname);
+    this.props.toggleFunction(pathname);
   };
 
   personalizedScoreIntroCompleted = () => {
+    const { pathname } = this.props;
     // Mark this so we know to show 'How it Works' as completed
     VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
-    this.props.toggleFunction(this.state.pathname);
-  };
-
-  clickNextStepButton = () => {
-    const {
-      nextStep, personalizedScoreSteps,
-    } = this.state;
-    // console.log('clickNextStepButton, nextStep:', nextStep);
-    if (nextStep) {
-      this.setState(personalizedScoreSteps[nextStep]);
-    }
-  };
-
-  clickPreviousStepButton = () => {
-    const {
-      previousStep, personalizedScoreSteps,
-    } = this.state;
-    // console.log('clickPreviousStepButton, previousStep:', previousStep);
-    if (previousStep) {
-      this.setState(personalizedScoreSteps[previousStep]);
-    }
+    this.props.toggleFunction(pathname);
   };
 
   render () {
     renderLog('PersonalizedScoreIntroModal');  // Set LOG_RENDER_EVENTS to log all renders
-    const { classes } = this.props;
-    const {
-      actionButtonText, closeSupportOpposeCountDisplayModal, controlAdviserMaterialUIPopoverFromProp,
-      explanationTextBottomBlue, explanationTextBottomPlain,
-      explanationTextTopBlue, explanationTextTopPlain, showPersonalizedScoreIntroCompletedButton,
-      nextStep, openAdviserMaterialUIPopover, openSupportOpposeCountDisplayModal,
-      supportOpposeCountDisplayModalTutorialOn, supportOpposeCountDisplayModalTutorialText,
-      previousStep,
-      showPersonalizedScoreDownArrow, showPersonalizedScoreUpArrow,
-    } = this.state;
+    const { classes, pathname, show } = this.props;
 
+    if (!show) {
+      return null;
+    }
     return (
       <Dialog
         classes={{ paper: classes.dialogPaper }}
-        open={this.props.show}
+        open={show}
         onClose={this.closeThisModal}
       >
         <ModalTitleArea>
@@ -339,117 +91,12 @@ class PersonalizedScoreIntroModal extends Component {
           </IconButtonWrapper>
         </ModalTitleArea>
         <DialogContent classes={{ root: classes.dialogContent }}>
-          <div className="full-width">
-            <ScrollableContentWrapper>
-              <CandidateItemOuterWrapper>
-                <CandidateItem
-                  candidateWeVoteId="candidateAlexanderHamilton"
-                  closeSupportOpposeCountDisplayModal={closeSupportOpposeCountDisplayModal}
-                  controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
-                  hideBallotItemSupportOpposeComment
-                  hideCandidateText
-                  hideCandidateUrl
-                  hideIssuesRelatedToCandidate
-                  hideShowMoreFooter
-                  openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
-                  openSupportOpposeCountDisplayModal={openSupportOpposeCountDisplayModal}
-                  supportOpposeCountDisplayModalTutorialOn={supportOpposeCountDisplayModalTutorialOn}
-                  supportOpposeCountDisplayModalTutorialText={supportOpposeCountDisplayModalTutorialText}
-                  showDownArrow={showPersonalizedScoreDownArrow}
-                  showUpArrow={showPersonalizedScoreUpArrow}
-                  showLargeImage
-                  showOfficeName
-                />
-              </CandidateItemOuterWrapper>
-              <ExplanationTextTop>
-                {explanationTextTopBlue && (
-                  <div
-                    style={{
-                      color: '#2e3c5d',
-                      fontSize: '18px',
-                      fontWeight: 600,
-                      margin: '6px 0 0 0',
-                    }}
-                  >
-                    {explanationTextTopBlue}
-                  </div>
-                )}
-                {explanationTextTopPlain && (
-                  <div
-                    style={{
-                      fontSize: '16px',
-                      fontWeight: 200,
-                      margin: '6px 0 0 0',
-                    }}
-                  >
-                    {explanationTextTopPlain}
-                  </div>
-                )}
-              </ExplanationTextTop>
-              <ExplanationTextBottom>
-                {explanationTextBottomBlue && (
-                  <div
-                    style={{
-                      color: '#2e3c5d',
-                      fontSize: '18px',
-                      fontWeight: 600,
-                      margin: '6px 0 0 0',
-                    }}
-                  >
-                    {explanationTextBottomBlue}
-                  </div>
-                )}
-                {explanationTextBottomPlain && (
-                  <div
-                    style={{
-                      fontSize: '16px',
-                      fontWeight: 200,
-                      margin: '6px 0 0 0',
-                    }}
-                  >
-                    {explanationTextBottomPlain}
-                  </div>
-                )}
-              </ExplanationTextBottom>
-            </ScrollableContentWrapper>
-            <ContinueButtonWrapper>
-              <TwoButtonsWrapper>
-                <div
-                  style={{
-                    width: '90%',
-                  }}
-                >
-                  <Button
-                    classes={{ root: classes.backButtonRoot }}
-                    color="primary"
-                    disabled={!(previousStep)}
-                    fullWidth
-                    id="personalizedScoreIntroModalBackButton"
-                    onClick={this.clickPreviousStepButton}
-                    variant="outlined"
-                  >
-                    Back
-                  </Button>
-                </div>
-                <div
-                  style={{
-                    width: '90%',
-                  }}
-                >
-                  <Button
-                    classes={{ root: classes.nextButtonRoot }}
-                    color="primary"
-                    id="personalizedScoreIntroModalNextButton"
-                    disabled={!(nextStep || showPersonalizedScoreIntroCompletedButton)}
-                    variant="contained"
-                    onClick={showPersonalizedScoreIntroCompletedButton ? this.personalizedScoreIntroCompleted : this.clickNextStepButton}
-                  >
-                    {actionButtonText}
-                  </Button>
-                </div>
-              </TwoButtonsWrapper>
-            </ContinueButtonWrapper>
-          </div>
+          <PersonalizedScoreIntroBody
+            inModal
+            pathname={pathname}
+            show={show}
+            toggleFunction={this.props.toggleFunction}
+          />
         </DialogContent>
       </Dialog>
     );
@@ -479,46 +126,9 @@ const styles = () => ({
   dialogContent: {
     background: 'white',
   },
-  explanationTextMain: {
-    color: '#2e3c5d',
-    fontSize: '22px',
-    fontWeight: 600,
-    margin: '6px 0 0 0',
-  },
   closeButton: {
   },
-  actionButtonRoot: {
-    margin: 'auto',
-  },
-  backButtonRoot: {
-    width: '85%',
-  },
-  nextButtonRoot: {
-    width: '90%',
-  },
 });
-
-const CandidateItemOuterWrapper = styled.div`
-`;
-
-const ContinueButtonWrapper = styled.div`
-  align-items: center;
-  background: #fff;
-  border-top: 1px solid #eee;
-  bottom: 0;
-  display: flex;
-  justify-content: space-between;
-  margin: 0 !important;
-  position: absolute;
-  width: 90%;
-  height: 50px;
-`;
-
-const ExplanationTextBottom = styled.div`
-`;
-
-const ExplanationTextTop = styled.div`
-`;
 
 const IconButtonWrapper = styled.div`
   margin: 4px 0 12px 0;
@@ -534,11 +144,6 @@ const ModalTitleArea = styled.div`
   }
 `;
 
-const ScrollableContentWrapper = styled.div`
-  padding-bottom: 60px;
-  overflow-y: auto;
-`;
-
 const Title = styled.div`
   color: black;
   font-size: 24px;
@@ -548,15 +153,6 @@ const Title = styled.div`
   @media (max-width: 769px) {
     font-size: 16px;
   }
-`;
-
-const TwoButtonsWrapper = styled.div`
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
-  margin: 0;
-  padding: 4px 0 0 0;
-  width: 100%;
 `;
 
 export default withTheme(withStyles(styles)(PersonalizedScoreIntroModal));

--- a/src/js/components/Friends/SuggestedFriendsPreview.jsx
+++ b/src/js/components/Friends/SuggestedFriendsPreview.jsx
@@ -20,11 +20,9 @@ export default class SuggestedFriendsPreview extends Component {
   }
 
   componentDidMount () {
-    FriendActions.suggestedFriendList();
-    this.setState({
-      suggestedFriendList: FriendStore.suggestedFriendList(),
-    });
     this.friendStoreListener = FriendStore.addListener(this.onFriendStoreChange.bind(this));
+    this.onFriendStoreChange();
+    FriendActions.suggestedFriendList();
   }
 
   componentWillUnmount () {
@@ -32,8 +30,14 @@ export default class SuggestedFriendsPreview extends Component {
   }
 
   onFriendStoreChange () {
+    const suggestedFriendList = FriendStore.suggestedFriendList();
+    // suggestedFriendList.sort((optionA, optionB) => (optionB.voter_photo_url_medium ? 1 : 0) - (optionA.voter_photo_url_medium ? 1 : 0));
+    // suggestedFriendList.sort((optionA, optionB) => optionB.positions_taken - optionA.positions_taken);
+    suggestedFriendList.sort((optionA, optionB) => optionB.voter_date_last_changed - optionA.voter_date_last_changed);
+    suggestedFriendList.sort((optionA, optionB) => optionB.mutual_friends - optionA.mutual_friends);
+    // console.log('suggestedFriendList:', suggestedFriendList);
     this.setState({
-      suggestedFriendList: FriendStore.suggestedFriendList(),
+      suggestedFriendList,
     });
   }
 

--- a/src/js/components/Intro/FriendInvitationOnboardingIntro.jsx
+++ b/src/js/components/Intro/FriendInvitationOnboardingIntro.jsx
@@ -22,7 +22,11 @@ class FriendInvitationOnboardingIntro extends Component {
 
   constructor (props) {
     super(props);
-    this.state = {};
+    this.state = {
+      showAllStepOne: false,
+      showAllStepTwo: false,
+      showAllStepThree: false,
+    };
   }
 
   componentDidMount () {
@@ -61,10 +65,28 @@ class FriendInvitationOnboardingIntro extends Component {
     }
   }
 
+  onClickShowAllStepOne = () => {
+    this.setState({
+      showAllStepOne: true,
+    });
+  }
+
+  onClickShowAllStepTwo = () => {
+    this.setState({
+      showAllStepTwo: true,
+    });
+  }
+
+  onClickShowAllStepThree = () => {
+    this.setState({
+      showAllStepThree: true,
+    });
+  }
+
   render () {
     renderLog('FriendInvitationOnboardingIntro');  // Set LOG_RENDER_EVENTS to log all renders
     const { friendFirstName, friendLastName, invitationMessage, friendImageUrlHttpsTiny } = this.props;
-    const { days, electionDate } = this.state;
+    const { days, electionDate, showAllStepOne, showAllStepTwo, showAllStepThree } = this.state;
     let showCountDownDays = (days && electionDate);
     if (convertToInteger(days) < 0) {
       showCountDownDays = false;
@@ -78,22 +100,6 @@ class FriendInvitationOnboardingIntro extends Component {
             src={cordovaDot(logoDark)}
           />
         </WeVoteLogoWrapper>
-        {showCountDownDays && (
-          <ElectionCountdownText>
-            <ElectionCountdownDays>
-              {days}
-              {' '}
-              days
-            </ElectionCountdownDays>
-            {' '}
-            until your next election on
-            {' '}
-            <span className="u-no-break">
-              {formatDateToMonthDayYear(electionDate)}
-              .
-            </span>
-          </ElectionCountdownText>
-        )}
         <FriendInvitationTopHeader className="FriendInvitationTopHeader">
           {friendFirstName || invitationMessage ? (
             <>
@@ -144,10 +150,7 @@ class FriendInvitationOnboardingIntro extends Component {
           )}
         </FriendInvitationTopHeader>
         <FriendInvitationIntroHeader className="FriendInvitationIntroHeader">
-          We Vote makes
-          <span className="u-show-mobile"><br /></span>
-          <span className="u-show-desktop-tablet">{' '}</span>
-          being a voter easier:
+          How We Vote helps you:
         </FriendInvitationIntroHeader>
         <FriendInvitationListWrapper>
           <FriendInvitationList>
@@ -157,7 +160,59 @@ class FriendInvitationOnboardingIntro extends Component {
             </FriendInvitationListTitleRow>
             <FriendInvitationListRow>
               <Dot><StepNumberPlaceholder>&nbsp;</StepNumberPlaceholder></Dot>
-              <StepText>Verify your registration. Make a plan for casting your vote. Find your polling location.</StepText>
+              {showAllStepOne ? (
+                <StepText>
+                  {showCountDownDays && (
+                    <>
+                      There are
+                      {' '}
+                      {days}
+                      {' '}
+                      days
+                      {' '}
+                      until your next election on
+                      {' '}
+                      <span className="u-no-break">
+                        {formatDateToMonthDayYear(electionDate)}
+                        .
+                      </span>
+                      {' '}
+                    </>
+                  )}
+                  Make a plan for casting your vote. Verify your registration. Find your polling location.
+                </StepText>
+              ) : (
+                <StepText onClick={this.onClickShowAllStepOne}>
+                  {showCountDownDays ? (
+                    <>
+                      There are
+                      {' '}
+                      {days}
+                      {' '}
+                      days
+                      {' '}
+                      until your next election on
+                      {' '}
+                      <span className="u-no-break">
+                        {formatDateToMonthDayYear(electionDate)}
+                        .
+                      </span>
+                      {' '}
+                      Make a plan...
+                    </>
+                  ) : (
+                    <>
+                      Make a plan for casting your vote. Verify your...
+                    </>
+                  )}
+                  {' '}
+                  (
+                  <span className="u-cursor--pointer u-link-color">
+                    more
+                  </span>
+                  )
+                </StepText>
+              )}
             </FriendInvitationListRow>
 
             <FriendInvitationListTitleRow>
@@ -166,16 +221,44 @@ class FriendInvitationOnboardingIntro extends Component {
             </FriendInvitationListTitleRow>
             <FriendInvitationListRow>
               <Dot><StepNumberPlaceholder>&nbsp;</StepNumberPlaceholder></Dot>
-              <StepText>Who&apos;s running for office? What do they stand for? With over 12,600 candidates running for 6,500 offices this year, We Vote helps you make sense of your options.</StepText>
+              {showAllStepTwo ? (
+                <StepText>
+                  Who&apos;s running for office? What do they stand for? We Vote helps you make sense of your options.
+                </StepText>
+              ) : (
+                <StepText onClick={this.onClickShowAllStepTwo}>
+                  Who&apos;s running for office? What do they...
+                  {' '}
+                  (
+                  <span className="u-cursor--pointer u-link-color">
+                    more
+                  </span>
+                  )
+                </StepText>
+              )}
             </FriendInvitationListRow>
 
             <FriendInvitationListTitleRow>
               <Dot><StepNumber>3</StepNumber></Dot>
-              <StepTitle>Be the change you want to see in the world</StepTitle>
+              <StepTitle>Help your friends</StepTitle>
             </FriendInvitationListTitleRow>
             <FriendInvitationListRow>
               <Dot><StepNumberPlaceholder>&nbsp;</StepNumberPlaceholder></Dot>
-              <StepText>You&apos;ve done your homework deciding how to vote. Now show your friends how to make sense of their decisions, so they can vote their values.</StepText>
+              {showAllStepThree ? (
+                <StepText>
+                  You&apos;ve done your homework deciding how to vote. Now show your friends how to make sense of their decisions, so they can vote their values.
+                </StepText>
+              ) : (
+                <StepText onClick={this.onClickShowAllStepThree}>
+                  You&apos;ve done your homework deciding...
+                  {' '}
+                  (
+                  <span className="u-cursor--pointer u-link-color">
+                    more
+                  </span>
+                  )
+                </StepText>
+              )}
             </FriendInvitationListRow>
           </FriendInvitationList>
         </FriendInvitationListWrapper>
@@ -204,33 +287,6 @@ const styles = theme => ({
 const Wrapper = styled.div`
   padding-left: 12px;
   padding-right: 12px;
-`;
-
-const ElectionCountdownDays = styled.span`
-  font-size: 32px;
-  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
-    font-size: 24px;
-  }
-  @media (max-width: ${({ theme }) => theme.breakpoints.xs}) {
-    font-size: 13px;
-  }
-`;
-
-const ElectionCountdownText = styled.h3`
-  font-size: 14px;
-  font-weight: 700;
-  color: #2E3C5D !important;
-  width: fit-content;
-  padding-bottom: 8px;
-  margin-top: 0;
-  width: 100%;
-  text-align: center;
-  @media (max-width: ${({ theme }) => theme.breakpoints.md}) {
-    font-size: 12px;
-  }
-  @media (max-width: ${({ theme }) => theme.breakpoints.xs}) {
-    font-size: 10px;
-  }
 `;
 
 const InvitationMessageWrapper = styled.div`
@@ -322,7 +378,7 @@ const StepTitle = styled.div`
 `;
 
 const StepText = styled.div`
-  color: #555;
+  color: #999;
   font-size: 16px;
   font-weight: 200;
   padding: 0 8px;

--- a/src/js/components/Intro/FriendInvitationOnboardingValues.jsx
+++ b/src/js/components/Intro/FriendInvitationOnboardingValues.jsx
@@ -24,9 +24,16 @@ class FriendInvitationOnboardingValues extends Component {
     this.state = {};
   }
 
+  onClickShowAllTopHeaderExplanation = () => {
+    this.setState({
+      showAllTopHeaderExplanation: true,
+    });
+  }
+
   render () {
     renderLog('FriendInvitationOnboardingValues');  // Set LOG_RENDER_EVENTS to log all renders
     const { friendFirstName, friendLastName, friendImageUrlHttpsTiny, friendIssueWeVoteIdList } = this.props;
+    const { showAllTopHeaderExplanation } = this.state;
     return (
       <Wrapper>
         <WeVoteLogoWrapper>
@@ -36,8 +43,31 @@ class FriendInvitationOnboardingValues extends Component {
             src={cordovaDot(logoDark)}
           />
         </WeVoteLogoWrapper>
-        <FriendInvitationTopHeader className="FriendInvitationTopHeader">
-          Follow what you care about.
+        <FriendInvitationTopHeader>
+          <div className="FriendInvitationTopHeader">
+            Follow what you care about.
+          </div>
+          {showAllTopHeaderExplanation ? (
+            <div className="FriendInvitationTopHeaderExplanation">
+              <i className="fas fa-info-circle" />
+              Opinions will be highlighted on your ballot based on what you follow. Follow as many values/issues as you would like.
+              {' '}
+              We promise to never sell your email address.
+              {' '}
+              You can stop following values/issues at any time in the &quot;Opinions&quot; section.
+            </div>
+          ) : (
+            <div className="FriendInvitationTopHeaderExplanation" onClick={this.onClickShowAllTopHeaderExplanation}>
+              <i className="fas fa-info-circle" />
+              Opinions will be highlighted on...
+              {' '}
+              (
+              <span className="u-cursor--pointer u-link-color">
+                more
+              </span>
+              )
+            </div>
+          )}
         </FriendInvitationTopHeader>
         {!!(friendIssueWeVoteIdList && friendIssueWeVoteIdList.length) && (
           <PopularValuesWrapper>

--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -167,7 +167,7 @@ class FooterBar extends React.Component {
               )}
             />
             */}
-            <BottomNavigationAction className="no-outline" id="newsTabFooterBar" label="News" showLabel icon={<People />} />
+            <BottomNavigationAction className="no-outline" id="newsTabFooterBar" label="Discuss" showLabel icon={<People />} />
             {isCordova() ? (
               <BottomNavigationAction
                 className="no-outline"

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -537,7 +537,7 @@ class HeaderBar extends Component {
                   />
                 ) */}
                 {(showFullNavigation) && (
-                  <Tab classes={{ root: classes.tabRootNews }} id="activityTabHeaderBar" label="News" onClick={() => this.handleNavigation('/news')} />
+                  <Tab classes={{ root: classes.tabRootNews }} id="activityTabHeaderBar" label="Discuss" onClick={() => this.handleNavigation('/news')} />
                 )}
               </Tabs>
             </div>

--- a/src/js/components/Navigation/HeaderNotificationMenu.jsx
+++ b/src/js/components/Navigation/HeaderNotificationMenu.jsx
@@ -57,8 +57,10 @@ class HeaderNotificationMenu extends Component {
       ActivityActions.activityNoticeListRetrieve([activityNotice.activity_notice_id]);
     }
     this.handleClose();
-    if (activityNotice.kind_of_notice === 'NOTICE_FRIEND_ENDORSEMENTS') {
+    if (activityNotice.kind_of_notice === 'NOTICE_FRIEND_ENDORSEMENTS' && activityNotice && activityNotice.activity_tidbit_we_vote_id) {
       historyPush(`/news/a/${activityNotice.activity_tidbit_we_vote_id}`);
+    } else {
+      historyPush('/news');
     }
   }
 

--- a/src/js/components/Ready/EditAddressOneHorizontalRow.jsx
+++ b/src/js/components/Ready/EditAddressOneHorizontalRow.jsx
@@ -168,16 +168,16 @@ class EditAddressOneHorizontalRow extends Component {
       <OuterWrapper>
         <InnerWrapper className="u-show-mobile">
           <AddressLabelMobile>
-            Enter full address for correct ballot
+            Enter full street address with house number for correct ballot
           </AddressLabelMobile>
         </InnerWrapper>
         <InnerWrapper>
           <AddressLabel>
             <span className="u-show-tablet">
-              Enter full address for correct ballot
+              Enter street address with house number for correct ballot
             </span>
             <span className="u-show-desktop">
-              Enter your full address to see correct ballot
+              Enter full street address with house number for correct ballot
             </span>
           </AddressLabel>
           <form onSubmit={this.voterAddressSave}>
@@ -232,6 +232,7 @@ const AddressLabel = styled.div`
 
 const AddressLabelMobile = styled.div`
   font-weight: 600;
+  text-align: center;
 `;
 
 const InternalFormWrapper = styled.div`

--- a/src/js/components/Ready/ReadyTaskBallot.jsx
+++ b/src/js/components/Ready/ReadyTaskBallot.jsx
@@ -104,6 +104,19 @@ class ReadyTaskBallot extends React.Component {
     this.calculateShowButtonStates(ballotItemsStatusCounts, showMoreButtonWasClicked);
   }
 
+  goToCandidateTypeAfterCalculation = () => {
+    const { federalTotalNumber, localTotalNumber, stateTotalNumber } = this.state;
+    if (federalTotalNumber) {
+      this.goToFederalRaces();
+    } else if (stateTotalNumber) {
+      this.goToStateRaces();
+    } else if (localTotalNumber) {
+      this.goToLocalRaces();
+    } else {
+      this.goToBallot();
+    }
+  }
+
   goToFederalRaces = () => {
     BallotActions.completionLevelFilterTypeSave('All');
     BallotActions.raceLevelFilterTypeSave('Federal');
@@ -175,10 +188,10 @@ class ReadyTaskBallot extends React.Component {
 
   calculateShowButtonStates = (ballotItemsStatusCounts, showMoreButtonWasClicked = false) => {
     const {
-      federalButtonNeeded, federalAllCompleted, federalNumberCompleted,
-      localButtonNeeded, localAllCompleted, localNumberCompleted,
+      federalButtonNeeded, federalAllCompleted, federalNumberCompleted, federalTotalNumber,
+      localButtonNeeded, localAllCompleted, localNumberCompleted, localTotalNumber,
       measureButtonNeeded, measureAllCompleted,
-      stateButtonNeeded, stateAllCompleted, stateNumberCompleted,
+      stateButtonNeeded, stateAllCompleted, stateNumberCompleted, stateTotalNumber,
     } = ballotItemsStatusCounts;
     const howItWorksCompleted = VoterStore.getInterfaceFlagState(VoterConstants.HOW_IT_WORKS_WATCHED);
     const personalizedScoreIntroCompleted = VoterStore.getInterfaceFlagState(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
@@ -324,15 +337,18 @@ class ReadyTaskBallot extends React.Component {
       allCandidatesShowButton,
       federalButtonNeeded,
       federalShowButton,
+      federalTotalNumber,
       howItWorksShowButton,
       localButtonNeeded,
       localShowButton,
+      localTotalNumber,
       measureButtonNeeded,
       measureShowButton,
       personalizedScoreIntroShowButton,
       showMoreShowButton,
       stateButtonNeeded,
       stateShowButton,
+      stateTotalNumber,
     });
   }
 
@@ -448,7 +464,7 @@ class ReadyTaskBallot extends React.Component {
               className="u-cursor--pointer"
               color="primary"
               completed={allCandidatesAllCompleted ? 'true' : undefined}
-              onClick={this.goToBallot}
+              onClick={this.goToCandidateTypeAfterCalculation}
               variant="outlined"
             >
               <ButtonLeft>

--- a/src/js/components/ReadyNoApi/ReadyIntroduction.jsx
+++ b/src/js/components/ReadyNoApi/ReadyIntroduction.jsx
@@ -29,16 +29,17 @@ class ReadyIntroduction extends Component {
     renderLog('ReadyIntroduction');  // Set LOG_RENDER_EVENTS to log all renders
     const { contentUnfurled } = this.state;
     const { showStep3WhenCompressed } = this.props;
-    const numberOfCandidates = '12,600';
-    const numberOfOffices = '6,500';
+    // const numberOfCandidates = '12,600';
+    // const numberOfOffices = '6,500';
     return (
       <OuterWrapper>
         <InnerWrapper>
           <IntroHeader>
-            We Vote makes
-            {' '}
-            <span className="u-no-break">
-              being a voter easier.
+            <span className="u-show-mobile-tablet">
+              How We Vote helps you:
+            </span>
+            <span className="u-show-desktop">
+              How We Vote helps:
             </span>
           </IntroHeader>
           <ListWrapper>
@@ -63,7 +64,7 @@ class ReadyIntroduction extends Component {
                   <Dot><StepNumberPlaceholder>&nbsp;</StepNumberPlaceholder></Dot>
                   <StepText>
                     <ReadMore
-                      textToDisplay={`Who's running for office? What do they stand for? With over ${numberOfCandidates} candidates running for ${numberOfOffices} offices this year, We Vote helps you make sense of your options.`}
+                      textToDisplay="Who's running for office? What do they stand for? We Vote helps you make sense of your options."
                       numberOfLines={3}
                     />
                   </StepText>
@@ -73,7 +74,7 @@ class ReadyIntroduction extends Component {
               {(contentUnfurled || showStep3WhenCompressed) && (
                 <ListTitleRow>
                   <Dot><StepNumber>3</StepNumber></Dot>
-                  <StepTitle>Be the change you want to see in the world</StepTitle>
+                  <StepTitle>Help your friends</StepTitle>
                 </ListTitleRow>
               )}
               {contentUnfurled && (

--- a/src/js/components/Share/SharedItemIntroduction.jsx
+++ b/src/js/components/Share/SharedItemIntroduction.jsx
@@ -6,20 +6,39 @@ import { renderLog } from '../../utils/logging';
 class SharedItemIntroduction extends Component {
   constructor (props) {
     super(props);
-    this.state = {};
+    this.state = {
+      showAllStepOne: false,
+      showAllStepTwo: false,
+      showAllStepThree: false,
+    };
+  }
+
+  onClickShowAllStepOne = () => {
+    this.setState({
+      showAllStepOne: true,
+    });
+  }
+
+  onClickShowAllStepTwo = () => {
+    this.setState({
+      showAllStepTwo: true,
+    });
+  }
+
+  onClickShowAllStepThree = () => {
+    this.setState({
+      showAllStepThree: true,
+    });
   }
 
   render () {
     renderLog('SharedItemIntroduction');  // Set LOG_RENDER_EVENTS to log all renders
+    const { showAllStepOne, showAllStepTwo, showAllStepThree } = this.state;
     return (
       <OuterWrapper>
         <InnerWrapper>
           <IntroHeader>
-            We Vote makes
-            {' '}
-            <span className="u-no-break">
-              being a voter easier:
-            </span>
+            How We Vote helps you:
           </IntroHeader>
           <ListWrapper>
             <ListMaxWidth>
@@ -29,7 +48,21 @@ class SharedItemIntroduction extends Component {
               </ListTitleRow>
               <ListRow>
                 <Dot><StepNumberPlaceholder>&nbsp;</StepNumberPlaceholder></Dot>
-                <StepText>Verify your registration. Make a plan for casting your vote. Find your polling location.</StepText>
+                {showAllStepOne ? (
+                  <StepText>
+                    Make a plan for casting your vote. Verify your registration. Find your polling location.
+                  </StepText>
+                ) : (
+                  <StepText onClick={this.onClickShowAllStepOne}>
+                    Make a plan for casting your vote. Verify your...
+                    {' '}
+                    (
+                    <span className="u-cursor--pointer u-link-color">
+                      more
+                    </span>
+                    )
+                  </StepText>
+                )}
               </ListRow>
 
               <ListTitleRow>
@@ -38,16 +71,44 @@ class SharedItemIntroduction extends Component {
               </ListTitleRow>
               <ListRow>
                 <Dot><StepNumberPlaceholder>&nbsp;</StepNumberPlaceholder></Dot>
-                <StepText>Who&apos;s running for office? What do they stand for? With over 12,600 candidates running for 6,500 offices this year, We Vote helps you make sense of your options.</StepText>
+                {showAllStepTwo ? (
+                  <StepText>
+                    Who&apos;s running for office? What do they stand for? We Vote helps you make sense of your options.
+                  </StepText>
+                ) : (
+                  <StepText onClick={this.onClickShowAllStepTwo}>
+                    Who&apos;s running for office? What do they...
+                    {' '}
+                    (
+                    <span className="u-cursor--pointer u-link-color">
+                      more
+                    </span>
+                    )
+                  </StepText>
+                )}
               </ListRow>
 
               <ListTitleRow>
                 <Dot><StepNumber>3</StepNumber></Dot>
-                <StepTitle>Be the change you want to see in the world</StepTitle>
+                <StepTitle>Help your friends</StepTitle>
               </ListTitleRow>
               <ListRow>
                 <Dot><StepNumberPlaceholder>&nbsp;</StepNumberPlaceholder></Dot>
-                <StepText>You&apos;ve done your homework deciding how to vote. Now show your friends how to make sense of their decisions, so they can vote their values.</StepText>
+                {showAllStepThree ? (
+                  <StepText>
+                    You&apos;ve done your homework deciding how to vote. Now show your friends how to make sense of their decisions, so they can vote their values.
+                  </StepText>
+                ) : (
+                  <StepText onClick={this.onClickShowAllStepThree}>
+                    You&apos;ve done your homework deciding...
+                    {' '}
+                    (
+                    <span className="u-cursor--pointer u-link-color">
+                      more
+                    </span>
+                    )
+                  </StepText>
+                )}
               </ListRow>
             </ListMaxWidth>
           </ListWrapper>

--- a/src/js/routes/Activity/News.jsx
+++ b/src/js/routes/Activity/News.jsx
@@ -290,7 +290,7 @@ class News extends Component {
 
     return (
       <span>
-        <Helmet title="News - We Vote" />
+        <Helmet title="Discuss - We Vote" />
         <BrowserPushMessage incomingProps={this.props} />
         <div className="row" style={unsetSomeRowStylesIfCordova}>
           <div className="col-sm-12 col-md-8" style={unsetSomeRowStylesIfCordova}>
@@ -369,6 +369,9 @@ class News extends Component {
                 </Card>
               </DelayedLoad>
             )}
+            <AddFriendsMobileWrapper className="u-show-mobile" style={unsetSideMarginsIfCordova}>
+              <SuggestedFriendsPreview inSideColumn />
+            </AddFriendsMobileWrapper>
             <div className="card u-show-mobile" style={unsetSideMarginsIfCordova}>
               <AddFriendsMobileWrapper className="card-main" style={unsetMarginsIfCordova}>
                 <SectionTitle>
@@ -384,7 +387,7 @@ class News extends Component {
               <DelayedLoad waitBeforeShow={1000}>
                 <SettingsAccountWrapper style={expandSideMarginsIfCordova}>
                   <SettingsAccount
-                    pleaseSignInTitle="Sign in to See Your News"
+                    pleaseSignInTitle="Sign in to Join the Discussion"
                     pleaseSignInSubTitle="We Vote is a community of friends who care about voting and democracy."
                   />
                 </SettingsAccountWrapper>
@@ -392,6 +395,7 @@ class News extends Component {
             )}
           </div>
           <div className="col-md-4 d-none d-md-block" style={unsetSomeRowStylesIfCordovaMdBlock}>
+            <SuggestedFriendsPreview inSideColumn />
             <div className="card">
               <div className="card-main" style={unsetMarginsIfCordova}>
                 <SectionTitle>
@@ -403,7 +407,6 @@ class News extends Component {
                 <AddFriendsByEmail inSideColumn uniqueExternalId="sidebar" />
               </div>
             </div>
-            <SuggestedFriendsPreview inSideColumn />
             <div className="card">
               <div className="card-main" style={unsetMarginsIfCordova}>
                 <Testimonial

--- a/src/js/routes/Intro/FriendInvitationOnboarding.jsx
+++ b/src/js/routes/Intro/FriendInvitationOnboarding.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Button } from '@material-ui/core';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import closeIcon from '../../../img/global/icons/x-close.png';
+import { hideZenDeskHelpVisibility, showZenDeskHelpVisibility } from '../../utils/applicationUtils';
 import { cordovaFooterHeight, cordovaNetworkNextButtonTop } from '../../utils/cordovaOffsets';
 import { cordovaDot, getAndroidSize, historyPush, isAndroid, isWebApp } from '../../utils/cordovaUtils';
 import FriendActions from '../../actions/FriendActions';
@@ -13,6 +14,7 @@ import FriendStore from '../../stores/FriendStore';
 import FriendInvitationOnboardingIntro from '../../components/Intro/FriendInvitationOnboardingIntro';
 import FriendInvitationOnboardingValues from '../../components/Intro/FriendInvitationOnboardingValues';
 import logoDark from '../../../img/global/svg-icons/we-vote-logo-horizontal-color-dark-141x46.svg';
+import PersonalizedScoreIntroBody from '../../components/CompleteYourProfile/PersonalizedScoreIntroBody';
 import { renderLog } from '../../utils/logging';
 import StepsChips from '../../components/Widgets/StepsChips';
 import VoterActions from '../../actions/VoterActions';
@@ -29,13 +31,7 @@ class FriendInvitationOnboarding extends Component {
     super(props);
     this.state = {
       activeSlideBefore: 0,
-      howItWorksWatchedThisSession: false,
-      imageDecideUrl: '/img/how-it-works/HowItWorksForVoters-Decide-20190401.gif',
-      imageDecideReloadUrl: '/img/how-it-works/HowItWorksForVoters-Decide-20190401.gif',
-      imageFollowUrl: '/img/how-it-works/HowItWorksForVoters-Follow-20190507.gif',
-      imageFollowReloadUrl: '/img/how-it-works/HowItWorksForVoters-Follow-20190507.gif',
-      imageReviewUrl: '/img/how-it-works/HowItWorksForVoters-Review-20190401.gif',
-      imageReviewReloadUrl: '/img/how-it-works/HowItWorksForVoters-Review-20190401.gif',
+      personalizedScoreIntroWatchedThisSession: false,
       invitationMessage: '',
     };
 
@@ -58,9 +54,9 @@ class FriendInvitationOnboarding extends Component {
     if (invitationSecretKey) {
       this.friendInvitationInformation(invitationSecretKey);
     }
-    const howItWorksWatched = VoterStore.getInterfaceFlagState(VoterConstants.HOW_IT_WORKS_WATCHED);
+    const personalizedScoreIntroCompleted = VoterStore.getInterfaceFlagState(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
     this.setState({
-      howItWorksWatched,
+      personalizedScoreIntroCompleted,
     });
   }
 
@@ -89,43 +85,33 @@ class FriendInvitationOnboarding extends Component {
 
   onVoterStoreChange () {
     this.onFriendStoreChange();
-    const howItWorksWatched = VoterStore.getInterfaceFlagState(VoterConstants.HOW_IT_WORKS_WATCHED);
+    const personalizedScoreIntroCompleted = VoterStore.getInterfaceFlagState(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
     this.setState({
-      howItWorksWatched,
+      personalizedScoreIntroCompleted,
     });
   }
 
   goToSpecificSlide = (index) => {
     // console.log('goToSpecificSlide index:', index);
-    const { imageDecideUrl, imageFollowUrl, imageReviewUrl } = this.state;
-    // Force the animated gifs to restart the animation
     if (index === 2) {
-      this.setState({ imageFollowReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageFollowReloadUrl: imageFollowUrl });
-      }, 0);
-    } else if (index === 3) {
-      this.setState({ imageReviewReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageReviewReloadUrl: imageReviewUrl });
-      }, 0);
-    } else if (index === 4) {
-      this.setState({ imageDecideReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageDecideReloadUrl: imageDecideUrl });
-      }, 0);
-      this.setState({ howItWorksWatchedThisSession: true });
+      this.setState({ personalizedScoreIntroWatchedThisSession: true });
     }
+    hideZenDeskHelpVisibility();
     this.slider.current.slickGoTo(index);
   }
 
   onExitOnboarding = () => {
-    const { howItWorksWatchedThisSession } = this.state;
-    if (howItWorksWatchedThisSession) {
-      VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.HOW_IT_WORKS_WATCHED);
+    const { personalizedScoreIntroWatchedThisSession } = this.state;
+    if (personalizedScoreIntroWatchedThisSession) {
+      VoterActions.voterUpdateInterfaceStatusFlags(VoterConstants.PERSONALIZED_SCORE_INTRO_COMPLETED);
     }
     const ballotLink = '/ready';
+    showZenDeskHelpVisibility();
     historyPush(ballotLink);
+  }
+
+  personalizedScoreIntroModalToggle = () => {
+    //
   }
 
   nextSlide () {
@@ -133,45 +119,18 @@ class FriendInvitationOnboarding extends Component {
     if (invitationSecretKey) {
       this.friendInvitationInformation(invitationSecretKey);
     }
-    const { activeSlideBefore, imageDecideUrl, imageFollowUrl, imageReviewUrl } = this.state;
+    hideZenDeskHelpVisibility();
+    const { activeSlideBefore } = this.state;
     // console.log('nextSlide activeSlideBefore:', activeSlideBefore);
-    // Force the animated gifs to restart the animation
     if (activeSlideBefore === 1) {
-      this.setState({ imageFollowReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageFollowReloadUrl: imageFollowUrl });
-      }, 0);
-    } else if (activeSlideBefore === 2) {
-      this.setState({ imageReviewReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageReviewReloadUrl: imageReviewUrl });
-      }, 0);
-    } else if (activeSlideBefore === 3) {
-      this.setState({ imageDecideReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageDecideReloadUrl: imageDecideUrl });
-      }, 0);
-      this.setState({ howItWorksWatchedThisSession: true });
+      this.setState({ personalizedScoreIntroWatchedThisSession: true });
     }
     this.slider.current.slickNext();
   }
 
   previousSlide () {
-    const { activeSlideBefore, imageFollowUrl, imageReviewUrl } = this.state;
     // console.log('previousSlide, activeSlideBefore:', activeSlideBefore);
-    // Force the animated gifs to restart the animation
-    if (activeSlideBefore === 3) {
-      this.setState({ imageFollowReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageFollowReloadUrl: imageFollowUrl });
-      }, 0);
-    } else if (activeSlideBefore === 4) {
-      this.setState({ imageReviewReloadUrl: '' });
-      setTimeout(() => {
-        this.setState({ imageReviewReloadUrl: imageReviewUrl });
-      }, 0);
-    }
-    // Cannot get to imageDecide using the previousSlide function
+    hideZenDeskHelpVisibility();
     this.slider.current.slickPrev();
   }
 
@@ -199,8 +158,7 @@ class FriendInvitationOnboarding extends Component {
     const {
       activeSlideBefore, friendFirstName, friendLastName,
       friendImageUrlHttpsTiny, friendIssueWeVoteIdList, howItWorksWatched,
-      imageDecideReloadUrl, imageFollowReloadUrl, imageReviewReloadUrl,
-      invitationMessage,
+      invitationMessage, personalizedScoreIntroCompleted,
     } = this.state;
     // console.log('render:', imageFollowReloadUrl);
 
@@ -218,12 +176,12 @@ class FriendInvitationOnboarding extends Component {
       // afterChange: current => this.setState({ activeSlideAfter: current }),
     };
 
-    const showReadyNextTextOnThisSlide = howItWorksWatched ? 1 : 4;
+    const showReadyNextTextOnThisSlide = personalizedScoreIntroCompleted ? 1 : 2;
     // console.log('activeSlideBefore: ', activeSlideBefore, ', activeSlideAfter:', activeSlideAfter);
-    const stepLabels = howItWorksWatched ? ['Invitation Accepted', 'Values'] : ['Invitation Accepted', 'Values', 'Follow', 'Review', 'Decide'];
+    const stepLabels = personalizedScoreIntroCompleted ? ['Invitation Accepted', 'Values'] : ['Invitation Accepted', 'Values', 'Personalized Score'];
     return (
       <div>
-        <Helmet title="Invitation Accepted!" />
+        <Helmet title="We Vote - Invitation Accepted!" />
         <div className="intro-story container-fluid well u-inset--md" style={this.overrideMediaQueryForAndroidTablets()}>
           <span onClick={this.onExitOnboarding}>
             <img
@@ -249,7 +207,7 @@ class FriendInvitationOnboarding extends Component {
                 friendIssueWeVoteIdList={friendIssueWeVoteIdList}
               />
             </div>
-            {!howItWorksWatched && (
+            {!personalizedScoreIntroCompleted && (
               <div key={3}>
                 <HowItWorksWrapper>
                   <WeVoteLogoWrapper>
@@ -260,52 +218,15 @@ class FriendInvitationOnboarding extends Component {
                     />
                   </WeVoteLogoWrapper>
                   <SlideShowTitle>
-                    Follow organizations and people you trust
+                    What&apos;s a Personalized Score?
                   </SlideShowTitle>
                   <HowItWorksDescription>
-                    Follow those you trust as you look through your ballot, and in the Values section.
-                  </HowItWorksDescription>
-                  <HowItWorksImage src={imageFollowReloadUrl ? cordovaDot(imageFollowReloadUrl) : ''} />
-                </HowItWorksWrapper>
-              </div>
-            )}
-            {!howItWorksWatched && (
-              <div key={4}>
-                <HowItWorksWrapper>
-                  <WeVoteLogoWrapper>
-                    <img
-                      className="header-logo-img"
-                      alt="We Vote logo"
-                      src={cordovaDot(logoDark)}
+                    <PersonalizedScoreIntroBody
+                      pathname=""
+                      show
+                      toggleFunction={this.personalizedScoreIntroModalToggle}
                     />
-                  </WeVoteLogoWrapper>
-                  <SlideShowTitle>
-                    See who endorsed each choice on your ballot
-                  </SlideShowTitle>
-                  <HowItWorksDescription>
-                    Learn from the people you trust. Their recommendations will be highlighted on your ballot.
                   </HowItWorksDescription>
-                  <HowItWorksImage src={imageReviewReloadUrl ? cordovaDot(imageReviewReloadUrl) : ''} />
-                </HowItWorksWrapper>
-              </div>
-            )}
-            {!howItWorksWatched && (
-              <div key={5}>
-                <HowItWorksWrapper>
-                  <WeVoteLogoWrapper>
-                    <img
-                      className="header-logo-img"
-                      alt="We Vote logo"
-                      src={cordovaDot(logoDark)}
-                    />
-                  </WeVoteLogoWrapper>
-                  <SlideShowTitle>
-                    Complete your ballot in under six minutes
-                  </SlideShowTitle>
-                  <HowItWorksDescription>
-                    We Vote is fast, mobile, and helps you decide on the go. Vote with confidence!
-                  </HowItWorksDescription>
-                  <HowItWorksImage src={imageDecideReloadUrl ? cordovaDot(imageDecideReloadUrl) : ''} />
                 </HowItWorksWrapper>
               </div>
             )}
@@ -397,19 +318,6 @@ const HowItWorksDescription = styled.div`
   padding-bottom: 12px;
   @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
     padding-bottom: 30px;
-  }
-`;
-
-const HowItWorksImage = styled.img`
-  border: 1px solid #999;
-  border-radius: 16px;
-  box-shadow: 2px 2px 4px 2px ${({ theme }) => theme.colors.grayLight};
-  width: 100%;
-  height: auto;
-  transition: all 150ms ease-in;
-  @media (max-width: ${({ theme }) => theme.breakpoints.sm}) {
-    width: 90vw;
-    height: calc(90vw * 0.5625);
   }
 `;
 

--- a/src/js/routes/Ready.jsx
+++ b/src/js/routes/Ready.jsx
@@ -12,6 +12,7 @@ import cookies from '../utils/cookies';
 import EditAddressOneHorizontalRow from '../components/Ready/EditAddressOneHorizontalRow';
 import ElectionCountdown from '../components/Ready/ElectionCountdown';
 import FindOpinionsForm from '../components/ReadyNoApi/FindOpinionsForm';
+import FriendActions from '../actions/FriendActions';
 import { historyPush, isWebApp } from '../utils/cordovaUtils';
 import IssueActions from '../actions/IssueActions';
 import IssueStore from '../stores/IssueStore';
@@ -61,6 +62,7 @@ class Ready extends Component {
     }
     ReadyActions.voterPlansForVoterRetrieve();
     ActivityActions.activityNoticeListRetrieve();
+    FriendActions.suggestedFriendList();
     AnalyticsActions.saveActionReadyVisit(VoterStore.electionId());
     this.setState({
       locationGuessClosed: cookies.getItem('location_guess_closed'),

--- a/src/js/routes/Values.jsx
+++ b/src/js/routes/Values.jsx
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
+import styled from 'styled-components';
 import AddEndorsements from '../components/Widgets/AddEndorsements';
+import AddFriendsByEmail from '../components/Friends/AddFriendsByEmail';
 import AnalyticsActions from '../actions/AnalyticsActions';
 import BrowserPushMessage from '../components/Widgets/BrowserPushMessage';
 import { cordovaDot } from '../utils/cordovaUtils';
@@ -13,6 +15,7 @@ import NetworkOpinionsFollowed from '../components/Values/NetworkOpinionsFollowe
 import OrganizationsToFollowPreview from '../components/Values/OrganizationsToFollowPreview';
 import PublicFiguresFollowedPreview from '../components/Values/PublicFiguresFollowedPreview';
 import PublicFiguresToFollowPreview from '../components/Values/PublicFiguresToFollowPreview';
+import SuggestedFriendsPreview from '../components/Friends/SuggestedFriendsPreview';
 import Testimonial from '../components/Widgets/Testimonial';
 import TestimonialPhoto from '../../img/global/photos/Dale_McGrew-200x200.jpg';
 import TwitterSignInCard from '../components/Twitter/TwitterSignInCard';
@@ -142,6 +145,18 @@ export default class Values extends Component {
               </div>
             )}
             {!!(issuesFollowedCount) && <ValuesFollowedPreview /> }
+            <SuggestedFriendsPreview />
+            <div className="card">
+              <div className="card-main">
+                <SectionTitle>
+                  Voting Is Better with Friends
+                </SectionTitle>
+                <SectionDescription>
+                  Add friends you feel comfortable talking politics with.
+                </SectionDescription>
+                <AddFriendsByEmail uniqueExternalId="ValuesPage" />
+              </div>
+            </div>
           </div>
           <div className="col-md-4 d-none d-md-block">
             <div className="card u-show-desktop">
@@ -176,3 +191,18 @@ export default class Values extends Component {
     );
   }
 }
+
+
+const SectionDescription = styled.div`
+  color: #999;
+  font-size: 14px;
+  margin-bottom: 4px;
+`;
+
+const SectionTitle = styled.h2`
+  width: fit-content;
+  font-weight: bolder;
+  font-size: 18px;
+  margin-bottom: 4px;
+  display: inline;
+`;

--- a/src/sass/components/_intro-story.scss
+++ b/src/sass/components/_intro-story.scss
@@ -9,6 +9,17 @@ $top-header-padding-top: 6px;
   }
 }
 
+.FriendInvitationTopHeaderExplanation {
+  color: $gray-mid;
+  font-size: 16px;
+  font-weight: 400;
+  padding-bottom: $space-none;
+  padding-top: $space-none;
+  @include breakpoints (max mid-small) {
+    font-size: 14px;
+  }
+}
+
 .FriendInvitationIntroHeader {
   color: $brand-blue;
   font-size: 24px;


### PR DESCRIPTION
Split out the contents of PersonalizedScoreIntroModal so we can use this training tool separate from the modal. Made changes to onboarding based on user testing. Renamed the "News" section to "Discuss". Made the "Enter street address" more explicit. Fixed problem where "Decide on Candidates" was taking voters to the "All" filter, which often has measures at the top.