### PR TITLE
Changes for first Apple Silicon release

### DIFF
--- a/src/js/actions/FacebookActions.js
+++ b/src/js/actions/FacebookActions.js
@@ -58,10 +58,11 @@ export default {
       console.log('FacebookActions.getFacebookData was not invoked, see ENABLE_FACEBOOK in config.js');
       return;
     }
-
+    // console.log('FacebookActions.getFacebookData invocation');
     if (this.facebookApi()) {
       this.facebookApi().api(
         '/me?fields=id,email,first_name,middle_name,last_name,cover', (response) => {
+          // console.log('FacebookActions.getFacebookData response ', response);
           oAuthLog('getFacebookData response', response);
           Dispatcher.dispatch({
             type: FacebookConstants.FACEBOOK_RECEIVED_DATA,
@@ -284,6 +285,7 @@ export default {
       this.facebookApi().getLoginStatus(
         (response) => {
           oAuthLog('FacebookActions this.facebookApi().getLoginStatus response: ', response);
+          // dumpObjProps('facebookApi().getLoginStatus()', response);
           if (response.status === 'connected') {
             Dispatcher.dispatch({
               type: FacebookConstants.FACEBOOK_LOGGED_IN,

--- a/src/js/components/Ready/ElectionCountdown.jsx
+++ b/src/js/components/Ready/ElectionCountdown.jsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import BallotStore from '../../stores/BallotStore';
+import { renderLog } from '../../utils/logging';
 import { formatDateToMonthDayYear } from '../../utils/textFormat';
 
 class ElectionCountdown extends React.Component {
@@ -114,6 +115,7 @@ class ElectionCountdown extends React.Component {
   }
 
   render () {
+    renderLog('ElectionCountdown');  // Set LOG_RENDER_EVENTS to log all renders
     const { daysOnlyMode } = this.props;
     const { days, daysMobile, electionIsToday, electionInPast, hours, minutes, seconds, electionDate } = this.state;
     const timeStillLoading = !(days || hours || minutes || seconds);

--- a/src/js/components/Ready/PledgeToVote.jsx
+++ b/src/js/components/Ready/PledgeToVote.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Button, Checkbox, FormControlLabel, TextField } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
+import { renderLog } from '../../utils/logging';
 import { formatDateToYearMonthDay } from '../../utils/textFormat';
 
 class PledgeToVote extends React.Component {
@@ -150,6 +151,7 @@ class PledgeToVote extends React.Component {
   }
 
   render () {
+    renderLog('PledgeToVote');  // Set LOG_RENDER_EVENTS to log all renders
     const { goal, total, shareNameAndEmail, commentsToDisplay } = this.state;
     const { classes } = this.props;
 

--- a/src/js/components/Ready/ReadyInformationDisclaimer.jsx
+++ b/src/js/components/Ready/ReadyInformationDisclaimer.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { Button, OverlayTrigger } from 'react-bootstrap';
+import Popover from 'react-bootstrap/Popover';
+import { isWebApp } from '../../utils/cordovaUtils';
+import { renderLog } from '../../utils/logging';
+
+class ReadyInformationDisclaimer extends React.Component {
+  render () {
+    renderLog('ReadyInformationDisclaimer');  // Set LOG_RENDER_EVENTS to log all renders
+
+    const cardStyles = {
+      backgroundClip: 'border-box',
+      backgroundColor: 'white',
+      boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12)',
+      display: 'flex',
+      flexDirection: 'column',
+      margin: '16px -16px 16px -16px',
+      minWidth: 0,
+      padding: '18px 16px 18px 16px',
+      position: 'relative',
+      wordWrap: 'break-word',
+    };
+
+    if (isWebApp()) {
+      return null;
+    }
+    return (
+      <div style={cardStyles}>
+        <span>
+          <span style={{ fontWeight: 'bold' }}>
+            We Vote helps you make your voting choices, but it does not electronically submit your vote.
+          </span>
+          <div style={{ padding: '6px' }} />
+          You will still need to vote by mail, or vote in person, to have your vote count.
+        </span>
+        <OverlayTrigger
+          trigger="click"
+          key="top"
+          placement="top"
+          overlay={(
+            <Popover id="popover-positioned-top">
+              <Popover.Content>
+                <strong>
+                  We Vote aggregates ballot data from non-partisan, non-profit, and government ballot databases.
+                </strong>
+                <br />
+                <br />
+                A balanced selection of clearly identified voting guides from newspapers
+                and media is provided, along with partisan voter guides from a diversity of sources.
+                <br />
+                <br />
+                These voting guides are captured and updated by volunteers.
+              </Popover.Content>
+            </Popover>
+          )}
+        >
+          <div style={{ justifyContent: 'center', paddingTop: '10px' }}>
+            <div style={{ width: '50%', margin: '0 auto' }}>
+              <Button
+                variant="primary"
+                fullwidth="false"
+                size="small"
+                style={{
+                  backgroundColor: 'rgb(46, 60, 93)',
+                  fontSize: '.75rem',
+                  lineHeight: 1,
+                }}
+              >
+                Where We Vote gets its data
+              </Button>
+            </div>
+          </div>
+        </OverlayTrigger>
+      </div>
+    );
+  }
+}
+
+export default ReadyInformationDisclaimer;

--- a/src/js/components/Ready/ReadyTaskBallot.jsx
+++ b/src/js/components/Ready/ReadyTaskBallot.jsx
@@ -10,6 +10,7 @@ import ballot100Percent from '../../../img/global/svg-icons/ready/ballot-100-per
 import BallotActions from '../../actions/BallotActions';
 import BallotStore from '../../stores/BallotStore';
 import { cordovaDot, historyPush } from '../../utils/cordovaUtils';
+import { renderLog } from '../../utils/logging';
 import { ButtonLeft, ButtonText, Icon, PercentComplete, ReadyCard, StyledButton, StyledCheckbox, StyledCheckboxCompleted, SubTitle, TitleRowWrapper } from './ReadyTaskStyles';
 import ShowMoreButtons from '../ReadyNoApi/ShowMoreButtons';
 import SupportStore from '../../stores/SupportStore';
@@ -367,6 +368,7 @@ class ReadyTaskBallot extends React.Component {
   }
 
   render () {
+    renderLog('ReadyTaskBallot');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes } = this.props;
     const {
       allCandidatesButtonNeeded, allCandidatesAllCompleted, allCandidatesNumberCompleted, allCandidatesShowButton, allCandidatesTotalNumber,

--- a/src/js/components/Ready/ReadyTaskFriends.jsx
+++ b/src/js/components/Ready/ReadyTaskFriends.jsx
@@ -5,6 +5,7 @@ import { ArrowForward, CheckCircle } from '@material-ui/icons';
 import { cordovaDot, historyPush } from '../../utils/cordovaUtils';
 import register0Percent from '../../../img/global/svg-icons/ready/register-0-percent.svg';
 import register100Percent from '../../../img/global/svg-icons/ready/register-100-percent.svg';
+import { renderLog } from '../../utils/logging';
 import {
   ButtonLeft,
   ButtonText,
@@ -43,6 +44,7 @@ class ReadyTaskFriends extends React.Component {
   }
 
   render () {
+    renderLog('ReadyTaskFriends');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes } = this.props;
     const {
       numberOfFriendsReady, numberOfFriendsRegistered, numberOfFriendsWithBallot,

--- a/src/js/components/Ready/ReadyTaskRegister.jsx
+++ b/src/js/components/Ready/ReadyTaskRegister.jsx
@@ -5,6 +5,7 @@ import { ArrowForward, CheckCircle } from '@material-ui/icons';
 import { cordovaDot, historyPush } from '../../utils/cordovaUtils';
 import register0Percent from '../../../img/global/svg-icons/ready/register-0-percent.svg';
 import register100Percent from '../../../img/global/svg-icons/ready/register-100-percent.svg';
+import { renderLog } from '../../utils/logging';
 import {
   ButtonLeft,
   ButtonText,
@@ -32,6 +33,7 @@ class ReadyTaskRegister extends React.Component {
   }
 
   render () {
+    renderLog('ReadyTaskRegister');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes } = this.props;
     const { completed } = this.state;
 

--- a/src/js/components/Share/ShareButtonDesktopTablet.jsx
+++ b/src/js/components/Share/ShareButtonDesktopTablet.jsx
@@ -31,6 +31,7 @@ class ShareButtonDesktopTablet extends Component {
     this.setState({
       chosenPreventSharingOpinions,
     });
+    // dumpObjProps('cookies in ShareButtonDesktopTablet: ', cookies.keys);
   }
 
   componentWillUnmount () {

--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import IssueFollowToggleButton from './IssueFollowToggleButton';
 import IssueImageDisplay from './IssueImageDisplay';
 import LoadingWheel from '../LoadingWheel';
+import { isCordova } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import ReadMore from '../Widgets/ReadMore';
 import { convertNameToSlug } from '../../utils/textFormat';
@@ -136,6 +137,7 @@ class IssueCard extends Component {
         key={`issue-card-${issueWeVoteId}`}
         className={this.props.condensed ? "card-child u-full-height" : "card-child u-inset__h--md u-padding-top--md u-padding-bottom--xs u-full-height"}
         condensed={!!this.props.condensed}
+        style={isCordova() ? { margin: 'unset' } : {}}   // stops horizontal scrolling
       >
         <Flex condensed={!!this.props.condensed} followToggleOnItsOwnLine={!!followToggleOnItsOwnLine}>
           <FlexNameAndIcon condensed={!!this.props.condensed}>

--- a/src/js/components/VoterGuide/CandidateForDrawer.jsx
+++ b/src/js/components/VoterGuide/CandidateForDrawer.jsx
@@ -8,6 +8,7 @@ import AnalyticsActions from '../../actions/AnalyticsActions';
 import AppStore from '../../stores/AppStore';
 import BallotStore from '../../stores/BallotStore';
 import CandidateActions from '../../actions/CandidateActions';
+import { isWebApp } from '../../utils/cordovaUtils';
 import CandidateItem from '../Ballot/CandidateItem';
 import ShareButtonDesktopTablet from '../Share/ShareButtonDesktopTablet';
 import CandidateStickyHeader from '../Ballot/CandidateStickyHeader';
@@ -250,7 +251,7 @@ class CandidateForDrawer extends Component {
             <CandidateStickyHeader candidate={candidate} />
           )
         }
-        <div className="card">
+        <div className="card" style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
           <TwoColumns>
             <LeftColumnWrapper>
               <CandidateItem
@@ -278,7 +279,7 @@ class CandidateForDrawer extends Component {
           </TwoColumns>
         </div>
         { !!(allCachedPositionsForThisCandidate.length) && (
-          <section className="card">
+          <section className="card" style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
             <DelayedLoad showLoadingText waitBeforeShow={500}>
               <PositionList
                 incomingPositionList={allCachedPositionsForThisCandidate}

--- a/src/js/components/VoterGuide/CandidateForDrawer.jsx
+++ b/src/js/components/VoterGuide/CandidateForDrawer.jsx
@@ -251,6 +251,7 @@ class CandidateForDrawer extends Component {
             <CandidateStickyHeader candidate={candidate} />
           )
         }
+        {/* The following style adjustment prevents horizontal scrolling from the .card style */}
         <div className="card" style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
           <TwoColumns>
             <LeftColumnWrapper>
@@ -279,6 +280,7 @@ class CandidateForDrawer extends Component {
           </TwoColumns>
         </div>
         { !!(allCachedPositionsForThisCandidate.length) && (
+          // The following style adjustment prevents horizontal scrolling from the .card style
           <section className="card" style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
             <DelayedLoad showLoadingText waitBeforeShow={500}>
               <PositionList

--- a/src/js/constants/CordovaPageConstants.js
+++ b/src/js/constants/CordovaPageConstants.js
@@ -29,6 +29,7 @@ const CordovaPageConstants = {
   voterGuideWild: null,
   ready: null,
   twitterSignIn: null,
+  twitterInfoPage: null,
   news: null,
   twitterIdMFollowers: null,
   defaultVal: null,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -16,15 +16,18 @@ String.prototype.numberOfNeedlesFoundInString = numberOfNeedlesFoundInString; //
 
 function startApp () {
   // http://harrymoreno.com/2015/07/14/Deploying-a-React-App-to-Cordova.html
+  // console.log('Cordova startApp entry');
   // eslint-disable-next-line no-undef
   if (window.device && window.device.platform === 'iOS') {
     const { device, Keyboard, Keyboard: { shrinkView, disableScrollingInShrinkView }, screen } = window;
     // eslint-disable-next-line no-undef
     console.log('cordova startup device: ', device);
     console.log('cordova startup window.screen: ', screen);
+    // dumpObjProps(window.device);
 
     // eslint-disable-next-line global-require
     window.$ = require('jquery');
+    // console.log('cordova startup after require(\'jquery\')');
 
     // prevent keyboard scrolling our view, https://www.npmjs.com/package/cordova-plugin-keyboard
     if (Keyboard) {
@@ -78,6 +81,7 @@ if (localIsCordova()) {
     const { plugins: { screensize } } = window;
     screensize.get((result) => {
       console.log('screensize.get: ', result);
+      // dumpObjProps('window.device', window.device);
       window.pbakondyScreenSize = result;
       if (isIPad()) {
         document.querySelector('body').style.height = getCordovaScreenHeight();

--- a/src/js/routes/Activity/News.jsx
+++ b/src/js/routes/Activity/News.jsx
@@ -289,7 +289,9 @@ class News extends Component {
     // eslint-disable-next-line prefer-object-spread
     const unsetSomeRowStylesIfCordovaMdBlock = Object.assign({}, unsetSomeRowStylesIfCordova);
     if (isIPad() /* || isAndroidTablet() */) {
-      unsetSomeRowStylesIfCordovaMdBlock.transform = 'translate(0, 5%)';
+      unsetSomeRowStylesIfCordovaMdBlock.transform = isIPad() ? 'translate(0, 0.2%)' : 'translate(0, 5%)';
+      unsetSomeRowStylesIfCordovaMdBlock.marginLeft = isIPad() ? 15 : 0;
+      unsetSomeRowStylesIfCordovaMdBlock.flex = isIPad() ? '0 0 31%' : '';
     }
 
     return (

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -26,7 +26,7 @@ import cookies from '../../utils/cookies';
 import CompleteYourProfile from '../../components/CompleteYourProfile/CompleteYourProfile';
 import { cordovaBallotFilterTopMargin } from '../../utils/cordovaOffsets';
 import cordovaScrollablePaneTopPadding from '../../utils/cordovaScrollablePaneTopPadding';
-import { chipLabelText, historyPush, isIOSAppOnMac, isCordova, isWebApp, isAndroid, getAndroidSize } from '../../utils/cordovaUtils';
+import { chipLabelText, historyPush, isIOSAppOnMac, isCordova, isWebApp, isAndroid, getAndroidSize, isIPadGiantSize } from '../../utils/cordovaUtils';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
 import EditAddressOneHorizontalRow from '../../components/Ready/EditAddressOneHorizontalRow';
 import ElectionActions from '../../actions/ElectionActions';
@@ -1075,8 +1075,9 @@ class Ballot extends Component {
       }
     }
 
+    const twoColumnDisplay = isIOSAppOnMac() || isIPadGiantSize();
     // Undo the breakpoints/media queries
-    const leftColumnIOSAppOnMac = isIOSAppOnMac() ? {
+    const leftTwoColumnDisplay = twoColumnDisplay ? {
       flex: '0 0 75%',
       maxWidth: '75%',
       position: 'relative',
@@ -1086,7 +1087,7 @@ class Ballot extends Component {
     } : {};
 
     // Undo the breakpoints/media queries
-    const rightColumnIOSAppOnMac = isIOSAppOnMac() ? {
+    const rightTwoColumnDisplay = twoColumnDisplay ? {
       display: 'block !important',
       flex: '0 0 25%',
       maxWidth: '25%',
@@ -1312,7 +1313,7 @@ class Ballot extends Component {
             <Wrapper padTop={cordovaScrollablePaneTopPadding()} padBottom={padBallotWindowBottomForCordova} id="ballotWrapper">
               {emptyBallot}
               {/* eslint-disable-next-line no-nested-ternary */}
-              <div className={showBallotDecisionsTabs() ? 'row ballot__body' : isWebApp() || isIOSAppOnMac() ? 'row ballot__body__no-decision-tabs' : undefined}>
+              <div className={showBallotDecisionsTabs() ? 'row ballot__body' : isWebApp() || twoColumnDisplay ? 'row ballot__body__no-decision-tabs' : undefined}>
                 <BrowserPushMessage incomingProps={this.props} />
                 {ballotWithItemsFromCompletionFilterType.length > 0 ? (
                   <BallotStatusMessage
@@ -1320,7 +1321,7 @@ class Ballot extends Component {
                     googleCivicElectionId={this.state.googleCivicElectionId}
                   />
                 ) : null}
-                <div className={isIOSAppOnMac() ? '' : 'col-sm-12 col-lg-9'} id="ballotRoute-topOfBallot" style={leftColumnIOSAppOnMac}>
+                <div className={twoColumnDisplay ? '' : 'col-sm-12 col-lg-9'} id="ballotRoute-topOfBallot" style={leftTwoColumnDisplay}>
                   {(isSearching && searchText) && (
                     <SearchTitle>
                       Searching for &quot;
@@ -1441,7 +1442,7 @@ class Ballot extends Component {
                     </div>
                   </BallotListWrapper>
                   {/* Show links to this candidate in the admin tools */}
-                  { !isIOSAppOnMac() && (this.state.voter && sourcePollingLocationWeVoteId) && (this.state.voter.is_admin || this.state.voter.is_verified_volunteer) ? (
+                  { (!twoColumnDisplay) && (this.state.voter && sourcePollingLocationWeVoteId) && (this.state.voter.is_admin || this.state.voter.is_verified_volunteer) ? (
                     <span className="u-wrap-links d-print-none">
                       <span>Admin:</span>
                       <OpenExternalWebSite
@@ -1462,7 +1463,7 @@ class Ballot extends Component {
 
                 { ballotWithItemsFromCompletionFilterType.length === 0 ?
                   null : (
-                    <div className={isIOSAppOnMac() ? '' : 'col-lg-3 d-none d-lg-block sidebar-menu'} style={rightColumnIOSAppOnMac} id="rightColumnSidebar">
+                    <div className={twoColumnDisplay ? '' : 'col-lg-3 d-none d-lg-block sidebar-menu'} style={rightTwoColumnDisplay} id="rightColumnSidebar">
                       <BallotSideBar
                         activeRaceItem={raceLevelFilterType}
                         displayTitle

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -307,6 +307,7 @@ class Ballot extends Component {
 
     if (isIOSAppOnMac() && appleSiliconDebug) {
       dumpCssFromId('ballotWrapper');
+      dumpCssFromId('rightColumnSidebar');
     }
   }
 
@@ -1074,6 +1075,27 @@ class Ballot extends Component {
       }
     }
 
+    // Undo the breakpoints/media queries
+    const leftColumnIOSAppOnMac = isIOSAppOnMac() ? {
+      flex: '0 0 75%',
+      maxWidth: '75%',
+      position: 'relative',
+      // width: '100%',
+      paddingRight: '15px',
+      paddingLeft: '15px',
+    } : {};
+
+    // Undo the breakpoints/media queries
+    const rightColumnIOSAppOnMac = isIOSAppOnMac() ? {
+      display: 'block !important',
+      flex: '0 0 25%',
+      maxWidth: '25%',
+      position: 'relative',
+      // width: '100%',
+      paddingRight: '15px',
+      paddingLeft: '15px',
+    } : {};
+
     if (!ballotWithItemsFromCompletionFilterType) {
       return (
         <DelayedLoad showLoadingText waitBeforeShow={2000}>
@@ -1290,7 +1312,7 @@ class Ballot extends Component {
             <Wrapper padTop={cordovaScrollablePaneTopPadding()} padBottom={padBallotWindowBottomForCordova} id="ballotWrapper">
               {emptyBallot}
               {/* eslint-disable-next-line no-nested-ternary */}
-              <div className={showBallotDecisionsTabs() ? 'row ballot__body' : isWebApp() ? 'row ballot__body__no-decision-tabs' : undefined}>
+              <div className={showBallotDecisionsTabs() ? 'row ballot__body' : isWebApp() || isIOSAppOnMac() ? 'row ballot__body__no-decision-tabs' : undefined}>
                 <BrowserPushMessage incomingProps={this.props} />
                 {ballotWithItemsFromCompletionFilterType.length > 0 ? (
                   <BallotStatusMessage
@@ -1298,7 +1320,7 @@ class Ballot extends Component {
                     googleCivicElectionId={this.state.googleCivicElectionId}
                   />
                 ) : null}
-                <div className="col-sm-12 col-lg-9" id="ballotRoute-topOfBallot">
+                <div className={isIOSAppOnMac() ? '' : 'col-sm-12 col-lg-9'} id="ballotRoute-topOfBallot" style={leftColumnIOSAppOnMac}>
                   {(isSearching && searchText) && (
                     <SearchTitle>
                       Searching for &quot;
@@ -1419,7 +1441,7 @@ class Ballot extends Component {
                     </div>
                   </BallotListWrapper>
                   {/* Show links to this candidate in the admin tools */}
-                  { (this.state.voter && sourcePollingLocationWeVoteId) && (this.state.voter.is_admin || this.state.voter.is_verified_volunteer) ? (
+                  { !isIOSAppOnMac() && (this.state.voter && sourcePollingLocationWeVoteId) && (this.state.voter.is_admin || this.state.voter.is_verified_volunteer) ? (
                     <span className="u-wrap-links d-print-none">
                       <span>Admin:</span>
                       <OpenExternalWebSite
@@ -1440,7 +1462,7 @@ class Ballot extends Component {
 
                 { ballotWithItemsFromCompletionFilterType.length === 0 ?
                   null : (
-                    <div className="col-lg-3 d-none d-lg-block sidebar-menu">
+                    <div className={isIOSAppOnMac() ? '' : 'col-lg-3 d-none d-lg-block sidebar-menu'} style={rightColumnIOSAppOnMac} id="rightColumnSidebar">
                       <BallotSideBar
                         activeRaceItem={raceLevelFilterType}
                         displayTitle

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -14,6 +14,7 @@ import CandidateItem from '../../components/Ballot/CandidateItem';
 import ShareButtonDesktopTablet from '../../components/Share/ShareButtonDesktopTablet';
 import CandidateStickyHeader from '../../components/Ballot/CandidateStickyHeader';
 import CandidateStore from '../../stores/CandidateStore';
+import { isWebApp } from '../../utils/cordovaUtils';
 import { capitalizeString, convertToInteger } from '../../utils/textFormat';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
 import EndorsementCard from '../../components/Widgets/EndorsementCard';
@@ -299,7 +300,7 @@ class Candidate extends Component {
             <CandidateStickyHeader candidate={candidate} />
           )
         }
-        <div className="card">
+        <div className="card" style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
           <TwoColumns>
             <LeftColumnWrapper>
               <CandidateItem

--- a/src/js/routes/Ballot/Candidate.jsx
+++ b/src/js/routes/Ballot/Candidate.jsx
@@ -300,6 +300,7 @@ class Candidate extends Component {
             <CandidateStickyHeader candidate={candidate} />
           )
         }
+        {/* The following style adjustment prevents horizontal scrolling from the .card style */}
         <div className="card" style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
           <TwoColumns>
             <LeftColumnWrapper>

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -4,6 +4,7 @@ import Helmet from 'react-helmet';
 import styled from 'styled-components';
 import { withStyles } from '@material-ui/core/styles';
 import { Info } from '@material-ui/icons';
+import { isWebApp } from '../../utils/cordovaUtils';
 import { capitalizeString } from '../../utils/textFormat';
 import LoadingWheel from '../../components/LoadingWheel';
 import { renderLog } from '../../utils/logging';
@@ -284,7 +285,7 @@ class Measure extends Component {
             <MeasureStickyHeader measureWeVoteId={measure.we_vote_id} />
           )
         }
-        <div className="card">
+        <div className="card"  style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
           <TwoColumns>
             <LeftColumnWrapper>
               <MeasureItem measureWeVoteId={measure.we_vote_id} />

--- a/src/js/routes/Ballot/Measure.jsx
+++ b/src/js/routes/Ballot/Measure.jsx
@@ -285,7 +285,8 @@ class Measure extends Component {
             <MeasureStickyHeader measureWeVoteId={measure.we_vote_id} />
           )
         }
-        <div className="card"  style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
+        {/* The following style adjustment prevents horizontal scrolling from the .card style */}
+        <div className="card" style={isWebApp() ? {} : { marginRight: 0, marginLeft: 0 }}>
           <TwoColumns>
             <LeftColumnWrapper>
               <MeasureItem measureWeVoteId={measure.we_vote_id} />

--- a/src/js/routes/Ready.jsx
+++ b/src/js/routes/Ready.jsx
@@ -26,6 +26,7 @@ import ReadyTaskBallot from '../components/Ready/ReadyTaskBallot';
 import ReadyTaskFriends from '../components/Ready/ReadyTaskFriends';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
 import ReadyTaskRegister from '../components/Ready/ReadyTaskRegister';
+import ReadyInformationDisclaimer from '../components/Ready/ReadyInformationDisclaimer';
 import { renderLog } from '../utils/logging';
 import ShareButtonDesktopTablet from '../components/Share/ShareButtonDesktopTablet';
 import ValuesToFollowPreview from '../components/Values/ValuesToFollowPreview';
@@ -250,6 +251,7 @@ class Ready extends Component {
               <ReadyTaskPlan
                 arrowsOn
               />
+              <ReadyInformationDisclaimer />
               {voterIsSignedIn && (
                 <FirstAndLastNameRequiredAlert />
               )}

--- a/src/js/startCordova.js
+++ b/src/js/startCordova.js
@@ -1,5 +1,4 @@
 import TwitterSignIn from './components/Twitter/TwitterSignIn';
-import { dumpScreenAndDeviceFields } from './utils/appleSiliconUtils';
 import { getProcessorArchitecture, isIOSAppOnMac, isCordova, isIOS,
   prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from './utils/cordovaUtils';
 import VoterActions from './actions/VoterActions';
@@ -29,19 +28,22 @@ export function initializationForCordova () { // eslint-disable-line
 
   getProcessorArchitecture();
 
-  const { cordova: { getAppVersion: getVersionNumber } } = window;
-  getVersionNumber().then((version) => {
-    window.weVoteAppVersion = version;
-    return true;
-  });
-
-
-  if (isIOSAppOnMac()) {
-    dumpScreenAndDeviceFields();
+  try {
+    const { cordova: { getAppVersion: getVersionNumber } } = window;
+    getVersionNumber().then((version) => {
+      window.weVoteAppVersion = version;
+      return true;
+    });
+  } catch (err) {
+    console.log('ERROR unable to determine version number');
   }
 
+  // if (isIOSAppOnMac()) {
+  //   dumpScreenAndDeviceFields();
+  // }
+
   // Special keyboard handling for iOS
-  if (isIOS()) {
+  if (isIOS() && !isIOSAppOnMac) {
     // Unfortunately this event only works on iOS, but fortunately it is most needed on iOS
     window.addEventListener('keyboardWillShow', localPrepareForCordovaKeyboard);
     window.addEventListener('keyboardDidHide', localRestoreStylesAfterCordovaKeyboard);

--- a/src/js/utils/appleSiliconUtils.js
+++ b/src/js/utils/appleSiliconUtils.js
@@ -2,14 +2,19 @@
 import cookies from './cookies';
 
 export function dumpCssFromId (id) {
-  const el = document.getElementById(id);
-  const styles = window.getComputedStyle(el);
-  return Object.keys(styles).forEach((index) => {
-    const value = styles.getPropertyValue(index);
-    if (value !== null  && value.length > 0) {
-      console.log(`style dump for ${id} - ${index}: ${value}`);
-    }
-  }, {});
+  try {
+    const el = document.getElementById(id);
+    const styles = window.getComputedStyle(el);
+    return Object.keys(styles).forEach((index) => {
+      const value = styles.getPropertyValue(index);
+      if (value !== null && value.length > 0) {
+        console.log(`style dump for ${id} - ${index}: ${value}`);
+      }
+    }, {});
+  } catch (error) {
+    console.log('Error in dumpCssFromId for id: "', id, '" - ', error);
+    return {};
+  }
 }
 
 export function dumpCookies () {

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -302,7 +302,7 @@ export function cordovaTopHeaderTopMargin () {
         }
       } else if (hasIPhoneNotch()) {
         switch (page) {
-          case CordovaPageConstants.officeWild:      style.marginTop = '30px'; break;
+          case CordovaPageConstants.officeWild:      style.marginTop = '36px'; break;
           case CordovaPageConstants.measureWild:     style.marginTop = '34px'; break;
           case CordovaPageConstants.candidate:       style.marginTop = '35px'; break;
           case CordovaPageConstants.candidateWild:   style.marginTop = '33px'; break;
@@ -319,8 +319,9 @@ export function cordovaTopHeaderTopMargin () {
           case CordovaPageConstants.settingsNotifications: style.marginTop = '36px'; break;
           case CordovaPageConstants.settingsWild:          style.marginTop = '38px'; break;
           case CordovaPageConstants.voterGuideCreatorWild: style.marginTop = '38px'; break; // $headroom-wrapper-webapp__voter-guide-creator
-          case CordovaPageConstants.voterGuideWild:        style.marginTop = '38px'; break; // Any page with btcand or btmeas
+          case CordovaPageConstants.voterGuideWild:        style.marginTop = '38px'; break; // Any voter page with btcand or btmeas
           case CordovaPageConstants.twitterIdMFollowers:   style.marginTop = '37px'; break; // /*/m/friends, /*/m/following, /*/m/followers
+          case CordovaPageConstants.twitterInfoPage:       style.marginTop = '32px'; break; // A twitter page guess, that ends with 'btcand' 'btmeas' or'btdb'
           default:                                         style.marginTop = '16px'; break;
         }
       } else if (isIOSAppOnMac()) {

--- a/src/js/utils/cordovaScrollablePaneTopPadding.js
+++ b/src/js/utils/cordovaScrollablePaneTopPadding.js
@@ -64,6 +64,7 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.moreTerms:             return '40px';
         case CordovaPageConstants.moreTools:             return '44px';
         case CordovaPageConstants.officeWild:            return '84px';
+        case CordovaPageConstants.ready:                 return '52px';
         case CordovaPageConstants.settingsAccount:       return '71px';
         case CordovaPageConstants.settingsHamburger:     return '66px';
         case CordovaPageConstants.settingsNotifications: return '57px';
@@ -90,6 +91,7 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.moreTerms:             return '44px';
         case CordovaPageConstants.moreTools:             return '44px';
         case CordovaPageConstants.officeWild:            return '84px';
+        case CordovaPageConstants.ready:                 return '53px';
         case CordovaPageConstants.settingsAccount:       return '76px';
         case CordovaPageConstants.settingsHamburger:     return '60px';
         case CordovaPageConstants.settingsNotifications: return '62px';
@@ -100,7 +102,7 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.voterGuideWild:        return '51px';
         case CordovaPageConstants.welcomeWild:           return '22px';
         case CordovaPageConstants.wevoteintroWild:       return '18px';
-        default:                          return '0px';
+        default:                                         return '0px';
       }
     } else if (isIPhone6p1in()) {  // XR  and maybe iPhone 11
       cordovaOffsetLog(`cordovaScrollablePaneTopPadding: isIPhone6p1in, page: ${page}`);
@@ -117,18 +119,18 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.officeWild:            return '101px';
         case CordovaPageConstants.opinions:              return '10px';
         case CordovaPageConstants.opinionsPubFigs:       return '25px';
-        case CordovaPageConstants.ready:                 return '24px';
+        case CordovaPageConstants.ready:                 return '74px';
         case CordovaPageConstants.settingsAccount:       return '81px';
         case CordovaPageConstants.settingsHamburger:     return '90px';
         case CordovaPageConstants.settingsNotifications: return '79px';
         case CordovaPageConstants.settingsWild:          return '89px';
         case CordovaPageConstants.twitterSignIn:         return '50px';
         case CordovaPageConstants.values:                return '25px';
-        case CordovaPageConstants.voterGuideWild:        return '74px';
         case CordovaPageConstants.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
+        case CordovaPageConstants.voterGuideWild:        return '74px';
         case CordovaPageConstants.welcomeWild:           return '22px';
         case CordovaPageConstants.wevoteintroWild:       return '32px';
-        default:                          return '0px';
+        default:                                         return '0px';
       }
     } else if (isIPhone6p5in()) {
       cordovaOffsetLog(`cordovaScrollablePaneTopPadding: isIPhone6p5in, page: ${page}`);
@@ -143,7 +145,7 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.moreTerms:             return '0px';
         case CordovaPageConstants.moreTools:             return '44px';
         case CordovaPageConstants.officeWild:            return '76px';
-        case CordovaPageConstants.ready:                 return '7px';
+        case CordovaPageConstants.ready:                 return '57px';
         case CordovaPageConstants.settingsAccount:       return '84px';
         case CordovaPageConstants.settingsHamburger:     return '81px';
         case CordovaPageConstants.settingsNotifications: return '79px';
@@ -152,39 +154,41 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.settingsWild:          return '63px';
         case CordovaPageConstants.twitterSignIn:         return '50px';
         case CordovaPageConstants.values:                return '3px';
-        case CordovaPageConstants.voterGuideWild:        return '59px';
         case CordovaPageConstants.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
+        case CordovaPageConstants.voterGuideWild:        return '59px';
         case CordovaPageConstants.welcomeWild:           return '22px';
         case CordovaPageConstants.wevoteintroWild:       return '32px';
-        default:                          return '0px';
+        default:                                         return '0px';
       }
-    } else if (hasIPhoneNotch()) {  // defaults for X or 11 Pro
+    } else if (hasIPhoneNotch()) {  // defaults for X or 11 Pro (5.8")
       cordovaOffsetLog(`cordovaScrollablePaneTopPadding: hasIPhoneNotch -- signed in: ${isSignedIn}  page: ${page}`);
       switch (page) {
-        case CordovaPageConstants.wevoteintroWild:       return '32px';
-        case CordovaPageConstants.measureWild:           return '72px';
+        case CordovaPageConstants.ballotLgHdrWild:       return showBallotDecisionsTabs() ? '58px' : '42px';
+        case CordovaPageConstants.ballotSmHdrWild:       return '163px';
+        case CordovaPageConstants.ballotVote:            return '162px';
         case CordovaPageConstants.candidate:             return '66px';
         case CordovaPageConstants.candidateWild:         return '69px';
-        case CordovaPageConstants.opinions:              return '24px';
-        case CordovaPageConstants.officeWild:            return '96px';
-        case CordovaPageConstants.ballotVote:            return '162px';
-        case CordovaPageConstants.ballotSmHdrWild:       return '163px';
-        case CordovaPageConstants.ballotLgHdrWild:       return showBallotDecisionsTabs() ? '58px' : '42px';
+        case CordovaPageConstants.measureWild:           return '72px';
         case CordovaPageConstants.moreAbout:             return '22px';
-        case CordovaPageConstants.settingsAccount:       return '81px';
-        case CordovaPageConstants.settingsNotifications: return '82px';
-        case CordovaPageConstants.values:                return '21px';
         case CordovaPageConstants.moreTerms:             return '60px';
-        case CordovaPageConstants.voterGuideWild:        return '75px'; // See cordovaVoterGuideTopPadding instead
-        case CordovaPageConstants.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
-        case CordovaPageConstants.welcomeWild:           return '22px';
-        case CordovaPageConstants.settingsHamburger:     return '35px';
         case CordovaPageConstants.moreTools:             return '44px';
+        case CordovaPageConstants.officeWild:            return '96px';
+        case CordovaPageConstants.opinions:              return '24px';
+        case CordovaPageConstants.opinionsPubFigs:       return '21px';
+        case CordovaPageConstants.ready:                 return '73px';
+        case CordovaPageConstants.settingsAccount:       return '81px';
+        case CordovaPageConstants.settingsHamburger:     return '35px';
+        case CordovaPageConstants.settingsNotifications: return '82px';
         case CordovaPageConstants.settingsSubscription:  return '87px';
         case CordovaPageConstants.settingsVoterGuideLst: return '72px';
         case CordovaPageConstants.settingsWild:          return '67px';
-        case CordovaPageConstants.ready:                 return '35px';
-        default:                          return '0px';
+        case CordovaPageConstants.twitterSignIn:         return '50px';
+        case CordovaPageConstants.values:                return '21px';
+        case CordovaPageConstants.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide
+        case CordovaPageConstants.voterGuideWild:        return '75px'; // See cordovaVoterGuideTopPadding instead
+        case CordovaPageConstants.welcomeWild:           return '22px';
+        case CordovaPageConstants.wevoteintroWild:       return '32px';
+        default:                                         return '0px';
       }
     } else if (isIOSAppOnMac()) {
       cordovaOffsetLog(`cordovaScrollablePaneTopPadding: is Apple Silicon ARM64, page: ${page}`);
@@ -211,13 +215,13 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.voterGuideWild:        return '47px';  // tested 10/1/20
         case CordovaPageConstants.welcomeWild:           return '0px';
         case CordovaPageConstants.wevoteintroWild:       return '18px';
-        default:                          return '0px';
+        default:                                         return '0px';
       }
     } else if (isIPad()) {
       cordovaOffsetLog(`cordovaScrollablePaneTopPadding: is IPad, page: ${page}`);
       switch (page) {
-        case CordovaPageConstants.ballotLgHdrWild:       return '86px';
-        case CordovaPageConstants.ballotSmHdrWild:       return '165px';
+        case CordovaPageConstants.ballotLgHdrWild:       return '67px';
+        case CordovaPageConstants.ballotSmHdrWild:       return '67px';
         case CordovaPageConstants.ballotVote:            return '131px';
         case CordovaPageConstants.candidate:             return '40px';
         case CordovaPageConstants.candidateWild:         return '65px';
@@ -229,12 +233,13 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.officeWild:            return '106px';
         case CordovaPageConstants.opinions:              return '14px';
         case CordovaPageConstants.opinionsPubFigs:       return '15px';
-        case CordovaPageConstants.ready:                 return '24px';
+        case CordovaPageConstants.ready:                 return '62px';
         case CordovaPageConstants.settingsAccount:       return '85px';
         case CordovaPageConstants.settingsHamburger:     return '75px';
         case CordovaPageConstants.settingsNotifications: return '83px';
         case CordovaPageConstants.settingsSubscription:  return '87px';
         case CordovaPageConstants.settingsWild:          return '61px';
+        case CordovaPageConstants.twitterSignIn:         return '50px';
         case CordovaPageConstants.values:                return '13px';
         case CordovaPageConstants.valuesList:            return '38px';
         case CordovaPageConstants.voterGuideCreatorWild: return '10px'; // $headroom-wrapper-webapp__voter-guide

--- a/src/js/utils/cordovaScrollablePaneTopPadding.js
+++ b/src/js/utils/cordovaScrollablePaneTopPadding.js
@@ -189,8 +189,8 @@ export default function cordovaScrollablePaneTopPadding () {
     } else if (isIOSAppOnMac()) {
       cordovaOffsetLog(`cordovaScrollablePaneTopPadding: is Apple Silicon ARM64, page: ${page}`);
       switch (page) {
-        case CordovaPageConstants.ballotLgHdrWild:       return '34px';  // tested 9/30/20
-        case CordovaPageConstants.ballotSmHdrWild:       return '134px'; // tested 10/2/20
+        case CordovaPageConstants.ballotLgHdrWild:       return '34px';  // tested 11/3/20
+        case CordovaPageConstants.ballotSmHdrWild:       return '34px';  // tested 11/2/20
         case CordovaPageConstants.ballotVote:            return '131px';
         case CordovaPageConstants.candidate:             return '40px';
         case CordovaPageConstants.candidateWild:         return '49px';  // tested 10/2/20
@@ -201,7 +201,7 @@ export default function cordovaScrollablePaneTopPadding () {
         case CordovaPageConstants.news:                  return '9px';   // tested 9/30/20
         case CordovaPageConstants.officeWild:            return '106px';
         case CordovaPageConstants.opinions:              return '14px';
-        case CordovaPageConstants.ready:                 return '0px';   // tested 9/30/20
+        case CordovaPageConstants.ready:                 return '50px';   // tested 11/3/20
         case CordovaPageConstants.settingsAccount:       return '85px';
         case CordovaPageConstants.settingsHamburger:     return '45px';  // tested 10/1/20
         case CordovaPageConstants.settingsNotifications: return '67px';  // tested 9/30/20

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -309,6 +309,23 @@ export function isIPad () {
   return false;
 }
 
+export function isIPadGiantSize () {
+  if (!isIPad()) {
+    return false;
+  }
+  const ratio = window.devicePixelRatio || 1;
+  const screen = {
+    width: window.screen.width * ratio,
+    height: window.screen.height * ratio,
+  };
+  if (screen.width === 2048 && screen.height === 2732) { // iPad Pro 12.9" Gen 2, 2018
+    logMatch('iPadGiantSize', true);
+    return true;
+  }
+  return false;
+}
+
+
 export function hasIPhoneNotch () {
   return isIPhone5p8in() || isIPhone6p1in() || isIPhone6p5in();
 }

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { browserHistory, hashHistory } from 'react-router';
 import webAppConfig from '../config';
 import { cordovaOffsetLog, oAuthLog } from './logging';
+import { dumpObjProps } from './appleSiliconUtils';
+
 
 /* global $  */
 
@@ -44,6 +46,11 @@ export function getProcessorArchitecture () {
   });
 }
 
+export function dumpScreenAndDeviceFields () {
+  dumpObjProps('window.screen', window.screen);
+  dumpObjProps('window.device', window.device);
+}
+
 export function isAndroid () {
   if (isWebApp()) return false;
   const { platform } = window.device || '';
@@ -75,6 +82,7 @@ export function cordovaDot (path) {
 }
 
 export function cordovaOpenSafariViewSub (requestURL, onExit) {
+  //  console.log(`cordovaOpenSafariView -0000- requestURL: ${requestURL}`);
   if (isIOS()) {
     console.log(`cordovaOpenSafariView -1- requestURL: ${requestURL}`);
     SafariViewController.isAvailable(() => { // eslint-disable-line no-undef
@@ -510,7 +518,7 @@ export function getCordovaScreenHeight () {
 }
 
 export function prepareForCordovaKeyboard (callerString) {
-  if (callerString && isCordova()) {
+  if (callerString && isCordova() && !isIOSAppOnMac()) {
     const fileName = callerString.substr(callerString.lastIndexOf('/') + 1);
     console.log(`prepareForCordovaKeyboard ^^^^^^^^^^ ${fileName}`);
     cordovaOffsetLog(`prepareForCordovaKeyboard ^^^^^^^^^^ ${fileName}`);
@@ -521,7 +529,7 @@ export function prepareForCordovaKeyboard (callerString) {
 }
 
 export function restoreStylesAfterCordovaKeyboard (callerString) {
-  if (callerString && isCordova()) {
+  if (callerString && isCordova() && !isIOSAppOnMac()) {
     const fileName = callerString.substr(callerString.lastIndexOf('/') + 1);
     cordovaOffsetLog(`restoreStylesAfterCordovaKeyboard vvvvvvvvvv ${fileName}`);
     $('#app').removeClass('app-wrapper__cordova').addClass('app-wrapper');

--- a/src/js/utils/cordovaUtilsPageEnumeration.js
+++ b/src/js/utils/cordovaUtilsPageEnumeration.js
@@ -87,6 +87,11 @@ export function pageEnumeration () {
     return CordovaPageConstants.news;
   } else if (href.indexOf('/m/followers') > 0 || href.indexOf('/m/friends') > 0 || href.indexOf('/m/following') > 0) {
     return CordovaPageConstants.twitterIdMFollowers;
+  } else if (stringContains('/index.html#/', href) && (
+    stringContains('btcand', href) ||
+    stringContains('btmeas', href) ||
+    stringContains('/btdb', href))) {
+    return CordovaPageConstants.twitterInfoPage;
   }
   return CordovaPageConstants.defaultVal;
 }


### PR DESCRIPTION
Made the two columns on Ballot (in roughly iPad aspect on Apple Silicon), side-by-side.  Same for News/Discussion for Apple Silicon and iPads.
Cleaned out experimental code.
Made two util functions crash proof, in case their Cordova package dependencies did not load correctly.
No need to deal with the virtual keyboard if Apple Silicon, since there isn't one.
A complete test round, and margin adjustments for iOS.
Fixed horizontal scrolling in four places:  IssueCard, CandidateForDrawer (card), Candidate (card), and Measure (card).
Added a ReadyInformationDisclaimer tab for Cordova, specifically for Googles concerns about our Android app.