### PR TITLE
Fixed a bldSrcCordova reversion, that caused an exception when clicking ballot immediately after the initial load.

### DIFF
--- a/node/buildSrcCordova.js
+++ b/node/buildSrcCordova.js
@@ -21,8 +21,10 @@ function fileRewriterForCordova (path) {
     // Inject cordova startup in index.jsx, replace "importStartCordovaToken" etc
     newValue = newValue.replace(/^.*?importStartCordovaToken.*?$/gim,
       'import { initializationForCordova } from \'./js/startCordova\';');
-    newValue = newValue.replace(/^.*?importRemoveCordovaListenersToken.*?$/gim,
+    newValue = newValue.replace(/^.*?importRemoveCordovaListenersToken1.*?$/gim,
       'import { removeCordovaSpecificListeners } from \'./js/startCordova\';');
+    newValue = newValue.replace(/^.*?importRemoveCordovaListenersToken2.*?$/gim,
+      'import { removeCordovaSpecificListeners } from \'../../startCordova\';');
     newValue = newValue.replace(/^.*?initializeCordovaToken.*?$/gim,
       '  initializationForCordova(() => startReact());');
     newValue = newValue.replace(/^.*?removeCordovaListenersToken.*?$/gim,

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ import { isWebApp } from './js/utils/cordovaUtils';
 import initializejQuery from './js/utils/initializejQuery';
 import { renderLog } from './js/utils/logging';
 import RouterV5SendMatch from './js/utils/RouterV5SendMatch';
-// importRemoveCordovaListenersToken  -- Do not remove this line!
+// importRemoveCordovaListenersToken1  -- Do not remove this line!
 
 // Root URL pages
 

--- a/src/js/components/CompleteYourProfile/FirstPositionIntroModal.jsx
+++ b/src/js/components/CompleteYourProfile/FirstPositionIntroModal.jsx
@@ -10,7 +10,7 @@ import { normalizedHref } from '../../utils/applicationUtils';
 import { hasIPhoneNotch } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 
-const CandidateItem = React.lazy(() => import(/* webpackChunkName: 'CandidateItem' */ '../../components/Ballot/CandidateItem'));
+const CandidateItem = React.lazy(() => import(/* webpackChunkName: 'CandidateItem' */ '../Ballot/CandidateItem'));
 
 class FirstPositionIntroModal extends Component {
   constructor (props) {

--- a/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
+++ b/src/js/components/CompleteYourProfile/PersonalizedScoreIntroBody.jsx
@@ -8,7 +8,7 @@ import VoterConstants from '../../constants/VoterConstants';
 import { hideZenDeskHelpVisibility, normalizedHref, setZenDeskHelpVisibility } from '../../utils/applicationUtils';
 import { renderLog } from '../../utils/logging';
 
-const CandidateItem = React.lazy(() => import(/* webpackChunkName: 'CandidateItem' */ '../../components/Ballot/CandidateItem'));
+const CandidateItem = React.lazy(() => import(/* webpackChunkName: 'CandidateItem' */ '../Ballot/CandidateItem'));
 
 class PersonalizedScoreIntroBody extends Component {
   constructor (props) {

--- a/src/js/components/Navigation/Footer.jsx
+++ b/src/js/components/Navigation/Footer.jsx
@@ -4,6 +4,7 @@ import { withStyles } from '@material-ui/core/styles';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
 import { getApplicationViewBooleans, normalizedHref } from '../../utils/applicationUtils';
 import { isWebApp } from '../../utils/cordovaUtils';
+// importRemoveCordovaListenersToken2  -- Do not remove this line!
 
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../Widgets/DelayedLoad'));

--- a/src/js/components/Settings/SettingsProfile.jsx
+++ b/src/js/components/Settings/SettingsProfile.jsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import AnalyticsActions from '../../actions/AnalyticsActions';
 import VoterStore from '../../stores/VoterStore';
+import { isWebApp } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import { HeaderContentContainer } from '../../utils/pageLayoutStyles';
 import LoadingWheel from '../LoadingWheel';
@@ -74,8 +75,12 @@ class SettingsProfile extends Component {
                 closeEditFormOnChoice
                 showEditToggleOption
               />
-              <SectionTitle>Profile Picture</SectionTitle>
-              <SettingsProfilePicture />
+              {isWebApp() && (
+                <>
+                  <SectionTitle>Profile Picture</SectionTitle>
+                  <SettingsProfilePicture />
+                </>
+              )}
             </div>
           </div>
         </div>

--- a/src/js/components/Share/ShareButtonFooter.jsx
+++ b/src/js/components/Share/ShareButtonFooter.jsx
@@ -12,7 +12,7 @@ import AppObservableStore, { messageService } from '../../stores/AppObservableSt
 import VoterStore from '../../stores/VoterStore';
 import { getApplicationViewBooleans, normalizedHref } from '../../utils/applicationUtils';
 import { shareBottomOffset } from '../../utils/cordovaOffsets';
-import { historyPush, isAndroid, isCordova, isWebApp } from '../../utils/cordovaUtils';
+import { cordovaLinkToBeSharedFixes, historyPush, isAndroid, isCordova, isWebApp } from '../../utils/cordovaUtils';
 import isMobile from '../../utils/isMobile';
 import { renderLog } from '../../utils/logging';
 import { stringContains } from '../../utils/textFormat';
@@ -495,9 +495,7 @@ class ShareButtonFooter extends Component {
       shareMenuTextDefault = 'Ballot';
       shareMenuTextAllOpinions = 'Ballot + Your Opinions';
     }
-    linkToBeShared = linkToBeShared.replace('https://file:/', 'https://wevote.us/');    // Cordova
-    linkToBeShared = linkToBeShared.replace('https://app:/', 'https://wevote.us/');     // Cordova iOS Nov 2021
-    linkToBeShared = linkToBeShared.replace('app://localhost/index.html#/', 'https://wevote.us/');  // Cordova iOS Nov 2021
+    linkToBeShared = cordovaLinkToBeSharedFixes(linkToBeShared);
     // console.log('ShareButtonFooter showShareButton: ', showShareButton, ', linkToBeShared:', linkToBeShared);
 
     const hideFooterBehindModal = showingOneCompleteYourProfileModal || showShareModal || showSignInModal || showVoterPlanModal;

--- a/src/js/components/Share/ShareModal.jsx
+++ b/src/js/components/Share/ShareModal.jsx
@@ -12,7 +12,7 @@ import AppObservableStore, { messageService } from '../../stores/AppObservableSt
 import FriendStore from '../../stores/FriendStore';
 import ShareStore from '../../common/stores/ShareStore';
 import VoterStore from '../../stores/VoterStore';
-import { cordovaDot, hasIPhoneNotch, isAndroid, isCordova, isWebApp } from '../../utils/cordovaUtils';
+import { cordovaDot, cordovaLinkToBeSharedFixes, hasIPhoneNotch, isAndroid, isCordova, isWebApp } from '../../utils/cordovaUtils';
 import sortFriendListByMutualFriends from '../../utils/friendFunctions';
 import { renderLog } from '../../utils/logging';
 import { stringContains } from '../../utils/textFormat';
@@ -250,7 +250,7 @@ class ShareModal extends Component {
       } else {
         linkToBeShared = currentFullUrlToShare;
       }
-      linkToBeShared = linkToBeShared.replace('https://file:/', 'https://wevote.us/');  // Cordova
+      linkToBeShared = cordovaLinkToBeSharedFixes(linkToBeShared);
       linkToBeSharedUrlEncoded = encodeURI(linkToBeShared);
       console.log('ShareModal linkToBeShared:', linkToBeShared);
 

--- a/src/js/components/VoterGuide/OrganizationModal.jsx
+++ b/src/js/components/VoterGuide/OrganizationModal.jsx
@@ -23,7 +23,7 @@ import { hasIPhoneNotch } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import { convertToInteger, stringContains } from '../../utils/textFormat';
 
-const CandidateItem = React.lazy(() => import(/* webpackChunkName: 'CandidateItem' */ '../../components/Ballot/CandidateItem'));
+const CandidateItem = React.lazy(() => import(/* webpackChunkName: 'CandidateItem' */ '../Ballot/CandidateItem'));
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../Widgets/DelayedLoad'));
 const MeasureItem = React.lazy(() => import(/* webpackChunkName: 'MeasureItem' */ '../Ballot/MeasureItem'));
 const PositionList = React.lazy(() => import(/* webpackChunkName: 'PositionList' */ '../Ballot/PositionList'));

--- a/src/js/components/Widgets/AddEndorsements.jsx
+++ b/src/js/components/Widgets/AddEndorsements.jsx
@@ -3,7 +3,7 @@ import { cordovaDot } from '../../utils/cordovaUtils';
 import InfoCircleIcon from './InfoCircleIcon';
 import SplitIconButton from './SplitIconButton';
 
-const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../Widgets/OpenExternalWebSite'));
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ './OpenExternalWebSite'));
 
 const positionIcon = '../../../img/global/svg-icons/positions-icon-24-x-24.svg';
 const text = 'Don\'t see your favorite organization or endorsement? We Vote is nonpartisan and welcomes public endorsements of candidates and measures from any organization or public figure.';

--- a/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Widgets/BallotItemSupportOpposeCountDisplay.jsx
@@ -16,7 +16,7 @@ import { stringContains } from '../../utils/textFormat';
 import StickyPopover from '../Ballot/StickyPopover';
 import { openSnackbar } from './SnackNotifier';
 
-const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ '../Widgets/ItemActionBar/ItemActionBar'));
+const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ './ItemActionBar/ItemActionBar'));
 const PositionSummaryListForPopover = React.lazy(() => import(/* webpackChunkName: 'PositionSummaryListForPopover' */ './PositionSummaryListForPopover'));
 const ShowMoreFooter = React.lazy(() => import(/* webpackChunkName: 'ShowMoreFooter' */ '../Navigation/ShowMoreFooter'));
 

--- a/src/js/components/Widgets/EndorsementCard.jsx
+++ b/src/js/components/Widgets/EndorsementCard.jsx
@@ -6,7 +6,7 @@ import VoterStore from '../../stores/VoterStore';
 import SplitIconButton from './SplitIconButton';
 import SvgImage from './SvgImage';
 
-const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../Widgets/OpenExternalWebSite'));
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ './OpenExternalWebSite'));
 
 
 class EndorsementCard extends PureComponent {

--- a/src/js/components/Widgets/ErrorBoundary.jsx
+++ b/src/js/components/Widgets/ErrorBoundary.jsx
@@ -21,8 +21,40 @@ class ErrorBoundary extends Component {
 
   render () {
     if (this.state.hasError) {
-      // You can render any custom fallback UI
-      return <h1 style={{ margin: '100px', color: 'black' }}>Something went wrong.</h1>;
+      // You could render any custom fallback UI here
+      return (
+        <div style={{
+          margin: '100px',
+          padding: '10px',
+          backgroundColor: 'white',
+          boxShadow: 'rgba(0, 0, 0, 0.2) 0px 1px 3px 0px, rgba(0, 0, 0, 0.14) 0px 1px 1px 0px, rgba(0, 0, 0, 0.12) 0px 2px 1px -1px',
+        }}
+        >
+          <h1 style={{ margin: '20px', color: 'black', fontSize: '24px' }}>Whoops! Something went wrong.</h1>
+          <h1 style={{ margin: '20px', color: 'black' }}>Try restarting the app.</h1>
+          <h1 style={{ margin: '20px', color: 'black' }}>
+            Please send us an email at &nbsp;
+            <a
+              href="mailto:info@WeVote.US"
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                color: 'blue',
+                textDecoration: 'underline',
+                hover: {
+                  textDecoration: 'none !important',
+                  color: 'black !important',
+                  transform: 'scale(1.05)',
+                  transitionDuration: '.25s',
+                },
+              }}
+            >
+              info@WeVote.US
+            </a>
+            &nbsp;describing the problem.
+          </h1>
+        </div>
+      );
     }
 
     return this.props.children;

--- a/src/js/components/Widgets/SignInModal.jsx
+++ b/src/js/components/Widgets/SignInModal.jsx
@@ -4,6 +4,7 @@ import { Close } from '@material-ui/icons';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import VoterStore from '../../stores/VoterStore';
 import { historyPush, isAndroid, isCordova, isIOS, isIOsSmallerThanPlus, isIPhone5p5inEarly, isIPhone5p5inMini, isIPhone5p8in, isIPhone6p1in, isIPhone6p5in, isWebApp, isWebAppHeight0to568, isWebAppHeight569to667, isWebAppHeight668to736, isWebAppHeight737to896, restoreStylesAfterCordovaKeyboard } from '../../utils/cordovaUtils';
 import initializeAppleSDK from '../../utils/initializeAppleSDK';
@@ -196,6 +197,19 @@ class SignInModal extends Component {
               )}
             </div>
           </section>
