### PR TITLE
Minor fixes for Cordova

### DIFF
--- a/src/js/components/Ballot/CandidateItemCompressed.jsx
+++ b/src/js/components/Ballot/CandidateItemCompressed.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import TextTruncate from 'react-text-truncate';
 import BallotItemSupportOpposeCountDisplay from '../Widgets/BallotItemSupportOpposeCountDisplay';
 import CandidateStore from '../../stores/CandidateStore';
-import { historyPush } from '../../utils/cordovaUtils';
+import { historyPush, isCordova } from '../../utils/cordovaUtils';
 import ImageHandler from '../ImageHandler';
 import LearnMore from '../Widgets/LearnMore';
 import { renderLog } from '../../utils/logging';
@@ -114,6 +114,7 @@ export default class CandidateItemCompressed extends Component {
     const candidatePartyText = this.state.oneCandidate.party && this.state.oneCandidate.party.length ? `${this.state.oneCandidate.party}. ` : '';
     const candidateDescriptionText = this.state.oneCandidate.twitter_description && this.state.oneCandidate.twitter_description.length ? this.state.oneCandidate.twitter_description : '';
     const candidateText = candidatePartyText + candidateDescriptionText;
+    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? "-cordova" : ""} o-media-object__anchor u-cursor--pointer u-self-start u-push--sm`;
 
     return (
       <div key={oneCandidateWeVoteId} className="u-stack--md">
@@ -124,7 +125,7 @@ export default class CandidateItemCompressed extends Component {
           {/* Candidate Photo, only shown in Desktop */}
           <Link to={this.getCandidateLink(this.state.oneCandidate.we_vote_id)}>
             <ImageHandler
-              className="card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm"
+              className={avatarCompressed}
               sizeClassName="icon-candidate-small u-push--sm "
               imageUrl={this.state.oneCandidate.candidate_photo_url_medium}
               alt="candidate-photo"

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -15,7 +15,7 @@ import OfficeActions from '../../actions/OfficeActions';
 import ShowMoreFooter from '../Navigation/ShowMoreFooter';
 import SupportStore from '../../stores/SupportStore';
 import TopCommentByBallotItem from '../Widgets/TopCommentByBallotItem';
-import { historyPush } from '../../utils/cordovaUtils';
+import { historyPush, isCordova } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import { sortCandidateList } from '../../utils/positionFunctions';
 import { arrayContains, toTitleCase } from '../../utils/textFormat';
@@ -255,6 +255,8 @@ class OfficeItemCompressed extends Component {
             const localUniqueId = oneCandidate.we_vote_id;
             voterSupportsBallotItem = SupportStore.voterSupportsList[oneCandidate.we_vote_id] || false;
             voterOpposesBallotItem = SupportStore.voterOpposesList[oneCandidate.we_vote_id] || false;
+            const avatarCompressed = `card-main__avatar-compressed${isCordova() ? "-cordova" : ""}`;
+
             return (
               <Column
                 candidateLength={candidatesToRender.length}
@@ -272,7 +274,7 @@ class OfficeItemCompressed extends Component {
                     >
                       {/* Candidate Image */}
                       <ImageHandler
-                        className="card-main__avatar-compressed"
+                        className={avatarCompressed}
                         sizeClassName="icon-candidate-small u-push--sm "
                         imageUrl={oneCandidate.candidate_photo_url_medium}
                         alt="candidate-photo"

--- a/src/js/components/OpinionsAndBallotItems/CandidateItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/CandidateItemForOpinions.jsx
@@ -10,7 +10,7 @@ import ItemPositionStatementActionBar from '../Widgets/ItemPositionStatementActi
 import { renderLog } from '../../utils/logging';
 import SupportStore from '../../stores/SupportStore';
 import { abbreviateNumber, numberWithCommas } from '../../utils/textFormat';
-import { historyPush } from '../../utils/cordovaUtils';
+import { historyPush, isCordova } from '../../utils/cordovaUtils';
 
 
 class CandidateItemForOpinions extends Component {
@@ -203,6 +203,7 @@ class CandidateItemForOpinions extends Component {
       null;
 
     const candidatePartyText = oneCandidate.party && oneCandidate.party.length ? `${oneCandidate.party}` : '';
+    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? "-cordova" : ""}`;
     return (
       <Wrapper>
         <CandidateTopRow>
@@ -210,7 +211,7 @@ class CandidateItemForOpinions extends Component {
             {/* Candidate Image */}
             <Link to={this.getCandidateLink()} className="card-main__no-underline">
               <ImageHandler
-                className="card-main__avatar-compressed"
+                className={avatarCompressed}
                 sizeClassName="icon-candidate-small u-push--sm "
                 imageUrl={oneCandidate.candidate_photo_url_medium}
                 alt="candidate-photo"

--- a/src/js/components/Settings/CandidateItemForAddPositions.jsx
+++ b/src/js/components/Settings/CandidateItemForAddPositions.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { withTheme, withStyles } from '@material-ui/core/styles';
 import CandidateStore from '../../stores/CandidateStore';
+import { isCordova } from '../../utils/cordovaUtils';
 import ImageHandler from '../ImageHandler';
 import ItemActionBar from '../Widgets/ItemActionBar/ItemActionBar';
 import ItemPositionStatementActionBar from '../Widgets/ItemPositionStatementActionBar';
@@ -182,6 +183,7 @@ class CandidateItemForAddPositions extends Component {
     ) :
       null;
 
+    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? "-cordova" : ""}`;
     const candidatePartyText = oneCandidate.party && oneCandidate.party.length ? `${oneCandidate.party}` : '';
     return (
       <Wrapper>
@@ -189,7 +191,7 @@ class CandidateItemForAddPositions extends Component {
           <Candidate>
             {/* Candidate Image */}
             <ImageHandler
-              className="card-main__avatar-compressed"
+              className={avatarCompressed}
               sizeClassName="icon-candidate-small u-push--sm "
               imageUrl={oneCandidate.candidate_photo_url_medium}
               alt="candidate-photo"

--- a/src/js/components/Share/SharedItemModal.jsx
+++ b/src/js/components/Share/SharedItemModal.jsx
@@ -409,6 +409,7 @@ class SharedItemModal extends Component {
     let textNextToInfoIcon = null;
     const nameForNextToInfoIcon = organizationName || 'This person';
     const nameForNextToInfoIconMidSentence = organizationName || 'this person';
+    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? "-cordova" : ""}`;
     if (isFriend) {
       textNextToInfoIcon = `${nameForNextToInfoIcon}'s opinions will be added to your personalized scores. `;
     } else if (isFollowing) {
@@ -466,7 +467,7 @@ class SharedItemModal extends Component {
                       {/* SharedByOrganization Image */}
                       <OrganizationImageWrapper>
                         <ImageHandler
-                          className="card-main__avatar-compressed"
+                          className={avatarCompressed}
                           sizeClassName="icon-candidate-small u-push--sm "
                           imageUrl={organizationPhotoUrlMedium}
                           alt={`${organizationName}`}

--- a/src/js/components/Widgets/BallotItemVoterGuideSupportOpposeDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemVoterGuideSupportOpposeDisplay.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import { Info, ThumbUp, ThumbDown } from '@material-ui/icons';
+import { isCordova } from '../../utils/cordovaUtils';
 import ImageHandler from '../ImageHandler';
 import { renderLog } from '../../utils/logging';
 import FriendsOnlyIndicator from './FriendsOnlyIndicator';
@@ -102,7 +103,7 @@ class BallotItemVoterGuideSupportOpposeDisplay extends Component {
                   <ThumbUp />
                 </OrganizationSupportIconWrapper>
               </OrganizationSupportSquare>
-              <OverlayImage className="image-border-support ">
+              <OverlayImage className="image-border-support " style={isCordova() ? {width: 20} : {}}>
                 <OrganizationIconWrapper>
                   {organizationImageUrlHttpsTiny ? (
                     <ImageHandler

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -42,7 +42,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsHamburger:     return '57px';
         case enums.settingsWild:          return '67px';
         case enums.twitterSignIn:         return '20px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         case enums.welcomeWild:           return '10px';
         case enums.wevoteintroWild:       return '18px';
         default:                          return '0px';
@@ -66,7 +66,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsVoterGuideLst: return '73px';
         case enums.settingsWild:          return '76px';
         case enums.twitterSignIn:         return '20px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         case enums.welcomeWild:           return '10px';
         case enums.wevoteintroWild:       return '18px';
         default:                          return '0px';
@@ -89,7 +89,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsVoterGuideLst: return '75px';
         case enums.settingsWild:          return '51px';
         case enums.twitterSignIn:         return '20px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         case enums.welcomeWild:           return '22px';
         case enums.wevoteintroWild:       return '18px';
         default:                          return '0px';
@@ -114,7 +114,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsWild:          return '89px';
         case enums.twitterSignIn:         return '20px';
         case enums.values:                return '10px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         case enums.welcomeWild:           return '22px';
         case enums.wevoteintroWild:       return '32px';
         default:                          return '0px';
@@ -140,7 +140,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsVoterGuideLst: return '98px';
         case enums.settingsWild:          return '63px';
         case enums.twitterSignIn:         return '50px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         case enums.welcomeWild:           return '22px';
         case enums.wevoteintroWild:       return '32px';
         default:                          return '0px';
@@ -162,7 +162,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsNotifications: return '82px';
         case enums.moreTerms:             return '60px';
         // case enums.voterGuideWild: return 'YYx'; // See cordovaVoterGuideTopPadding instead
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         case enums.welcomeWild:           return '22px';
         case enums.settingsHamburger:     return '35px';
         case enums.moreTools:             return '44px';
@@ -192,7 +192,8 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsHamburger:     return '75px';
         case enums.settingsSubscription:  return '87px';
         case enums.settingsWild:          return '61px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideWild:        return '27px';
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         case enums.welcomeWild:           return '0px';
         case enums.wevoteintroWild:       return '18px';
         default:                          return '0px';
@@ -234,7 +235,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.twitterSignIn:
           return hasAndroidNotch() ? '20px' : '10px';
         case enums.voterGuideCreatorWild:
-          return '10px'; // $headroom-wrapper-webapp-voter-guide
+          return '10px'; // $headroom-wrapper-webapp__voter-guide
         default:
           return '0px';
       }
@@ -269,7 +270,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.twitterSignIn:
           return hasAndroidNotch() ? '20px' : '10px';
         case enums.voterGuideCreatorWild:
-          return '10px'; // $headroom-wrapper-webapp-voter-guide
+          return '10px'; // $headroom-wrapper-webapp__voter-guide
         default:
           return '0px';
       }
@@ -289,7 +290,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsSubscription:  return '54px';
         case enums.settingsWild:          return '57px';
         case enums.twitterSignIn:         return hasAndroidNotch() ? '20px' : '10px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         default:                          return '0px';
       }
     } else if (sizeString === '--lg') {
@@ -306,7 +307,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsNotifications: return '39px';
         case enums.settingsSubscription:  return '87px';
         case enums.settingsWild:          return '61px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         default:                          return '0px';
       }
     } if (sizeString === '--md') {
@@ -324,7 +325,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsNotifications: return '39px';
         case enums.settingsSubscription:  return '53px';
         case enums.settingsWild:          return '61px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         default:                          return '0px';
       }
     } else if (sizeString === '--sm') {
@@ -340,7 +341,7 @@ export function cordovaScrollablePaneTopPadding () {
         case enums.settingsHamburger:     return '43px';
         case enums.settingsNotifications: return '39px';
         case enums.settingsWild:          return '55px';
-        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp-voter-guide
+        case enums.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
         default:                          return '0px';
       }
     }
