### PR TITLE
Ready page data source information disclosure for Android

### DIFF
--- a/src/js/components/Ready/ReadyInformationDisclaimer.jsx
+++ b/src/js/components/Ready/ReadyInformationDisclaimer.jsx
@@ -1,7 +1,8 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, OverlayTrigger } from 'react-bootstrap';
 import Popover from 'react-bootstrap/Popover';
-import { isWebApp } from '../../utils/cordovaUtils';
+import { isAndroid, isIOS, isWebApp } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 
 class ReadyInformationDisclaimer extends React.Component {
@@ -14,14 +15,16 @@ class ReadyInformationDisclaimer extends React.Component {
       boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12)',
       display: 'flex',
       flexDirection: 'column',
-      margin: '16px -16px 16px -16px',
+      // margin: '16px -16px 16px -16px',
       minWidth: 0,
       padding: '18px 16px 18px 16px',
       position: 'relative',
       wordWrap: 'break-word',
     };
 
-    if (isWebApp()) {
+    const { top, bottom } = this.props;
+
+    if (isWebApp() || (isAndroid() && bottom)  || (isIOS() && top)) {
       return null;
     }
     return (
@@ -75,5 +78,9 @@ class ReadyInformationDisclaimer extends React.Component {
     );
   }
 }
+ReadyInformationDisclaimer.propTypes = {
+  bottom: PropTypes.bool,
+  top: PropTypes.bool,
+};
 
 export default ReadyInformationDisclaimer;

--- a/src/js/routes/Ready.jsx
+++ b/src/js/routes/Ready.jsx
@@ -68,7 +68,8 @@ class Ready extends Component {
     ActivityActions.activityNoticeListRetrieve();
     FriendActions.suggestedFriendList();
 
-    const modalToOpen = this.props.params.modal_to_show || '';
+    let { modalToOpen } = this.props.params;
+    modalToOpen = modalToOpen || '';
     // console.log('componentDidMount modalToOpen:', modalToOpen);
     if (modalToOpen === 'share') {
       this.modalOpenTimer = setTimeout(() => {
@@ -203,6 +204,7 @@ class Ready extends Component {
                   </div>
                 </Card>
               )}
+              <ReadyInformationDisclaimer top />
               <ReadyTaskBallot
                 arrowsOn
               />
@@ -251,7 +253,7 @@ class Ready extends Component {
               <ReadyTaskPlan
                 arrowsOn
               />
-              <ReadyInformationDisclaimer />
+              <ReadyInformationDisclaimer bottom />
               {voterIsSignedIn && (
                 <FirstAndLastNameRequiredAlert />
               )}


### PR DESCRIPTION
Moved the Data disclosure pane to the bottom for iOS, and left it higher for Android approval.
(We did get approved by Google with this change in place.)

