### PR TITLE
Do not lazy load react-bootstrap components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "moment-locales-webpack-plugin": "^1.2.0",
         "pre-commit": "^1.2.2",
         "react-hot-loader": "^4.13.0",
-        "stylelint": "^13.9.0",
+        "stylelint": "^13.13.1",
         "stylelint-config-standard": "^20.0.0",
         "terser-webpack-plugin": "^5.1.2",
         "unused-webpack-plugin": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "moment-locales-webpack-plugin": "^1.2.0",
     "pre-commit": "^1.2.2",
     "react-hot-loader": "^4.13.0",
-    "stylelint": "^13.9.0",
+    "stylelint": "^13.13.1",
     "stylelint-config-standard": "^20.0.0",
     "terser-webpack-plugin": "^5.1.2",
     "unused-webpack-plugin": "^2.4.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -481,10 +481,13 @@ class App extends Component {
 const WeVoteBody = styled.div`
   background-color: rgb(235, 236, 238);
   color: #333;
+  display: block;
   font-family: "Nunito Sans", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   line-height: 1.4;
-  margin: 0;
-  display: block;
+  margin: 0 auto;
+  max-width: 960px;
+  position: relative;
+  z-index: 0;
 `;
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import React, { Component, Suspense } from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import styled, { ThemeProvider } from 'styled-components';
 import Header from './js/components/Navigation/Header';
+import HeaderBarSuspense from './js/components/Navigation/HeaderBarSuspense';
 import ErrorBoundary from './js/components/Widgets/ErrorBoundary';
 import WeVoteRouter from './js/components/Widgets/WeVoteRouter';
 import muiTheme from './js/mui-theme';
