### PR TITLE
Now capture the react-router-dom history object in global.weVoteGlobalHistory, no need to pass history everywhere we need to do a pushHistory

### DIFF
--- a/src/js/Application.jsx
+++ b/src/js/Application.jsx
@@ -6,7 +6,7 @@ import AppActions from './actions/AppActions';
 import AppStore from './stores/AppStore';
 import { getApplicationViewBooleans, setZenDeskHelpVisibility } from './utils/applicationUtils';
 import cookies from './utils/cookies';
-import { getToastClass, historyPushV5, isIOSAppOnMac, isCordova, isWebApp } from './utils/cordovaUtils';
+import { getToastClass, historyPush, isIOSAppOnMac, isCordova, isWebApp } from './utils/cordovaUtils';
 import { cordovaContainerMainOverride, cordovaVoterGuideTopPadding } from './utils/cordovaOffsets';
 import cordovaScrollablePaneTopPadding from './utils/cordovaScrollablePaneTopPadding';
 import DelayedLoad from './components/Widgets/DelayedLoad';
@@ -39,7 +39,7 @@ class Application extends Component {
   componentDidMount () {
     const voterDeviceId = VoterStore.voterDeviceId();
     VoterActions.voterRetrieve();
-    // console.log('===== VoterRetrieve from Application, voterDeviceId:', voterDeviceId);
+    console.log('===== VoterRetrieve from Application, voterDeviceId:', voterDeviceId);
 
     let { hostname } = window.location;
     hostname = hostname || '';
@@ -205,7 +205,6 @@ class Application extends Component {
   incomingVariableManagement () {
     console.log('Application, incomingVariableManagement, this.props.location.query: ', this.props.location.query);
     const { location: { pathname, query } } = window;
-    const { history } = this.props;
     if (query) {
       // Cookie needs to expire in One day i.e. 24*60*60 = 86400
       let atLeastOneQueryVariableFound = false;
@@ -262,9 +261,11 @@ class Application extends Component {
         }
 
         if (atLeastOneQueryVariableFound && pathname) {
-          // console.log('atLeastOneQueryVariableFound push: ', atLeastOneQueryVariableFound);
-          // console.log('pathname: ', pathname);
-          historyPushV5(history, pathname);
+          console.log('atLeastOneQueryVariableFound push: ', atLeastOneQueryVariableFound);
+          console.log('pathname: ', pathname);
+          historyPush(pathname);
+        } else {
+          console.log('atLeastOneQueryVariableFound NO NO NO push no query vars found: ');
         }
       }
     }
@@ -273,7 +274,7 @@ class Application extends Component {
   render () {
     renderLog('Application');  // Set LOG_RENDER_EVENTS to log all renders
     const { location: { pathname } } = window;
-    const { history, params } = this.props;
+    const { params } = this.props;
 
     const { StripeCheckout } = window;
     const waitForStripe = (String(pathname) === '/more/donate' && StripeCheckout === undefined);
@@ -356,7 +357,7 @@ class Application extends Component {
       return (
         <div className={this.getAppBaseClass()} id="app-base-id">
           <ToastContainer closeButton={false} className={getToastClass()} />
-          <Header params={params} pathname={pathname} history={history} />
+          <Header params={params} pathname={pathname} />
           <SnackNotifier />
           <Wrapper id="voterGuideModes" padTop={cordovaVoterGuideTopPadding()}>
             <div className="page-content-container">
@@ -380,7 +381,7 @@ class Application extends Component {
       return (
         <div className={this.getAppBaseClass()} id="app-base-id">
           <ToastContainer closeButton={false} className={getToastClass()} />
-          <Header params={params} pathname={pathname} history={history} />
+          <Header params={params} pathname={pathname} />
           <SnackNotifier />
           <Wrapper id="settings" padTop={cordovaScrollablePaneTopPadding()}>
             <div className="page-content-container">
@@ -405,7 +406,7 @@ class Application extends Component {
     return (
       <div className={this.getAppBaseClass()} id="app-base-id">
         <ToastContainer closeButton={false} className={getToastClass()} />
-        <Header params={params} pathname={pathname} history={history} />
+        <Header params={params} pathname={pathname} />
         <SnackNotifier />
         { typeof pathname !== 'undefined' && pathname &&
           (String(pathname) === '/for-campaigns' ||
@@ -447,7 +448,6 @@ class Application extends Component {
 }
 Application.propTypes = {
   children: PropTypes.object,
-  history: PropTypes.object,
   location: PropTypes.object,
   params: PropTypes.object,
 };

--- a/src/js/Root.jsx
+++ b/src/js/Root.jsx
@@ -88,13 +88,15 @@ polyfillFixes('Root.jsx');
 // See /js/components/Navigation/HeaderBar.jsx for show_full_navigation cookie
 // const ballotHasBeenVisited = cookies.getItem('ballot_has_been_visited');
 const firstVisit = !cookies.getItem('voter_device_id');
-const { history } = window;
+// const { history } = window;
+// const history = useHistory();
+// const history = global.weVoteGlobalHistory;
 let { hostname } = window.location;
 hostname = hostname || '';
 const weVoteSites = ['wevote.us', 'quality.wevote.us', 'localhost', 'silicon', ''];   // localhost on Cordova is a ''
 const isWeVoteMarketingSite = weVoteSites.includes(String(hostname));
 const isNotWeVoteMarketingSite = !isWeVoteMarketingSite;
-const bcand3TermRegex = '/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable($)?';
+// const bcand3TermRegex = '/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable($)?';
 /* eslint-disable react/jsx-props-no-spreading */
 const routes = () => {
   // console.log('window.innerWidth:', window.innerWidth);
@@ -115,7 +117,7 @@ const routes = () => {
       {/* </Suspense> */}
       <Suspense fallback={<div>Loading...</div>}>
         {/* <Route path="/settings/notifications/esk/:email_subscription_secret_key" component={componentLoader('SettingsNotificationsUnsubscribe')} /> */}
-        <Application history={history} location={window.location}>
+        <Application location={window.location}>
           {/* <Route component={({ match }) => { */}
           <Switch>
             {/* <Route component={componentLoader('Intro')} /> */}
@@ -350,7 +352,7 @@ const routes = () => {
             <Route path=":twitter_handle/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
             <Route path=":twitter_handle/:action_variable" component={TwitterHandleLanding} />
             {/* Next line handles: ":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable" */}
-            <Route path={bcand3TermRegex} component={TwitterHandleLanding} />
+            <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable($)?" component={TwitterHandleLanding} />
             <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
             <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
             <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show" component={TwitterHandleLanding} />
@@ -381,7 +383,7 @@ const routes = () => {
             <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
             <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
             <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
-            <Route path=":twitter_handle" component={TwitterHandleLanding} />
+            <Route path=":twitter_handle($)?" component={TwitterHandleLanding} />
             <Route path=":twitter_handle/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
             <Route path=":twitter_handle/modal/:modal_to_show" component={TwitterHandleLanding} />
             <Route path="*" component={PageNotFound} />

--- a/src/js/WeVoteRouter.jsx
+++ b/src/js/WeVoteRouter.jsx
@@ -26,10 +26,10 @@ import webAppConfig from './config';
 
 // Possible: https://stackoverflow.com/questions/59402649/how-can-i-use-history-pushpath-in-react-router-5-1-2-in-stateful-component
 // Possible: https://stackoverflow.com/questions/63400050/refactoring-react-class-to-hooks-entity-update-component
-
 export default class WeVoteRouter extends BrowserRouter {
   constructor (props) {
     super(props);
+    global.weVoteGlobalHistory = this.history;
     if (webAppConfig.LOG_ROUTING) {
       console.log('Router: initial history is: ', JSON.stringify(this.history, null, 2));
       this.history.listen((location, action) => {

--- a/src/js/components/Ballot/BallotItemCompressed.jsx
+++ b/src/js/components/Ballot/BallotItemCompressed.jsx
@@ -7,7 +7,7 @@ import OfficeItemCompressed from './OfficeItemCompressed';
 export default class BallotItemCompressed extends PureComponent {
   render () {
     renderLog('BallotItemCompressed');  // Set LOG_RENDER_EVENTS to log all renders
-    const { history, isMeasure, weVoteId, ballotItemDisplayName, candidateList, candidatesToShowForSearchResults } = this.props;
+    const { isMeasure, weVoteId, ballotItemDisplayName, candidateList, candidatesToShowForSearchResults } = this.props;
     return (
       <div className="BallotItem card" id={weVoteId}>
         { isMeasure ? (
@@ -20,7 +20,6 @@ export default class BallotItemCompressed extends PureComponent {
             ballotItemDisplayName={ballotItemDisplayName}
             candidateList={candidateList}
             candidatesToShowForSearchResults={candidatesToShowForSearchResults}
-            history={history}
           />
         )}
       </div>
@@ -33,5 +32,4 @@ BallotItemCompressed.propTypes = {
   candidatesToShowForSearchResults: PropTypes.array,
   weVoteId: PropTypes.string.isRequired,
   isMeasure: PropTypes.bool,
-  history: PropTypes.object,
 };

--- a/src/js/components/Ballot/CandidateItemCompressed.jsx
+++ b/src/js/components/Ballot/CandidateItemCompressed.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import TextTruncate from 'react-text-truncate';
 import BallotItemSupportOpposeCountDisplay from '../Widgets/BallotItemSupportOpposeCountDisplay';
@@ -11,6 +10,7 @@ import { renderLog } from '../../utils/logging';
 import OrganizationStore from '../../stores/OrganizationStore';
 import SupportStore from '../../stores/SupportStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
+import LinkWithPushHistory from '../Navigation/LinkWithPushHistory';
 
 export default class CandidateItemCompressed extends Component {
   constructor (props) {
@@ -119,26 +119,32 @@ export default class CandidateItemCompressed extends Component {
         </div>
         <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">
           {/* Candidate Photo, only shown in Desktop */}
-          <Link to={this.getCandidateLink(this.state.oneCandidate.we_vote_id)}>
-            <ImageHandler
-              className={avatarCompressed}
-              sizeClassName="icon-candidate-small u-push--sm "
-              imageUrl={this.state.oneCandidate.candidate_photo_url_medium}
-              alt="candidate-photo"
-              kind_of_ballot_item="CANDIDATE"
-            />
-          </Link>
+          <LinkWithPushHistory
+            to={this.getCandidateLink(this.state.oneCandidate.we_vote_id)}
+            childMarkup={(
+              <ImageHandler
+                className={avatarCompressed}
+                sizeClassName="icon-candidate-small u-push--sm "
+                imageUrl={this.state.oneCandidate.candidate_photo_url_medium}
+                alt="candidate-photo"
+                kind_of_ballot_item="CANDIDATE"
+              />
+            )}
+          />
           <div className="o-media-object__body u-flex u-flex-column u-flex-auto u-justify-between">
             {/* Candidate Name */}
             <h4 className="card-main__candidate-name u-f5">
-              <Link to={this.getCandidateLink(this.state.oneCandidate.we_vote_id)}>
-                <TextTruncate
-                  line={1}
-                  truncateText="…"
-                  text={this.state.oneCandidate.ballot_item_display_name}
-                  textTruncateChild={null}
-                />
-              </Link>
+              <LinkWithPushHistory
+                to={this.getCandidateLink(this.state.oneCandidate.we_vote_id)}
+                childMarkup={(
+                  <TextTruncate
+                    line={1}
+                    truncateText="…"
+                    text={this.state.oneCandidate.ballot_item_display_name}
+                    textTruncateChild={null}
+                  />
+                )}
+              />
             </h4>
             {/* Description under candidate name */}
             <LearnMore

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import { ArrowForward } from '@material-ui/icons';
 import { Button } from '@material-ui/core';
+import LinkWithPushHistory from '../Navigation/LinkWithPushHistory';
 import BallotItemSupportOpposeCountDisplay from '../Widgets/BallotItemSupportOpposeCountDisplay';
 import BallotStore from '../../stores/BallotStore';
 import CandidateStore from '../../stores/CandidateStore';
@@ -15,7 +15,7 @@ import OfficeActions from '../../actions/OfficeActions';
 import ShowMoreFooter from '../Navigation/ShowMoreFooter';
 import SupportStore from '../../stores/SupportStore';
 import TopCommentByBallotItem from '../Widgets/TopCommentByBallotItem';
-import { historyPushV5, isCordova } from '../../utils/cordovaUtils';
+import { historyPush, isCordova } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import { sortCandidateList } from '../../utils/positionFunctions';
 import { arrayContains, toTitleCase } from '../../utils/textFormat';
@@ -211,15 +211,13 @@ class OfficeItemCompressed extends Component {
   }
 
   goToCandidateLink (candidateWeVoteId) {
-    const { history } = this.props;
     const candidateLink = this.getCandidateLink(candidateWeVoteId);
-    historyPushV5(history, candidateLink);
+    historyPush(candidateLink);
   }
 
   goToOfficeLink () {
     const officeLink = this.getOfficeLink();
-    const { history } = this.props;
-    historyPushV5(history, officeLink);
+    historyPush(officeLink);
   }
 
   generateCandidates () {
@@ -365,14 +363,18 @@ class OfficeItemCompressed extends Component {
           name={officeWeVoteId}
         />
         {/* Desktop */}
-        <Link id={`officeItemCompressedTopNameLink-${officeWeVoteId}`} to={this.getOfficeLink()}>
-          <Title>
-            {ballotItemDisplayName}
-            <ArrowForward
-              classes={{ root: classes.cardHeaderIconRoot }}
-            />
-          </Title>
-        </Link>
+        <LinkWithPushHistory
+          id={`officeItemCompressedTopNameLink-${officeWeVoteId}`}
+          to={this.getOfficeLink()}
+          childMarkup={(
+            <Title>
+              {ballotItemDisplayName}
+              <ArrowForward
+                classes={{ root: classes.cardHeaderIconRoot }}
+              />
+            </Title>
+          )}
+        />
         {/* *************************
           Display either a) the candidates the voter supports, or b) the first several candidates running for this office
           ************************* */}

--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -6,7 +6,7 @@ import VoterStore from '../../stores/VoterStore';
 import { dumpCssFromId } from '../../utils/appleSiliconUtils';
 import { getApplicationViewBooleans, weVoteBrandingOff } from '../../utils/applicationUtils';
 import { cordovaTopHeaderTopMargin } from '../../utils/cordovaOffsets';
-import { hasIPhoneNotch, historyPushV5, isCordova, isIOS, isIOSAppOnMac, isIPad, isWebApp } from '../../utils/cordovaUtils';
+import { hasIPhoneNotch, historyPush, isCordova, isIOS, isIOSAppOnMac, isIPad, isWebApp } from '../../utils/cordovaUtils';
 import displayFriendsTabs from '../../utils/displayFriendsTabs';
 import { renderLog } from '../../utils/logging';
 import { startsWith, stringContains } from '../../utils/textFormat';
@@ -51,6 +51,7 @@ export default class Header extends Component {
   }
 
   shouldComponentUpdate (nextProps, nextState) {
+    console.log('HEADER shouldComponentUpdate ===================================');
     const { location: { pathname } } = window;
     if (this.state.activityTidbitWeVoteIdForDrawer !== nextState.activityTidbitWeVoteIdForDrawer) return true;
     if (this.state.organizationModalBallotItemWeVoteId !== nextState.organizationModalBallotItemWeVoteId) return true;
@@ -113,16 +114,15 @@ export default class Header extends Component {
     const { location: { pathname } } = window;
     if (stringContains('/modal/sic/', pathname)) {
       const pathnameWithoutModalSharedItem = pathname.substring(0, pathname.indexOf('/modal/sic/'));
-      const { history } = this.props;
-      historyPushV5(history, pathnameWithoutModalSharedItem);
+      historyPush(pathnameWithoutModalSharedItem);
     }
   }
 
   render () {
     renderLog('Header');  // Set LOG_RENDER_EVENTS to log all renders
 
-    const { history, params } = this.props;
-    console.log('Header props', this.props);
+    const { params } = this.props;
+    console.log('Header global.weVoteGlobalHistory', global.weVoteGlobalHistory);
     const { location: { pathname } } = window;
     const {
       activityTidbitWeVoteIdForDrawer, sharedItemCode, showActivityTidbitDrawer,
@@ -164,9 +164,9 @@ export default class Header extends Component {
       if (showBackToVoterGuide) {
         const backToVoterGuideLinkDesktop = pathname.substring(0, pathname.indexOf('/m/')); // Remove the "/m/followers", "/m/following", or "/m/friends" from the end of the string
         // console.log('pathname:', pathname, ', backToVoterGuideLinkDesktop:', backToVoterGuideLinkDesktop);
-        headerBarObject = <HeaderBackTo backToLink={backToVoterGuideLinkDesktop} backToLinkText="Back" history={history} />;
+        headerBarObject = <HeaderBackTo backToLink={backToVoterGuideLinkDesktop} backToLinkText="Back" />;
       } else if (showBackToBallotHeader) {
-        headerBarObject = <HeaderBackToBallot params={params} history={history} />;
+        headerBarObject = <HeaderBackToBallot params={params} />;
       } else if (showBackToVoterGuides) {
         headerBarObject = <HeaderBackToVoterGuides params={params} />;
       } else {
@@ -226,7 +226,7 @@ export default class Header extends Component {
               { showBackToSettingsDesktop && (
                 <span>
                   <span className="u-show-desktop-tablet">
-                    <HeaderBackTo backToLink={backToSettingsLinkDesktop} backToLinkText={backToSettingsLinkText} history={history} />
+                    <HeaderBackTo backToLink={backToSettingsLinkDesktop} backToLinkText={backToSettingsLinkText} />
                   </span>
                   { !showBackToVoterGuides && !showBackToSettingsMobile && (
                     <span className="u-show-mobile">
@@ -241,7 +241,6 @@ export default class Header extends Component {
                     <HeaderBackTo
                       backToLink={backToSettingsLinkMobile}
                       backToLinkText={backToSettingsLinkText}
-                      history={history}
                     />
                   </span>
                   { isWebApp() && !showBackToVoterGuides && !showBackToSettingsDesktop && (
@@ -303,7 +302,7 @@ export default class Header extends Component {
           <div className={isWebApp ? 'headroom-wrapper-webapp__default' : ''} id="headroom-wrapper">
             <div className={pageHeaderClasses} style={cordovaTopHeaderTopMargin()} id="header-container">
               { showBackToValues ?
-                <HeaderBackTo backToLink={backToValuesLink} backToLinkText={backToValuesLinkText} history={history} /> :
+                <HeaderBackTo backToLink={backToValuesLink} backToLinkText={backToValuesLinkText} /> :
                 <HeaderBar />}
             </div>
           </div>
@@ -348,7 +347,7 @@ export default class Header extends Component {
           <div className={isWebApp ? 'headroom-wrapper-webapp__default' : ''} id="headroom-wrapper">
             <div className={pageHeaderClasses} style={cordovaTopHeaderTopMargin()} id="header-container">
               { showBackToFriends ?
-                <HeaderBackTo backToLink={backToFriendsLink} backToLinkText={backToFriendsLinkText} history={history} /> :
+                <HeaderBackTo backToLink={backToFriendsLink} backToLinkText={backToFriendsLinkText} /> :
                 <HeaderBar />}
             </div>
           </div>
@@ -417,7 +416,7 @@ export default class Header extends Component {
           >
             <div className={pageHeaderClasses} style={cordovaTopHeaderTopMargin()} id="header-container">
               { showBackToBallotHeader ?
-                <HeaderBackToBallot params={params} history={history} /> :
+                <HeaderBackToBallot params={params} /> :
                 <HeaderBar />}
             </div>
           </div>
@@ -466,5 +465,4 @@ export default class Header extends Component {
 Header.propTypes = {
   params: PropTypes.object,
   pathname: PropTypes.string.isRequired,
-  history: PropTypes.object,
 };

--- a/src/js/components/Navigation/HeaderBackTo.jsx
+++ b/src/js/components/Navigation/HeaderBackTo.jsx
@@ -210,7 +210,7 @@ class HeaderBackTo extends Component {
   render () {
     renderLog('HeaderBackTo');  // Set LOG_RENDER_EVENTS to log all renders
     // console.log('HeaderBackTo render');
-    const { classes, history } = this.props;
+    const { classes } = this.props;
     const {
       backToLink, backToLinkText, profilePopUpOpen, showSignInModal,
       voter, voterFirstName, voterIsSignedIn,
@@ -241,12 +241,11 @@ class HeaderBackTo extends Component {
             backToLinkText={backToLinkText}
             className="HeaderBackTo"
             id="backToLinkTabHeader"
-            history={history}
           />
 
           {isWebApp() && (
           <NotificationsAndProfileWrapper className="u-cursor--pointer">
-            <HeaderNotificationMenu history={history} />
+            <HeaderNotificationMenu />
             {voterIsSignedIn ? (
               <span>
                 {voterPhotoUrlMedium ? (

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -8,7 +8,7 @@ import AppActions from '../../actions/AppActions';
 import AppStore from '../../stores/AppStore';
 import { dumpCssFromId } from '../../utils/appleSiliconUtils';
 import CandidateStore from '../../stores/CandidateStore';
-import { hasIPhoneNotch, historyPushV5, isAndroid, isIOSAppOnMac, isCordova, isIPad, isWebApp } from '../../utils/cordovaUtils';
+import { hasIPhoneNotch, historyPush, isAndroid, isIOSAppOnMac, isCordova, isIPad, isWebApp } from '../../utils/cordovaUtils';
 import HeaderBackToButton from './HeaderBackToButton';
 import HeaderBarProfilePopUp from './HeaderBarProfilePopUp';
 import HeaderNotificationMenu from './HeaderNotificationMenu';
@@ -567,8 +567,7 @@ class HeaderBackToBallot extends Component {
     if (stringContains('/modal/share', pathname) && isWebApp()) {
       const pathnameWithoutModalShare = pathname.replace('/modal/share', '');
       // console.log('navigation closeShareModal ', pathnameWithoutModalShare);
-      const { history } = this.props;
-      historyPushV5(history, pathnameWithoutModalShare);
+      historyPush(pathnameWithoutModalShare);
     }
   }
 
@@ -635,7 +634,7 @@ class HeaderBackToBallot extends Component {
       shareModalStep, showShareModal, voter, voterFirstName, voterIsSignedIn,
     } = this.state;
     const voterPhotoUrlMedium = voterPhoto(voter);
-    const { classes, history } = this.props;
+    const { classes } = this.props;
     const { location: { pathname } } = window;
 
     // console.log('HeaderBackToBallot googleCivicElectionId:', googleCivicElectionId);
@@ -723,7 +722,7 @@ class HeaderBackToBallot extends Component {
           />
 
           <NotificationsAndProfileWrapper className="u-cursor--pointer">
-            <HeaderNotificationMenu history={history} />
+            <HeaderNotificationMenu />
             {voterIsSignedIn ? (
               <span onClick={this.toggleAccountMenu}>
                 {voterPhotoUrlMedium ? (
@@ -815,7 +814,6 @@ class HeaderBackToBallot extends Component {
 }
 HeaderBackToBallot.propTypes = {
   classes: PropTypes.object,
-  history: PropTypes.object,
   params: PropTypes.object,
 };
 

--- a/src/js/components/Navigation/HeaderBackToButton.jsx
+++ b/src/js/components/Navigation/HeaderBackToButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Button } from '@material-ui/core';
 import { ArrowBack, ArrowBackIos } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
-import { historyPushV5, isIOS } from '../../utils/cordovaUtils';
+import { historyPush, isIOS } from '../../utils/cordovaUtils';
 
 import { shortenText } from '../../utils/textFormat';
 import { renderLog } from '../../utils/logging';
@@ -22,7 +22,7 @@ const styles = {
 class HeaderBackToButton extends Component {
   render () {
     renderLog('HeaderBackToButton');  // Set LOG_RENDER_EVENTS to log all renders
-    const { classes, className, backToLink, backToLinkText, history } = this.props;
+    const { classes, className, backToLink, backToLinkText } = this.props;
 
     return (
       <Button
@@ -31,7 +31,7 @@ class HeaderBackToButton extends Component {
         classes={{ root: classes.root }}
         className={`page-header__backToButton ${className}`}
         id="backToLinkTabHeader"
-        onClick={() => historyPushV5(history, backToLink)}
+        onClick={() => historyPush(backToLink)}
       >
         {isIOS() ? (
           <ArrowBackIos className="button-icon" />
@@ -50,7 +50,6 @@ HeaderBackToButton.propTypes = {
   backToLinkText: PropTypes.string,
   className: PropTypes.string,
   classes: PropTypes.object,
-  history: PropTypes.object,
 };
 
 export default withStyles(styles)(HeaderBackToButton);

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import { Button, AppBar, Toolbar, Tabs, IconButton, Tooltip } from '@material-ui/core';
 import { Place, AccountCircle } from '@material-ui/icons';
 import { withStyles } from '@material-ui/core/styles';
-import { hasIPhoneNotch, historyPushV5, isIOSAppOnMac, isCordova, isWebApp } from '../../utils/cordovaUtils';
+import { hasIPhoneNotch, historyPush, isIOSAppOnMac, isCordova, isWebApp } from '../../utils/cordovaUtils';
 import AdviserIntroModal from '../CompleteYourProfile/AdviserIntroModal';
 import AppActions from '../../actions/AppActions';
 import AppStore from '../../stores/AppStore';
@@ -344,10 +344,9 @@ class HeaderBar extends Component {
     AppActions.setShareModalStep('');
     const { location: { href } } = window;
     if (stringContains('/modal/share', href) && isWebApp()) {
-      const { history } = this.props;
       const pathnameWithoutModalShare = href.replace('/modal/share', '');  // Cordova
       // console.log('Navigation closeShareModal ', pathnameWithoutModalShare)
-      historyPushV5.push(history, pathnameWithoutModalShare);
+      historyPush.push(null, pathnameWithoutModalShare);
     }
   }
 
@@ -424,7 +423,7 @@ class HeaderBar extends Component {
       return null;
     }
 
-    const { classes, history } = this.props;
+    const { classes } = this.props;
     const { location: { pathname } } = window;
 
     const {
@@ -550,7 +549,7 @@ class HeaderBar extends Component {
                   <div>
                     {showEditAddressButton && editAddressButtonHtml}
                   </div>
-                  <HeaderNotificationMenu history={history} />
+                  <HeaderNotificationMenu />
                   <div id="profileAvatarHeaderBar"
                     className={`header-nav__avatar-container ${isCordova() ? 'header-nav__avatar-cordova' : undefined}`}
                     style={isCordova() ? { marginBottom: 2 } : {}}
@@ -586,7 +585,7 @@ class HeaderBar extends Component {
                     <div>
                       {showEditAddressButton && editAddressButtonHtml}
                     </div>
-                    <HeaderNotificationMenu history={history} />
+                    <HeaderNotificationMenu />
                     <IconButton
                       classes={{ root: classes.iconButtonRoot }}
                       id="profileAvatarHeaderBar"
@@ -619,7 +618,7 @@ class HeaderBar extends Component {
                 <div>
                   {showEditAddressButton && editAddressButtonHtml}
                 </div>
-                <HeaderNotificationMenu history={history} />
+                <HeaderNotificationMenu />
                 <Button
                   color="primary"
                   classes={{ root: classes.headerButtonRoot }}
@@ -699,7 +698,6 @@ class HeaderBar extends Component {
 }
 HeaderBar.propTypes = {
   classes: PropTypes.object,
-  history: PropTypes.object,
 };
 
 const styles = (theme) => ({

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -346,7 +346,7 @@ class HeaderBar extends Component {
     if (stringContains('/modal/share', href) && isWebApp()) {
       const pathnameWithoutModalShare = href.replace('/modal/share', '');  // Cordova
       // console.log('Navigation closeShareModal ', pathnameWithoutModalShare)
-      historyPush.push(null, pathnameWithoutModalShare);
+      historyPush.push(pathnameWithoutModalShare);
     }
   }
 

--- a/src/js/components/Navigation/HeaderNotificationMenu.jsx
+++ b/src/js/components/Navigation/HeaderNotificationMenu.jsx
@@ -6,7 +6,7 @@ import { Badge, IconButton, Menu, MenuItem } from '@material-ui/core';
 import { withStyles } from '@material-ui/core/styles';
 import ActivityActions from '../../actions/ActivityActions';
 import ActivityStore from '../../stores/ActivityStore';
-import { historyPushV5, isIOSAppOnMac, setIconBadgeMessageCount } from '../../utils/cordovaUtils';
+import { historyPush, isIOSAppOnMac, setIconBadgeMessageCount } from '../../utils/cordovaUtils';
 import ImageHandler from '../ImageHandler';
 import { renderLog } from '../../utils/logging';
 import { createDescriptionOfFriendPosts } from '../../utils/activityUtils';
@@ -58,21 +58,19 @@ class HeaderNotificationMenu extends Component {
   }
 
   onMenuItemClick (activityNotice) {
-    const { history } = this.props;
     if (activityNotice.activity_notice_id > 0) {
       ActivityActions.activityNoticeListRetrieve([activityNotice.activity_notice_id]);
     }
     this.handleClose();
     if (activityNotice && activityNotice.activity_tidbit_we_vote_id) {
-      historyPushV5(history, `/news/a/${activityNotice.activity_tidbit_we_vote_id}`);
+      historyPush(`/news/a/${activityNotice.activity_tidbit_we_vote_id}`);
     } else {
-      historyPushV5(history, '/news');
+      historyPush('/news');
     }
   }
 
   onSettingsClick = () => {
-    const { history } = this.props;
-    historyPushV5(history, '/settings/notifications');
+    historyPush('/settings/notifications');
   }
 
   generateMenuItemList = (allActivityNotices) => {
@@ -270,7 +268,6 @@ class HeaderNotificationMenu extends Component {
 }
 HeaderNotificationMenu.propTypes = {
   classes: PropTypes.object,
-  history: PropTypes.object,
 };
 
 const styles = (theme) => ({

--- a/src/js/components/Navigation/LinkWithPushHistory.jsx
+++ b/src/js/components/Navigation/LinkWithPushHistory.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+
+/*
+ The simplest way to define a component is to write a JavaScript function:
+ This function is a valid React component because it accepts a single “props”
+ (which stands for properties) object argument with data and returns a React element.
+ We call such components “function components” because they are literally JavaScript functions.
+ https://reactrouter.com/native/api/Hooks/usehistory
+*/
+export default function LinkWithPushHistory (props) {
+  const { id, className, onClick, to, childMarkup } = props;
+  // const history = useHistory();
+
+  // function handleClick () {
+  //   history.push(to);
+  // }
+
+  // see https://reactrouter.com/web/api/Link
+  // Dec 2020: There are more params to <Link that we don't use and have not been implemented
+  return (
+    <Link id={id} className={className} to={to} onClick={onClick}>
+      {childMarkup}
+    </Link>
+
+  );
+}
+LinkWithPushHistory.propTypes = {
+  id: PropTypes.string,
+  className: PropTypes.object,
+  onClick: PropTypes.object,
+  to: PropTypes.object.isRequired,
+  childMarkup: PropTypes.object,
+};

--- a/src/js/components/Share/ShareButtonFooter.jsx
+++ b/src/js/components/Share/ShareButtonFooter.jsx
@@ -435,7 +435,7 @@ class ShareButtonFooter extends Component {
     }
 
     if (!VoterStore.getVoter().voter_we_vote_id) {
-      console.log('ShareButtonFooter, waiting for voterRetrieve to complete');
+      console.log('ShareButtonFooter, waiting for voterRetrieve to complete -- DEC 2020 debug, we shouldn\'t be getting this if the footer is not displayed!');
       return LoadingWheel;
     }
 

--- a/src/js/components/Values/OrganizationsToFollowPreview.jsx
+++ b/src/js/components/Values/OrganizationsToFollowPreview.jsx
@@ -1,8 +1,7 @@
 import React, { Component, Suspense } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import GuideList from '../VoterGuide/GuideList';
-import { historyPushV5 } from '../../utils/cordovaUtils';
+import { historyPush } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import ShowMoreFooter from '../Navigation/ShowMoreFooter';
 import VoterGuideStore from '../../stores/VoterGuideStore';
@@ -35,8 +34,7 @@ export default class OrganizationsToFollowPreview extends Component {
   }
 
   goToOrganizations () {
-    const { history } = this.props;
-    historyPushV5(history, '/opinions/f/showOrganizationsFilter');
+    historyPush('/opinions/f/showOrganizationsFilter');
   }
 
   render () {
@@ -76,7 +74,6 @@ export default class OrganizationsToFollowPreview extends Component {
   }
 }
 OrganizationsToFollowPreview.propTypes = {
-  history: PropTypes.object,
 };
 
 const SectionDescription = styled.div`

--- a/src/js/components/Values/PublicFiguresToFollowPreview.jsx
+++ b/src/js/components/Values/PublicFiguresToFollowPreview.jsx
@@ -1,8 +1,7 @@
 import React, { Component, Suspense } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import GuideList from '../VoterGuide/GuideList';
-import { historyPushV5 } from '../../utils/cordovaUtils';
+import { historyPush } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import ShowMoreFooter from '../Navigation/ShowMoreFooter';
 import VoterGuideStore from '../../stores/VoterGuideStore';
@@ -34,8 +33,7 @@ export default class PublicFiguresToFollowPreview extends Component {
   }
 
   goToPublicFigures () {
-    const { history } = this.props;
-    historyPushV5(history, '/opinions/f/showPublicFiguresFilter');
+    historyPush('/opinions/f/showPublicFiguresFilter');
   }
 
   render () {
@@ -75,7 +73,6 @@ export default class PublicFiguresToFollowPreview extends Component {
   }
 }
 PublicFiguresToFollowPreview.propTypes = {
-  history: PropTypes.object,
 };
 
 const SectionDescription = styled.h2`

--- a/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
@@ -379,4 +379,5 @@ OrganizationVoterGuideTabs.propTypes = {
   activeRouteChanged: PropTypes.func,
   organizationWeVoteId: PropTypes.string.isRequired,
   match: PropTypes.object,
+  params: PropTypes.object,
 };

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -26,7 +26,7 @@ import cookies from '../../utils/cookies';
 import CompleteYourProfile from '../../components/CompleteYourProfile/CompleteYourProfile';
 import { cordovaBallotFilterTopMargin } from '../../utils/cordovaOffsets';
 import cordovaScrollablePaneTopPadding from '../../utils/cordovaScrollablePaneTopPadding';
-import { chipLabelText, historyPushV5, isIOSAppOnMac, isCordova, isWebApp, isAndroid, getAndroidSize, isIPadGiantSize } from '../../utils/cordovaUtils';
+import { chipLabelText, historyPush, isIOSAppOnMac, isCordova, isWebApp, isAndroid, getAndroidSize, isIPadGiantSize } from '../../utils/cordovaUtils';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
 import EditAddressOneHorizontalRow from '../../components/Ready/EditAddressOneHorizontalRow';
 import ElectionActions from '../../actions/ElectionActions';
@@ -113,7 +113,6 @@ class Ballot extends Component {
 
   componentDidMount () {
     const { location: { pathname: currentPathname } } = window;
-    const { history } = this.props;
     // console.log('componentDidMount, Current pathname:', currentPathname);
     const ballotBaseUrl = '/ballot';
     this.appStoreListener = AppStore.addListener(this.onAppStoreChange.bind(this));
@@ -178,13 +177,13 @@ class Ballot extends Component {
         BallotActions.voterBallotItemsRetrieve(0, '', ballotLocationShortcut);
 
         // Change the URL to match
-        historyPushV5(history, `${ballotBaseUrl}/${ballotLocationShortcut}`);
+        historyPush(`${ballotBaseUrl}/${ballotLocationShortcut}`);
       } else if (ballotReturnedWeVoteId !== '') {
         // Change the ballot on load to make sure we are getting what we expect from the url
         BallotActions.voterBallotItemsRetrieve(0, ballotReturnedWeVoteId, '');
 
         // Change the URL to match
-        historyPushV5(history, `${ballotBaseUrl}/id/${ballotReturnedWeVoteId}`);
+        historyPush(`${ballotBaseUrl}/id/${ballotReturnedWeVoteId}`);
       } else if (googleCivicElectionIdFromUrl !== 0) {
         // Change the ballot on load to make sure we are getting what we expect from the url
         if (googleCivicElectionId !== googleCivicElectionIdFromUrl) {
@@ -198,7 +197,7 @@ class Ballot extends Component {
           if (!currentPathnameStartsWithNewUrl) {
             // As long as the current pathname starts with the new URL, do NOT redirect
             // console.log('REDIRECTING TO ballotElectionUrl');
-            historyPushV5(history, ballotElectionUrl);
+            historyPush(ballotElectionUrl);
           }
         }
 
@@ -212,12 +211,12 @@ class Ballot extends Component {
         // console.log('ballotElectionUrl2: ', ballotElectionUrl2);
         const currentPathnameStartsWithNewUrl2 = currentPathname && startsWith(ballotElectionUrl2, currentPathname);
         if (!currentPathnameStartsWithNewUrl2) {
-          historyPushV5(history, ballotElectionUrl2);
+          historyPush(ballotElectionUrl2);
         }
       }
     } else if (BallotStore.ballotProperties && BallotStore.ballotProperties.ballot_found === false) { // No ballot found
       // console.log('if (BallotStore.ballotProperties && BallotStore.ballotProperties.ballot_found === false');
-      historyPushV5(history, '/settings/location');
+      historyPush('/settings/location');
     } else if (ballotWithItemsFromCompletionFilterType === undefined) {
       // console.log('WebApp doesn\'t know the election or have ballot data, so ask the API server to return best guess');
       BallotActions.voterBallotItemsRetrieve(0, '', '');
@@ -538,7 +537,6 @@ class Ballot extends Component {
     // console.log('Ballot.jsx onVoterStoreChange');
     const { mounted, googleCivicElectionId } = this.state;
     const { location: { pathname, query } } = window;
-    const { history } = this.props;
 
     if (mounted) {
       let voterRefreshTimerOn = false;
@@ -552,9 +550,9 @@ class Ballot extends Component {
         const voter = VoterStore.getVoter();
         const { numberOfVoterRetrieveAttempts } = this.state;
         if (voter && voter.is_signed_in) {
-          // console.log('onVoterStoreChange, about to historyPushV5(history, pathname):', pathname);
+          // console.log('onVoterStoreChange, about to historyPush(pathname):', pathname);
           // Return to the same page without the 'voter_refresh_timer_on' variable
-          historyPushV5(history, pathname);
+          historyPush(pathname);
         } else if (numberOfVoterRetrieveAttempts < 3) {
           // console.log('About to startTimerToRetrieveVoter');
           this.startTimerToRetrieveVoter();
@@ -562,7 +560,7 @@ class Ballot extends Component {
           // We have exceeded the number of allowed attempts and want to 'turn off' the request to refresh the voter object
           // Return to the same page without the 'voter_refresh_timer_on' variable
           // console.log('Exiting voterRefreshTimerOn');
-          historyPushV5(history, pathname);
+          historyPush(pathname);
         }
       } else {
         // console.log('Ballot.jsx onVoterStoreChange VoterStore.getVoter: ', VoterStore.getVoter());
@@ -970,11 +968,10 @@ class Ballot extends Component {
 
   toggleSelectBallotModal (destinationUrlForHistoryPush = '', hideAddressEdit = false, hideElections = false) {
     const { showSelectBallotModal } = this.state;
-    const { history } = this.props;
     // console.log('Ballot toggleSelectBallotModal, destinationUrlForHistoryPush:', destinationUrlForHistoryPush, ', showSelectBallotModal:', showSelectBallotModal);
     if (showSelectBallotModal && destinationUrlForHistoryPush && destinationUrlForHistoryPush !== '') {
       // console.log('toggleSelectBallotModal destinationUrlForHistoryPush:', destinationUrlForHistoryPush);
-      historyPushV5(history, destinationUrlForHistoryPush);
+      historyPush(destinationUrlForHistoryPush);
     } else {
       // console.log('Ballot toggleSelectBallotModal, BallotActions.voterBallotListRetrieve()');
       BallotActions.voterBallotListRetrieve(); // Retrieve a list of ballots for the voter from other elections
@@ -1053,7 +1050,7 @@ class Ballot extends Component {
   render () {
     renderLog('Ballot');  // Set LOG_RENDER_EVENTS to log all renders
     const ballotBaseUrl = '/ballot';
-    const { classes, history } = this.props;
+    const { classes } = this.props;
     const { location: { pathname, search } } = window;
 
     const {
@@ -1178,7 +1175,7 @@ class Ballot extends Component {
 
     if (ballotWithItemsFromCompletionFilterType.length === 0 && inRemainingDecisionsMode) {
       // console.log('inRemainingDecisionsMode historyPush');
-      historyPushV5(history, pathname);
+      historyPush(pathname);
     }
     const showAddressVerificationForm = !locationGuessClosed || !textForMapSearch;
 
@@ -1417,7 +1414,6 @@ class Ballot extends Component {
                                   candidateList={item.candidate_list}
                                   candidatesToShowForSearchResults={item.candidatesToShowForSearchResults}
                                   weVoteId={item.we_vote_id}
-                                  history={history}
                                 />
                               </>
                             </DelayedLoad>
@@ -1513,7 +1509,6 @@ class Ballot extends Component {
 }
 Ballot.propTypes = {
   classes: PropTypes.object,
-  history: PropTypes.object,
   location: PropTypes.object,
   match: PropTypes.object,
 };

--- a/src/js/routes/Ballot/BallotTitleHeader.jsx
+++ b/src/js/routes/Ballot/BallotTitleHeader.jsx
@@ -7,6 +7,7 @@ import { Settings } from '@material-ui/icons';
 import { isAndroid, isAndroidSizeFold, isIOSAppOnMac, isIPad, isIPhone3p5in, isIPhone4in, isWebApp } from '../../utils/cordovaUtils';
 import ShareButtonDesktopTablet from '../../components/Share/ShareButtonDesktopTablet';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
+import { renderLog } from '../../utils/logging';
 import { shortenText } from '../../utils/textFormat';
 // import webAppConfig from '../../config';
 
@@ -38,6 +39,7 @@ class BallotTitleHeader extends Component {
   }
 
   render () {
+    renderLog('BallotTitleHeader');  // Set LOG_RENDER_EVENTS to log all renders
     // const nextReleaseFeaturesEnabled = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES === undefined ? false : webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;
     const { classes, electionName, electionDayTextObject, scrolled } = this.props;
 

--- a/src/js/routes/Friends/Friends.jsx
+++ b/src/js/routes/Friends/Friends.jsx
@@ -10,7 +10,7 @@ import AnalyticsActions from '../../actions/AnalyticsActions';
 import AppStore from '../../stores/AppStore';
 import BrowserPushMessage from '../../components/Widgets/BrowserPushMessage';
 import { cordovaBallotFilterTopMargin, cordovaFriendsWrapper } from '../../utils/cordovaOffsets';
-import { cordovaDot, historyPushV5, isCordova, isWebApp } from '../../utils/cordovaUtils';
+import { cordovaDot, historyPush, isCordova, isWebApp } from '../../utils/cordovaUtils';
 import displayFriendsTabs from '../../utils/displayFriendsTabs';
 import FacebookSignInCard from '../../components/Facebook/FacebookSignInCard';
 import FirstAndLastNameRequiredAlert from '../../components/Widgets/FirstAndLastNameRequiredAlert';
@@ -43,12 +43,12 @@ const testimonial = 'Instead of searching through emails and social media for re
 class Friends extends Component {
   static getDerivedStateFromProps (props, state) {
     const { defaultTabItem } = state;
-    const { history, match: { params: { tabItem } } } = props;
+    const { match: { params: { tabItem } } } = props;
     // console.log('Friends getDerivedStateFromProps defaultTabItem:', defaultTabItem, ', tabItem:', tabItem);
     // We only redirect when in mobile mode (when "displayFriendsTabs()" is true), a tab param has not been passed in, and we have a defaultTab specified
     // This solves an edge case where you re-click the Friends Footer tab when you are in the friends section
     if (displayFriendsTabs() && tabItem === undefined && defaultTabItem) {
-      historyPushV5(history, `/friends/${defaultTabItem}`);
+      historyPush(`/friends/${defaultTabItem}`);
     }
     return null;
   }
@@ -193,7 +193,7 @@ class Friends extends Component {
     return selectedTab;
   }
 
-  handleNavigation = (to) => historyPushV5(this.props.history, to);
+  handleNavigation = (to) => historyPush(to);
 
   resetDefaultTabForMobile (friendInvitationsSentToMe, suggestedFriendList, friendInvitationsSentByMe) {
     const { match: { params: { tabItem } } } = this.props;
@@ -600,7 +600,6 @@ class Friends extends Component {
 Friends.propTypes = {
   classes: PropTypes.object,
   match: PropTypes.object,
-  history: PropTypes.object,
 };
 
 const styles = () => ({

--- a/src/js/routes/Intro/Intro.jsx
+++ b/src/js/routes/Intro/Intro.jsx
@@ -112,6 +112,5 @@ export default class Intro extends Component {
   }
 }
 Intro.propTypes = {
-  history: PropTypes.object,
   children: PropTypes.object,
 };

--- a/src/js/routes/TwitterHandleLanding.jsx
+++ b/src/js/routes/TwitterHandleLanding.jsx
@@ -206,4 +206,5 @@ export default class TwitterHandleLanding extends Component {
 TwitterHandleLanding.propTypes = {
   activeRoute: PropTypes.string,
   match: PropTypes.object,
+  params: PropTypes.object,
 };

--- a/src/js/routes/Values.jsx
+++ b/src/js/routes/Values.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import styled from 'styled-components';
 import AddEndorsements from '../components/Widgets/AddEndorsements';
@@ -95,7 +94,6 @@ export default class Values extends Component {
     if (!this.state.voter) {
       return LoadingWheel;
     }
-    const { history } = this.props;
     const { issuesFollowedCount, issuesToFollowShouldBeDisplayed, voterIsSignedIn } = this.state;
 
     let publicFiguresBlockToDisplay = null;
@@ -105,7 +103,7 @@ export default class Values extends Component {
       publicFiguresBlockToDisplay = <PublicFiguresFollowedPreview />;
     } else {
       // console.log('PublicFiguresToFollowPreview');
-      publicFiguresBlockToDisplay = <PublicFiguresToFollowPreview history={history} />;
+      publicFiguresBlockToDisplay = <PublicFiguresToFollowPreview />;
     }
 
     let organizationsBlockToDisplay = null;
@@ -113,7 +111,7 @@ export default class Values extends Component {
     if (organizationsFollowedCount > 0) {
       organizationsBlockToDisplay = <NetworkOpinionsFollowed />;
     } else {
-      organizationsBlockToDisplay = <OrganizationsToFollowPreview history={history} />;
+      organizationsBlockToDisplay = <OrganizationsToFollowPreview />;
     }
 
     return (
@@ -200,7 +198,6 @@ export default class Values extends Component {
   }
 }
 Values.propTypes = {
-  history: PropTypes.object,
 };
 
 const SectionDescription = styled.div`

--- a/src/js/startReactReadyApp.jsx
+++ b/src/js/startReactReadyApp.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { render } from 'react-dom';
 import { Router /* , applyRouterMiddleware */ } from 'react-router-dom';
 // import { useScroll } from 'react-router-scroll';
-import { createBrowserHistory } from 'history';
 import { MuiThemeProvider } from '@material-ui/core/styles';
 import { ThemeProvider } from 'styled-components';
 import muiTheme from './mui-theme';
@@ -21,14 +20,12 @@ String.prototype.numberOfNeedlesFoundInString = numberOfNeedlesFoundInString; //
 function startReactReadyApp () {
   renderLog('startReactReadyApp');  // Set LOG_RENDER_EVENTS to log all renders
   console.log('startReactReadyApp first line in startReactReadyApp');
-  const history = createBrowserHistory();
+  // TODO: This should not be necessary with V5 react-router <Router history={history} >
   const element = (
     // eslint-disable-next-line react/jsx-filename-extension
     <MuiThemeProvider theme={muiTheme}>
       <ThemeProvider theme={styledTheme}>
-        <Router
-          history={history}
-        >
+        <Router>
           {routes()}
         </Router>
       </ThemeProvider>

--- a/src/js/utils/applicationUtils.js
+++ b/src/js/utils/applicationUtils.js
@@ -11,7 +11,7 @@ export function getApplicationViewBooleans (pathname) {
   let extensionPageMode = false;
   let friendsMode = false;
   const pathnameLowerCase = pathname.toLowerCase() || '';
-  // console.log('applicationUtils, pathnameLowerCase:', pathnameLowerCase);
+  console.log('getApplicationViewBooleans, pathnameLowerCase:', pathnameLowerCase);
   let readyMode = false;
   let settingsMode = false;
   let sharedItemLandingPage = false;
@@ -219,7 +219,7 @@ export function getApplicationViewBooleans (pathname) {
     showShareButtonFooter = !isIOSAppOnMac();
   }
 
-  // console.log('applicationUtils, showFooterBar: ', showFooterBar, ', pathnameLowerCase:', pathnameLowerCase, ', showBackToSettingsMobile:', showBackToSettingsMobile);
+  console.log('getApplicationViewBooleans, showBackToBallotHeader: ', showBackToBallotHeader, ' showFooterBar: ', showFooterBar, ', pathnameLowerCase:', pathnameLowerCase, ', showBackToSettingsMobile:', showBackToSettingsMobile);
 
   return {
     inTheaterMode,

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -71,20 +71,9 @@ export function historyPush (route) {
   // history.push(route);
   // HTML5 Test hack (reloads app from zero, does not save route in history)
   // window.location.href = origin + route;
+  // IMPORTANT:  The HTML5 window.history, is very different from the react-router V5 history, don't use window.history!
   global.weVoteGlobalHistory.push(route);
 }
-
-// export function historyPushV5 (history, route) {
-//   // TODO: BEGIN TEST HACK
-//   // if (history  && history.push) {
-//   //   history.push(route);
-//   // } else {
-//   //   console.error('historyPushV5 did not receive a valid history object, reloading the app with .replace()');
-//   //   window.location.replace(route);
-//   // }
-//   // TODO: END TEST HACK
-//   global.weVoteGlobalHistory.push(route);
-// }
 
 // Webapp image paths are "absolute" relative to the running webapp cwd,
 // for Cordova, we need them to include the http path to the server.

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { createBrowserHistory, createHashHistory } from 'history';
-import { useHistory } from "react-router-dom";
+// import { createBrowserHistory, createHashHistory } from 'history';
+// import { useHistory } from "react-router-dom";
 import webAppConfig from '../config';
 import { cordovaOffsetLog, oAuthLog } from './logging';
 import { dumpObjProps } from './appleSiliconUtils';
-import { stringContains } from './textFormat';
 
 /* global $  */
 
@@ -64,26 +63,28 @@ export function isAndroid () {
 // For the V4 router (Jan 2020) this simply changes the url and browsed page without using history
 // If history retention is needed, see TabWithPushHistory.jsx for an example of how to do it.
 // See v5: https://reactrouter.com/native/api/Hooks/usehistory
-// See v3: https://reactrouter.com/native/api/Hooks/usehistory
+// See v3: https://github.com/ReactTraining/react-router/blob/v3/docs/guides/Histories.md
 export function historyPush (route) {
   console.log(`historyPush ******** ${route} *******`);
-  // v3 code:
+  // react-router v3 code:
   // const history = useHistory();
   // history.push(route);
-  // v5 work around:
-  const { location: { origin } } = window; // origin: "https://localhost:3000"
-  console.warn('DEPRECATED historyPush (full reload) was called for route:', route);
-  window.location.href = origin + route;
+  // HTML5 Test hack (reloads app from zero, does not save route in history)
+  // window.location.href = origin + route;
+  global.weVoteGlobalHistory.push(route);
 }
 
-export function historyPushV5 (history, route) {
-  if (history) {
-    history.push(route);
-  } else {
-    console.error('historyPushV5 did not receive a valid history object, reloading the app with .replace()');
-    window.location.replace(route);
-  }
-}
+// export function historyPushV5 (history, route) {
+//   // TODO: BEGIN TEST HACK
+//   // if (history  && history.push) {
+//   //   history.push(route);
+//   // } else {
+//   //   console.error('historyPushV5 did not receive a valid history object, reloading the app with .replace()');
+//   //   window.location.replace(route);
+//   // }
+//   // TODO: END TEST HACK
+//   global.weVoteGlobalHistory.push(route);
+// }
 
 // Webapp image paths are "absolute" relative to the running webapp cwd,
 // for Cordova, we need them to include the http path to the server.


### PR DESCRIPTION
Removed all passing of history
Many links still  need to be tested
Some routes in Root still need improved regexes for V5 react-router
The Application.jsx updating the header on path changes is not yet reliably working.