### PR TITLE
Renamed componentWillReceiveProps to UNSAFE_componentWillReceiveProps globally

### DIFF
--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -43,6 +43,7 @@ class AddressBox extends Component {
     this.handleKeyPress = this.handleKeyPress.bind(this);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('AddressBox');
   }

--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -43,7 +43,7 @@ class AddressBox extends Component {
     this.handleKeyPress = this.handleKeyPress.bind(this);
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('AddressBox');
   }
 

--- a/src/js/components/Ballot/BallotSearchResults.jsx
+++ b/src/js/components/Ballot/BallotSearchResults.jsx
@@ -40,7 +40,7 @@ export default class BallotSearchResults extends Component {
     // this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("BallotSearchResults componentWillReceiveProps, nextProps.clearSearchTextNow:", nextProps.clearSearchTextNow);
     this.setState({
       clearSearchTextNow: nextProps.clearSearchTextNow,

--- a/src/js/components/Ballot/BallotSearchResults.jsx
+++ b/src/js/components/Ballot/BallotSearchResults.jsx
@@ -40,6 +40,7 @@ export default class BallotSearchResults extends Component {
     // this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("BallotSearchResults componentWillReceiveProps, nextProps.clearSearchTextNow:", nextProps.clearSearchTextNow);
     this.setState({

--- a/src/js/components/Ballot/BallotStatusMessage.jsx
+++ b/src/js/components/Ballot/BallotStatusMessage.jsx
@@ -66,6 +66,7 @@ class BallotStatusMessage extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("BallotStatusMessage componentWillReceiveProps");
     this.setState({

--- a/src/js/components/Ballot/BallotStatusMessage.jsx
+++ b/src/js/components/Ballot/BallotStatusMessage.jsx
@@ -66,7 +66,7 @@ class BallotStatusMessage extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("BallotStatusMessage componentWillReceiveProps");
     this.setState({
       ballotLocationChosen: nextProps.ballotLocationChosen,

--- a/src/js/components/Ballot/CandidateItemCompressed.jsx
+++ b/src/js/components/Ballot/CandidateItemCompressed.jsx
@@ -47,7 +47,7 @@ export default class CandidateItemCompressed extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("officeItem nextProps", nextProps);
     if (nextProps.candidateWeVoteId) {
       const candidate = CandidateStore.getCandidate(nextProps.candidateWeVoteId);

--- a/src/js/components/Ballot/CandidateItemCompressed.jsx
+++ b/src/js/components/Ballot/CandidateItemCompressed.jsx
@@ -47,6 +47,7 @@ export default class CandidateItemCompressed extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("officeItem nextProps", nextProps);
     if (nextProps.candidateWeVoteId) {

--- a/src/js/components/Ballot/PositionList.jsx
+++ b/src/js/components/Ballot/PositionList.jsx
@@ -139,7 +139,7 @@ class PositionList extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('PositionList componentWillReceiveProps');
     const { incomingPositionList } = nextProps;
     this.setState({

--- a/src/js/components/Ballot/PositionList.jsx
+++ b/src/js/components/Ballot/PositionList.jsx
@@ -139,6 +139,7 @@ class PositionList extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('PositionList componentWillReceiveProps');
     const { incomingPositionList } = nextProps;

--- a/src/js/components/Ballot/StickyPopover.jsx
+++ b/src/js/components/Ballot/StickyPopover.jsx
@@ -39,6 +39,7 @@ class StickyPopover extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.openPopoverByProp) {
       this.setState({ showPopover: true });

--- a/src/js/components/Ballot/StickyPopover.jsx
+++ b/src/js/components/Ballot/StickyPopover.jsx
@@ -39,7 +39,7 @@ class StickyPopover extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.openPopoverByProp) {
       this.setState({ showPopover: true });
     } else if (nextProps.closePopoverByProp) {

--- a/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
+++ b/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
@@ -41,7 +41,7 @@ class HowItWorksModal extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.show) {
       hideZenDeskHelpVisibility();
     } else {

--- a/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
+++ b/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
@@ -41,6 +41,7 @@ class HowItWorksModal extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.show) {
       hideZenDeskHelpVisibility();

--- a/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
+++ b/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
@@ -258,6 +258,7 @@ class PersonalizedScoreIntroBody extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.show) {
       hideZenDeskHelpVisibility();

--- a/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
+++ b/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
@@ -258,7 +258,7 @@ class PersonalizedScoreIntroBody extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.show) {
       hideZenDeskHelpVisibility();
     } else {

--- a/src/js/components/CompleteYourProfile/PersonalizedScoreIntroModal.jsx
+++ b/src/js/components/CompleteYourProfile/PersonalizedScoreIntroModal.jsx
@@ -30,6 +30,7 @@ class PersonalizedScoreIntroModal extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.show) {
       hideZenDeskHelpVisibility();

--- a/src/js/components/CompleteYourProfile/PersonalizedScoreIntroModal.jsx
+++ b/src/js/components/CompleteYourProfile/PersonalizedScoreIntroModal.jsx
@@ -30,7 +30,7 @@ class PersonalizedScoreIntroModal extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.show) {
       hideZenDeskHelpVisibility();
     } else {

--- a/src/js/components/Connect/CurrentFriends.jsx
+++ b/src/js/components/Connect/CurrentFriends.jsx
@@ -32,7 +32,7 @@ export default class CurrentFriends extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("CurrentFriends, componentWillReceiveProps, nextProps.currentFriendList:", nextProps.currentFriendList);
     // if (nextProps.instantRefreshOn ) {
     // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked

--- a/src/js/components/Connect/CurrentFriends.jsx
+++ b/src/js/components/Connect/CurrentFriends.jsx
@@ -32,6 +32,7 @@ export default class CurrentFriends extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("CurrentFriends, componentWillReceiveProps, nextProps.currentFriendList:", nextProps.currentFriendList);
     // if (nextProps.instantRefreshOn ) {

--- a/src/js/components/Connect/FacebookFriendsDisplay.jsx
+++ b/src/js/components/Connect/FacebookFriendsDisplay.jsx
@@ -38,6 +38,7 @@ export default class FacebookFriendsDisplay extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       facebookInvitableFriendsList: nextProps.facebookInvitableFriendsList,

--- a/src/js/components/Connect/FacebookFriendsDisplay.jsx
+++ b/src/js/components/Connect/FacebookFriendsDisplay.jsx
@@ -38,7 +38,7 @@ export default class FacebookFriendsDisplay extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       facebookInvitableFriendsList: nextProps.facebookInvitableFriendsList,
       maximumFriendDisplay: nextProps.maximumFriendDisplay,

--- a/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
+++ b/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
@@ -33,7 +33,7 @@ export default class OrganizationsFollowedOnTwitter extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("OrganizationsFollowedOnTwitter, componentWillReceiveProps, nextProps.organizationsFollowedOnTwitter:", nextProps.organizationsFollowedOnTwitter);
     // if (nextProps.instantRefreshOn ) {
     // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked

--- a/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
+++ b/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
@@ -33,6 +33,7 @@ export default class OrganizationsFollowedOnTwitter extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("OrganizationsFollowedOnTwitter, componentWillReceiveProps, nextProps.organizationsFollowedOnTwitter:", nextProps.organizationsFollowedOnTwitter);
     // if (nextProps.instantRefreshOn ) {

--- a/src/js/components/Filter/OpinionsAndBallotItemsFilter.jsx
+++ b/src/js/components/Filter/OpinionsAndBallotItemsFilter.jsx
@@ -73,7 +73,7 @@ class OpinionsAndBallotItemsFilter extends Component {
     this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { filtersAlreadyPassedInOnce, selectedStates } = this.state;
     const { filtersPassedInOnce, selectedFilters } = nextProps;
     // console.log('componentWillReceiveProps selectedFilters at start:', selectedFilters);

--- a/src/js/components/Filter/OpinionsAndBallotItemsFilter.jsx
+++ b/src/js/components/Filter/OpinionsAndBallotItemsFilter.jsx
@@ -73,6 +73,7 @@ class OpinionsAndBallotItemsFilter extends Component {
     this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { filtersAlreadyPassedInOnce, selectedStates } = this.state;
     const { filtersPassedInOnce, selectedFilters } = nextProps;

--- a/src/js/components/Filter/SettingsAddBallotItemsFilter.jsx
+++ b/src/js/components/Filter/SettingsAddBallotItemsFilter.jsx
@@ -75,6 +75,7 @@ class SettingsAddBallotItemsFilter extends Component {
     this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { filtersAlreadyPassedInOnce, selectedStates } = this.state;
     const { filtersPassedInOnce, selectedFilters } = nextProps;

--- a/src/js/components/Filter/SettingsAddBallotItemsFilter.jsx
+++ b/src/js/components/Filter/SettingsAddBallotItemsFilter.jsx
@@ -75,7 +75,7 @@ class SettingsAddBallotItemsFilter extends Component {
     this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { filtersAlreadyPassedInOnce, selectedStates } = this.state;
     const { filtersPassedInOnce, selectedFilters } = nextProps;
     // console.log('componentWillReceiveProps selectedFilters at start:', selectedFilters);

--- a/src/js/components/Friends/SuggestedFriendList.jsx
+++ b/src/js/components/Friends/SuggestedFriendList.jsx
@@ -23,6 +23,7 @@ export default class SuggestedFriendList extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       suggestedFriendList: nextProps.friendList,

--- a/src/js/components/Friends/SuggestedFriendList.jsx
+++ b/src/js/components/Friends/SuggestedFriendList.jsx
@@ -23,7 +23,7 @@ export default class SuggestedFriendList extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       suggestedFriendList: nextProps.friendList,
     });

--- a/src/js/components/Navigation/BallotSummaryAccordion.jsx
+++ b/src/js/components/Navigation/BallotSummaryAccordion.jsx
@@ -30,7 +30,7 @@ class BallotSummaryAccordion extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('BallotSummaryAccordion componentWillReceiveProps');
     const openSections = {};
     const { children } = nextProps;

--- a/src/js/components/Navigation/BallotSummaryAccordion.jsx
+++ b/src/js/components/Navigation/BallotSummaryAccordion.jsx
@@ -30,6 +30,7 @@ class BallotSummaryAccordion extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('BallotSummaryAccordion componentWillReceiveProps');
     const openSections = {};

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -189,7 +189,6 @@ class HeaderBackToBallot extends Component {
   }
 
   // eslint-disable-next-line camelcase,react/sort-comp
-  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // WARN: Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
     // console.log('HeaderBackToBallot componentWillReceiveProps, nextProps: ', nextProps);

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -189,6 +189,7 @@ class HeaderBackToBallot extends Component {
   }
 
   // eslint-disable-next-line camelcase,react/sort-comp
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // WARN: Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
     // console.log('HeaderBackToBallot componentWillReceiveProps, nextProps: ', nextProps);

--- a/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
+++ b/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
@@ -109,7 +109,6 @@ class HeaderBackToVoterGuides extends Component {
   }
 
   // eslint-disable-next-line camelcase,react/sort-comp
-  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // WARN: Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
     // console.log('HeaderBackToVoterGuides componentWillReceiveProps, nextProps: ', nextProps);

--- a/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
+++ b/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
@@ -109,6 +109,7 @@ class HeaderBackToVoterGuides extends Component {
   }
 
   // eslint-disable-next-line camelcase,react/sort-comp
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // WARN: Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
     // console.log('HeaderBackToVoterGuides componentWillReceiveProps, nextProps: ', nextProps);

--- a/src/js/components/Navigation/SettingsPersonalSideBar.jsx
+++ b/src/js/components/Navigation/SettingsPersonalSideBar.jsx
@@ -43,6 +43,7 @@ export default class SettingsPersonalSideBar extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { isSignedIn } = nextProps;
     this.setState({

--- a/src/js/components/Navigation/SettingsPersonalSideBar.jsx
+++ b/src/js/components/Navigation/SettingsPersonalSideBar.jsx
@@ -43,7 +43,7 @@ export default class SettingsPersonalSideBar extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { isSignedIn } = nextProps;
     this.setState({
       isOnPartnerUrl: AppStore.isOnPartnerUrl(),

--- a/src/js/components/Navigation/VoterGuideSettingsSideBar.jsx
+++ b/src/js/components/Navigation/VoterGuideSettingsSideBar.jsx
@@ -29,7 +29,7 @@ export default class VoterGuideSettingsSideBar extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("VoterGuideSettingsSideBar componentWillReceiveProps");
     this.setState({
       editMode: nextProps.editMode,

--- a/src/js/components/Navigation/VoterGuideSettingsSideBar.jsx
+++ b/src/js/components/Navigation/VoterGuideSettingsSideBar.jsx
@@ -29,6 +29,7 @@ export default class VoterGuideSettingsSideBar extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("VoterGuideSettingsSideBar componentWillReceiveProps");
     this.setState({

--- a/src/js/components/OpinionsAndBallotItems/BallotItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/BallotItemForOpinions.jsx
@@ -44,6 +44,7 @@ class BallotItemForOpinions extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('componentDidMount, nextProps.candidateList', nextProps.candidateList);
     // console.log('componentDidMount, nextProps.kindOfBallotItem', nextProps.kindOfBallotItem);

--- a/src/js/components/OpinionsAndBallotItems/BallotItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/BallotItemForOpinions.jsx
@@ -44,7 +44,7 @@ class BallotItemForOpinions extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('componentDidMount, nextProps.candidateList', nextProps.candidateList);
     // console.log('componentDidMount, nextProps.kindOfBallotItem', nextProps.kindOfBallotItem);
     const candidateList = nextProps.candidateList || [];

--- a/src/js/components/OpinionsAndBallotItems/MeasureItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/MeasureItemForOpinions.jsx
@@ -62,6 +62,7 @@ class MeasureItemForOpinions extends Component {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const organizationWeVoteId = (nextProps.organization && nextProps.organization.organization_we_vote_id) ? nextProps.organization.organization_we_vote_id : nextProps.organization_we_vote_id;
     if (nextProps.ballotItemWeVoteId) {

--- a/src/js/components/OpinionsAndBallotItems/MeasureItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/MeasureItemForOpinions.jsx
@@ -62,7 +62,7 @@ class MeasureItemForOpinions extends Component {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const organizationWeVoteId = (nextProps.organization && nextProps.organization.organization_we_vote_id) ? nextProps.organization.organization_we_vote_id : nextProps.organization_we_vote_id;
     if (nextProps.ballotItemWeVoteId) {
       const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(nextProps.ballotItemWeVoteId);

--- a/src/js/components/OpinionsAndBallotItems/OfficeItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/OfficeItemForOpinions.jsx
@@ -43,7 +43,7 @@ class OfficeItemForOpinions extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const organizationWeVoteId = (nextProps.organization && nextProps.organization.organization_we_vote_id) ? nextProps.organization.organization_we_vote_id : nextProps.organizationWeVoteId;
     // console.log('officeItemCompressed componentWillReceiveProps, organizationWeVoteId:', organizationWeVoteId);
     this.setState({

--- a/src/js/components/OpinionsAndBallotItems/OfficeItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/OfficeItemForOpinions.jsx
@@ -43,6 +43,7 @@ class OfficeItemForOpinions extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const organizationWeVoteId = (nextProps.organization && nextProps.organization.organization_we_vote_id) ? nextProps.organization.organization_we_vote_id : nextProps.organizationWeVoteId;
     // console.log('officeItemCompressed componentWillReceiveProps, organizationWeVoteId:', organizationWeVoteId);

--- a/src/js/components/Organization/OpinionsFollowedList.jsx
+++ b/src/js/components/Organization/OpinionsFollowedList.jsx
@@ -23,7 +23,7 @@ export default class OpinionsFollowedList extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       organizationsFollowed: nextProps.organizationsFollowed,
     });

--- a/src/js/components/Organization/OpinionsFollowedList.jsx
+++ b/src/js/components/Organization/OpinionsFollowedList.jsx
@@ -23,6 +23,7 @@ export default class OpinionsFollowedList extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       organizationsFollowed: nextProps.organizationsFollowed,

--- a/src/js/components/Organization/OpinionsFollowedListCompressed.jsx
+++ b/src/js/components/Organization/OpinionsFollowedListCompressed.jsx
@@ -26,7 +26,7 @@ export default class OpinionsFollowedListCompressed extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // if (nextProps.instantRefreshOn ) {
     // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked
     this.setState({

--- a/src/js/components/Organization/OpinionsFollowedListCompressed.jsx
+++ b/src/js/components/Organization/OpinionsFollowedListCompressed.jsx
@@ -26,6 +26,7 @@ export default class OpinionsFollowedListCompressed extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // if (nextProps.instantRefreshOn ) {
     // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked

--- a/src/js/components/Organization/OpinionsIgnoredList.jsx
+++ b/src/js/components/Organization/OpinionsIgnoredList.jsx
@@ -25,7 +25,7 @@ export default class OpinionsIgnoredList extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // if (nextProps.instantRefreshOn ) {
     // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked
     this.setState({

--- a/src/js/components/Organization/OpinionsIgnoredList.jsx
+++ b/src/js/components/Organization/OpinionsIgnoredList.jsx
@@ -25,6 +25,7 @@ export default class OpinionsIgnoredList extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // if (nextProps.instantRefreshOn ) {
     // NOTE: This is off because we don't want the organization to disappear from the "More opinions" list when clicked

--- a/src/js/components/Organization/OrganizationDisplayForList.jsx
+++ b/src/js/components/Organization/OrganizationDisplayForList.jsx
@@ -35,6 +35,7 @@ export default class OrganizationDisplayForList extends Component {
     this.OrganizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       organization: OrganizationStore.getOrganizationByWeVoteId(nextProps.organizationWeVoteId),

--- a/src/js/components/Organization/OrganizationDisplayForList.jsx
+++ b/src/js/components/Organization/OrganizationDisplayForList.jsx
@@ -35,7 +35,7 @@ export default class OrganizationDisplayForList extends Component {
     this.OrganizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       organization: OrganizationStore.getOrganizationByWeVoteId(nextProps.organizationWeVoteId),
       organizationWeVoteId: nextProps.organizationWeVoteId,

--- a/src/js/components/Ready/VoterPlanModal.jsx
+++ b/src/js/components/Ready/VoterPlanModal.jsx
@@ -87,7 +87,7 @@ class VoterPlanModal extends Component {
     AnalyticsActions.saveActionModalVoterPlan(VoterStore.electionId());
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { pathname } = this.props;
     if (nextProps.show) {
       hideZenDeskHelpVisibility();

--- a/src/js/components/Ready/VoterPlanModal.jsx
+++ b/src/js/components/Ready/VoterPlanModal.jsx
@@ -87,6 +87,7 @@ class VoterPlanModal extends Component {
     AnalyticsActions.saveActionModalVoterPlan(VoterStore.electionId());
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { pathname } = this.props;
     if (nextProps.show) {

--- a/src/js/components/Search/SearchBar.jsx
+++ b/src/js/components/Search/SearchBar.jsx
@@ -38,7 +38,7 @@ export default class SearchBar extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("SearchBar, nextProps.clearSearchTextNow:", nextProps.clearSearchTextNow);
     if (nextProps.clearSearchTextNow) {
       this.props.clearFunction();

--- a/src/js/components/Search/SearchBar.jsx
+++ b/src/js/components/Search/SearchBar.jsx
@@ -38,6 +38,7 @@ export default class SearchBar extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("SearchBar, nextProps.clearSearchTextNow:", nextProps.clearSearchTextNow);
     if (nextProps.clearSearchTextNow) {

--- a/src/js/components/Settings/BallotItemForAddPositions.jsx
+++ b/src/js/components/Settings/BallotItemForAddPositions.jsx
@@ -48,6 +48,7 @@ class BallotItemForAddPositions extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('componentDidMount, nextProps.candidateList', nextProps.candidateList);
     // console.log('componentDidMount, nextProps.kindOfBallotItem', nextProps.kindOfBallotItem);

--- a/src/js/components/Settings/BallotItemForAddPositions.jsx
+++ b/src/js/components/Settings/BallotItemForAddPositions.jsx
@@ -48,7 +48,7 @@ class BallotItemForAddPositions extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('componentDidMount, nextProps.candidateList', nextProps.candidateList);
     // console.log('componentDidMount, nextProps.kindOfBallotItem', nextProps.kindOfBallotItem);
     const candidateList = nextProps.candidateList || [];

--- a/src/js/components/Settings/MeasureItemForAddPositions.jsx
+++ b/src/js/components/Settings/MeasureItemForAddPositions.jsx
@@ -63,7 +63,7 @@ class MeasureItemForAddPositions extends Component {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const organizationWeVoteId = (nextProps.organization && nextProps.organization.organization_we_vote_id) ? nextProps.organization.organization_we_vote_id : nextProps.organization_we_vote_id;
     if (nextProps.ballotItemWeVoteId) {
       const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(nextProps.ballotItemWeVoteId);

--- a/src/js/components/Settings/MeasureItemForAddPositions.jsx
+++ b/src/js/components/Settings/MeasureItemForAddPositions.jsx
@@ -63,6 +63,7 @@ class MeasureItemForAddPositions extends Component {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const organizationWeVoteId = (nextProps.organization && nextProps.organization.organization_we_vote_id) ? nextProps.organization.organization_we_vote_id : nextProps.organization_we_vote_id;
     if (nextProps.ballotItemWeVoteId) {

--- a/src/js/components/Settings/OfficeItemForAddPositions.jsx
+++ b/src/js/components/Settings/OfficeItemForAddPositions.jsx
@@ -50,7 +50,7 @@ class OfficeItemForAddPositions extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const candidatesToShowForSearchResults = nextProps.candidatesToShowForSearchResults || [];
     const candidatesToShowForSearchResultsCount = candidatesToShowForSearchResults.length;
     const organizationWeVoteId = (nextProps.organization && nextProps.organization.organization_we_vote_id) ? nextProps.organization.organization_we_vote_id : nextProps.organizationWeVoteId;

--- a/src/js/components/Settings/OfficeItemForAddPositions.jsx
+++ b/src/js/components/Settings/OfficeItemForAddPositions.jsx
@@ -50,6 +50,7 @@ class OfficeItemForAddPositions extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const candidatesToShowForSearchResults = nextProps.candidatesToShowForSearchResults || [];
     const candidatesToShowForSearchResultsCount = candidatesToShowForSearchResults.length;

--- a/src/js/components/Settings/PaidAccountUpgradeModal.jsx
+++ b/src/js/components/Settings/PaidAccountUpgradeModal.jsx
@@ -100,6 +100,7 @@ class PaidAccountUpgradeModal extends Component {
     this.donateStoreListener = DonateStore.addListener(this.onDonateStoreChange);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       pathname: nextProps.pathname,

--- a/src/js/components/Settings/PaidAccountUpgradeModal.jsx
+++ b/src/js/components/Settings/PaidAccountUpgradeModal.jsx
@@ -100,7 +100,7 @@ class PaidAccountUpgradeModal extends Component {
     this.donateStoreListener = DonateStore.addListener(this.onDonateStoreChange);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.setState({
       pathname: nextProps.pathname,
     });

--- a/src/js/components/Settings/SettingsBannerAndOrganizationCard.jsx
+++ b/src/js/components/Settings/SettingsBannerAndOrganizationCard.jsx
@@ -22,7 +22,7 @@ export default class SettingsBannerAndOrganizationCard extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("SettingsBannerAndOrganizationCard componentWillReceiveProps");
     this.setState({
       organization: nextProps.organization,

--- a/src/js/components/Settings/SettingsBannerAndOrganizationCard.jsx
+++ b/src/js/components/Settings/SettingsBannerAndOrganizationCard.jsx
@@ -22,6 +22,7 @@ export default class SettingsBannerAndOrganizationCard extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("SettingsBannerAndOrganizationCard componentWillReceiveProps");
     this.setState({

--- a/src/js/components/Settings/SettingsIssueLinks.jsx
+++ b/src/js/components/Settings/SettingsIssueLinks.jsx
@@ -73,6 +73,7 @@ export default class SettingsIssueLinks extends Component {
     this.setState(newState);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const newState = {};
     if (nextProps.organizationWeVoteId !== this.state.organizationWeVoteId) {

--- a/src/js/components/Settings/SettingsIssueLinks.jsx
+++ b/src/js/components/Settings/SettingsIssueLinks.jsx
@@ -73,7 +73,7 @@ export default class SettingsIssueLinks extends Component {
     this.setState(newState);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const newState = {};
     if (nextProps.organizationWeVoteId !== this.state.organizationWeVoteId) {
       IssueActions.retrieveIssuesToLinkForOrganization(

--- a/src/js/components/Settings/SettingsStripePayment.jsx
+++ b/src/js/components/Settings/SettingsStripePayment.jsx
@@ -56,6 +56,7 @@ class SettingsStripePayment extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('SettingsStripePayment, RELOAD componentWillReceiveProps');
     this.setState({

--- a/src/js/components/Settings/SettingsStripePayment.jsx
+++ b/src/js/components/Settings/SettingsStripePayment.jsx
@@ -56,7 +56,7 @@ class SettingsStripePayment extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('SettingsStripePayment, RELOAD componentWillReceiveProps');
     this.setState({
       couponCode: nextProps.couponCode,

--- a/src/js/components/Settings/SettingsWidgetAccountType.jsx
+++ b/src/js/components/Settings/SettingsWidgetAccountType.jsx
@@ -38,7 +38,7 @@ export default class SettingsWidgetAccountType extends Component {
     this.updateOrganizationType = this.updateOrganizationType.bind(this);
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('SettingsWidgetAccountType');
   }
 

--- a/src/js/components/Settings/SettingsWidgetAccountType.jsx
+++ b/src/js/components/Settings/SettingsWidgetAccountType.jsx
@@ -38,6 +38,7 @@ export default class SettingsWidgetAccountType extends Component {
     this.updateOrganizationType = this.updateOrganizationType.bind(this);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('SettingsWidgetAccountType');
   }

--- a/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
@@ -35,7 +35,7 @@ class SettingsWidgetOrganizationDescription extends Component {
     this.updateOrganizationDescription = this.updateOrganizationDescription.bind(this);
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('SettingsWidgetOrganizationDescription');
   }
 

--- a/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
@@ -35,6 +35,7 @@ class SettingsWidgetOrganizationDescription extends Component {
     this.updateOrganizationDescription = this.updateOrganizationDescription.bind(this);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('SettingsWidgetOrganizationDescription');
   }

--- a/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
@@ -34,7 +34,7 @@ class SettingsWidgetOrganizationWebsite extends Component {
     this.updateOrganizationWebsite = this.updateOrganizationWebsite.bind(this);
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('SettingsWidgetOrganizationWebsite');
   }
 

--- a/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
@@ -34,6 +34,7 @@ class SettingsWidgetOrganizationWebsite extends Component {
     this.updateOrganizationWebsite = this.updateOrganizationWebsite.bind(this);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     prepareForCordovaKeyboard('SettingsWidgetOrganizationWebsite');
   }

--- a/src/js/components/Settings/VoterGuideListSearchResults.jsx
+++ b/src/js/components/Settings/VoterGuideListSearchResults.jsx
@@ -45,7 +45,7 @@ class VoterGuideListSearchResults extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("VoterGuideListSearchResults componentWillReceiveProps, nextProps.clearSearchTextNow:", nextProps.clearSearchTextNow);
     this.setState({
       clearSearchTextNow: nextProps.clearSearchTextNow,

--- a/src/js/components/Settings/VoterGuideListSearchResults.jsx
+++ b/src/js/components/Settings/VoterGuideListSearchResults.jsx
@@ -45,6 +45,7 @@ class VoterGuideListSearchResults extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("VoterGuideListSearchResults componentWillReceiveProps, nextProps.clearSearchTextNow:", nextProps.clearSearchTextNow);
     this.setState({

--- a/src/js/components/Settings/VoterGuideSettingsAddPositions.jsx
+++ b/src/js/components/Settings/VoterGuideSettingsAddPositions.jsx
@@ -120,6 +120,7 @@ class VoterGuideSettingsAddPositions extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('componentWillReceiveProps addNewPositionsMode:', nextProps.addNewPositionsMode, ', nextProps.voterGuideWeVoteId:', nextProps.voterGuideWeVoteId);
     this.setState({

--- a/src/js/components/Settings/VoterGuideSettingsAddPositions.jsx
+++ b/src/js/components/Settings/VoterGuideSettingsAddPositions.jsx
@@ -120,7 +120,7 @@ class VoterGuideSettingsAddPositions extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('componentWillReceiveProps addNewPositionsMode:', nextProps.addNewPositionsMode, ', nextProps.voterGuideWeVoteId:', nextProps.voterGuideWeVoteId);
     this.setState({
       addNewPositionsMode: nextProps.addNewPositionsMode,

--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -58,6 +58,7 @@ class IssueCard extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("IssueCard, componentWillReceiveProps, nextProps:", nextProps);
     if (nextProps.issue && nextProps.issue.issue_we_vote_id) {

--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -58,7 +58,7 @@ class IssueCard extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("IssueCard, componentWillReceiveProps, nextProps:", nextProps);
     if (nextProps.issue && nextProps.issue.issue_we_vote_id) {
       const { issue_we_vote_id: issueWeVoteId } = nextProps.issue;

--- a/src/js/components/Values/IssueCardCompressed.jsx
+++ b/src/js/components/Values/IssueCardCompressed.jsx
@@ -51,6 +51,7 @@ class IssueCardCompressed extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("IssueCard, componentWillReceiveProps, nextProps:", nextProps);
     if (nextProps.issue && nextProps.issue.issue_we_vote_id) {

--- a/src/js/components/Values/IssueCardCompressed.jsx
+++ b/src/js/components/Values/IssueCardCompressed.jsx
@@ -51,7 +51,7 @@ class IssueCardCompressed extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("IssueCard, componentWillReceiveProps, nextProps:", nextProps);
     if (nextProps.issue && nextProps.issue.issue_we_vote_id) {
       const imageSizes = new Set(['SMALL', 'MEDIUM', 'LARGE']);

--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -59,7 +59,7 @@ class IssuesByBallotItemDisplayList extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('IssuesByBallotItemDisplayList componentWillReceiveProps, nextProps.ballotItemWeVoteId:', nextProps.ballotItemWeVoteId);
     const issuesUnderThisBallotItemVoterIsFollowing = IssueStore.getIssuesUnderThisBallotItemVoterIsFollowing(nextProps.ballotItemWeVoteId) || [];
     const issuesUnderThisBallotItemVoterIsNotFollowing = IssueStore.getIssuesUnderThisBallotItemVoterNotFollowing(nextProps.ballotItemWeVoteId) || [];

--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -59,6 +59,7 @@ class IssuesByBallotItemDisplayList extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('IssuesByBallotItemDisplayList componentWillReceiveProps, nextProps.ballotItemWeVoteId:', nextProps.ballotItemWeVoteId);
     const issuesUnderThisBallotItemVoterIsFollowing = IssueStore.getIssuesUnderThisBallotItemVoterIsFollowing(nextProps.ballotItemWeVoteId) || [];

--- a/src/js/components/Values/IssuesByOrganizationDisplayList.jsx
+++ b/src/js/components/Values/IssuesByOrganizationDisplayList.jsx
@@ -55,7 +55,7 @@ class IssuesByOrganizationDisplayList extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const issuesUnderThisOrganization = IssueStore.getIssuesLinkedToByOrganization(nextProps.organizationWeVoteId) || [];
     const issuesUnderThisOrganizationLength = issuesUnderThisOrganization.length;
     const { organizationWeVoteId } = nextProps;

--- a/src/js/components/Values/IssuesByOrganizationDisplayList.jsx
+++ b/src/js/components/Values/IssuesByOrganizationDisplayList.jsx
@@ -55,6 +55,7 @@ class IssuesByOrganizationDisplayList extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const issuesUnderThisOrganization = IssueStore.getIssuesLinkedToByOrganization(nextProps.organizationWeVoteId) || [];
     const issuesUnderThisOrganizationLength = issuesUnderThisOrganization.length;

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -58,7 +58,7 @@ class GuideList extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('GuideList componentWillReceiveProps');
     // Do not update the state if the voterGuideList list looks the same, and the ballotItemWeVoteId hasn't changed
     const { ballotItemWeVoteId } = this.state;

--- a/src/js/components/VoterGuide/GuideList.jsx
+++ b/src/js/components/VoterGuide/GuideList.jsx
@@ -58,6 +58,7 @@ class GuideList extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('GuideList componentWillReceiveProps');
     // Do not update the state if the voterGuideList list looks the same, and the ballotItemWeVoteId hasn't changed

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -80,6 +80,7 @@ export default class OrganizationCard extends Component {
     // If no position, we need to call positionListForOpinionMaker here
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationCard, componentWillReceiveProps, nextProps:', nextProps);
     if (nextProps.organization && nextProps.organization.organization_we_vote_id) {

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -80,7 +80,7 @@ export default class OrganizationCard extends Component {
     // If no position, we need to call positionListForOpinionMaker here
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationCard, componentWillReceiveProps, nextProps:', nextProps);
     if (nextProps.organization && nextProps.organization.organization_we_vote_id) {
       this.setState({

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -109,7 +109,7 @@ export default class OrganizationPositionItem extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationPositionItem componentWillReceiveProps');
     const { organizationWeVoteId, position } = nextProps;
     this.setState({

--- a/src/js/components/VoterGuide/OrganizationPositionItem.jsx
+++ b/src/js/components/VoterGuide/OrganizationPositionItem.jsx
@@ -109,6 +109,7 @@ export default class OrganizationPositionItem extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationPositionItem componentWillReceiveProps');
     const { organizationWeVoteId, position } = nextProps;

--- a/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
@@ -92,6 +92,7 @@ export default class OrganizationVoterGuideTabs extends Component {
     document.body.scrollTop = this.state.scrollDownValue;
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationVoterGuideTabs, componentWillReceiveProps');
     // When a new organization is passed in, update this component to show the new data

--- a/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
@@ -92,7 +92,7 @@ export default class OrganizationVoterGuideTabs extends Component {
     document.body.scrollTop = this.state.scrollDownValue;
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationVoterGuideTabs, componentWillReceiveProps');
     // When a new organization is passed in, update this component to show the new data
     // let different_election = this.state.current_google_civic_election_id !== VoterStore.electionId();

--- a/src/js/components/VoterGuide/PledgeToSupportOrganizationButton.jsx
+++ b/src/js/components/VoterGuide/PledgeToSupportOrganizationButton.jsx
@@ -28,7 +28,7 @@ export default class PledgeToSupportOrganizationButton extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new organization is passed in, update this component to show the new data
     this.setState({
       organization: nextProps.organization,

--- a/src/js/components/VoterGuide/PledgeToSupportOrganizationButton.jsx
+++ b/src/js/components/VoterGuide/PledgeToSupportOrganizationButton.jsx
@@ -28,6 +28,7 @@ export default class PledgeToSupportOrganizationButton extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new organization is passed in, update this component to show the new data
     this.setState({

--- a/src/js/components/VoterGuide/PledgeToSupportOrganizationStatusBar.jsx
+++ b/src/js/components/VoterGuide/PledgeToSupportOrganizationStatusBar.jsx
@@ -25,6 +25,7 @@ export default class PledgeToSupportOrganizationStatusBar extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new organization is passed in, update this component to show the new data
     this.setState({

--- a/src/js/components/VoterGuide/PledgeToSupportOrganizationStatusBar.jsx
+++ b/src/js/components/VoterGuide/PledgeToSupportOrganizationStatusBar.jsx
@@ -25,7 +25,7 @@ export default class PledgeToSupportOrganizationStatusBar extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new organization is passed in, update this component to show the new data
     this.setState({
       organization: nextProps.organization,

--- a/src/js/components/VoterGuide/VoterGuideBallot.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallot.jsx
@@ -223,7 +223,7 @@ class VoterGuideBallot extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuideBallot componentWillReceiveProps, nextProps: ', nextProps);
 
     // We don't want to let the googleCivicElectionId disappear

--- a/src/js/components/VoterGuide/VoterGuideBallot.jsx
+++ b/src/js/components/VoterGuide/VoterGuideBallot.jsx
@@ -223,6 +223,7 @@ class VoterGuideBallot extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuideBallot componentWillReceiveProps, nextProps: ', nextProps);
 

--- a/src/js/components/VoterGuide/VoterGuideChooseElectionModal.jsx
+++ b/src/js/components/VoterGuide/VoterGuideChooseElectionModal.jsx
@@ -28,6 +28,7 @@ class VoterGuideChooseElectionModal extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps () {
     this.setState({
     });

--- a/src/js/components/VoterGuide/VoterGuideChooseElectionModal.jsx
+++ b/src/js/components/VoterGuide/VoterGuideChooseElectionModal.jsx
@@ -28,7 +28,7 @@ class VoterGuideChooseElectionModal extends Component {
     });
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     this.setState({
     });
   }

--- a/src/js/components/VoterGuide/VoterGuideChooseElectionWithPositionsModal.jsx
+++ b/src/js/components/VoterGuide/VoterGuideChooseElectionWithPositionsModal.jsx
@@ -30,7 +30,7 @@ class VoterGuideChooseElectionWithPositionsModal extends Component {
     });
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     this.setState({
     });
   }

--- a/src/js/components/VoterGuide/VoterGuideChooseElectionWithPositionsModal.jsx
+++ b/src/js/components/VoterGuide/VoterGuideChooseElectionWithPositionsModal.jsx
@@ -30,6 +30,7 @@ class VoterGuideChooseElectionWithPositionsModal extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps () {
     this.setState({
     });

--- a/src/js/components/VoterGuide/VoterGuideEndorsements.jsx
+++ b/src/js/components/VoterGuide/VoterGuideEndorsements.jsx
@@ -143,6 +143,7 @@ class VoterGuideEndorsements extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuideEndorsements componentWillReceiveProps');
     // When a new organization is passed in, update this component to show the new data

--- a/src/js/components/VoterGuide/VoterGuideEndorsements.jsx
+++ b/src/js/components/VoterGuide/VoterGuideEndorsements.jsx
@@ -143,7 +143,7 @@ class VoterGuideEndorsements extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuideEndorsements componentWillReceiveProps');
     // When a new organization is passed in, update this component to show the new data
     const differentElection = this.state.currentGoogleCivicElectionId !== VoterStore.electionId();

--- a/src/js/components/VoterGuide/VoterGuideFollowers.jsx
+++ b/src/js/components/VoterGuide/VoterGuideFollowers.jsx
@@ -52,6 +52,7 @@ class VoterGuideFollowers extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { organizationWeVoteId } = this.props;
     const { organizationWeVoteId: nextOrganizationWeVoteId } = nextProps;

--- a/src/js/components/VoterGuide/VoterGuideFollowers.jsx
+++ b/src/js/components/VoterGuide/VoterGuideFollowers.jsx
@@ -52,7 +52,7 @@ class VoterGuideFollowers extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { organizationWeVoteId } = this.props;
     const { organizationWeVoteId: nextOrganizationWeVoteId } = nextProps;
     // When a new organization is passed in, update this component to show the new data

--- a/src/js/components/VoterGuide/VoterGuideFollowing.jsx
+++ b/src/js/components/VoterGuide/VoterGuideFollowing.jsx
@@ -55,6 +55,7 @@ class VoterGuideFollowing extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { organizationWeVoteId } = this.props;
     const { organizationWeVoteId: nextOrganizationWeVoteId } = nextProps;

--- a/src/js/components/VoterGuide/VoterGuideFollowing.jsx
+++ b/src/js/components/VoterGuide/VoterGuideFollowing.jsx
@@ -55,7 +55,7 @@ class VoterGuideFollowing extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { organizationWeVoteId } = this.props;
     const { organizationWeVoteId: nextOrganizationWeVoteId } = nextProps;
     // When a new organization is passed in, update this component to show the new data

--- a/src/js/components/VoterGuide/VoterGuideMeasureItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideMeasureItemCompressed.jsx
@@ -67,7 +67,7 @@ class VoterGuideMeasureItemCompressed extends Component {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { measureWeVoteId, organizationWeVoteId } = nextProps;
     const measure = MeasureStore.getMeasure(measureWeVoteId);
     const organization = OrganizationStore.getOrganizationByWeVoteId(organizationWeVoteId);

--- a/src/js/components/VoterGuide/VoterGuideMeasureItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideMeasureItemCompressed.jsx
@@ -67,6 +67,7 @@ class VoterGuideMeasureItemCompressed extends Component {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { measureWeVoteId, organizationWeVoteId } = nextProps;
     const measure = MeasureStore.getMeasure(measureWeVoteId);

--- a/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
@@ -47,7 +47,7 @@ export default class VoterGuideOfficeItemCompressed extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('officeItemCompressed componentWillReceiveProps, nextProps.candidate_list:', nextProps.candidate_list);
     // 2018-05-10 I don't think we need to trigger a new render because the incoming candidate_list should be the same
     // if (nextProps.candidate_list && nextProps.candidate_list.length) {

--- a/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
+++ b/src/js/components/VoterGuide/VoterGuideOfficeItemCompressed.jsx
@@ -47,6 +47,7 @@ export default class VoterGuideOfficeItemCompressed extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('officeItemCompressed componentWillReceiveProps, nextProps.candidate_list:', nextProps.candidate_list);
     // 2018-05-10 I don't think we need to trigger a new render because the incoming candidate_list should be the same

--- a/src/js/components/VoterGuide/VoterGuidePositionList.jsx
+++ b/src/js/components/VoterGuide/VoterGuidePositionList.jsx
@@ -146,7 +146,7 @@ class VoterGuidePositionList extends Component {
     });
   }
 
-  // componentWillReceiveProps (nextProps) {
+  // UNSAFE_componentWillReceiveProps (nextProps) {
   //   let { incomingPositionList } = nextProps;
   //   console.log('VoterGuidePositionList componentWillReceiveProps, incomingPositionList:', incomingPositionList);
   //   const candidateAlreadySeenThisYear = {};

--- a/src/js/components/VoterGuide/VoterGuidePositions.jsx
+++ b/src/js/components/VoterGuide/VoterGuidePositions.jsx
@@ -169,6 +169,7 @@ class VoterGuidePositions extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuidePositions componentWillReceiveProps');
     // When a new organization is passed in, update this component to show the new data

--- a/src/js/components/VoterGuide/VoterGuidePositions.jsx
+++ b/src/js/components/VoterGuide/VoterGuidePositions.jsx
@@ -169,7 +169,7 @@ class VoterGuidePositions extends Component {
     window.addEventListener('scroll', this.onScroll);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuidePositions componentWillReceiveProps');
     // When a new organization is passed in, update this component to show the new data
     const differentElection = this.state.currentGoogleCivicElectionId !== VoterStore.electionId();

--- a/src/js/components/VoterGuide/VoterGuideRecommendationsFromOneOrganization.jsx
+++ b/src/js/components/VoterGuide/VoterGuideRecommendationsFromOneOrganization.jsx
@@ -28,7 +28,7 @@ export default class VoterGuideRecommendationsFromOneOrganization extends Compon
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new organization_we_vote_id is passed in, update this component to show the new data
     this.setState({
       organizationWeVoteId: nextProps.organization_we_vote_id,

--- a/src/js/components/VoterGuide/VoterGuideRecommendationsFromOneOrganization.jsx
+++ b/src/js/components/VoterGuide/VoterGuideRecommendationsFromOneOrganization.jsx
@@ -28,6 +28,7 @@ export default class VoterGuideRecommendationsFromOneOrganization extends Compon
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new organization_we_vote_id is passed in, update this component to show the new data
     this.setState({

--- a/src/js/components/VoterGuide/YourPositionsVisibilityMessage.jsx
+++ b/src/js/components/VoterGuide/YourPositionsVisibilityMessage.jsx
@@ -35,7 +35,7 @@ export default class YourPositionsVisibilityMessage extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("BallotStatusMessage componentWillReceiveProps");
     let visibleToPublicCount = 0;
     let visibleToFriendsOnlyCount = 0;

--- a/src/js/components/VoterGuide/YourPositionsVisibilityMessage.jsx
+++ b/src/js/components/VoterGuide/YourPositionsVisibilityMessage.jsx
@@ -35,6 +35,7 @@ export default class YourPositionsVisibilityMessage extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log("BallotStatusMessage componentWillReceiveProps");
     let visibleToPublicCount = 0;

--- a/src/js/components/Widgets/BallotItemSupportOpposeComment.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeComment.jsx
@@ -66,7 +66,7 @@ class BallotItemSupportOpposeComment extends PureComponent {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('BallotItemSupportOpposeComment, componentWillReceiveProps');
     let ballotItemDisplayName = '';
     let ballotItemType;

--- a/src/js/components/Widgets/BallotItemSupportOpposeComment.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeComment.jsx
@@ -66,6 +66,7 @@ class BallotItemSupportOpposeComment extends PureComponent {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('BallotItemSupportOpposeComment, componentWillReceiveProps');
     let ballotItemDisplayName = '';

--- a/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
@@ -117,7 +117,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
     this.onCachedPositionsOrIssueStoreChange();
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('BallotItemSupportOpposeCountDisplay componentWillReceiveProps, nextProps: ', nextProps);
     let ballotItemDisplayName;
     const { ballotItemWeVoteId } = nextProps;

--- a/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
@@ -117,6 +117,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
     this.onCachedPositionsOrIssueStoreChange();
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('BallotItemSupportOpposeCountDisplay componentWillReceiveProps, nextProps: ', nextProps);
     let ballotItemDisplayName;

--- a/src/js/components/Widgets/BrowserPushMessage.jsx
+++ b/src/js/components/Widgets/BrowserPushMessage.jsx
@@ -21,6 +21,7 @@ class BrowserPushMessage extends Component {
     };
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new candidate is passed in, update this component to show the new data
     if (nextProps.incomingProps && nextProps.incomingProps.location && nextProps.incomingProps.location.state) {

--- a/src/js/components/Widgets/BrowserPushMessage.jsx
+++ b/src/js/components/Widgets/BrowserPushMessage.jsx
@@ -21,7 +21,7 @@ class BrowserPushMessage extends Component {
     };
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new candidate is passed in, update this component to show the new data
     if (nextProps.incomingProps && nextProps.incomingProps.location && nextProps.incomingProps.location.state) {
       this.setState({

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -16,13 +16,13 @@ export default class CopyLinkModal extends Component {
     };
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     this.setState({
       wasCopied: false,
     });
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     this.setState({
       wasCopied: false,
     });

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -16,12 +16,14 @@ export default class CopyLinkModal extends Component {
     };
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     this.setState({
       wasCopied: false,
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps () {
     this.setState({
       wasCopied: false,

--- a/src/js/components/Widgets/EditAddressInPlace.jsx
+++ b/src/js/components/Widgets/EditAddressInPlace.jsx
@@ -37,7 +37,7 @@ class EditAddressInPlace extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('EditAddressInPlace componentWillReceiveProps');
     this.setState({
       textForMapSearch: nextProps.address.text_for_map_search || '',

--- a/src/js/components/Widgets/EditAddressInPlace.jsx
+++ b/src/js/components/Widgets/EditAddressInPlace.jsx
@@ -37,6 +37,7 @@ class EditAddressInPlace extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('EditAddressInPlace componentWillReceiveProps');
     this.setState({

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -104,6 +104,7 @@ class ItemActionBar extends PureComponent {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('itemActionBar, RELOAD componentWillReceiveProps');
     if (nextProps.ballotItemWeVoteId !== undefined && nextProps.ballotItemWeVoteId && nextProps.ballotItemWeVoteId !== this.state.ballotItemWeVoteId) {

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -104,7 +104,7 @@ class ItemActionBar extends PureComponent {
     this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('itemActionBar, RELOAD componentWillReceiveProps');
     if (nextProps.ballotItemWeVoteId !== undefined && nextProps.ballotItemWeVoteId && nextProps.ballotItemWeVoteId !== this.state.ballotItemWeVoteId) {
       // console.log('itemActionBar, ballotItemWeVoteId setState');

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -60,7 +60,7 @@ class ItemPositionStatementActionBar extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { ballotItemWeVoteId } = this.props;
     const { showEditPositionStatementInput } = this.state;
     const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);

--- a/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar.jsx
@@ -60,6 +60,7 @@ class ItemPositionStatementActionBar extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { ballotItemWeVoteId } = this.props;
     const { showEditPositionStatementInput } = this.state;

--- a/src/js/components/Widgets/ItemPositionStatementActionBar2020.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar2020.jsx
@@ -55,6 +55,7 @@ class ItemPositionStatementActionBar2020 extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { ballotItemWeVoteId } = this.props;
     const { showEditPositionStatementInput } = this.state;

--- a/src/js/components/Widgets/ItemPositionStatementActionBar2020.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar2020.jsx
@@ -55,7 +55,7 @@ class ItemPositionStatementActionBar2020 extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { ballotItemWeVoteId } = this.props;
     const { showEditPositionStatementInput } = this.state;
     const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);

--- a/src/js/components/Widgets/OfficeNameText.jsx
+++ b/src/js/components/Widgets/OfficeNameText.jsx
@@ -17,6 +17,7 @@ export default class OfficeNameText extends Component {
     };
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps () {
     this.setState();
   }

--- a/src/js/components/Widgets/OfficeNameText.jsx
+++ b/src/js/components/Widgets/OfficeNameText.jsx
@@ -17,7 +17,7 @@ export default class OfficeNameText extends Component {
     };
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     this.setState();
   }
 

--- a/src/js/components/Widgets/PositionItemScorePopoverTextOnly.jsx
+++ b/src/js/components/Widgets/PositionItemScorePopoverTextOnly.jsx
@@ -65,7 +65,7 @@ class PositionItemScorePopoverTextOnly extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     console.log('componentWillReceiveProps, nextProps: ', nextProps);
     const { positionItem } = nextProps;
     if (positionItem) {

--- a/src/js/components/Widgets/PositionItemScorePopoverTextOnly.jsx
+++ b/src/js/components/Widgets/PositionItemScorePopoverTextOnly.jsx
@@ -65,6 +65,7 @@ class PositionItemScorePopoverTextOnly extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     console.log('componentWillReceiveProps, nextProps: ', nextProps);
     const { positionItem } = nextProps;

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -58,7 +58,7 @@ class PositionPublicToggle extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.onVoterStoreChange();
     const { ballotItemWeVoteId } = nextProps;
     let voterPositionIsPublic = false;

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -58,6 +58,7 @@ class PositionPublicToggle extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.onVoterStoreChange();
     const { ballotItemWeVoteId } = nextProps;

--- a/src/js/components/Widgets/TopCommentByBallotItem.jsx
+++ b/src/js/components/Widgets/TopCommentByBallotItem.jsx
@@ -84,6 +84,7 @@ class TopCommentByBallotItem extends Component {
     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('TopCommentByBallotItem componentWillReceiveProps');
     // Do not update the state if the organizationsToFollow list looks the same, and the ballotItemWeVoteId hasn't changed

--- a/src/js/components/Widgets/TopCommentByBallotItem.jsx
+++ b/src/js/components/Widgets/TopCommentByBallotItem.jsx
@@ -84,7 +84,7 @@ class TopCommentByBallotItem extends Component {
     this.voterGuideStoreListener = VoterGuideStore.addListener(this.onVoterGuideStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('TopCommentByBallotItem componentWillReceiveProps');
     // Do not update the state if the organizationsToFollow list looks the same, and the ballotItemWeVoteId hasn't changed
     const { ballotItemWeVoteId } = nextProps;

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -145,6 +145,7 @@ class Candidate extends Component {
     AnalyticsActions.saveActionCandidate(VoterStore.electionId(), candidateWeVoteId);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Candidate componentWillReceiveProps');
     const modalToOpen = nextProps.params.modal_to_show || '';

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -145,7 +145,7 @@ class Candidate extends Component {
     AnalyticsActions.saveActionCandidate(VoterStore.electionId(), candidateWeVoteId);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Candidate componentWillReceiveProps');
     const modalToOpen = nextProps.params.modal_to_show || '';
     if (modalToOpen === 'share') {

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -117,7 +117,7 @@ class Measure extends Component {
     AnalyticsActions.saveActionMeasure(VoterStore.electionId(), measureWeVoteId);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const modalToOpen = nextProps.params.modal_to_show || '';
     if (modalToOpen === 'share') {
       this.modalOpenTimer = setTimeout(() => {

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -117,6 +117,7 @@ class Measure extends Component {
     AnalyticsActions.saveActionMeasure(VoterStore.electionId(), measureWeVoteId);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const modalToOpen = nextProps.params.modal_to_show || '';
     if (modalToOpen === 'share') {

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -120,6 +120,7 @@ class Office extends Component {
     AnalyticsActions.saveActionOffice(VoterStore.electionId(), this.props.params.office_we_vote_id);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Office componentWillReceiveProps');
     const modalToOpen = nextProps.params.modal_to_show || '';

--- a/src/js/routes/Ballot/Office.jsx
+++ b/src/js/routes/Ballot/Office.jsx
@@ -120,7 +120,7 @@ class Office extends Component {
     AnalyticsActions.saveActionOffice(VoterStore.electionId(), this.props.params.office_we_vote_id);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Office componentWillReceiveProps');
     const modalToOpen = nextProps.params.modal_to_show || '';
     if (modalToOpen === 'share') {

--- a/src/js/routes/FacebookInvitableFriends.jsx
+++ b/src/js/routes/FacebookInvitableFriends.jsx
@@ -60,6 +60,7 @@ export default class FacebookInvitableFriends extends Component {
     };
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     this.selectedCheckBoxes = [];
   }

--- a/src/js/routes/FacebookInvitableFriends.jsx
+++ b/src/js/routes/FacebookInvitableFriends.jsx
@@ -60,7 +60,7 @@ export default class FacebookInvitableFriends extends Component {
     };
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     this.selectedCheckBoxes = [];
   }
 

--- a/src/js/routes/HowItWorks.jsx
+++ b/src/js/routes/HowItWorks.jsx
@@ -168,6 +168,7 @@ class HowItWorks extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (!this.props.inModal) {
       if (nextProps.params.category_string === 'for-campaigns') {

--- a/src/js/routes/HowItWorks.jsx
+++ b/src/js/routes/HowItWorks.jsx
@@ -168,7 +168,7 @@ class HowItWorks extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (!this.props.inModal) {
       if (nextProps.params.category_string === 'for-campaigns') {
         this.setState({

--- a/src/js/routes/Intro/FriendInvitationOnboarding.jsx
+++ b/src/js/routes/Intro/FriendInvitationOnboarding.jsx
@@ -39,7 +39,7 @@ class FriendInvitationOnboarding extends Component {
     this.previousSlide = this.previousSlide.bind(this);
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';
   }

--- a/src/js/routes/Intro/FriendInvitationOnboarding.jsx
+++ b/src/js/routes/Intro/FriendInvitationOnboarding.jsx
@@ -39,6 +39,7 @@ class FriendInvitationOnboarding extends Component {
     this.previousSlide = this.previousSlide.bind(this);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';

--- a/src/js/routes/Intro/GetStarted.jsx
+++ b/src/js/routes/Intro/GetStarted.jsx
@@ -17,6 +17,7 @@ export default class GetStarted extends Component {
     };
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';

--- a/src/js/routes/Intro/GetStarted.jsx
+++ b/src/js/routes/Intro/GetStarted.jsx
@@ -17,7 +17,7 @@ export default class GetStarted extends Component {
     };
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';
   }

--- a/src/js/routes/Intro/IntroNetwork.jsx
+++ b/src/js/routes/Intro/IntroNetwork.jsx
@@ -23,7 +23,7 @@ export default class IntroNetwork extends Component {
     this.slider = React.createRef();
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';
   }

--- a/src/js/routes/Intro/IntroNetwork.jsx
+++ b/src/js/routes/Intro/IntroNetwork.jsx
@@ -23,6 +23,7 @@ export default class IntroNetwork extends Component {
     this.slider = React.createRef();
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';

--- a/src/js/routes/Intro/SampleBallot.jsx
+++ b/src/js/routes/Intro/SampleBallot.jsx
@@ -10,6 +10,7 @@ export default class SampleBallot extends Component {
     this.state = {};
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';

--- a/src/js/routes/Intro/SampleBallot.jsx
+++ b/src/js/routes/Intro/SampleBallot.jsx
@@ -10,7 +10,7 @@ export default class SampleBallot extends Component {
     this.state = {};
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     document.body.style.backgroundColor = '#A3A3A3';
     document.body.className = 'story-view';
     cookies.setItem('show_full_navigation', '1', Infinity, '/');

--- a/src/js/routes/More/Pricing.jsx
+++ b/src/js/routes/More/Pricing.jsx
@@ -390,6 +390,7 @@ class Pricing extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.onVoterStoreChange();
     let pricingChoice = '';

--- a/src/js/routes/More/Pricing.jsx
+++ b/src/js/routes/More/Pricing.jsx
@@ -390,7 +390,7 @@ class Pricing extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.onVoterStoreChange();
     let pricingChoice = '';
     if (nextProps.params && nextProps.params.pricing_choice) {

--- a/src/js/routes/More/SearchPage.jsx
+++ b/src/js/routes/More/SearchPage.jsx
@@ -40,6 +40,7 @@ export default class SearchPage extends Component {
     this.searchAllStoreListener = SearchAllStore.addListener(this.onSearchAllStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     this.onSearchAllStoreChange();
     if (nextProps.params.encoded_search_string) {

--- a/src/js/routes/More/SearchPage.jsx
+++ b/src/js/routes/More/SearchPage.jsx
@@ -40,7 +40,7 @@ export default class SearchPage extends Component {
     this.searchAllStoreListener = SearchAllStore.addListener(this.onSearchAllStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     this.onSearchAllStoreChange();
     if (nextProps.params.encoded_search_string) {
       this.setState({ textFromSearchField: nextProps.params.encoded_search_string || '' });

--- a/src/js/routes/Settings/SettingsDashboard.jsx
+++ b/src/js/routes/Settings/SettingsDashboard.jsx
@@ -92,7 +92,7 @@ export default class SettingsDashboard extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const voter = VoterStore.getVoter();
     this.setState({
       voter,

--- a/src/js/routes/Settings/SettingsDashboard.jsx
+++ b/src/js/routes/Settings/SettingsDashboard.jsx
@@ -92,6 +92,7 @@ export default class SettingsDashboard extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const voter = VoterStore.getVoter();
     this.setState({

--- a/src/js/routes/Settings/SettingsMenuMobile.jsx
+++ b/src/js/routes/Settings/SettingsMenuMobile.jsx
@@ -52,6 +52,7 @@ export default class SettingsMenuMobile extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps () {
     const voter = VoterStore.getVoter();
     this.setState({

--- a/src/js/routes/Settings/SettingsMenuMobile.jsx
+++ b/src/js/routes/Settings/SettingsMenuMobile.jsx
@@ -52,7 +52,7 @@ export default class SettingsMenuMobile extends Component {
     }
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     const voter = VoterStore.getVoter();
     this.setState({
       voter,

--- a/src/js/routes/Settings/VoterGuideListDashboard.jsx
+++ b/src/js/routes/Settings/VoterGuideListDashboard.jsx
@@ -56,7 +56,7 @@ class VoterGuideListDashboard extends Component {
     }
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     const voter = VoterStore.getVoter();
     const voterIsSignedIn = voter.is_signed_in;
     this.setState({

--- a/src/js/routes/Settings/VoterGuideListDashboard.jsx
+++ b/src/js/routes/Settings/VoterGuideListDashboard.jsx
@@ -56,6 +56,7 @@ class VoterGuideListDashboard extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps () {
     const voter = VoterStore.getVoter();
     const voterIsSignedIn = voter.is_signed_in;

--- a/src/js/routes/Settings/VoterGuideSettingsDashboard.jsx
+++ b/src/js/routes/Settings/VoterGuideSettingsDashboard.jsx
@@ -70,6 +70,7 @@ class VoterGuideSettingsDashboard extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuideSettingsDashboard componentDidMount');
     this.onAppStoreChange();

--- a/src/js/routes/Settings/VoterGuideSettingsDashboard.jsx
+++ b/src/js/routes/Settings/VoterGuideSettingsDashboard.jsx
@@ -70,7 +70,7 @@ class VoterGuideSettingsDashboard extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('VoterGuideSettingsDashboard componentDidMount');
     this.onAppStoreChange();
     // console.log('nextProps.params.voter_guide_we_vote_id:', nextProps.params.voter_guide_we_vote_id);

--- a/src/js/routes/Settings/VoterGuideSettingsMenuMobile.jsx
+++ b/src/js/routes/Settings/VoterGuideSettingsMenuMobile.jsx
@@ -73,7 +73,7 @@ export default class VoterGuideSettingsMenuMobile extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.params.edit_mode) {
       this.setState({ editMode: nextProps.params.edit_mode });
     }

--- a/src/js/routes/Settings/VoterGuideSettingsMenuMobile.jsx
+++ b/src/js/routes/Settings/VoterGuideSettingsMenuMobile.jsx
@@ -73,6 +73,7 @@ export default class VoterGuideSettingsMenuMobile extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.params.edit_mode) {
       this.setState({ editMode: nextProps.params.edit_mode });

--- a/src/js/routes/Settings/VoterGuidesMenuMobile.jsx
+++ b/src/js/routes/Settings/VoterGuidesMenuMobile.jsx
@@ -37,6 +37,7 @@ export default class VoterGuidesMenuMobile extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps () {
     const voter = VoterStore.getVoter();
     const linkedOrganizationWeVoteId = voter.linked_organization_we_vote_id;

--- a/src/js/routes/Settings/VoterGuidesMenuMobile.jsx
+++ b/src/js/routes/Settings/VoterGuidesMenuMobile.jsx
@@ -37,7 +37,7 @@ export default class VoterGuidesMenuMobile extends Component {
     }
   }
 
-  componentWillReceiveProps () {
+  UNSAFE_componentWillReceiveProps () {
     const voter = VoterStore.getVoter();
     const linkedOrganizationWeVoteId = voter.linked_organization_we_vote_id;
     // console.log('VoterGuidesMenuMobile componentWillReceiveProps linkedOrganizationWeVoteId: ', linkedOrganizationWeVoteId);

--- a/src/js/routes/TwitterHandleLanding.jsx
+++ b/src/js/routes/TwitterHandleLanding.jsx
@@ -45,7 +45,7 @@ export default class TwitterHandleLanding extends Component {
     this.onVoterStoreChange();
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('TwitterHandleLanding componentWillReceiveProps');
     const { activeRoute, params } = nextProps;
     const { twitter_handle: nextTwitterHandle } = params;

--- a/src/js/routes/TwitterHandleLanding.jsx
+++ b/src/js/routes/TwitterHandleLanding.jsx
@@ -45,6 +45,7 @@ export default class TwitterHandleLanding extends Component {
     this.onVoterStoreChange();
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('TwitterHandleLanding componentWillReceiveProps');
     const { activeRoute, params } = nextProps;

--- a/src/js/routes/Values/ValuesList.jsx
+++ b/src/js/routes/Values/ValuesList.jsx
@@ -45,7 +45,7 @@ export default class ValuesList extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const { currentIssue } = nextProps;
     const allIssues = IssueStore.getAllIssues();
     this.setState({

--- a/src/js/routes/Values/ValuesList.jsx
+++ b/src/js/routes/Values/ValuesList.jsx
@@ -45,6 +45,7 @@ export default class ValuesList extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const { currentIssue } = nextProps;
     const allIssues = IssueStore.getAllIssues();

--- a/src/js/routes/Values/VoterGuidesUnderOneValue.jsx
+++ b/src/js/routes/Values/VoterGuidesUnderOneValue.jsx
@@ -42,6 +42,7 @@ class VoterGuidesUnderOneValue extends Component {
     }
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     const issue = IssueStore.getIssueBySlug(nextProps.params.value_slug);
     const voterGuidesForValue = VoterGuideStore.getVoterGuidesForValue(issue.issue_we_vote_id);

--- a/src/js/routes/Values/VoterGuidesUnderOneValue.jsx
+++ b/src/js/routes/Values/VoterGuidesUnderOneValue.jsx
@@ -42,7 +42,7 @@ class VoterGuidesUnderOneValue extends Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const issue = IssueStore.getIssueBySlug(nextProps.params.value_slug);
     const voterGuidesForValue = VoterGuideStore.getVoterGuidesForValue(issue.issue_we_vote_id);
     const voterGuidesForValueLength = voterGuidesForValue.length || 0;

--- a/src/js/routes/Vote.jsx
+++ b/src/js/routes/Vote.jsx
@@ -183,6 +183,7 @@ class Vote extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Ballot componentWillReceiveProps');
 

--- a/src/js/routes/Vote.jsx
+++ b/src/js/routes/Vote.jsx
@@ -183,7 +183,7 @@ class Vote extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Ballot componentWillReceiveProps');
 
     // We don't want to let the googleCivicElectionId disappear

--- a/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
@@ -125,6 +125,7 @@ export default class OrganizationVoterGuide extends Component {
     FriendActions.currentFriends();  // We need this so we can identify if the voter is friends with this organization/person
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationVoterGuide, componentWillReceiveProps, nextProps.params.organization_we_vote_id: ', nextProps.params.organization_we_vote_id);
     // When a new organization is passed in, update this component to show the new data

--- a/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuide.jsx
@@ -125,7 +125,7 @@ export default class OrganizationVoterGuide extends Component {
     FriendActions.currentFriends();  // We need this so we can identify if the voter is friends with this organization/person
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationVoterGuide, componentWillReceiveProps, nextProps.params.organization_we_vote_id: ', nextProps.params.organization_we_vote_id);
     // When a new organization is passed in, update this component to show the new data
     // if (nextProps.params.action_variable === AUTO_FOLLOW) {

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideCandidate.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideCandidate.jsx
@@ -66,7 +66,7 @@ class OrganizationVoterGuideCandidate extends Component {
     // console.log('OrganizationVoterGuideCandidate, organizationWeVoteId: ', organizationWeVoteId);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Candidate componentWillReceiveProps');
     const { candidateWeVoteId: priorCandidateWeVoteId } = this.state;
     const { candidate_we_vote_id: candidateWeVoteId } = nextProps.params;

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideCandidate.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideCandidate.jsx
@@ -66,6 +66,7 @@ class OrganizationVoterGuideCandidate extends Component {
     // console.log('OrganizationVoterGuideCandidate, organizationWeVoteId: ', organizationWeVoteId);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('Candidate componentWillReceiveProps');
     const { candidateWeVoteId: priorCandidateWeVoteId } = this.state;

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideMeasure.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideMeasure.jsx
@@ -54,6 +54,7 @@ export default class OrganizationVoterGuideMeasure extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new measure is passed in, update this component to show the new data
     if (nextProps.params.measure_we_vote_id !== this.state.measureWeVoteId) {

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideMeasure.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideMeasure.jsx
@@ -54,7 +54,7 @@ export default class OrganizationVoterGuideMeasure extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new measure is passed in, update this component to show the new data
     if (nextProps.params.measure_we_vote_id !== this.state.measureWeVoteId) {
       MeasureActions.measureRetrieve(nextProps.params.measure_we_vote_id);

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideMobileDetails.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideMobileDetails.jsx
@@ -35,7 +35,7 @@ class OrganizationVoterGuideMobileDetails extends Component {
     });
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationVoterGuideMobileDetails componentWillReceiveProps');
     const { params } = nextProps;
     const { incomingTwitterHandle } = this.state;

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideMobileDetails.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideMobileDetails.jsx
@@ -35,6 +35,7 @@ class OrganizationVoterGuideMobileDetails extends Component {
     });
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // console.log('OrganizationVoterGuideMobileDetails componentWillReceiveProps');
     const { params } = nextProps;

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideOffice.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideOffice.jsx
@@ -42,6 +42,7 @@ export default class OrganizationVoterGuideOffice extends Component {
     // console.log("OrganizationVoterGuideOffice, organization_we_vote_id: ", this.props.params.organization_we_vote_id);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new office is passed in, update this component to show the new data
     const office = OfficeStore.getOffice(nextProps.params.office_we_vote_id);

--- a/src/js/routes/VoterGuide/OrganizationVoterGuideOffice.jsx
+++ b/src/js/routes/VoterGuide/OrganizationVoterGuideOffice.jsx
@@ -42,7 +42,7 @@ export default class OrganizationVoterGuideOffice extends Component {
     // console.log("OrganizationVoterGuideOffice, organization_we_vote_id: ", this.props.params.organization_we_vote_id);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new office is passed in, update this component to show the new data
     const office = OfficeStore.getOffice(nextProps.params.office_we_vote_id);
     if (!office || !office.ballot_item_display_name) {

--- a/src/js/routes/VoterGuide/PositionListForFriends.jsx
+++ b/src/js/routes/VoterGuide/PositionListForFriends.jsx
@@ -31,6 +31,7 @@ export default class PositionListForFriends extends Component {
     OrganizationActions.positionListForOpinionMakerForFriends(organizationWeVoteId, false, true);
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new candidate is passed in, update this component to show the new data
     this.setState({ organizationWeVoteId: nextProps.params.organization_we_vote_id });

--- a/src/js/routes/VoterGuide/PositionListForFriends.jsx
+++ b/src/js/routes/VoterGuide/PositionListForFriends.jsx
@@ -31,7 +31,7 @@ export default class PositionListForFriends extends Component {
     OrganizationActions.positionListForOpinionMakerForFriends(organizationWeVoteId, false, true);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // When a new candidate is passed in, update this component to show the new data
     this.setState({ organizationWeVoteId: nextProps.params.organization_we_vote_id });
 

--- a/src/js/routes/YourPage.jsx
+++ b/src/js/routes/YourPage.jsx
@@ -16,7 +16,7 @@ export default class YourPage extends Component {
     this.state = { voter: VoterStore.getVoter() };
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     const { voter } = this.state;
 
     const voterHasTwitterHandle = !!voter.twitter_screen_name;

--- a/src/js/routes/YourPage.jsx
+++ b/src/js/routes/YourPage.jsx
@@ -16,6 +16,7 @@ export default class YourPage extends Component {
     this.state = { voter: VoterStore.getVoter() };
   }
 
+  // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
     const { voter } = this.state;
 


### PR DESCRIPTION
Also renamed componentWillMount to UNSAFE_componentWillMount
This suppresses pages of JavaScript console logging.
All of these UNSAFE deprecated React methods will need to be removed over time.
Suppressed two lint errors introduced by the renaming, since the method name is
meant to be ugly (by the Facebook React authors), and the renamed methods will
be going away.