@@ -205,7 +206,7 @@ class App extends Component {
 
     return (
       <ErrorBoundary>
-        <Suspense fallback={<span>&nbsp;</span>}>
+        <Suspense fallback={<HeaderBarSuspense />}>
           <MuiThemeProvider theme={muiTheme}>
             <ThemeProvider theme={styledTheme}>
               <WeVoteRouter>

--- a/src/js/attributions.js
+++ b/src/js/attributions.js
@@ -169,9 +169,6 @@ module.exports = [
   // Jan 2019, https://github.com/styled-components/styled-components/blob/master/LICENSE
   'styled-components/styled-components is licensed under the MIT License (MIT)\n' +
   'Copyright (c) 2016-present Glen Maddern and Maximilian Stoiber\n',
-  // Jan 2019, https://github.com/visionmedia/superagent/blob/master/LICENSE
-  'visionmedia/superagent is licensed under the MIT License (MIT)\n' +
-  'Copyright (c) 2014-2016 TJ Holowaychuk <tj@vision-media.ca>\n',
   // Jan 2021,
   'topojson/topojson-client is licensed under the ISC License\n' +
   'Copyright 2012-2019 Michael Bostock\n',

--- a/src/js/compileDate.js
+++ b/src/js/compileDate.js
@@ -1,1 +1,1 @@
-module.exports = ['5/13/2021, 1:34:59 PM'];
+module.exports = ['5/13/2021, 4:49:54 PM'];

--- a/src/js/compileDate.js
+++ b/src/js/compileDate.js
@@ -1,1 +1,1 @@
-module.exports = ['5/13/2021, 4:49:54 PM'];
+module.exports = ['5/14/2021, 3:44:21 PM'];

--- a/src/js/components/Ballot/StickyPopover.jsx
+++ b/src/js/components/Ballot/StickyPopover.jsx
@@ -1,11 +1,10 @@
 import { withStyles, withTheme } from '@material-ui/core/styles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import Overlay from 'react-bootstrap/Overlay';
+import Popover from 'react-bootstrap/Popover';
 import styled from 'styled-components';
 import { renderLog } from '../../utils/logging';
-
-const Overlay = React.lazy(() => import(/* webpackChunkName: 'BootstrapOverlay' */ 'react-bootstrap/Overlay'));
-const Popover = React.lazy(() => import(/* webpackChunkName: 'BootstrapPopover' */ 'react-bootstrap/Popover'));
 
 
 class StickyPopover extends Component {

--- a/src/js/components/Connect/CurrentFriends.jsx
+++ b/src/js/components/Connect/CurrentFriends.jsx
@@ -1,12 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import Popover from 'react-bootstrap/Popover';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import { Link } from 'react-router-dom';
 import { renderLog } from '../../utils/logging';
 import FriendDisplayForList from '../Friends/FriendDisplayForList';
 import CurrentFriendTinyDisplay from './CurrentFriendTinyDisplay';
-
-const OverlayTrigger = React.lazy(() => import(/* webpackChunkName: 'BootstrapOverlay' */'react-bootstrap/OverlayTrigger'));
-const Popover = React.lazy(() => import(/* webpackChunkName: 'BootstrapPopover' */ 'react-bootstrap/Popover'));
 
 
 export default class CurrentFriends extends Component {

--- a/src/js/components/Connect/FacebookFriendsDisplay.jsx
+++ b/src/js/components/Connect/FacebookFriendsDisplay.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
 import { Link } from 'react-router-dom';
 import FacebookActions from '../../actions/FacebookActions';
 import FacebookStore from '../../stores/FacebookStore';
@@ -8,7 +9,6 @@ import { renderLog } from '../../utils/logging';
 import FacebookFriendCard from './FacebookFriendCard';
 import FacebookFriendTinyDisplay from './FacebookFriendTinyDisplay';
 
-const Popover = React.lazy(() => import(/* webpackChunkName: 'BootstrapPopover' */ 'react-bootstrap/Popover'));
 
 export default class FacebookFriendsDisplay extends Component {
   constructor (props) {

--- a/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
+++ b/src/js/components/Connect/OrganizationsFollowedOnTwitter.jsx
@@ -1,12 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
 import { Link } from 'react-router-dom';
 import { renderLog } from '../../utils/logging';
 import OrganizationCard from '../VoterGuide/OrganizationCard';
 import OrganizationTinyDisplay from '../VoterGuide/OrganizationTinyDisplay';
 
-const Popover = React.lazy(() => import(/* webpackChunkName: 'BootstrapPopover' */ 'react-bootstrap/Popover'));
 const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ '../Widgets/FollowToggle'));
 
 export default class OrganizationsFollowedOnTwitter extends Component {

--- a/src/js/components/Navigation/HeaderBarSuspense.jsx
+++ b/src/js/components/Navigation/HeaderBarSuspense.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { renderLog } from '../../utils/logging';
+
+function SmallCloud (params) {
+  const styleObj = {
+    position: 'absolute',
+    top: '30%',
+    marginLeft: params.left,
+  };
+
+  const wider = params.wide !== undefined;
+
+  return (
+    <div style={styleObj}>
+      <span
+        style={{
+          width: wider ? 180 : 160,
+          height: 20,
+          background: 'grey',
+          borderRadius: '50%',
+          filter: 'blur(3px)',
+        }}
+      >
+        <span>
+          &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+        </span>
+      </span>
+    </div>
+  );
+}
+
+
+
+export default function HeaderBarSuspense () {
+  renderLog('"Render" of HeaderBarSuspense');
+  const left = (window.innerWidth - 964) / 2;  // about 358 on a high res screen
+
+  return (
+    <div style={{
+      // boxSizing: 'border-box',
+      position: 'relative',
+      color: 'rgb(51, 51, 51)',
+      backgroundColor: 'white',
+      // display: 'block',
+      fontFamily: '"Nunito Sans", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif',
+      fontSize: 16,
+      fontWeight: 400,
+      height: '48px',
+      boxShadow: 'rgba(0, 0, 0, 0.2) 0px 2px 4px -1px, rgba(0, 0, 0, 0.14) 0px 4px 5px 0px, rgba(0, 0, 0, 0.12) 0px 1px 10px 0px',
+    }}
+    >
+      <SmallCloud left={`${left}px`} wide />
+      <SmallCloud left={`${left + 166}px`} />
+      <SmallCloud left={`${left + 256}px`} />
+      <SmallCloud left={`${left + 341}px`} />
+      <SmallCloud left={`${left + 441}px`} />
+      <SmallCloud left={`${left + 926}px`} />
+    </div>
+  );
+}

--- a/src/js/components/Navigation/WelcomeAppbar.jsx
+++ b/src/js/components/Navigation/WelcomeAppbar.jsx
@@ -493,6 +493,8 @@ const styles = (theme) => ({
   toolbar: {
     width: 960,
     maxWidth: '95%',
+    marginLeft: 'auto',
+    marginRight: 'auto',
     justifyContent: 'space-between',
     borderBottom: '2px solid rgba(255, 255, 255, 0.1)',
   },
@@ -538,6 +540,7 @@ const styles = (theme) => ({
 
 const DesktopView = styled.div`
   display: inherit;
+  max-width: unset;
   @media (max-width: ${({ theme }) => theme.breakpoints.lg}) {
     display: none;
   }

--- a/src/js/components/Ready/ReadyInformationDisclaimer.jsx
+++ b/src/js/components/Ready/ReadyInformationDisclaimer.jsx
@@ -2,10 +2,10 @@ import { Button } from '@material-ui/core';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { OverlayTrigger } from 'react-bootstrap'; // TODO APRIL 2021:  Replace with MUI
+import Popover from 'react-bootstrap/Popover';
 import { isAndroid, isIOS, isWebApp } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 
-const Popover = React.lazy(() => import(/* webpackChunkName: 'BootstrapPopover' */ 'react-bootstrap/Popover')); // TODO APRIL 2021:  Replace with MUI
 
 class ReadyInformationDisclaimer extends React.Component {
   render () {

--- a/src/js/components/Values/IssueLinkToggle.jsx
+++ b/src/js/components/Values/IssueLinkToggle.jsx
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Button from 'react-bootstrap/Button';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
 import IssueActions from '../../actions/IssueActions';
 import { renderLog } from '../../utils/logging';
 import IssueImageDisplay from './IssueImageDisplay';
 
-const Popover = React.lazy(() => import(/* webpackChunkName: 'BootstrapPopover' */ 'react-bootstrap/Popover'));
 
 export default class IssueLinkToggle extends Component {
   constructor (props) {

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -327,6 +327,11 @@ class Ballot extends Component {
       News.preload();
       Values.preload();
     }, 2000);
+
+    if (window.serviceWorkerLoaded === undefined) {
+      navigator.serviceWorker.register('/sw.js');
+      window.serviceWorkerLoaded = true;
+    }
   }  // end of componentDidMount
 
   // eslint-disable-next-line camelcase,react/sort-comp

--- a/src/js/stores/VoterGuideStore.js
+++ b/src/js/stores/VoterGuideStore.js
@@ -9,6 +9,7 @@ import convertVoterGuideToElection from '../utils/voterGuideFunctions';
 import OrganizationStore from './OrganizationStore'; // eslint-disable-line import/no-cycle
 import VoterStore from './VoterStore'; // eslint-disable-line import/no-cycle
 
+
 class VoterGuideStore extends ReduceStore {
   // The store keeps nested attributes of voter guides in allCachedVoterGuides, whereas the followed, ignoring, to_follow are just lists of ids.
   getInitialState () {
@@ -38,7 +39,7 @@ class VoterGuideStore extends ReduceStore {
     // console.log("VoterGuideStore, returnVoterGuidesFromListOfIds listOfOrganizationWeVoteIds: ", listOfOrganizationWeVoteIds);
     // console.log("VoterGuideStore, returnVoterGuidesFromListOfIds state.allCachedVoterGuides: ", state.allCachedVoterGuides);
     const filteredVoterGuides = [];
-    if (listOfOrganizationWeVoteIds) {
+    if (listOfOrganizationWeVoteIds && listOfOrganizationWeVoteIds.length) {
       // voterGuidesFollowedRetrieve API returns more than one voter guide per organization some times.
       const uniqueOrganizationWeVoteIdArray = listOfOrganizationWeVoteIds.filter((value, index, self) => self.indexOf(value) === index);
       uniqueOrganizationWeVoteIdArray.forEach((organizationWeVoteId) => {
@@ -236,6 +237,10 @@ class VoterGuideStore extends ReduceStore {
   voterGuidesToFollowRetrieveStopped () {
     // While this is set to true, don't allow any more calls to this API
     return this.getState().voterGuidesToFollowRetrieveStopped;
+  }
+
+  getOrganizationWeVoteIdsByIssueWeVoteIdDict () {
+    return this.getState().organizationWeVoteIdsByIssueWeVoteId;
   }
 
   voterGuidesUpcomingFromFriendsStopped (googleCivicElectionId) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,9 @@ module.exports = (env, argv) => ({
           },
         }),
       ] : []),
-      new CssMinimizerPlugin(),
+      new CssMinimizerPlugin({
+        test: /\.css$/i,
+      }),
     ],
   },
   resolve: {


### PR DESCRIPTION
They weren't in the main chunk anyways, just some similarly named components from other packages
Added a Suspense component for the header, makes the lazy load look better.
Since I cut back on many unessential API calls for the first load of a page, ValuesToFollowPreview on values/Opinions needed the google_civic_id if it was first page loaded, so had to do a voterBallotItemsRetrieve then a voterGuidesFromFriendsUpcomingRetrieve to populate it.
Restored the 960px max-width of the various pages

**There is still more to fix**

Todo:
* Slow APIs:
  * voterGuidesFromFriendsUpcomingRetrieve takes 8.45 seconds to return two simple records (Ready signed in)
  * issuesUnderBallotItemsRetrieve fetches 34,868 rows of data and executes in the range of 500ms to 10 seconds
* Backport current Stripe implementation from Campaigns
* PaidAccountUpgradeModal and Donations are currently commented out -- fix this
* Test every initial page route, in a new session to confirm required lazy loading is covered.
