### PR TITLE
Microsoft Internet Explorer fixes, Part 4

### DIFF
--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -2,7 +2,7 @@ import React, { Suspense } from 'react';
 import { IndexRedirect, Route } from 'react-router'; // Route,
 import cookies from './utils/cookies';
 import componentLoader from './utils/componentLoader';
-import { isWebApp } from './utils/cordovaUtils';
+import { isWebApp, polyfillFixes } from './utils/cordovaUtils';
 
 // Temp until we can find alternative
 const OrganizationVoterGuide = React.lazy(() => import('./routes/VoterGuide/OrganizationVoterGuide'));
@@ -12,7 +12,7 @@ const WelcomeForVoters = React.lazy(() => import('./routes/WelcomeForVoters'));
 const WelcomeForCampaigns = React.lazy(() => import('./routes/WelcomeForCampaigns'));
 const WelcomeForOrganizations = React.lazy(() => import('./routes/WelcomeForOrganizations'));
 
-// polyfillFixes();
+polyfillFixes('Root.jsx');
 
 // See /js/components/Navigation/HeaderBar.jsx for show_full_navigation cookie
 // const ballotHasBeenVisited = cookies.getItem('ballot_has_been_visited');

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Button, AppBar, Toolbar, Tabs, Tab, IconButton, Tooltip } from '@material-ui/core';
 import { Place, AccountCircle } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
-import { hasIPhoneNotch, historyPush, isIOSAppOnMac, isCordova, isWebApp, isAndroid, getAndroidSize } from '../../utils/cordovaUtils';
+import { hasIPhoneNotch, historyPush, isIOSAppOnMac, isCordova, isWebApp } from '../../utils/cordovaUtils';
 import AdviserIntroModal from '../CompleteYourProfile/AdviserIntroModal';
 import AppActions from '../../actions/AppActions';
 import AppStore from '../../stores/AppStore';

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,8 +1,7 @@
 import webAppConfig from './config';
 import startReactApp from './startReactApp';
-import { polyfillFixes } from './utils/applicationUtils';
 import { numberOfNeedlesFoundInString } from './utils/searchFunctions';
-import { isWebApp, isIPad, getCordovaScreenHeight } from './utils/cordovaUtils';
+import { isWebApp, isIPad, getCordovaScreenHeight, polyfillFixes } from './utils/cordovaUtils';
 
 // If in Cordova, need this function before cordovaUtils might be loaded
 function localIsCordova () {
@@ -39,7 +38,7 @@ function startApp () {
 
 // begin of inline startup code
 console.log('index.js loaded');
-polyfillFixes();
+polyfillFixes('index.js');
 
 // ServiceWorker setup for Workbox Progressive Web App (PWA)
 if ('ENABLE_WORKBOX_SERVICE_WORKER' in webAppConfig &&

--- a/src/js/routes/Activity/News.jsx
+++ b/src/js/routes/Activity/News.jsx
@@ -323,7 +323,7 @@ class News extends Component {
                   activityTidbitWeVoteId = oneActivityTidbit.we_vote_id;
                   return (
                     <ActivityTidbitWrapper key={activityTidbitWeVoteId}>
-                      <a // eslint-disable-line jsx-a11y/anchor-has-content
+                      <a // eslint-disable-line jsx-a11y/anchor-has-content, jsx-a11y/control-has-associated-label
                         href={`#${activityTidbitWeVoteId}`}
                         name={activityTidbitWeVoteId}
                       />

--- a/src/js/startReactReadyApp.js
+++ b/src/js/startReactReadyApp.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import { render } from 'react-dom';
-import {
-  browserHistory, Router, applyRouterMiddleware,
-} from 'react-router';
+import { browserHistory, Router, applyRouterMiddleware } from 'react-router';
 import { useScroll } from 'react-router-scroll';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { ThemeProvider } from 'styled-components';
-import routes from './RootForReady';
 import muiTheme from './mui-theme';
+import routes from './RootForReady';
 import styledTheme from './styled-theme';
+import { polyfillFixes } from './utils/cordovaUtils';
 import { renderLog } from './utils/logging';
 import { numberOfNeedlesFoundInString } from './utils/searchFunctions';
 
+polyfillFixes('startReactReadyApp');
 
 // Adding functions to the String prototype will make stuff like `for (char in str)` break, because it will loop over the substringOccurrences property.
 // As long as we use `forEach()` or `for (char of str)` then that side effect will be mitigated.

--- a/src/js/utils/applicationUtils.js
+++ b/src/js/utils/applicationUtils.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { isIOSAppOnMac, isCordova, isWebApp } from './cordovaUtils';
 import { startsWith, stringContains } from './textFormat';
 
@@ -244,58 +243,6 @@ export function getApplicationViewBooleans (pathname) {
     voterGuideCreatorMode,
     voterGuideMode,
   };
-}
-
-export function polyfillFixes () {
-  // November 2, 2018:  Polyfill for "Object.entries"
-  //   react-bootstrap 1.0 (bootstrap 4) relies on Object.entries in splitComponentProps.js
-  //   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#Polyfill
-  if (!Object.entries) {
-    Object.entries = function poly (obj) {
-      const localProps = Object.keys(obj);
-      let i = localProps.length;
-      const resArray = new Array(i); // preallocate the Array
-      while (i--) resArray[i] = [localProps[i], obj[localProps[i]]];
-      return resArray;
-    };
-  }
-
-  // And another for ObjectAssign
-  if (!Object.assign) {
-    Object.assign = React.__spread;
-  }
-
-  // And another for Microsoft Internet Explorer 11
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
-  if (!String.prototype.includes) {
-    // eslint-disable-next-line no-extend-native,func-names
-    String.prototype.includes = function (search, start) {
-      // eslint-disable-next-line
-      'use strict';
-
-      if (search instanceof RegExp) {
-        throw TypeError('first argument must not be a RegExp');
-      }
-      // eslint-disable-next-line no-param-reassign
-      if (start === undefined) { start = 0; }
-      return this.indexOf(search, start) !== -1;
-    };
-  }
-
-  // And yet, another for Microsoft Internet Explorer 11
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
-  if (!String.prototype.startsWith) {
-    // eslint-disable-next-line no-extend-native
-    Object.defineProperty(String.prototype, 'startsWith', {
-      // eslint-disable-next-line object-shorthand
-      value: function(search, rawPos) {
-        // eslint-disable-next-line no-var, no-bitwise
-        var pos = rawPos > 0 ? rawPos | 0 : 0;
-        return this.substring(pos, pos + search.length) === search;
-      },
-    });
-  }
-
 }
 
 // Choose to show/hide zendesk help widget based on route


### PR DESCRIPTION
Call polyfillFixes() from a few places, but have it set a global within the file, so that it only runs once.  Then we should be hardened against variations in the way webpac compiles the bundles.
Lint cleanup.
Moved polyfillFixes() to cordovaUtils.js to avoid a circular dependency.

For wevote/WebApp/issues/3184