+          {isCordova && (
+            <div className="text-center">
+              <span id="termsAndPrivacySignInModal" className="terms-and-privacy">
+                <Link to="/more/privacy" onClick={this.closeFunction}>
+                  <span className="u-no-break" style={{ color: 'black', textDecoration: 'underline' }}>Privacy Policy</span>
+                </Link>
+                <span style={{ paddingLeft: 20 }} />
+                <Link to="/more/terms" onClick={this.closeFunction}>
+                  <span className="u-no-break" style={{ color: 'black', textDecoration: 'underline' }}>Terms of Service</span>
+                </Link>
+              </span>
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     );

--- a/src/js/routes/Ballot/Ballot.jsx
+++ b/src/js/routes/Ballot/Ballot.jsx
@@ -322,7 +322,7 @@ class Ballot extends Component {
 
     this.preloadTimer = setTimeout(() => lazyPreloadPages(), 2000);
 
-    if (webAppConfig.ENABLE_WORKBOX_SERVICE_WORKER &&
+    if (isWebApp() && webAppConfig.ENABLE_WORKBOX_SERVICE_WORKER &&
         window.serviceWorkerLoaded === undefined) {
       navigator.serviceWorker.register('/sw.js');
       window.serviceWorkerLoaded = true;

--- a/src/js/utils/cordovaUtils.js
+++ b/src/js/utils/cordovaUtils.js
@@ -774,5 +774,14 @@ export function polyfillFixes (file) {
   }
 }
 
+export function cordovaLinkToBeSharedFixes (link) {
+  let linkToBeShared = link;
+  linkToBeShared = linkToBeShared.replace('https://file:/', 'https://wevote.us/');  // Cordova
+  linkToBeShared = linkToBeShared.replace('https://file:/', 'https://wevote.us/');    // Cordova
+  linkToBeShared = linkToBeShared.replace('https://app:/', 'https://wevote.us/');     // Cordova iOS Nov 2021
+  linkToBeShared = linkToBeShared.replace('app://localhost/index.html#/', 'https://wevote.us/');  // Cordova iOS Nov 2021
+  return linkToBeShared;
+}
+
 // In-line
 polyfillFixes('cordovaUtils.js'); // Possibly redundant, but its need was confirmed in the debugger.  This has to run, before any polyfill is needed.


### PR DESCRIPTION
Cleared some lint problems
Made the "We're sorry" page more useful.
Released to TestFlight as Version 1.1.1 build 2.2.1.3
Removed SettingsProfilePicture for Cordova
Added privacy policy to SignInModal for Facebook