### PR TITLE
Basic functionality for notifications to iOS app under Cordova is working

### DIFF
--- a/src/js/actions/VoterActions.js
+++ b/src/js/actions/VoterActions.js
@@ -336,4 +336,11 @@ export default {
       identity_token: identityToken,
     });
   },
+
+  deviceStoreFirebaseCloudMessagingToken (firebaseFCMToken) {
+    Dispatcher.loadEndpoint('deviceStoreFirebaseCloudMessagingToken', {
+      firebase_fcm_token: firebaseFCMToken,
+    });
+  },
+
 };

--- a/src/js/stores/VoterStore.js
+++ b/src/js/stores/VoterStore.js
@@ -273,9 +273,9 @@ class VoterStore extends ReduceStore {
     // Eg: if interfaceStatusFlags = 5, then we can confirm that bits representing 1 and 4 are set (i.e., 0101)
     // so for value of flag = 1 and 4, we return a positive integer,
     // but, the bit representing 2 and 8 are not set, so for flag = 2 and 8, we return zero
-    const flagIsSet = interfaceStatusFlags & flag;  // eslint-disable-line no-bitwise
+    // const flagIsSet = interfaceStatusFlags & flag;  // eslint-disable-line no-bitwise
     // console.log("VoterStore getInterfaceFlagState flagIsSet: ", flagIsSet);
-    return flagIsSet;
+    return interfaceStatusFlags & flag;  // eslint-disable-line no-bitwise
   }
 
   getNotificationSettingsFlagState (flag) {
@@ -863,6 +863,16 @@ class VoterStore extends ReduceStore {
           console.log('Received a bad response from appleSignInSave API call');
           return state;
         }
+
+      case 'deviceStoreFirebaseCloudMessagingToken':
+        if (action.res.success) {
+          // console.log('Received success from deviceStoreFirebaseCloudMessagingToken API call');
+          return state;
+        } else {
+          console.log('Received a bad response from deviceStoreFirebaseCloudMessagingToken API call');
+          return state;
+        }
+
 
       case 'error-voterRetrieve' || 'error-voterAddressRetrieve' || 'error-voterAddressSave':
         // console.log('VoterStore action', action);

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -547,3 +547,13 @@ export function snackOffset () {
 
   return snackOffsetValue;
 }
+
+export function setIconBadgeMessageCount (countString) {
+  const { cordova: { plugins: { firebase: { messaging: { setBadge } } } } } = window;
+  setBadge(countString);
+}
+
+export function getIconBadgeMessageCount () {
+  const { cordova: { plugins: { firebase: { messaging: { getBadge } } } } } = window;
+  return getBadge();
+}


### PR DESCRIPTION
Uses Firebase Cloud Messaging (FCM) to communicate to apps, and we will
develop a link from our Python servers to send the FCM devices specific
"token" to the Google Firebase cloud.  The token is now gathered in startCordova.js
and sent to the API server via deviceStoreFirebaseCloudMessagingToken
where it is stored in the voter_device_link table.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