@@ -491,6 +492,7 @@ export function cordovaVoterGuideTopPadding () {
     } else if (isIPad()) {
       switch (pageEnumeration()) {
         case enums.news:             return '19px';
+        case enums.voterGuideWild:   return '26px';
         default:                     return '0px';
       }
     }
@@ -609,7 +611,7 @@ export function cordovaTopHeaderTopMargin () {
           case enums.ballotLgHdrWild: style.marginTop = '19px'; break;
           case enums.ballotVote:      style.marginTop = '19px'; break;
           case enums.settingsWild:    style.marginTop = '22px'; break;
-          case enums.voterGuideCreatorWild: style.marginTop = '38px'; break; // $headroom-wrapper-webapp-voter-guide-creator
+          case enums.voterGuideCreatorWild: style.marginTop = '38px'; break; // $headroom-wrapper-webapp__voter-guide-creator
           case enums.twitterIdMFollowers:   style.marginTop = '37px'; break; // /*/m/friends, /*/m/following, /*/m/followers
           default:                          style.marginTop = '19px'; break;
         }
@@ -631,7 +633,7 @@ export function cordovaTopHeaderTopMargin () {
           case enums.settingsSubscription:  style.marginTop = '34px'; break;
           case enums.settingsNotifications: style.marginTop = '36px'; break;
           case enums.settingsWild:          style.marginTop = '38px'; break;
-          case enums.voterGuideCreatorWild: style.marginTop = '38px'; break; // $headroom-wrapper-webapp-voter-guide-creator
+          case enums.voterGuideCreatorWild: style.marginTop = '38px'; break; // $headroom-wrapper-webapp__voter-guide-creator
           case enums.voterGuideWild:        style.marginTop = '38px'; break; // Any page with btcand or btmeas
           case enums.twitterIdMFollowers:   style.marginTop = '37px'; break; // /*/m/friends, /*/m/following, /*/m/followers
           default:                          style.marginTop = '16px'; break;

--- a/src/js/utilsApi/cordovaUtilsPageEnumeration.js
+++ b/src/js/utilsApi/cordovaUtilsPageEnumeration.js
@@ -77,7 +77,8 @@ export function pageEnumeration () {
   } else if (href.indexOf('/index.html#/vg/') > 0) {
     return enums.voterGuideCreatorWild;
   } else if (stringContains('btcand', href) ||
-             stringContains('btmeas', href)) {
+             stringContains('btmeas', href) ||
+             stringContains('/btdb', href)) { // Added Sept 24, 2020 -- for iPadPro 1.9", hope it is ok in all device sizes
     return enums.voterGuideWild;
   } else if (href.indexOf('/index.html#/wevoteintro/') > 0) {
     return enums.wevoteintroWild;

--- a/src/js/utilsApi/cordovaUtilsPageEnumeration.js
+++ b/src/js/utilsApi/cordovaUtilsPageEnumeration.js
@@ -78,7 +78,7 @@ export function pageEnumeration () {
     return enums.voterGuideCreatorWild;
   } else if (stringContains('btcand', href) ||
              stringContains('btmeas', href) ||
-             stringContains('/btdb', href)) { // Added Sept 24, 2020 -- for iPadPro 1.9", hope it is ok in all device sizes
+             stringContains('/btdb', href)) { // Added Sept 24, 2020 -- for iPadPro 9.1"
     return enums.voterGuideWild;
   } else if (href.indexOf('/index.html#/wevoteintro/') > 0) {
     return enums.wevoteintroWild;

--- a/src/sass/components/_card.scss
+++ b/src/sass/components/_card.scss
@@ -127,10 +127,25 @@ $outline-radius: 3px;
     }
 
     &__avatar-compressed {
-      // March 2019, The paths are different in Cordova (where this fails).
-      // Revert back to original path to allow webpack resolve correctly
-      // TODO: Need to find a solution to make both Cordova and Webpack happy
+      // March 2019, The paths are different in Cordova. Please don't put URLs in scss
       background-image: url('../img/global/svg-icons/avatar-generic.svg');
+      border-radius: $radius-xs;
+      width: 40px;
+      height: 40px;
+      .card-main & {
+        @include breakpoints(mid-small) {
+          width: 40px;
+        }
+        border-radius: $radius-rounded;
+      }
+      @include print {
+        width: 40px;
+      }
+    }
+
+    &__avatar-compressed-cordova {
+      // March 2019, The paths are different in Cordova. Please don't put URLs in scss
+      background-image: url('https://wevote.us/img/global/svg-icons/avatar-generic.svg');
       border-radius: $radius-xs;
       width: 40px;
       height: 40px;

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -13,6 +13,7 @@ $header-height-back-to-ballot: 96px;
 $header-height-back-to-ballot-cordova: 71px;
 $header-height-voter-guide-creator: 108px;
 $header-padding-left: 15px;
+$ipad-margin-top: 26px;
 
 .page-header {
   // required overrides for Bootstrap :(
@@ -36,7 +37,6 @@ $header-padding-left: 15px;
   }
 
   &__container_ipad {
-    $ipad-margin-top: 26px;
     background-color: $page-header-color;
     margin-top: $ipad-margin-top !important;
   }


### PR DESCRIPTION
Made the tiny icon (that duplicates the candidate icon on the "+1 to score" button) square.
Worked around the hardcoded path in _card.scss for the compressed icon, when in Cordova.
Fixed the top margin, when on a candidate via twitter handle page, for iPads.
