### PR TITLE
Fixed regression in TwitterSignInProcess

### DIFF
--- a/src/js/routes/Process/TwitterSignInProcess.jsx
+++ b/src/js/routes/Process/TwitterSignInProcess.jsx
@@ -21,7 +21,6 @@ export default class TwitterSignInProcess extends Component {
       redirectInProgress: false,
       twitterAuthResponse: {},
       yesPleaseMergeAccounts: false,
-      jQueryInitialized: false,
     };
   }
 
@@ -170,8 +169,7 @@ export default class TwitterSignInProcess extends Component {
     if (redirectInProgress) {
       return null;
     }
-    const { jQueryInitialized } = this.state;
-    if (!jQueryInitialized) {
+    if (window.$ === undefined) {
       return (
         <div className="twitter_sign_in_root">
           <div className="page-content-container" style={{ paddingTop: `${cordovaScrollablePaneTopPadding()}` }}>
@@ -185,7 +183,6 @@ export default class TwitterSignInProcess extends Component {
         </div>
       );
     }
-
 
     oAuthLog('TwitterSignInProcess render');
     if (!twitterAuthResponse ||

--- a/src/js/utils/lazyPreloadPages.js
+++ b/src/js/utils/lazyPreloadPages.js
@@ -11,7 +11,8 @@ const loaded = {
 
 function lazyWithPreload (factory) {
   if (webAppConfig.LOG_RENDER_EVENTS || webAppConfig.LOG_ONLY_FIRST_RENDER_EVENTS) {
-    console.log(`preload ==== ${factory} ====`);
+    const result = factory.toString().match(/.*?\| (.*?) \*\//);
+    console.log(`preload ==== ${result.length > 1 ? result[1] : factory} ====`);
   }
 
   const Component = React.lazy(factory);


### PR DESCRIPTION
Todo:
* More font awesome to replace with material-ui Icons
* Slow APIs:
  * issuesUnderBallotItemsRetrieve via CDN in 10 seconds, (333kb, 34,800 records)
  * voterGuidesFromFriendsUpcomingRetrieve 9.9 seconds, 2 simple records, 4kb via VoterGuideActions.js:106
  * issuesUnderBallotItemsRetrieve/CDN 9.9 seconds, 35k records, 334kb via Ballot.js:238
  * voterGuidesFollowedRetrieve in 2 seconds (retrieves 855 records, 804kb)
  * friendList/?kind_of_list=CURRENT_FRIENDS 1.5 seconds (and we were doing it twice in parallel)
* Backport current Stripe implementation from Campaigns
* PaidAccountUpgradeModal and Donations are currently commented out -- fix this
* Test every initial page route, in a new session to confirm required lazy loading is covered.
