### PR TITLE
Fixed routing of URLs that begin with a twitter handle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@loadable/component": "^5.14.1",
-        "@material-ui/core": "~4.11.3",
+        "@material-ui/core": "^4.11.4",
         "@material-ui/icons": "~4.11.2",
         "@material-ui/lab": "^4.0.0-alpha.57",
         "@material-ui/styles": "^4.11.4",
@@ -1839,14 +1839,14 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/@material-ui/core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
-      "integrity": "sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
       "dependencies": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.3",
+        "@material-ui/styles": "^4.11.4",
         "@material-ui/system": "^4.11.3",
-        "@material-ui/types": "^5.1.0",
+        "@material-ui/types": "5.1.0",
         "@material-ui/utils": "^4.11.2",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",
@@ -1858,6 +1858,20 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/material-ui"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@material-ui/icons": {
@@ -22634,14 +22648,14 @@
       }
     },
     "@material-ui/core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.3.tgz",
-      "integrity": "sha512-Adt40rGW6Uds+cAyk3pVgcErpzU/qxc7KBR94jFHBYretU4AtWZltYcNsbeMn9tXL86jjVL1kuGcIHsgLgFGRw==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-oqb+lJ2Dl9HXI9orc6/aN8ZIAMkeThufA5iZELf2LQeBn2NtjVilF5D2w7e9RpntAzDb4jK5DsVhkfOvFY/8fg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
-        "@material-ui/styles": "^4.11.3",
+        "@material-ui/styles": "^4.11.4",
         "@material-ui/system": "^4.11.3",
-        "@material-ui/types": "^5.1.0",
+        "@material-ui/types": "5.1.0",
         "@material-ui/utils": "^4.11.2",
         "@types/react-transition-group": "^4.2.0",
         "clsx": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@loadable/component": "^5.14.1",
-    "@material-ui/core": "~4.11.3",
+    "@material-ui/core": "^4.11.4",
     "@material-ui/icons": "~4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.57",
     "@material-ui/styles": "^4.11.4",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,11 +8,9 @@ import ErrorBoundary from './js/components/Widgets/ErrorBoundary';
 import WeVoteRouter from './js/components/Widgets/WeVoteRouter';
 import muiTheme from './js/mui-theme';
 import styledTheme from './js/styled-theme';
-import cookies from './js/utils/cookies';
 import initializejQuery from './js/utils/initializejQuery';
 import { renderLog } from './js/utils/logging';
 import RouterV5SendMatch from './js/utils/RouterV5SendMatch';
-// import SnackNotifier from './js/components/Widgets/SnackNotifier';
 
 // Root URL pages
 
@@ -91,32 +89,24 @@ const WelcomeForOrganizations = React.lazy(() => import(/* webpackChunkName: 'We
 const WelcomeForVoters = React.lazy(() => import(/* webpackChunkName: 'WelcomeForVoters' */ './js/routes/WelcomeForVoters'));
 const YourPage = React.lazy(() => import(/* webpackChunkName: 'YourPage' */ './js/routes/YourPage'));
 
-// There are just too many "prop spreadings", if someone can figure out an alternative...
+// There are just too many "prop spreadings" in the use of Route, if someone can figure out an alternative...
 /* eslint-disable react/jsx-props-no-spreading */
 
 class App extends Component {
   constructor (props) {
     super(props);
     this.state = {
-      doShowHeader: true,
-      doShowFooter: true,
-      isInitialized: false,
+      // doShowHeader: true,
+      // doShowFooter: true,
+      // isInitialized: false,
       showReadyLight: true,
     };
-    this.setShowHeader = this.setShowHeader.bind(this);
-    this.setShowFooter = this.setShowFooter.bind(this);
-    this.setShowHeaderFooter = this.setShowHeaderFooter.bind(this);
+    // this.setShowHeader = this.setShowHeader.bind(this);
+    // this.setShowFooter = this.setShowFooter.bind(this);
+    // this.setShowHeaderFooter = this.setShowHeaderFooter.bind(this);
     this.setShowReadyHeavy = this.setShowReadyHeavy.bind(this);
     this.localIsCordova();
   }
-
-  // From index.js (4/20/21)
-  localIsCordova () {
-    const { cordova } = window;
-    window.isCordovaGlobal = cordova !== undefined;    // So now we set a global
-    return cordova !== undefined;
-  }
-
 
   // See https://reactjs.org/docs/error-boundaries.html
   static getDerivedStateFromError (error) { // eslint-disable-line no-unused-vars
@@ -137,41 +127,53 @@ class App extends Component {
     console.error('App caught error: ', `${error} with info: `, info);
   }
 
-  setShowHeader (doShowHeader) {
-    console.log('-----------HEADER setShowHeader');
-    this.setState({ doShowHeader });
-  }
+  // setShowHeader (doShowHeader) {
+  //   console.log('-----------HEADER setShowHeader');
+  //   this.setState({ doShowHeader });
+  // }
 
-  setShowFooter (doShowFooter) {
-    console.log('-----------HEADER setShowFooter');
-    this.setState({ doShowFooter });
-  }
+  // setShowFooter (doShowFooter) {
+  //   console.log('-----------HEADER setShowFooter');
+  //   this.setState({ doShowFooter });
+  // }
 
-  setShowHeaderFooter (doShow) {
-    console.log('-----------HEADER setShowHeaderFooter', doShow);
-    // console.log('setShowHeaderFooter -------------- doShow:', doShow);
-    this.setState({
-      doShowHeader: doShow,
-      doShowFooter: doShow,
-    });
-  }
+  // setShowHeaderFooter (doShow) {
+  //   console.log('-----------HEADER setShowHeaderFooter', doShow);
+  //   // console.log('setShowHeaderFooter -------------- doShow:', doShow);
+  //   this.setState({
+  //     doShowHeader: doShow,
+  //     doShowFooter: doShow,
+  //   });
+  // }
 
   setShowReadyHeavy () {
     this.setState({ showReadyLight: false });
   }
 
+  // From index.js (4/20/21)
+  localIsCordova () {
+    const { cordova } = window;
+    window.isCordovaGlobal = cordova !== undefined;    // So now we set a global
+    return cordova !== undefined;
+  }
+
   render () {
     renderLog('App');
-    const { doShowHeader, doShowFooter, jQueryInitialized, showReadyLight } = this.state;
+    const { /* doShowHeader, doShowFooter, */ showReadyLight } = this.state;
     // console.log(`App doShowHeader: ${doShowHeader}, doShowFooter:${doShowFooter}`);
     let { hostname } = window.location;
     hostname = hostname || '';
     const weVoteSites = ['wevote.us', 'quality.wevote.us', 'localhost', 'silicon', ''];   // localhost on Cordova is a ''
     const isWeVoteMarketingSite = weVoteSites.includes(String(hostname));
     const isNotWeVoteMarketingSite = !isWeVoteMarketingSite;
-    const firstVisit = !cookies.getItem('voter_device_id');
+    // const firstVisit = !cookies.getItem('voter_device_id');
 
     console.log('href in App.js render: ', window.location.href);
+
+    /*
+    Note: To debug routing, set a breakpoint in the class that routing takes you to -- then look at the received props.
+    The props.match.path shows exactly which route string from this file, was selected by the <Switch>
+    */
 
     return (
       <ErrorBoundary>
@@ -381,54 +383,55 @@ class App extends Component {
                     <Route path="/wevoteintro/network" component={IntroNetwork} />
                     <Route path="/wevoteintro/newfriend/:invitationSecretKey" component={FriendInvitationOnboarding} />
                     <Route path="/yourpage" component={YourPage} />
-                    <Route path=":twitter_handle($)?" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/:action_variable" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/ballot/:ballot_location_shortcut" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/ballot/election/:google_civic_election_id" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/ballot/election/:google_civic_election_id/:view_mode" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/ballot/empty" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/ballot/id/:ballot_returned_we_vote_id" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/ballot/id/:ballot_returned_we_vote_id/:view_mode" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/followers" component={(props) => <TwitterHandleLanding {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/following" component={(props) => <TwitterHandleLanding {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/positions" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show/:shared_item_code" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/followers" component={(props) => <TwitterHandleLanding {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/following" component={(props) => <TwitterHandleLanding {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/modal/:modal_to_show" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/positions" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show/:shared_item_code" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/followers" component={(props) => <TwitterHandleLanding {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/following" component={(props) => <TwitterHandleLanding {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
-                    <Route path=":twitter_handle/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
-                    <Route path=":twitter_handle/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />}  />
-                    <Route path=":twitter_handle/modal/:modal_to_show" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
-                    <Route path=":twitter_handle/positions" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/positions/modal/:modal_to_show" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
-                    <Route path=":twitter_handle/positions/modal/:modal_to_show/:shared_item_code" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/:action_variable" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/ballot/:ballot_location_shortcut" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/ballot/election/:google_civic_election_id" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/ballot/election/:google_civic_election_id/:view_mode" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/ballot/empty" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/ballot/id/:ballot_returned_we_vote_id" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/ballot/id/:ballot_returned_we_vote_id/:view_mode" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/:action_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/followers" component={(props) => <TwitterHandleLanding {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/following" component={(props) => <TwitterHandleLanding {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/positions" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/btcand/:back_to_cand_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show/:shared_item_code" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/:action_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/followers" component={(props) => <TwitterHandleLanding {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/following" component={(props) => <TwitterHandleLanding {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/modal/:modal_to_show" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/positions" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/btmeas/:back_to_meas_we_vote_id/b/:back_to_variable/positions/modal/:modal_to_show/:shared_item_code" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/followers" component={(props) => <TwitterHandleLanding {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/following" component={(props) => <TwitterHandleLanding {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/m/followers" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="followers" />} />
+                    <Route path="/:twitter_handle/m/following" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="following" />} />
+                    <Route path="/:twitter_handle/m/friends" component={(props) => <OrganizationVoterGuideMobileDetails {...props} activeRoute="friends" />}  />
+                    <Route path="/:twitter_handle/modal/:modal_to_show" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/modal/:modal_to_show/:shared_item_code" component={TwitterHandleLanding} />
+                    <Route path="/:twitter_handle/positions" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/positions/modal/:modal_to_show" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle/positions/modal/:modal_to_show/:shared_item_code" component={(props) => <TwitterHandleLanding {...props} activeRoute="positions" />} />
+                    <Route path="/:twitter_handle($)?" component={TwitterHandleLanding} />
                     <Route path="*" component={PageNotFound} />
                   </Switch>
                   {/*

--- a/src/js/compileDate.js
+++ b/src/js/compileDate.js
@@ -1,1 +1,1 @@
-module.exports = ['6/2/2021, 2:21:27 PM'];
+module.exports = ['6/3/2021, 9:38:02 AM'];

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -335,7 +335,7 @@ class Ballot extends Component {
   // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
     // WARN: Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.
-    console.log('Ballot UNSAFE_componentWillReceiveProps');
+    // console.log('Ballot UNSAFE_componentWillReceiveProps');
     const { match: { params: nextParams } } = nextProps;
 
     // We don't want to let the googleCivicElectionId disappear

--- a/src/js/routes/TwitterHandleLanding.jsx
+++ b/src/js/routes/TwitterHandleLanding.jsx
@@ -45,8 +45,20 @@ export default class TwitterHandleLanding extends Component {
 
   // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillReceiveProps (nextProps) {
-    // console.log('TwitterHandleLanding componentWillReceiveProps');
-    const { match: { location: { pathname: activeRoute }, params: { twitter_handle: nextTwitterHandle } } } = nextProps;
+    console.log('TwitterHandleLanding componentWillReceiveProps');
+    let activeRoute = '';
+    let nextTwitterHandle;
+    if (nextProps.match && nextProps.match.location) {
+      const { match: { location: { pathname }, params: { twitter_handle: twitter } }  } = nextProps;
+      activeRoute = pathname;
+      nextTwitterHandle = twitter;
+      // eslint-disable-next-line react/prop-types
+    } else if (this.props && this.props.location) {
+      // eslint-disable-next-line react/prop-types
+      const { location: { pathname } } = this.props;
+      activeRoute = pathname;
+    }
+
     const { twitterHandle } = this.state;
     this.setState({
       activeRoute,

--- a/src/js/utils/dateFormat.js
+++ b/src/js/utils/dateFormat.js
@@ -23,12 +23,18 @@ export function formatDateToYearMonthDay (dateString) {
 }
 
 export function timeFromDate (dateString) {
-  initializeMoment(() => {
-    if (!dateString || dateString === '') {
-      return '';
-    }
-    return window.moment.utc(dateString).fromNow();
-  });
+  if (!window.moment) {
+    initializeMoment(() => {
+      if (!dateString || dateString === '') {
+        return '';
+      }
+      return window.moment.utc(dateString).fromNow();
+    });
+  }
+  if (!dateString || dateString === '') {
+    return '';
+  }
+  return window.moment.utc(dateString).fromNow();
 }
 
 export function electionDateTomorrowFormatted (dayText) {

--- a/src/js/utils/dateFormat.js
+++ b/src/js/utils/dateFormat.js
@@ -23,7 +23,7 @@ export function formatDateToYearMonthDay (dateString) {
 }
 
 export function timeFromDate (dateString) {
-  if (!window.moment) {
+  if (window.moment === undefined) {
     initializeMoment(() => {
       if (!dateString || dateString === '') {
         return '';
@@ -31,7 +31,7 @@ export function timeFromDate (dateString) {
       return window.moment.utc(dateString).fromNow();
     });
   }
-  if (!dateString || dateString === '') {
+  if (!dateString || dateString === '' || window.moment === undefined) {
     return '';
   }
   return window.moment.utc(dateString).fromNow();


### PR DESCRIPTION
Todo:
* More font awesome to replace with material-ui Icons
* Slow APIs:
  * issuesUnderBallotItemsRetrieve via CDN in 10 seconds, (333kb, 34,800 records)
  * voterGuidesFromFriendsUpcomingRetrieve 9.9 seconds, 2 simple records, 4kb via VoterGuideActions.js:106
  * issuesUnderBallotItemsRetrieve/CDN 9.9 seconds, 35k records, 334kb via Ballot.js:238
  * voterGuidesFollowedRetrieve in 2 seconds (retrieves 855 records, 804kb)
  * friendList/?kind_of_list=CURRENT_FRIENDS 1.5 seconds (and we were doing it twice in parallel)
* Backport current Stripe implementation from Campaigns
* PaidAccountUpgradeModal and Donations are currently commented out -- fix this