### PR TITLE
Reduced size of main.css by 88% to speed loading

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1,13 +1,10 @@
-@charset "UTF-8";
-/*!
+@charset "UTF-8"; /*!
  * Bootstrap v4.6.0 (https://getbootstrap.com/)
  * Copyright 2011-2021 The Bootstrap Authors
  * Copyright 2011-2021 Twitter, Inc.
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */
-@import url('https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap');
-
-:root {
+@import url('https://fonts.googleapis.com/css?family=Nunito+Sans:400,700&display=swap'); :root {
   --blue: #007bff;
   --indigo: #6610f2;
   --purple: #6f42c1;
@@ -35,20 +32,21 @@
   --breakpoint-lg: 992px;
   --breakpoint-xl: 1200px;
   --font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-  --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+  --font-family-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
 
-*,
-*::before,
-*::after {
-  box-sizing: border-box; }
+*, *::before, *::after {
+  box-sizing: border-box;
+}
 
 html {
   box-sizing: border-box;
   /* 1 */
-  -ms-text-size-adjust: 100%;
+  /*-ms-text-size-adjust: 100%;*/
   /* 2 */
   -webkit-text-size-adjust: 100%;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0); }
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+}
 
 body {
   background-color: #ebecee;
@@ -64,203 +62,219 @@ body {
 }
 
 article, aside, figcaption, figure, footer, header, hgroup, main, nav, section {
-  display: block; }
+  display: block;
+}
 
 [tabindex="-1"]:focus:not(:focus-visible) {
-  outline: 0 !important; }
+  outline: 0 !important;
+}
 
 hr {
   box-sizing: content-box;
   height: 0;
-  overflow: visible; }
+  overflow: visible;
+}
 
 h1, h2, h3, h4, h5, h6 {
   margin-top: 0;
-  margin-bottom: 0.5rem; }
+  margin-bottom: 0.5rem;
+}
 
 p {
   margin-top: 0;
-  margin-bottom: 1rem; }
-
-abbr[title],
-abbr[data-original-title] {
-  text-decoration: underline;
-  -webkit-text-decoration: underline dotted;
-  text-decoration: underline dotted;
-  cursor: help;
-  border-bottom: 0;
-  -webkit-text-decoration-skip-ink: none;
-  text-decoration-skip-ink: none; }
-
-address {
   margin-bottom: 1rem;
-  font-style: normal;
-  line-height: inherit; }
+}
 
-ol,
-ul,
-dl {
+/*abbr[title], abbr[data-original-title] {*/
+/*  text-decoration: underline;*/
+/*  -webkit-text-decoration: underline dotted;*/
+/*  text-decoration: underline dotted;*/
+/*  cursor: help;*/
+/*  border-bottom: 0;*/
+/*  -webkit-text-decoration-skip-ink: none;*/
+/*  text-decoration-skip-ink: none;*/
+/*}*/
+
+/*address {*/
+/*  margin-bottom: 1rem;*/
+/*  font-style: normal;*/
+/*  line-height: inherit;*/
+/*}*/
+
+ol, ul, dl {
   margin-top: 0;
-  margin-bottom: 1rem; }
+  margin-bottom: 1rem;
+}
 
-ol ol,
-ul ul,
-ol ul,
-ul ol {
-  margin-bottom: 0; }
+/*ol ol, ul ul, ol ul, ul ol {*/
+/*  margin-bottom: 0;*/
+/*}*/
 
-dt {
-  font-weight: 700; }
+/*dt {*/
+/*  font-weight: 700;*/
+/*}*/
 
-dd {
-  margin-bottom: .5rem;
-  margin-left: 0; }
+/*dd {*/
+/*  margin-bottom: .5rem;*/
+/*  margin-left: 0;*/
+/*}*/
 
-blockquote {
-  margin: 0 0 1rem; }
+/*blockquote {*/
+/*  margin: 0 0 1rem;*/
+/*}*/
 
-b,
-strong {
-  font-weight: bolder; }
+b, strong {
+  font-weight: bolder;
+}
 
 small {
-  font-size: 80%; }
+  font-size: 80%;
+}
 
-sub,
-sup {
-  position: relative;
-  font-size: 75%;
-  line-height: 0;
-  vertical-align: baseline; }
+/*sub, sup {*/
+/*  position: relative;*/
+/*  font-size: 75%;*/
+/*  line-height: 0;*/
+/*  vertical-align: baseline;*/
+/*}*/
 
-sub {
-  bottom: -.25em; }
+/*sub {*/
+/*  bottom: -.25em;*/
+/*}*/
 
-sup {
-  top: -.5em; }
+/*sup {*/
+/*  top: -.5em;*/
+/*}*/
 
 a {
   color: #007bff;
   text-decoration: none;
-  background-color: transparent; }
+  background-color: transparent;
+}
 
 a:hover {
   color: #0056b3;
-  text-decoration: underline; }
+  text-decoration: underline;
+}
 
 a:not([href]):not([class]) {
   color: inherit;
-  text-decoration: none; }
+  text-decoration: none;
+}
 
 a:not([href]):not([class]):hover {
   color: inherit;
-  text-decoration: none; }
+  text-decoration: none;
+}
 
-pre,
-code,
-kbd,
-samp {
-  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  font-size: 1em; }
+/*pre, code, kbd, samp {*/
+/*  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;*/
+/*  font-size: 1em;*/
+/*}*/
 
-pre {
-  margin-top: 0;
-  margin-bottom: 1rem;
-  overflow: auto;
-  -ms-overflow-style: scrollbar; }
+/*pre {*/
+/*  margin-top: 0;*/
+/*  margin-bottom: 1rem;*/
+/*  overflow: auto;*/
+/*  -ms-overflow-style: scrollbar;*/
+/*}*/
 
 figure {
-  margin: 0 0 1rem; }
+  margin: 0 0 1rem;
+}
 
 img {
   vertical-align: middle;
-  border-style: none; }
+  border-style: none;
+}
 
 svg {
   overflow: hidden;
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 table {
-  border-collapse: collapse; }
+  border-collapse: collapse;
+}
 
-caption {
-  padding-top: 0.75rem;
-  padding-bottom: 0.75rem;
-  color: #6c757d;
-  text-align: left;
-  caption-side: bottom; }
+/*caption {*/
+/*  padding-top: 0.75rem;*/
+/*  padding-bottom: 0.75rem;*/
+/*  color: #6c757d;*/
+/*  text-align: left;*/
+/*  caption-side: bottom;*/
+/*}*/
 
 th {
   text-align: inherit;
-  text-align: -webkit-match-parent; }
+  text-align: -webkit-match-parent;
+}
 
 label {
   display: inline-block;
-  margin-bottom: 0.5rem; }
+  margin-bottom: 0.5rem;
+}
 
 button {
-  border-radius: 0; }
+  border-radius: 0;
+}
 
 button:focus:not(:focus-visible) {
-  outline: 0; }
+  outline: 0;
+}
 
-input,
-button,
-select,
-optgroup,
-textarea {
+input, button, select, optgroup, textarea {
   margin: 0;
   font-family: inherit;
   font-size: inherit;
-  line-height: inherit; }
+  line-height: inherit;
+}
 
-button,
-input {
-  overflow: visible; }
+button, input {
+  overflow: visible;
+}
 
-button,
-select {
-  text-transform: none; }
+button, select {
+  text-transform: none;
+}
 
 [role="button"] {
-  cursor: pointer; }
+  cursor: pointer;
+}
 
 select {
-  word-wrap: normal; }
+  word-wrap: normal;
+}
 
-button,
-[type="button"],
-[type="reset"],
-[type="submit"] {
-  -webkit-appearance: button; }
+button, [type="button"], [type="reset"], [type="submit"] {
+  -webkit-appearance: button;
+}
 
-button:not(:disabled),
-[type="button"]:not(:disabled),
-[type="reset"]:not(:disabled),
-[type="submit"]:not(:disabled) {
-  cursor: pointer; }
+button:not(:disabled), [type="button"]:not(:disabled), [type="reset"]:not(:disabled), [type="submit"]:not(:disabled) {
+  cursor: pointer;
+}
 
-button::-moz-focus-inner,
-[type="button"]::-moz-focus-inner,
-[type="reset"]::-moz-focus-inner,
-[type="submit"]::-moz-focus-inner {
+button::-moz-focus-inner, [type="button"]::-moz-focus-inner, [type="reset"]::-moz-focus-inner, [type="submit"]::-moz-focus-inner {
   padding: 0;
-  border-style: none; }
+  border-style: none;
+}
 
-input[type="radio"],
-input[type="checkbox"] {
+input[type="radio"], input[type="checkbox"] {
   box-sizing: border-box;
-  padding: 0; }
+  padding: 0;
+}
 
 textarea {
   overflow: auto;
-  resize: vertical; }
+  resize: vertical;
+}
 
 fieldset {
   min-width: 0;
   padding: 0;
   margin: 0;
-  border: 0; }
+  border: 0;
+}
 
 legend {
   display: block;
@@ -271,1333 +285,1809 @@ legend {
   font-size: 1.5rem;
   line-height: inherit;
   color: inherit;
-  white-space: normal; }
+  white-space: normal;
+}
 
-progress {
-  vertical-align: baseline; }
+/*progress {*/
+/*  vertical-align: baseline;*/
+/*}*/
 
-[type="number"]::-webkit-inner-spin-button,
-[type="number"]::-webkit-outer-spin-button {
-  height: auto; }
+/*[type="number"]::-webkit-inner-spin-button, [type="number"]::-webkit-outer-spin-button {*/
+/*  height: auto;*/
+/*}*/
 
-[type="search"] {
-  outline-offset: -2px;
-  -webkit-appearance: none; }
+/*[type="search"] {*/
+/*  outline-offset: -2px;*/
+/*  -webkit-appearance: none;*/
+/*}*/
 
-[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none; }
+/*[type="search"]::-webkit-search-decoration {*/
+/*  -webkit-appearance: none;*/
+/*}*/
 
-::-webkit-file-upload-button {
-  font: inherit;
-  -webkit-appearance: button; }
+/*::-webkit-file-upload-button {*/
+/*  font: inherit;*/
+/*  -webkit-appearance: button;*/
+/*}*/
 
-output {
-  display: inline-block; }
+/*output {*/
+/*  display: inline-block;*/
+/*}*/
 
-summary {
-  display: list-item;
-  cursor: pointer; }
+/*summary {*/
+/*  display: list-item;*/
+/*  cursor: pointer;*/
+/*}*/
 
-template {
-  display: none; }
+/*template {*/
+/*  display: none;*/
+/*}*/
 
 [hidden] {
-  display: none !important; }
+  display: none !important;
+}
 
-h1, h2, h3, h4, h5, h6,
-.h1, .h2, .h3, .h4, .h5, .h6 {
+h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   margin-bottom: 0.5rem;
   font-weight: 500;
-  line-height: 1.2; }
+  line-height: 1.2;
+}
 
 h1, .h1 {
-  font-size: 2.5rem; }
+  font-size: 2.5rem;
+}
 
 h2, .h2 {
-  font-size: 2rem; }
+  font-size: 2rem;
+}
 
 h3, .h3 {
-  font-size: 1.75rem; }
+  font-size: 1.75rem;
+}
 
 h4, .h4 {
-  font-size: 1.5rem; }
+  font-size: 1.5rem;
+}
 
 h5, .h5 {
-  font-size: 1.25rem; }
+  font-size: 1.25rem;
+}
 
 h6, .h6 {
-  font-size: 1rem; }
+  font-size: 1rem;
+}
 
-.lead {
-  font-size: 1.25rem;
-  font-weight: 300; }
+/*.lead {*/
+/*  font-size: 1.25rem;*/
+/*  font-weight: 300;*/
+/*}*/
 
-.display-1 {
-  font-size: 6rem;
-  font-weight: 300;
-  line-height: 1.2; }
+/*.display-1 {*/
+/*  font-size: 6rem;*/
+/*  font-weight: 300;*/
+/*  line-height: 1.2;*/
+/*}*/
 
-.display-2 {
-  font-size: 5.5rem;
-  font-weight: 300;
-  line-height: 1.2; }
+/*.display-2 {*/
+/*  font-size: 5.5rem;*/
+/*  font-weight: 300;*/
+/*  line-height: 1.2;*/
+/*}*/
 
-.display-3 {
-  font-size: 4.5rem;
-  font-weight: 300;
-  line-height: 1.2; }
+/*.display-3 {*/
+/*  font-size: 4.5rem;*/
+/*  font-weight: 300;*/
+/*  line-height: 1.2;*/
+/*}*/
 
-.display-4 {
-  font-size: 3.5rem;
-  font-weight: 300;
-  line-height: 1.2; }
+/*.display-4 {*/
+/*  font-size: 3.5rem;*/
+/*  font-weight: 300;*/
+/*  line-height: 1.2;*/
+/*}*/
 
 hr {
   margin-top: 1rem;
   margin-bottom: 1rem;
   border: 0;
-  border-top: 1px solid rgba(0, 0, 0, 0.1); }
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+}
 
-small,
-.small {
+small, .small {
   font-size: 80%;
-  font-weight: 400; }
+  font-weight: 400;
+}
 
-mark,
-.mark {
-  padding: 0.2em;
-  background-color: #fcf8e3; }
+/*mark, .mark {*/
+/*  padding: 0.2em;*/
+/*  background-color: #fcf8e3;*/
+/*}*/
 
 .list-unstyled {
   padding-left: 0;
-  list-style: none; }
+  list-style: none;
+}
 
-.list-inline {
-  padding-left: 0;
-  list-style: none; }
+/*.list-inline {*/
+/*  padding-left: 0;*/
+/*  list-style: none;*/
+/*}*/
 
-.list-inline-item {
-  display: inline-block; }
+/*.list-inline-item {*/
+/*  display: inline-block;*/
+/*}*/
 
-.list-inline-item:not(:last-child) {
-  margin-right: 0.5rem; }
+/*.list-inline-item:not(:last-child) {*/
+/*  margin-right: 0.5rem;*/
+/*}*/
 
-.initialism {
-  font-size: 90%;
-  text-transform: uppercase; }
+/*.initialism {*/
+/*  font-size: 90%;*/
+/*  text-transform: uppercase;*/
+/*}*/
 
-.blockquote {
-  margin-bottom: 1rem;
-  font-size: 1.25rem; }
+/*.blockquote {*/
+/*  margin-bottom: 1rem;*/
+/*  font-size: 1.25rem;*/
+/*}*/
 
-.blockquote-footer {
-  display: block;
-  font-size: 80%;
-  color: #6c757d; }
+/*.blockquote-footer {*/
+/*  display: block;*/
+/*  font-size: 80%;*/
+/*  color: #6c757d;*/
+/*}*/
 
-.blockquote-footer::before {
-  content: "\2014\00A0"; }
+/*.blockquote-footer::before {*/
+/*  content: "\2014\00A0";*/
+/*}*/
 
-.img-fluid {
-  max-width: 100%;
-  height: auto; }
+/*.img-fluid {*/
+/*  max-width: 100%;*/
+/*  height: auto;*/
+/*}*/
 
-.img-thumbnail {
-  padding: 0.25rem;
-  background-color: #fff;
-  border: 1px solid #dee2e6;
-  border-radius: 0.25rem;
-  max-width: 100%;
-  height: auto; }
+/*.img-thumbnail {*/
+/*  padding: 0.25rem;*/
+/*  background-color: #fff;*/
+/*  border: 1px solid #dee2e6;*/
+/*  border-radius: 0.25rem;*/
+/*  max-width: 100%;*/
+/*  height: auto;*/
+/*}*/
 
-.figure {
-  display: inline-block; }
+/*.figure {*/
+/*  display: inline-block;*/
+/*}*/
 
-.figure-img {
-  margin-bottom: 0.5rem;
-  line-height: 1; }
+/*.figure-img {*/
+/*  margin-bottom: 0.5rem;*/
+/*  line-height: 1;*/
+/*}*/
 
-.figure-caption {
-  font-size: 90%;
-  color: #6c757d; }
+/*.figure-caption {*/
+/*  font-size: 90%;*/
+/*  color: #6c757d;*/
+/*}*/
 
-code {
-  font-size: 87.5%;
-  color: #e83e8c;
-  word-wrap: break-word; }
+/*code {*/
+/*  font-size: 87.5%;*/
+/*  color: #e83e8c;*/
+/*  word-wrap: break-word;*/
+/*}*/
 
-a > code {
-  color: inherit; }
+/*a > code {*/
+/*  color: inherit;*/
+/*}*/
 
-kbd {
-  padding: 0.2rem 0.4rem;
-  font-size: 87.5%;
-  color: #fff;
-  background-color: #212529;
-  border-radius: 0.2rem; }
+/*kbd {*/
+/*  padding: 0.2rem 0.4rem;*/
+/*  font-size: 87.5%;*/
+/*  color: #fff;*/
+/*  background-color: #212529;*/
+/*  border-radius: 0.2rem;*/
+/*}*/
 
-kbd kbd {
-  padding: 0;
-  font-size: 100%;
-  font-weight: 700; }
+/*kbd kbd {*/
+/*  padding: 0;*/
+/*  font-size: 100%;*/
+/*  font-weight: 700;*/
+/*}*/
 
-pre {
-  display: block;
-  font-size: 87.5%;
-  color: #212529; }
+/*pre {*/
+/*  display: block;*/
+/*  font-size: 87.5%;*/
+/*  color: #212529;*/
+/*}*/
 
-pre code {
-  font-size: inherit;
-  color: inherit;
-  word-break: normal; }
+/*pre code {*/
+/*  font-size: inherit;*/
+/*  color: inherit;*/
+/*  word-break: normal;*/
+/*}*/
 
-.pre-scrollable {
-  max-height: 340px;
-  overflow-y: scroll; }
+/*.pre-scrollable {*/
+/*  max-height: 340px;*/
+/*  overflow-y: scroll;*/
+/*}*/
 
-.container,
-.container-fluid,
-.container-sm,
-.container-md,
-.container-lg,
-.container-xl {
+.container, .container-fluid, .container-sm, .container-md, .container-lg, .container-xl {
   width: 100%;
   padding-right: 15px;
   padding-left: 15px;
   margin-right: auto;
-  margin-left: auto; }
+  margin-left: auto;
+}
 
 @media (min-width: 576px) {
   .container, .container-sm {
-    max-width: 540px; } }
+    max-width: 540px;
+  }
+}
 
 @media (min-width: 768px) {
   .container, .container-sm, .container-md {
-    max-width: 720px; } }
+    max-width: 720px;
+  }
+}
 
 @media (min-width: 992px) {
   .container, .container-sm, .container-md, .container-lg {
-    max-width: 960px; } }
+    max-width: 960px;
+  }
+}
 
 @media (min-width: 1200px) {
   .container, .container-sm, .container-md, .container-lg, .container-xl {
-    max-width: 1140px; } }
+    max-width: 1140px;
+  }
+}
 
 .row {
-  display: -ms-flexbox;
+  /*display: -ms-flexbox;*/
   display: flex;
-  -ms-flex-wrap: wrap;
+  /*-ms-flex-wrap: wrap;*/
   flex-wrap: wrap;
   margin-right: -15px;
-  margin-left: -15px; }
+  margin-left: -15px;
+}
 
-.no-gutters {
-  margin-right: 0;
-  margin-left: 0; }
+/*.no-gutters {*/
+/*  margin-right: 0;*/
+/*  margin-left: 0;*/
+/*}*/
 
-.no-gutters > .col,
-.no-gutters > [class*="col-"] {
-  padding-right: 0;
-  padding-left: 0; }
+/*.no-gutters > .col, .no-gutters > [class*="col-"] {*/
+/*  padding-right: 0;*/
+/*  padding-left: 0;*/
+/*}*/
 
-.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col,
-.col-auto, .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm,
-.col-sm-auto, .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .col-md,
-.col-md-auto, .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg,
-.col-lg-auto, .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12, .col-xl,
-.col-xl-auto {
+.col-1, .col-2, .col-3, .col-4, .col-5, .col-6, .col-7, .col-8, .col-9, .col-10, .col-11, .col-12, .col, .col-auto, .col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm, .col-sm-auto, .col-md-1, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9, .col-md-10, .col-md-11, .col-md-12, .col-md, .col-md-auto, .col-lg-1, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg, .col-lg-auto, .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12, .col-xl, .col-xl-auto {
   position: relative;
   width: 100%;
   padding-right: 15px;
-  padding-left: 15px; }
+  padding-left: 15px;
+}
 
 .col {
-  -ms-flex-preferred-size: 0;
+  /*-ms-flex-preferred-size: 0;*/
   flex-basis: 0;
-  -ms-flex-positive: 1;
+  /*-ms-flex-positive: 1;*/
   flex-grow: 1;
-  max-width: 100%; }
+  max-width: 100%;
+}
 
-.row-cols-1 > * {
-  -ms-flex: 0 0 100%;
-  flex: 0 0 100%;
-  max-width: 100%; }
+/*.row-cols-1 > * {*/
+/*-ms-flex: 0 0 100%;*/
+/*  flex: 0 0 100%;*/
+/*  max-width: 100%;*/
+/*}*/
 
-.row-cols-2 > * {
-  -ms-flex: 0 0 50%;
-  flex: 0 0 50%;
-  max-width: 50%; }
+/*.row-cols-2 > * {*/
+/*  -ms-flex: 0 0 50%;*/
+/*  flex: 0 0 50%;*/
+/*  max-width: 50%;*/
+/*}*/
 
-.row-cols-3 > * {
-  -ms-flex: 0 0 33.333333%;
-  flex: 0 0 33.333333%;
-  max-width: 33.333333%; }
+/*.row-cols-3 > * {*/
+/*  -ms-flex: 0 0 33.333333%;*/
+/*  flex: 0 0 33.333333%;*/
+/*  max-width: 33.333333%;*/
+/*}*/
 
-.row-cols-4 > * {
-  -ms-flex: 0 0 25%;
-  flex: 0 0 25%;
-  max-width: 25%; }
+/*.row-cols-4 > * {*/
+/*  -ms-flex: 0 0 25%;*/
+/*  flex: 0 0 25%;*/
+/*  max-width: 25%;*/
+/*}*/
 
-.row-cols-5 > * {
-  -ms-flex: 0 0 20%;
-  flex: 0 0 20%;
-  max-width: 20%; }
+/*.row-cols-5 > * {*/
+/*  -ms-flex: 0 0 20%;*/
+/*  flex: 0 0 20%;*/
+/*  max-width: 20%;*/
+/*}*/
 
-.row-cols-6 > * {
-  -ms-flex: 0 0 16.666667%;
-  flex: 0 0 16.666667%;
-  max-width: 16.666667%; }
+/*.row-cols-6 > * {*/
+/*  -ms-flex: 0 0 16.666667%;*/
+/*  flex: 0 0 16.666667%;*/
+/*  max-width: 16.666667%;*/
+/*}*/
 
-.col-auto {
-  -ms-flex: 0 0 auto;
-  flex: 0 0 auto;
-  width: auto;
-  max-width: 100%; }
+/*.col-auto {*/
+/*  -ms-flex: 0 0 auto;*/
+/*  flex: 0 0 auto;*/
+/*  width: auto;*/
+/*  max-width: 100%;*/
+/*}*/
 
-.col-1 {
-  -ms-flex: 0 0 8.333333%;
-  flex: 0 0 8.333333%;
-  max-width: 8.333333%; }
+/*.col-1 {*/
+/*  -ms-flex: 0 0 8.333333%;*/
+/*  flex: 0 0 8.333333%;*/
+/*  max-width: 8.333333%;*/
+/*}*/
 
-.col-2 {
-  -ms-flex: 0 0 16.666667%;
-  flex: 0 0 16.666667%;
-  max-width: 16.666667%; }
+/*.col-2 {*/
+/*  -ms-flex: 0 0 16.666667%;*/
+/*  flex: 0 0 16.666667%;*/
+/*  max-width: 16.666667%;*/
+/*}*/
 
-.col-3 {
-  -ms-flex: 0 0 25%;
-  flex: 0 0 25%;
-  max-width: 25%; }
+/*.col-3 {*/
+/*  -ms-flex: 0 0 25%;*/
+/*  flex: 0 0 25%;*/
+/*  max-width: 25%;*/
+/*}*/
 
 .col-4 {
-  -ms-flex: 0 0 33.333333%;
+  /*-ms-flex: 0 0 33.333333%;*/
   flex: 0 0 33.333333%;
-  max-width: 33.333333%; }
+  max-width: 33.333333%;
+}
 
-.col-5 {
-  -ms-flex: 0 0 41.666667%;
-  flex: 0 0 41.666667%;
-  max-width: 41.666667%; }
+/*.col-5 {*/
+/*  -ms-flex: 0 0 41.666667%;*/
+/*  flex: 0 0 41.666667%;*/
+/*  max-width: 41.666667%;*/
+/*}*/
 
 .col-6 {
-  -ms-flex: 0 0 50%;
+  /*-ms-flex: 0 0 50%;*/
   flex: 0 0 50%;
-  max-width: 50%; }
+  max-width: 50%;
+}
 
-.col-7 {
-  -ms-flex: 0 0 58.333333%;
-  flex: 0 0 58.333333%;
-  max-width: 58.333333%; }
+/*.col-7 {*/
+/*  -ms-flex: 0 0 58.333333%;*/
+/*  flex: 0 0 58.333333%;*/
+/*  max-width: 58.333333%;*/
+/*}*/
 
-.col-8 {
-  -ms-flex: 0 0 66.666667%;
-  flex: 0 0 66.666667%;
-  max-width: 66.666667%; }
+/*.col-8 {*/
+/*  -ms-flex: 0 0 66.666667%;*/
+/*  flex: 0 0 66.666667%;*/
+/*  max-width: 66.666667%;*/
+/*}*/
 
-.col-9 {
-  -ms-flex: 0 0 75%;
-  flex: 0 0 75%;
-  max-width: 75%; }
+/*.col-9 {*/
+/*  -ms-flex: 0 0 75%;*/
+/*  flex: 0 0 75%;*/
+/*  max-width: 75%;*/
+/*}*/
 
-.col-10 {
-  -ms-flex: 0 0 83.333333%;
-  flex: 0 0 83.333333%;
-  max-width: 83.333333%; }
+/*.col-10 {*/
+/*  -ms-flex: 0 0 83.333333%;*/
+/*  flex: 0 0 83.333333%;*/
+/*  max-width: 83.333333%;*/
+/*}*/
 
-.col-11 {
-  -ms-flex: 0 0 91.666667%;
-  flex: 0 0 91.666667%;
-  max-width: 91.666667%; }
+/*.col-11 {*/
+/*  -ms-flex: 0 0 91.666667%;*/
+/*  flex: 0 0 91.666667%;*/
+/*  max-width: 91.666667%;*/
+/*}*/
 
 .col-12 {
-  -ms-flex: 0 0 100%;
+  /*-ms-flex: 0 0 100%;*/
   flex: 0 0 100%;
-  max-width: 100%; }
+  max-width: 100%;
+}
 
-.order-first {
-  -ms-flex-order: -1;
-  order: -1; }
+/*.order-first {*/
+/*  -ms-flex-order: -1;*/
+/*  order: -1;*/
+/*}*/
 
-.order-last {
-  -ms-flex-order: 13;
-  order: 13; }
+/*.order-last {*/
+/*  -ms-flex-order: 13;*/
+/*  order: 13;*/
+/*}*/
 
-.order-0 {
-  -ms-flex-order: 0;
-  order: 0; }
+/*.order-0 {*/
+/*  -ms-flex-order: 0;*/
+/*  order: 0;*/
+/*}*/
 
-.order-1 {
-  -ms-flex-order: 1;
-  order: 1; }
+/*.order-1 {*/
+/*  -ms-flex-order: 1;*/
+/*  order: 1;*/
+/*}*/
 
-.order-2 {
-  -ms-flex-order: 2;
-  order: 2; }
+/*.order-2 {*/
+/*  -ms-flex-order: 2;*/
+/*  order: 2;*/
+/*}*/
 
-.order-3 {
-  -ms-flex-order: 3;
-  order: 3; }
+/*.order-3 {*/
+/*  -ms-flex-order: 3;*/
+/*  order: 3;*/
+/*}*/
 
-.order-4 {
-  -ms-flex-order: 4;
-  order: 4; }
+/*.order-4 {*/
+/*  -ms-flex-order: 4;*/
+/*  order: 4;*/
+/*}*/
 
-.order-5 {
-  -ms-flex-order: 5;
-  order: 5; }
+/*.order-5 {*/
+/*  -ms-flex-order: 5;*/
+/*  order: 5;*/
+/*}*/
 
-.order-6 {
-  -ms-flex-order: 6;
-  order: 6; }
+/*.order-6 {*/
+/*  -ms-flex-order: 6;*/
+/*  order: 6;*/
+/*}*/
 
-.order-7 {
-  -ms-flex-order: 7;
-  order: 7; }
+/*.order-7 {*/
+/*  -ms-flex-order: 7;*/
+/*  order: 7;*/
+/*}*/
 
-.order-8 {
-  -ms-flex-order: 8;
-  order: 8; }
+/*.order-8 {*/
+/*  -ms-flex-order: 8;*/
+/*  order: 8;*/
+/*}*/
 
-.order-9 {
-  -ms-flex-order: 9;
-  order: 9; }
+/*.order-9 {*/
+/*  -ms-flex-order: 9;*/
+/*  order: 9;*/
+/*}*/
 
-.order-10 {
-  -ms-flex-order: 10;
-  order: 10; }
+/*.order-10 {*/
+/*  -ms-flex-order: 10;*/
+/*  order: 10;*/
+/*}*/
 
-.order-11 {
-  -ms-flex-order: 11;
-  order: 11; }
+/*.order-11 {*/
+/*  -ms-flex-order: 11;*/
+/*  order: 11;*/
+/*}*/
 
-.order-12 {
-  -ms-flex-order: 12;
-  order: 12; }
+/*.order-12 {*/
+/*  -ms-flex-order: 12;*/
+/*  order: 12;*/
+/*}*/
 
-.offset-1 {
-  margin-left: 8.333333%; }
+/*.offset-1 {*/
+/*  margin-left: 8.333333%;*/
+/*}*/
 
-.offset-2 {
-  margin-left: 16.666667%; }
+/*.offset-2 {*/
+/*  margin-left: 16.666667%;*/
+/*}*/
 
-.offset-3 {
-  margin-left: 25%; }
+/*.offset-3 {*/
+/*  margin-left: 25%;*/
+/*}*/
 
-.offset-4 {
-  margin-left: 33.333333%; }
+/*.offset-4 {*/
+/*  margin-left: 33.333333%;*/
+/*}*/
 
-.offset-5 {
-  margin-left: 41.666667%; }
+/*.offset-5 {*/
+/*  margin-left: 41.666667%;*/
+/*}*/
 
-.offset-6 {
-  margin-left: 50%; }
+/*.offset-6 {*/
+/*  margin-left: 50%;*/
+/*}*/
 
-.offset-7 {
-  margin-left: 58.333333%; }
+/*.offset-7 {*/
+/*  margin-left: 58.333333%;*/
+/*}*/
 
-.offset-8 {
-  margin-left: 66.666667%; }
+/*.offset-8 {*/
+/*  margin-left: 66.666667%;*/
+/*}*/
 
-.offset-9 {
-  margin-left: 75%; }
+/*.offset-9 {*/
+/*  margin-left: 75%;*/
+/*}*/
 
-.offset-10 {
-  margin-left: 83.333333%; }
+/*.offset-10 {*/
+/*  margin-left: 83.333333%;*/
+/*}*/
 
-.offset-11 {
-  margin-left: 91.666667%; }
+/*.offset-11 {*/
+/*  margin-left: 91.666667%;*/
+/*}*/
 
-@media (min-width: 576px) {
-  .col-sm {
-    -ms-flex-preferred-size: 0;
-    flex-basis: 0;
-    -ms-flex-positive: 1;
-    flex-grow: 1;
-    max-width: 100%; }
-  .row-cols-sm-1 > * {
-    -ms-flex: 0 0 100%;
-    flex: 0 0 100%;
-    max-width: 100%; }
-  .row-cols-sm-2 > * {
-    -ms-flex: 0 0 50%;
-    flex: 0 0 50%;
-    max-width: 50%; }
-  .row-cols-sm-3 > * {
-    -ms-flex: 0 0 33.333333%;
-    flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
-  .row-cols-sm-4 > * {
-    -ms-flex: 0 0 25%;
-    flex: 0 0 25%;
-    max-width: 25%; }
-  .row-cols-sm-5 > * {
-    -ms-flex: 0 0 20%;
-    flex: 0 0 20%;
-    max-width: 20%; }
-  .row-cols-sm-6 > * {
-    -ms-flex: 0 0 16.666667%;
-    flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
-  .col-sm-auto {
-    -ms-flex: 0 0 auto;
-    flex: 0 0 auto;
-    width: auto;
-    max-width: 100%; }
-  .col-sm-1 {
-    -ms-flex: 0 0 8.333333%;
-    flex: 0 0 8.333333%;
-    max-width: 8.333333%; }
-  .col-sm-2 {
-    -ms-flex: 0 0 16.666667%;
-    flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
-  .col-sm-3 {
-    -ms-flex: 0 0 25%;
-    flex: 0 0 25%;
-    max-width: 25%; }
-  .col-sm-4 {
-    -ms-flex: 0 0 33.333333%;
-    flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
-  .col-sm-5 {
-    -ms-flex: 0 0 41.666667%;
-    flex: 0 0 41.666667%;
-    max-width: 41.666667%; }
-  .col-sm-6 {
-    -ms-flex: 0 0 50%;
-    flex: 0 0 50%;
-    max-width: 50%; }
-  .col-sm-7 {
-    -ms-flex: 0 0 58.333333%;
-    flex: 0 0 58.333333%;
-    max-width: 58.333333%; }
-  .col-sm-8 {
-    -ms-flex: 0 0 66.666667%;
-    flex: 0 0 66.666667%;
-    max-width: 66.666667%; }
-  .col-sm-9 {
-    -ms-flex: 0 0 75%;
-    flex: 0 0 75%;
-    max-width: 75%; }
-  .col-sm-10 {
-    -ms-flex: 0 0 83.333333%;
-    flex: 0 0 83.333333%;
-    max-width: 83.333333%; }
-  .col-sm-11 {
-    -ms-flex: 0 0 91.666667%;
-    flex: 0 0 91.666667%;
-    max-width: 91.666667%; }
-  .col-sm-12 {
-    -ms-flex: 0 0 100%;
-    flex: 0 0 100%;
-    max-width: 100%; }
-  .order-sm-first {
-    -ms-flex-order: -1;
-    order: -1; }
-  .order-sm-last {
-    -ms-flex-order: 13;
-    order: 13; }
-  .order-sm-0 {
-    -ms-flex-order: 0;
-    order: 0; }
-  .order-sm-1 {
-    -ms-flex-order: 1;
-    order: 1; }
-  .order-sm-2 {
-    -ms-flex-order: 2;
-    order: 2; }
-  .order-sm-3 {
-    -ms-flex-order: 3;
-    order: 3; }
-  .order-sm-4 {
-    -ms-flex-order: 4;
-    order: 4; }
-  .order-sm-5 {
-    -ms-flex-order: 5;
-    order: 5; }
-  .order-sm-6 {
-    -ms-flex-order: 6;
-    order: 6; }
-  .order-sm-7 {
-    -ms-flex-order: 7;
-    order: 7; }
-  .order-sm-8 {
-    -ms-flex-order: 8;
-    order: 8; }
-  .order-sm-9 {
-    -ms-flex-order: 9;
-    order: 9; }
-  .order-sm-10 {
-    -ms-flex-order: 10;
-    order: 10; }
-  .order-sm-11 {
-    -ms-flex-order: 11;
-    order: 11; }
-  .order-sm-12 {
-    -ms-flex-order: 12;
-    order: 12; }
-  .offset-sm-0 {
-    margin-left: 0; }
-  .offset-sm-1 {
-    margin-left: 8.333333%; }
-  .offset-sm-2 {
-    margin-left: 16.666667%; }
-  .offset-sm-3 {
-    margin-left: 25%; }
-  .offset-sm-4 {
-    margin-left: 33.333333%; }
-  .offset-sm-5 {
-    margin-left: 41.666667%; }
-  .offset-sm-6 {
-    margin-left: 50%; }
-  .offset-sm-7 {
-    margin-left: 58.333333%; }
-  .offset-sm-8 {
-    margin-left: 66.666667%; }
-  .offset-sm-9 {
-    margin-left: 75%; }
-  .offset-sm-10 {
-    margin-left: 83.333333%; }
-  .offset-sm-11 {
-    margin-left: 91.666667%; } }
+/*@media (min-width: 576px) {*/
+/*  .col-sm {*/
+/*    -ms-flex-preferred-size: 0;*/
+/*    flex-basis: 0;*/
+/*    -ms-flex-positive: 1;*/
+/*    flex-grow: 1;*/
+/*    max-width: 100%;*/
+/*  }*/
+
+/*  .row-cols-sm-1 > * {*/
+/*    -ms-flex: 0 0 100%;*/
+/*    flex: 0 0 100%;*/
+/*    max-width: 100%;*/
+/*  }*/
+
+/*  .row-cols-sm-2 > * {*/
+/*    -ms-flex: 0 0 50%;*/
+/*    flex: 0 0 50%;*/
+/*    max-width: 50%;*/
+/*  }*/
+
+/*  .row-cols-sm-3 > * {*/
+/*    -ms-flex: 0 0 33.333333%;*/
+/*    flex: 0 0 33.333333%;*/
+/*    max-width: 33.333333%;*/
+/*  }*/
+
+/*  .row-cols-sm-4 > * {*/
+/*    -ms-flex: 0 0 25%;*/
+/*    flex: 0 0 25%;*/
+/*    max-width: 25%;*/
+/*  }*/
+
+/*  .row-cols-sm-5 > * {*/
+/*    -ms-flex: 0 0 20%;*/
+/*    flex: 0 0 20%;*/
+/*    max-width: 20%;*/
+/*  }*/
+
+/*  .row-cols-sm-6 > * {*/
+/*    -ms-flex: 0 0 16.666667%;*/
+/*    flex: 0 0 16.666667%;*/
+/*    max-width: 16.666667%;*/
+/*  }*/
+
+/*  .col-sm-auto {*/
+/*    -ms-flex: 0 0 auto;*/
+/*    flex: 0 0 auto;*/
+/*    width: auto;*/
+/*    max-width: 100%;*/
+/*  }*/
+
+/*  .col-sm-1 {*/
+/*    -ms-flex: 0 0 8.333333%;*/
+/*    flex: 0 0 8.333333%;*/
+/*    max-width: 8.333333%;*/
+/*  }*/
+
+/*  .col-sm-2 {*/
+/*    -ms-flex: 0 0 16.666667%;*/
+/*    flex: 0 0 16.666667%;*/
+/*    max-width: 16.666667%;*/
+/*  }*/
+
+/*  .col-sm-3 {*/
+/*    -ms-flex: 0 0 25%;*/
+/*    flex: 0 0 25%;*/
+/*    max-width: 25%;*/
+/*  }*/
+
+/*  .col-sm-4 {*/
+/*    -ms-flex: 0 0 33.333333%;*/
+/*    flex: 0 0 33.333333%;*/
+/*    max-width: 33.333333%;*/
+/*  }*/
+
+/*  .col-sm-5 {*/
+/*    -ms-flex: 0 0 41.666667%;*/
+/*    flex: 0 0 41.666667%;*/
+/*    max-width: 41.666667%;*/
+/*  }*/
+
+.col-sm-6 {
+  /*-ms-flex: 0 0 50%;*/
+  flex: 0 0 50%;
+  max-width: 50%;
+}
+
+/*  .col-sm-7 {*/
+/*    -ms-flex: 0 0 58.333333%;*/
+/*    flex: 0 0 58.333333%;*/
+/*    max-width: 58.333333%;*/
+/*  }*/
+
+.col-sm-8 {
+  /*-ms-flex: 0 0 66.666667%;*/
+  flex: 0 0 66.666667%;
+  max-width: 66.666667%;
+}
+
+/*  .col-sm-9 {*/
+/*    -ms-flex: 0 0 75%;*/
+/*    flex: 0 0 75%;*/
+/*    max-width: 75%;*/
+/*  }*/
+
+/*  .col-sm-10 {*/
+/*    -ms-flex: 0 0 83.333333%;*/
+/*    flex: 0 0 83.333333%;*/
+/*    max-width: 83.333333%;*/
+/*  }*/
+
+/*  .col-sm-11 {*/
+/*    -ms-flex: 0 0 91.666667%;*/
+/*    flex: 0 0 91.666667%;*/
+/*    max-width: 91.666667%;*/
+/*  }*/
+
+.col-sm-12 {
+  /*-ms-flex: 0 0 100%;*/
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+
+/*  .order-sm-first {*/
+/*    -ms-flex-order: -1;*/
+/*    order: -1;*/
+/*  }*/
+
+/*  .order-sm-last {*/
+/*    -ms-flex-order: 13;*/
+/*    order: 13;*/
+/*  }*/
+
+/*  .order-sm-0 {*/
+/*    -ms-flex-order: 0;*/
+/*    order: 0;*/
+/*  }*/
+
+/*  .order-sm-1 {*/
+/*    -ms-flex-order: 1;*/
+/*    order: 1;*/
+/*  }*/
+
+/*  .order-sm-2 {*/
+/*    -ms-flex-order: 2;*/
+/*    order: 2;*/
+/*  }*/
+
+/*  .order-sm-3 {*/
+/*    -ms-flex-order: 3;*/
+/*    order: 3;*/
+/*  }*/
+
+/*  .order-sm-4 {*/
+/*    -ms-flex-order: 4;*/
+/*    order: 4;*/
+/*  }*/
+
+/*  .order-sm-5 {*/
+/*    -ms-flex-order: 5;*/
+/*    order: 5;*/
+/*  }*/
+
+/*  .order-sm-6 {*/
+/*    -ms-flex-order: 6;*/
+/*    order: 6;*/
+/*  }*/
+
+/*  .order-sm-7 {*/
+/*    -ms-flex-order: 7;*/
+/*    order: 7;*/
+/*  }*/
+
+/*  .order-sm-8 {*/
+/*    -ms-flex-order: 8;*/
+/*    order: 8;*/
+/*  }*/
+
+/*  .order-sm-9 {*/
+/*    -ms-flex-order: 9;*/
+/*    order: 9;*/
+/*  }*/
+
+/*  .order-sm-10 {*/
+/*    -ms-flex-order: 10;*/
+/*    order: 10;*/
+/*  }*/
+
+/*  .order-sm-11 {*/
+/*    -ms-flex-order: 11;*/
+/*    order: 11;*/
+/*  }*/
+
+/*  .order-sm-12 {*/
+/*    -ms-flex-order: 12;*/
+/*    order: 12;*/
+/*  }*/
+
+/*  .offset-sm-0 {*/
+/*    margin-left: 0;*/
+/*  }*/
+
+/*  .offset-sm-1 {*/
+/*    margin-left: 8.333333%;*/
+/*  }*/
+
+/*  .offset-sm-2 {*/
+/*    margin-left: 16.666667%;*/
+/*  }*/
+
+/*  .offset-sm-3 {*/
+/*    margin-left: 25%;*/
+/*  }*/
+
+/*  .offset-sm-4 {*/
+/*    margin-left: 33.333333%;*/
+/*  }*/
+
+/*  .offset-sm-5 {*/
+/*    margin-left: 41.666667%;*/
+/*  }*/
+
+/*  .offset-sm-6 {*/
+/*    margin-left: 50%;*/
+/*  }*/
+
+/*  .offset-sm-7 {*/
+/*    margin-left: 58.333333%;*/
+/*  }*/
+
+/*  .offset-sm-8 {*/
+/*    margin-left: 66.666667%;*/
+/*  }*/
+
+/*  .offset-sm-9 {*/
+/*    margin-left: 75%;*/
+/*  }*/
+
+/*  .offset-sm-10 {*/
+/*    margin-left: 83.333333%;*/
+/*  }*/
+
+/*  .offset-sm-11 {*/
+/*    margin-left: 91.666667%;*/
+/*  }*/
+/*}*/
 
 @media (min-width: 768px) {
   .col-md {
-    -ms-flex-preferred-size: 0;
+    /*-ms-flex-preferred-size: 0;*/
     flex-basis: 0;
-    -ms-flex-positive: 1;
+    /*-ms-flex-positive: 1;*/
     flex-grow: 1;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .row-cols-md-1 > * {
-    -ms-flex: 0 0 100%;
+    /*-ms-flex: 0 0 100%;*/
     flex: 0 0 100%;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .row-cols-md-2 > * {
-    -ms-flex: 0 0 50%;
+    /*-ms-flex: 0 0 50%;*/
     flex: 0 0 50%;
-    max-width: 50%; }
+    max-width: 50%;
+  }
+
   .row-cols-md-3 > * {
-    -ms-flex: 0 0 33.333333%;
+    /*-ms-flex: 0 0 33.333333%;*/
     flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
+    max-width: 33.333333%;
+  }
+
   .row-cols-md-4 > * {
-    -ms-flex: 0 0 25%;
+    /*-ms-flex: 0 0 25%;*/
     flex: 0 0 25%;
-    max-width: 25%; }
+    max-width: 25%;
+  }
+
   .row-cols-md-5 > * {
-    -ms-flex: 0 0 20%;
+    /*-ms-flex: 0 0 20%;*/
     flex: 0 0 20%;
-    max-width: 20%; }
+    max-width: 20%;
+  }
+
   .row-cols-md-6 > * {
-    -ms-flex: 0 0 16.666667%;
+    /*-ms-flex: 0 0 16.666667%;*/
     flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
+    max-width: 16.666667%;
+  }
+
   .col-md-auto {
-    -ms-flex: 0 0 auto;
+    /*-ms-flex: 0 0 auto;*/
     flex: 0 0 auto;
     width: auto;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .col-md-1 {
-    -ms-flex: 0 0 8.333333%;
+    /*-ms-flex: 0 0 8.333333%;*/
     flex: 0 0 8.333333%;
-    max-width: 8.333333%; }
+    max-width: 8.333333%;
+  }
+
   .col-md-2 {
-    -ms-flex: 0 0 16.666667%;
+    /*-ms-flex: 0 0 16.666667%;*/
     flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
+    max-width: 16.666667%;
+  }
+
   .col-md-3 {
-    -ms-flex: 0 0 25%;
+    /*-ms-flex: 0 0 25%;*/
     flex: 0 0 25%;
-    max-width: 25%; }
+    max-width: 25%;
+  }
+
   .col-md-4 {
-    -ms-flex: 0 0 33.333333%;
+    /*-ms-flex: 0 0 33.333333%;*/
     flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
+    max-width: 33.333333%;
+  }
+
   .col-md-5 {
-    -ms-flex: 0 0 41.666667%;
+    /*-ms-flex: 0 0 41.666667%;*/
     flex: 0 0 41.666667%;
-    max-width: 41.666667%; }
+    max-width: 41.666667%;
+  }
+
   .col-md-6 {
-    -ms-flex: 0 0 50%;
+    /*-ms-flex: 0 0 50%;*/
     flex: 0 0 50%;
-    max-width: 50%; }
+    max-width: 50%;
+  }
+
   .col-md-7 {
-    -ms-flex: 0 0 58.333333%;
+    /*-ms-flex: 0 0 58.333333%;*/
     flex: 0 0 58.333333%;
-    max-width: 58.333333%; }
+    max-width: 58.333333%;
+  }
+
   .col-md-8 {
-    -ms-flex: 0 0 66.666667%;
+    /*-ms-flex: 0 0 66.666667%;*/
     flex: 0 0 66.666667%;
-    max-width: 66.666667%; }
+    max-width: 66.666667%;
+  }
+
   .col-md-9 {
-    -ms-flex: 0 0 75%;
+    /*-ms-flex: 0 0 75%;*/
     flex: 0 0 75%;
-    max-width: 75%; }
+    max-width: 75%;
+  }
+
   .col-md-10 {
-    -ms-flex: 0 0 83.333333%;
+    /*-ms-flex: 0 0 83.333333%;*/
     flex: 0 0 83.333333%;
-    max-width: 83.333333%; }
+    max-width: 83.333333%;
+  }
+
   .col-md-11 {
-    -ms-flex: 0 0 91.666667%;
+    /*-ms-flex: 0 0 91.666667%;*/
     flex: 0 0 91.666667%;
-    max-width: 91.666667%; }
+    max-width: 91.666667%;
+  }
+
   .col-md-12 {
-    -ms-flex: 0 0 100%;
+    /*-ms-flex: 0 0 100%;*/
     flex: 0 0 100%;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .order-md-first {
-    -ms-flex-order: -1;
-    order: -1; }
+    /*-ms-flex-order: -1;*/
+    order: -1;
+  }
+
   .order-md-last {
-    -ms-flex-order: 13;
-    order: 13; }
+    /*-ms-flex-order: 13;*/
+    order: 13;
+  }
+
   .order-md-0 {
-    -ms-flex-order: 0;
-    order: 0; }
+    /*-ms-flex-order: 0;*/
+    order: 0;
+  }
+
   .order-md-1 {
-    -ms-flex-order: 1;
-    order: 1; }
+    /*-ms-flex-order: 1;*/
+    order: 1;
+  }
+
   .order-md-2 {
-    -ms-flex-order: 2;
-    order: 2; }
+    /*-ms-flex-order: 2;*/
+    order: 2;
+  }
+
   .order-md-3 {
-    -ms-flex-order: 3;
-    order: 3; }
+    /*-ms-flex-order: 3;*/
+    order: 3;
+  }
+
   .order-md-4 {
-    -ms-flex-order: 4;
-    order: 4; }
+    /*-ms-flex-order: 4;*/
+    order: 4;
+  }
+
   .order-md-5 {
-    -ms-flex-order: 5;
-    order: 5; }
+    /*-ms-flex-order: 5;*/
+    order: 5;
+  }
+
   .order-md-6 {
-    -ms-flex-order: 6;
-    order: 6; }
+    /*-ms-flex-order: 6;*/
+    order: 6;
+  }
+
   .order-md-7 {
-    -ms-flex-order: 7;
-    order: 7; }
+    /*-ms-flex-order: 7;*/
+    order: 7;
+  }
+
   .order-md-8 {
-    -ms-flex-order: 8;
-    order: 8; }
+    /*-ms-flex-order: 8;*/
+    order: 8;
+  }
+
   .order-md-9 {
-    -ms-flex-order: 9;
-    order: 9; }
+    /*-ms-flex-order: 9;*/
+    order: 9;
+  }
+
   .order-md-10 {
-    -ms-flex-order: 10;
-    order: 10; }
+    /*-ms-flex-order: 10;*/
+    order: 10;
+  }
+
   .order-md-11 {
-    -ms-flex-order: 11;
-    order: 11; }
+    /*-ms-flex-order: 11;*/
+    order: 11;
+  }
+
   .order-md-12 {
-    -ms-flex-order: 12;
-    order: 12; }
+    /*-ms-flex-order: 12;*/
+    order: 12;
+  }
+
   .offset-md-0 {
-    margin-left: 0; }
+    margin-left: 0;
+  }
+
   .offset-md-1 {
-    margin-left: 8.333333%; }
+    margin-left: 8.333333%;
+  }
+
   .offset-md-2 {
-    margin-left: 16.666667%; }
+    margin-left: 16.666667%;
+  }
+
   .offset-md-3 {
-    margin-left: 25%; }
+    margin-left: 25%;
+  }
+
   .offset-md-4 {
-    margin-left: 33.333333%; }
+    margin-left: 33.333333%;
+  }
+
   .offset-md-5 {
-    margin-left: 41.666667%; }
+    margin-left: 41.666667%;
+  }
+
   .offset-md-6 {
-    margin-left: 50%; }
+    margin-left: 50%;
+  }
+
   .offset-md-7 {
-    margin-left: 58.333333%; }
+    margin-left: 58.333333%;
+  }
+
   .offset-md-8 {
-    margin-left: 66.666667%; }
+    margin-left: 66.666667%;
+  }
+
   .offset-md-9 {
-    margin-left: 75%; }
+    margin-left: 75%;
+  }
+
   .offset-md-10 {
-    margin-left: 83.333333%; }
+    margin-left: 83.333333%;
+  }
+
   .offset-md-11 {
-    margin-left: 91.666667%; } }
+    margin-left: 91.666667%;
+  }
+}
 
 @media (min-width: 992px) {
   .col-lg {
-    -ms-flex-preferred-size: 0;
+    /*-ms-flex-preferred-size: 0;*/
     flex-basis: 0;
-    -ms-flex-positive: 1;
+    /*-ms-flex-positive: 1;*/
     flex-grow: 1;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .row-cols-lg-1 > * {
-    -ms-flex: 0 0 100%;
+    /*-ms-flex: 0 0 100%;*/
     flex: 0 0 100%;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .row-cols-lg-2 > * {
-    -ms-flex: 0 0 50%;
+    /*-ms-flex: 0 0 50%;*/
     flex: 0 0 50%;
-    max-width: 50%; }
+    max-width: 50%;
+  }
+
   .row-cols-lg-3 > * {
-    -ms-flex: 0 0 33.333333%;
+    /*-ms-flex: 0 0 33.333333%;*/
     flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
+    max-width: 33.333333%;
+  }
+
   .row-cols-lg-4 > * {
-    -ms-flex: 0 0 25%;
+    /*-ms-flex: 0 0 25%;*/
     flex: 0 0 25%;
-    max-width: 25%; }
+    max-width: 25%;
+  }
+
   .row-cols-lg-5 > * {
-    -ms-flex: 0 0 20%;
+    /*-ms-flex: 0 0 20%;*/
     flex: 0 0 20%;
-    max-width: 20%; }
+    max-width: 20%;
+  }
+
   .row-cols-lg-6 > * {
-    -ms-flex: 0 0 16.666667%;
+    /*-ms-flex: 0 0 16.666667%;*/
     flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
+    max-width: 16.666667%;
+  }
+
   .col-lg-auto {
-    -ms-flex: 0 0 auto;
+    /*-ms-flex: 0 0 auto;*/
     flex: 0 0 auto;
     width: auto;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .col-lg-1 {
-    -ms-flex: 0 0 8.333333%;
+    /*-ms-flex: 0 0 8.333333%;*/
     flex: 0 0 8.333333%;
-    max-width: 8.333333%; }
+    max-width: 8.333333%;
+  }
+
   .col-lg-2 {
-    -ms-flex: 0 0 16.666667%;
+    /*-ms-flex: 0 0 16.666667%;*/
     flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
+    max-width: 16.666667%;
+  }
+
   .col-lg-3 {
-    -ms-flex: 0 0 25%;
+    /*-ms-flex: 0 0 25%;*/
     flex: 0 0 25%;
-    max-width: 25%; }
+    max-width: 25%;
+  }
+
   .col-lg-4 {
-    -ms-flex: 0 0 33.333333%;
+    /*-ms-flex: 0 0 33.333333%;*/
     flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
+    max-width: 33.333333%;
+  }
+
   .col-lg-5 {
-    -ms-flex: 0 0 41.666667%;
+    /*-ms-flex: 0 0 41.666667%;*/
     flex: 0 0 41.666667%;
-    max-width: 41.666667%; }
+    max-width: 41.666667%;
+  }
+
   .col-lg-6 {
-    -ms-flex: 0 0 50%;
+    /*-ms-flex: 0 0 50%;*/
     flex: 0 0 50%;
-    max-width: 50%; }
+    max-width: 50%;
+  }
+
   .col-lg-7 {
-    -ms-flex: 0 0 58.333333%;
+    /*-ms-flex: 0 0 58.333333%;*/
     flex: 0 0 58.333333%;
-    max-width: 58.333333%; }
+    max-width: 58.333333%;
+  }
+
   .col-lg-8 {
-    -ms-flex: 0 0 66.666667%;
+    /*-ms-flex: 0 0 66.666667%;*/
     flex: 0 0 66.666667%;
-    max-width: 66.666667%; }
+    max-width: 66.666667%;
+  }
+
   .col-lg-9 {
-    -ms-flex: 0 0 75%;
+    /*-ms-flex: 0 0 75%;*/
     flex: 0 0 75%;
-    max-width: 75%; }
+    max-width: 75%;
+  }
+
   .col-lg-10 {
-    -ms-flex: 0 0 83.333333%;
+    /*-ms-flex: 0 0 83.333333%;*/
     flex: 0 0 83.333333%;
-    max-width: 83.333333%; }
+    max-width: 83.333333%;
+  }
+
   .col-lg-11 {
-    -ms-flex: 0 0 91.666667%;
+    /*-ms-flex: 0 0 91.666667%;*/
     flex: 0 0 91.666667%;
-    max-width: 91.666667%; }
+    max-width: 91.666667%;
+  }
+
   .col-lg-12 {
-    -ms-flex: 0 0 100%;
+    /*-ms-flex: 0 0 100%;*/
     flex: 0 0 100%;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .order-lg-first {
-    -ms-flex-order: -1;
-    order: -1; }
+    /*-ms-flex-order: -1;*/
+    order: -1;
+  }
+
   .order-lg-last {
-    -ms-flex-order: 13;
-    order: 13; }
+    /*-ms-flex-order: 13;*/
+    order: 13;
+  }
+
   .order-lg-0 {
-    -ms-flex-order: 0;
-    order: 0; }
+    /*-ms-flex-order: 0;*/
+    order: 0;
+  }
+
   .order-lg-1 {
-    -ms-flex-order: 1;
-    order: 1; }
+    /*-ms-flex-order: 1;*/
+    order: 1;
+  }
+
   .order-lg-2 {
-    -ms-flex-order: 2;
-    order: 2; }
+    /*-ms-flex-order: 2;*/
+    order: 2;
+  }
+
   .order-lg-3 {
-    -ms-flex-order: 3;
-    order: 3; }
+    /*-ms-flex-order: 3;*/
+    order: 3;
+  }
+
   .order-lg-4 {
-    -ms-flex-order: 4;
-    order: 4; }
+    /*-ms-flex-order: 4;*/
+    order: 4;
+  }
+
   .order-lg-5 {
-    -ms-flex-order: 5;
-    order: 5; }
+    /*-ms-flex-order: 5;*/
+    order: 5;
+  }
+
   .order-lg-6 {
-    -ms-flex-order: 6;
-    order: 6; }
+    /*-ms-flex-order: 6;*/
+    order: 6;
+  }
+
   .order-lg-7 {
-    -ms-flex-order: 7;
-    order: 7; }
+    /*-ms-flex-order: 7;*/
+    order: 7;
+  }
+
   .order-lg-8 {
-    -ms-flex-order: 8;
-    order: 8; }
+    /*-ms-flex-order: 8;*/
+    order: 8;
+  }
+
   .order-lg-9 {
-    -ms-flex-order: 9;
-    order: 9; }
+    /*-ms-flex-order: 9;*/
+    order: 9;
+  }
+
   .order-lg-10 {
-    -ms-flex-order: 10;
-    order: 10; }
+    /*-ms-flex-order: 10;*/
+    order: 10;
+  }
+
   .order-lg-11 {
-    -ms-flex-order: 11;
-    order: 11; }
+    /*-ms-flex-order: 11;*/
+    order: 11;
+  }
+
   .order-lg-12 {
-    -ms-flex-order: 12;
-    order: 12; }
+    /*-ms-flex-order: 12;*/
+    order: 12;
+  }
+
   .offset-lg-0 {
-    margin-left: 0; }
+    margin-left: 0;
+  }
+
   .offset-lg-1 {
-    margin-left: 8.333333%; }
+    margin-left: 8.333333%;
+  }
+
   .offset-lg-2 {
-    margin-left: 16.666667%; }
+    margin-left: 16.666667%;
+  }
+
   .offset-lg-3 {
-    margin-left: 25%; }
+    margin-left: 25%;
+  }
+
   .offset-lg-4 {
-    margin-left: 33.333333%; }
+    margin-left: 33.333333%;
+  }
+
   .offset-lg-5 {
-    margin-left: 41.666667%; }
+    margin-left: 41.666667%;
+  }
+
   .offset-lg-6 {
-    margin-left: 50%; }
+    margin-left: 50%;
+  }
+
   .offset-lg-7 {
-    margin-left: 58.333333%; }
+    margin-left: 58.333333%;
+  }
+
   .offset-lg-8 {
-    margin-left: 66.666667%; }
+    margin-left: 66.666667%;
+  }
+
   .offset-lg-9 {
-    margin-left: 75%; }
+    margin-left: 75%;
+  }
+
   .offset-lg-10 {
-    margin-left: 83.333333%; }
+    margin-left: 83.333333%;
+  }
+
   .offset-lg-11 {
-    margin-left: 91.666667%; } }
+    margin-left: 91.666667%;
+  }
+}
 
 @media (min-width: 1200px) {
   .col-xl {
-    -ms-flex-preferred-size: 0;
+    /*-ms-flex-preferred-size: 0;*/
     flex-basis: 0;
-    -ms-flex-positive: 1;
+    /*-ms-flex-positive: 1;*/
     flex-grow: 1;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .row-cols-xl-1 > * {
-    -ms-flex: 0 0 100%;
+    /*-ms-flex: 0 0 100%;*/
     flex: 0 0 100%;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .row-cols-xl-2 > * {
-    -ms-flex: 0 0 50%;
+    /*-ms-flex: 0 0 50%;*/
     flex: 0 0 50%;
-    max-width: 50%; }
+    max-width: 50%;
+  }
+
   .row-cols-xl-3 > * {
-    -ms-flex: 0 0 33.333333%;
+    /*-ms-flex: 0 0 33.333333%;*/
     flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
+    max-width: 33.333333%;
+  }
+
   .row-cols-xl-4 > * {
-    -ms-flex: 0 0 25%;
+    /*-ms-flex: 0 0 25%;*/
     flex: 0 0 25%;
-    max-width: 25%; }
+    max-width: 25%;
+  }
+
   .row-cols-xl-5 > * {
-    -ms-flex: 0 0 20%;
+    /*-ms-flex: 0 0 20%;*/
     flex: 0 0 20%;
-    max-width: 20%; }
+    max-width: 20%;
+  }
+
   .row-cols-xl-6 > * {
-    -ms-flex: 0 0 16.666667%;
+    /*-ms-flex: 0 0 16.666667%;*/
     flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
+    max-width: 16.666667%;
+  }
+
   .col-xl-auto {
-    -ms-flex: 0 0 auto;
+    /*-ms-flex: 0 0 auto;*/
     flex: 0 0 auto;
     width: auto;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .col-xl-1 {
-    -ms-flex: 0 0 8.333333%;
+    /*-ms-flex: 0 0 8.333333%;*/
     flex: 0 0 8.333333%;
-    max-width: 8.333333%; }
+    max-width: 8.333333%;
+  }
+
   .col-xl-2 {
-    -ms-flex: 0 0 16.666667%;
+    /*-ms-flex: 0 0 16.666667%;*/
     flex: 0 0 16.666667%;
-    max-width: 16.666667%; }
+    max-width: 16.666667%;
+  }
+
   .col-xl-3 {
-    -ms-flex: 0 0 25%;
+    /*-ms-flex: 0 0 25%;*/
     flex: 0 0 25%;
-    max-width: 25%; }
+    max-width: 25%;
+  }
+
   .col-xl-4 {
-    -ms-flex: 0 0 33.333333%;
+    /*-ms-flex: 0 0 33.333333%;*/
     flex: 0 0 33.333333%;
-    max-width: 33.333333%; }
+    max-width: 33.333333%;
+  }
+
   .col-xl-5 {
-    -ms-flex: 0 0 41.666667%;
+    /*-ms-flex: 0 0 41.666667%;*/
     flex: 0 0 41.666667%;
-    max-width: 41.666667%; }
+    max-width: 41.666667%;
+  }
+
   .col-xl-6 {
-    -ms-flex: 0 0 50%;
+    /*-ms-flex: 0 0 50%;*/
     flex: 0 0 50%;
-    max-width: 50%; }
+    max-width: 50%;
+  }
+
   .col-xl-7 {
-    -ms-flex: 0 0 58.333333%;
+    /*-ms-flex: 0 0 58.333333%;*/
     flex: 0 0 58.333333%;
-    max-width: 58.333333%; }
+    max-width: 58.333333%;
+  }
+
   .col-xl-8 {
-    -ms-flex: 0 0 66.666667%;
+    /*-ms-flex: 0 0 66.666667%;*/
     flex: 0 0 66.666667%;
-    max-width: 66.666667%; }
+    max-width: 66.666667%;
+  }
+
   .col-xl-9 {
-    -ms-flex: 0 0 75%;
+    /*-ms-flex: 0 0 75%;*/
     flex: 0 0 75%;
-    max-width: 75%; }
+    max-width: 75%;
+  }
+
   .col-xl-10 {
-    -ms-flex: 0 0 83.333333%;
+    /*-ms-flex: 0 0 83.333333%;*/
     flex: 0 0 83.333333%;
-    max-width: 83.333333%; }
+    max-width: 83.333333%;
+  }
+
   .col-xl-11 {
-    -ms-flex: 0 0 91.666667%;
+    /*-ms-flex: 0 0 91.666667%;*/
     flex: 0 0 91.666667%;
-    max-width: 91.666667%; }
+    max-width: 91.666667%;
+  }
+
   .col-xl-12 {
-    -ms-flex: 0 0 100%;
+    /*-ms-flex: 0 0 100%;*/
     flex: 0 0 100%;
-    max-width: 100%; }
+    max-width: 100%;
+  }
+
   .order-xl-first {
-    -ms-flex-order: -1;
-    order: -1; }
+    /*-ms-flex-order: -1;*/
+    order: -1;
+  }
+
   .order-xl-last {
-    -ms-flex-order: 13;
-    order: 13; }
+    /*-ms-flex-order: 13;*/
+    order: 13;
+  }
+
   .order-xl-0 {
-    -ms-flex-order: 0;
-    order: 0; }
+    /*-ms-flex-order: 0;*/
+    order: 0;
+  }
+
   .order-xl-1 {
-    -ms-flex-order: 1;
-    order: 1; }
+    /*-ms-flex-order: 1;*/
+    order: 1;
+  }
+
   .order-xl-2 {
-    -ms-flex-order: 2;
-    order: 2; }
+    /*-ms-flex-order: 2;*/
+    order: 2;
+  }
+
   .order-xl-3 {
-    -ms-flex-order: 3;
-    order: 3; }
+    /*-ms-flex-order: 3;*/
+    order: 3;
+  }
+
   .order-xl-4 {
-    -ms-flex-order: 4;
-    order: 4; }
+    /*-ms-flex-order: 4;*/
+    order: 4;
+  }
+
   .order-xl-5 {
-    -ms-flex-order: 5;
-    order: 5; }
+    /*-ms-flex-order: 5;*/
+    order: 5;
+  }
+
   .order-xl-6 {
-    -ms-flex-order: 6;
-    order: 6; }
+    /*-ms-flex-order: 6;*/
+    order: 6;
+  }
+
   .order-xl-7 {
-    -ms-flex-order: 7;
-    order: 7; }
+    /*-ms-flex-order: 7;*/
+    order: 7;
+  }
+
   .order-xl-8 {
-    -ms-flex-order: 8;
-    order: 8; }
+    /*-ms-flex-order: 8;*/
+    order: 8;
+  }
+
   .order-xl-9 {
-    -ms-flex-order: 9;
-    order: 9; }
+    /*-ms-flex-order: 9;*/
+    order: 9;
+  }
+
   .order-xl-10 {
-    -ms-flex-order: 10;
-    order: 10; }
+    /*-ms-flex-order: 10;*/
+    order: 10;
+  }
+
   .order-xl-11 {
-    -ms-flex-order: 11;
-    order: 11; }
+    /*-ms-flex-order: 11;*/
+    order: 11;
+  }
+
   .order-xl-12 {
-    -ms-flex-order: 12;
-    order: 12; }
+    /*-ms-flex-order: 12;*/
+    order: 12;
+  }
+
   .offset-xl-0 {
-    margin-left: 0; }
+    margin-left: 0;
+  }
+
   .offset-xl-1 {
-    margin-left: 8.333333%; }
+    margin-left: 8.333333%;
+  }
+
   .offset-xl-2 {
-    margin-left: 16.666667%; }
+    margin-left: 16.666667%;
+  }
+
   .offset-xl-3 {
-    margin-left: 25%; }
+    margin-left: 25%;
+  }
+
   .offset-xl-4 {
-    margin-left: 33.333333%; }
+    margin-left: 33.333333%;
+  }
+
   .offset-xl-5 {
-    margin-left: 41.666667%; }
+    margin-left: 41.666667%;
+  }
+
   .offset-xl-6 {
-    margin-left: 50%; }
+    margin-left: 50%;
+  }
+
   .offset-xl-7 {
-    margin-left: 58.333333%; }
+    margin-left: 58.333333%;
+  }
+
   .offset-xl-8 {
-    margin-left: 66.666667%; }
+    margin-left: 66.666667%;
+  }
+
   .offset-xl-9 {
-    margin-left: 75%; }
+    margin-left: 75%;
+  }
+
   .offset-xl-10 {
-    margin-left: 83.333333%; }
+    margin-left: 83.333333%;
+  }
+
   .offset-xl-11 {
-    margin-left: 91.666667%; } }
+    margin-left: 91.666667%;
+  }
+}
 
 .table {
   width: 100%;
   margin-bottom: 1rem;
-  color: #212529; }
+  color: #212529;
+}
 
-.table th,
-.table td {
+.table th, .table td {
   padding: 0.75rem;
   vertical-align: top;
-  border-top: 1px solid #dee2e6; }
+  border-top: 1px solid #dee2e6;
+}
 
-.table thead th {
-  vertical-align: bottom;
-  border-bottom: 2px solid #dee2e6; }
+/*.table thead th {*/
+/*  vertical-align: bottom;*/
+/*  border-bottom: 2px solid #dee2e6;*/
+/*}*/
 
-.table tbody + tbody {
-  border-top: 2px solid #dee2e6; }
+/*.table tbody + tbody {*/
+/*  border-top: 2px solid #dee2e6;*/
+/*}*/
 
-.table-sm th,
-.table-sm td {
-  padding: 0.3rem; }
+/*.table-sm th, .table-sm td {*/
+/*  padding: 0.3rem;*/
+/*}*/
 
-.table-bordered {
-  border: 1px solid #dee2e6; }
+/*.table-bordered {*/
+/*  border: 1px solid #dee2e6;*/
+/*}*/
 
-.table-bordered th,
-.table-bordered td {
-  border: 1px solid #dee2e6; }
+/*.table-bordered th, .table-bordered td {*/
+/*  border: 1px solid #dee2e6;*/
+/*}*/
 
-.table-bordered thead th,
-.table-bordered thead td {
-  border-bottom-width: 2px; }
+/*.table-bordered thead th, .table-bordered thead td {*/
+/*  border-bottom-width: 2px;*/
+/*}*/
 
-.table-borderless th,
-.table-borderless td,
-.table-borderless thead th,
-.table-borderless tbody + tbody {
-  border: 0; }
+/*.table-borderless th, .table-borderless td, .table-borderless thead th, .table-borderless tbody + tbody {*/
+/*  border: 0;*/
+/*}*/
 
-.table-striped tbody tr:nth-of-type(odd) {
-  background-color: rgba(0, 0, 0, 0.05); }
+/*.table-striped tbody tr:nth-of-type(odd) {*/
+/*  background-color: rgba(0, 0, 0, 0.05);*/
+/*}*/
 
-.table-hover tbody tr:hover {
-  color: #212529;
-  background-color: rgba(0, 0, 0, 0.075); }
+/*.table-hover tbody tr:hover {*/
+/*  color: #212529;*/
+/*  background-color: rgba(0, 0, 0, 0.075);*/
+/*}*/
 
-.table-primary,
-.table-primary > th,
-.table-primary > td {
-  background-color: #b8daff; }
+/*.table-primary, .table-primary > th, .table-primary > td {*/
+/*  background-color: #b8daff;*/
+/*}*/
 
-.table-primary th,
-.table-primary td,
-.table-primary thead th,
-.table-primary tbody + tbody {
-  border-color: #7abaff; }
+/*.table-primary th, .table-primary td, .table-primary thead th, .table-primary tbody + tbody {*/
+/*  border-color: #7abaff;*/
+/*}*/
 
-.table-hover .table-primary:hover {
-  background-color: #9fcdff; }
+/*.table-hover .table-primary:hover {*/
+/*  background-color: #9fcdff;*/
+/*}*/
 
-.table-hover .table-primary:hover > td,
-.table-hover .table-primary:hover > th {
-  background-color: #9fcdff; }
+/*.table-hover .table-primary:hover > td, .table-hover .table-primary:hover > th {*/
+/*  background-color: #9fcdff;*/
+/*}*/
 
-.table-secondary,
-.table-secondary > th,
-.table-secondary > td {
-  background-color: #d6d8db; }
+/*.table-secondary, .table-secondary > th, .table-secondary > td {*/
+/*  background-color: #d6d8db;*/
+/*}*/
 
-.table-secondary th,
-.table-secondary td,
-.table-secondary thead th,
-.table-secondary tbody + tbody {
-  border-color: #b3b7bb; }
+/*.table-secondary th, .table-secondary td, .table-secondary thead th, .table-secondary tbody + tbody {*/
+/*  border-color: #b3b7bb;*/
+/*}*/
 
-.table-hover .table-secondary:hover {
-  background-color: #c8cbcf; }
+/*.table-hover .table-secondary:hover {*/
+/*  background-color: #c8cbcf;*/
+/*}*/
 
-.table-hover .table-secondary:hover > td,
-.table-hover .table-secondary:hover > th {
-  background-color: #c8cbcf; }
+/*.table-hover .table-secondary:hover > td, .table-hover .table-secondary:hover > th {*/
+/*  background-color: #c8cbcf;*/
+/*}*/
 
-.table-success,
-.table-success > th,
-.table-success > td {
-  background-color: #c3e6cb; }
+/*.table-success, .table-success > th, .table-success > td {*/
+/*  background-color: #c3e6cb;*/
+/*}*/
 
-.table-success th,
-.table-success td,
-.table-success thead th,
-.table-success tbody + tbody {
-  border-color: #8fd19e; }
+/*.table-success th, .table-success td, .table-success thead th, .table-success tbody + tbody {*/
+/*  border-color: #8fd19e;*/
+/*}*/
 
-.table-hover .table-success:hover {
-  background-color: #b1dfbb; }
+/*.table-hover .table-success:hover {*/
+/*  background-color: #b1dfbb;*/
+/*}*/
 
-.table-hover .table-success:hover > td,
-.table-hover .table-success:hover > th {
-  background-color: #b1dfbb; }
+/*.table-hover .table-success:hover > td, .table-hover .table-success:hover > th {*/
+/*  background-color: #b1dfbb;*/
+/*}*/
 
-.table-info,
-.table-info > th,
-.table-info > td {
-  background-color: #bee5eb; }
+/*.table-info, .table-info > th, .table-info > td {*/
+/*  background-color: #bee5eb;*/
+/*}*/
 
-.table-info th,
-.table-info td,
-.table-info thead th,
-.table-info tbody + tbody {
-  border-color: #86cfda; }
+/*.table-info th, .table-info td, .table-info thead th, .table-info tbody + tbody {*/
+/*  border-color: #86cfda;*/
+/*}*/
 
-.table-hover .table-info:hover {
-  background-color: #abdde5; }
+/*.table-hover .table-info:hover {*/
+/*  background-color: #abdde5;*/
+/*}*/
 
-.table-hover .table-info:hover > td,
-.table-hover .table-info:hover > th {
-  background-color: #abdde5; }
+/*.table-hover .table-info:hover > td, .table-hover .table-info:hover > th {*/
+/*  background-color: #abdde5;*/
+/*}*/
 
-.table-warning,
-.table-warning > th,
-.table-warning > td {
-  background-color: #ffeeba; }
+/*.table-warning, .table-warning > th, .table-warning > td {*/
+/*  background-color: #ffeeba;*/
+/*}*/
 
-.table-warning th,
-.table-warning td,
-.table-warning thead th,
-.table-warning tbody + tbody {
-  border-color: #ffdf7e; }
+/*.table-warning th, .table-warning td, .table-warning thead th, .table-warning tbody + tbody {*/
+/*  border-color: #ffdf7e;*/
+/*}*/
 
-.table-hover .table-warning:hover {
-  background-color: #ffe8a1; }
+/*.table-hover .table-warning:hover {*/
+/*  background-color: #ffe8a1;*/
+/*}*/
 
-.table-hover .table-warning:hover > td,
-.table-hover .table-warning:hover > th {
-  background-color: #ffe8a1; }
+/*.table-hover .table-warning:hover > td, .table-hover .table-warning:hover > th {*/
+/*  background-color: #ffe8a1;*/
+/*}*/
 
-.table-danger,
-.table-danger > th,
-.table-danger > td {
-  background-color: #f5c6cb; }
+/*.table-danger, .table-danger > th, .table-danger > td {*/
+/*  background-color: #f5c6cb;*/
+/*}*/
 
-.table-danger th,
-.table-danger td,
-.table-danger thead th,
-.table-danger tbody + tbody {
-  border-color: #ed969e; }
+/*.table-danger th, .table-danger td, .table-danger thead th, .table-danger tbody + tbody {*/
+/*  border-color: #ed969e;*/
+/*}*/
 
-.table-hover .table-danger:hover {
-  background-color: #f1b0b7; }
+/*.table-hover .table-danger:hover {*/
+/*  background-color: #f1b0b7;*/
+/*}*/
 
-.table-hover .table-danger:hover > td,
-.table-hover .table-danger:hover > th {
-  background-color: #f1b0b7; }
+/*.table-hover .table-danger:hover > td, .table-hover .table-danger:hover > th {*/
+/*  background-color: #f1b0b7;*/
+/*}*/
 
-.table-light,
-.table-light > th,
-.table-light > td {
-  background-color: #fdfdfe; }
+/*.table-light, .table-light > th, .table-light > td {*/
+/*  background-color: #fdfdfe;*/
+/*}*/
 
-.table-light th,
-.table-light td,
-.table-light thead th,
-.table-light tbody + tbody {
-  border-color: #fbfcfc; }
+/*.table-light th, .table-light td, .table-light thead th, .table-light tbody + tbody {*/
+/*  border-color: #fbfcfc;*/
+/*}*/
 
-.table-hover .table-light:hover {
-  background-color: #ececf6; }
+/*.table-hover .table-light:hover {*/
+/*  background-color: #ececf6;*/
+/*}*/
 
-.table-hover .table-light:hover > td,
-.table-hover .table-light:hover > th {
-  background-color: #ececf6; }
+/*.table-hover .table-light:hover > td, .table-hover .table-light:hover > th {*/
+/*  background-color: #ececf6;*/
+/*}*/
 
-.table-dark,
-.table-dark > th,
-.table-dark > td {
-  background-color: #c6c8ca; }
+/*.table-dark, .table-dark > th, .table-dark > td {*/
+/*  background-color: #c6c8ca;*/
+/*}*/
 
-.table-dark th,
-.table-dark td,
-.table-dark thead th,
-.table-dark tbody + tbody {
-  border-color: #95999c; }
+/*.table-dark th, .table-dark td, .table-dark thead th, .table-dark tbody + tbody {*/
+/*  border-color: #95999c;*/
+/*}*/
 
-.table-hover .table-dark:hover {
-  background-color: #b9bbbe; }
+/*.table-hover .table-dark:hover {*/
+/*  background-color: #b9bbbe;*/
+/*}*/
 
-.table-hover .table-dark:hover > td,
-.table-hover .table-dark:hover > th {
-  background-color: #b9bbbe; }
+/*.table-hover .table-dark:hover > td, .table-hover .table-dark:hover > th {*/
+/*  background-color: #b9bbbe;*/
+/*}*/
 
-.table-active,
-.table-active > th,
-.table-active > td {
-  background-color: rgba(0, 0, 0, 0.075); }
+/*.table-active, .table-active > th, .table-active > td {*/
+/*  background-color: rgba(0, 0, 0, 0.075);*/
+/*}*/
 
-.table-hover .table-active:hover {
-  background-color: rgba(0, 0, 0, 0.075); }
+/*.table-hover .table-active:hover {*/
+/*  background-color: rgba(0, 0, 0, 0.075);*/
+/*}*/
 
-.table-hover .table-active:hover > td,
-.table-hover .table-active:hover > th {
-  background-color: rgba(0, 0, 0, 0.075); }
+/*.table-hover .table-active:hover > td, .table-hover .table-active:hover > th {*/
+/*  background-color: rgba(0, 0, 0, 0.075);*/
+/*}*/
 
-.table .thead-dark th {
-  color: #fff;
-  background-color: #343a40;
-  border-color: #454d55; }
+/*.table .thead-dark th {*/
+/*  color: #fff;*/
+/*  background-color: #343a40;*/
+/*  border-color: #454d55;*/
+/*}*/
 
-.table .thead-light th {
-  color: #495057;
-  background-color: #e9ecef;
-  border-color: #dee2e6; }
+/*.table .thead-light th {*/
+/*  color: #495057;*/
+/*  background-color: #e9ecef;*/
+/*  border-color: #dee2e6;*/
+/*}*/
 
-.table-dark {
-  color: #fff;
-  background-color: #343a40; }
+/*.table-dark {*/
+/*  color: #fff;*/
+/*  background-color: #343a40;*/
+/*}*/
 
-.table-dark th,
-.table-dark td,
-.table-dark thead th {
-  border-color: #454d55; }
+/*.table-dark th, .table-dark td, .table-dark thead th {*/
+/*  border-color: #454d55;*/
+/*}*/
 
-.table-dark.table-bordered {
-  border: 0; }
+/*.table-dark.table-bordered {*/
+/*  border: 0;*/
+/*}*/
 
-.table-dark.table-striped tbody tr:nth-of-type(odd) {
-  background-color: rgba(255, 255, 255, 0.05); }
+/*.table-dark.table-striped tbody tr:nth-of-type(odd) {*/
+/*  background-color: rgba(255, 255, 255, 0.05);*/
+/*}*/
 
-.table-dark.table-hover tbody tr:hover {
-  color: #fff;
-  background-color: rgba(255, 255, 255, 0.075); }
+/*.table-dark.table-hover tbody tr:hover {*/
+/*  color: #fff;*/
+/*  background-color: rgba(255, 255, 255, 0.075);*/
+/*}*/
 
-@media (max-width: 575.98px) {
-  .table-responsive-sm {
-    display: block;
-    width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch; }
-  .table-responsive-sm > .table-bordered {
-    border: 0; } }
+/*@media (max-width: 575.98px) {*/
+/*  .table-responsive-sm {*/
+/*    display: block;*/
+/*    width: 100%;*/
+/*    overflow-x: auto;*/
+/*    -webkit-overflow-scrolling: touch;*/
+/*  }*/
 
-@media (max-width: 767.98px) {
-  .table-responsive-md {
-    display: block;
-    width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch; }
-  .table-responsive-md > .table-bordered {
-    border: 0; } }
+/*  .table-responsive-sm > .table-bordered {*/
+/*    border: 0;*/
+/*  }*/
+/*}*/
 
-@media (max-width: 991.98px) {
-  .table-responsive-lg {
-    display: block;
-    width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch; }
-  .table-responsive-lg > .table-bordered {
-    border: 0; } }
+/*@media (max-width: 767.98px) {*/
+/*  .table-responsive-md {*/
+/*    display: block;*/
+/*    width: 100%;*/
+/*    overflow-x: auto;*/
+/*    -webkit-overflow-scrolling: touch;*/
+/*  }*/
 
-@media (max-width: 1199.98px) {
-  .table-responsive-xl {
-    display: block;
-    width: 100%;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch; }
-  .table-responsive-xl > .table-bordered {
-    border: 0; } }
+/*  .table-responsive-md > .table-bordered {*/
+/*    border: 0;*/
+/*  }*/
+/*}*/
+
+/*@media (max-width: 991.98px) {*/
+/*  .table-responsive-lg {*/
+/*    display: block;*/
+/*    width: 100%;*/
+/*    overflow-x: auto;*/
+/*    -webkit-overflow-scrolling: touch;*/
+/*  }*/
+
+/*  .table-responsive-lg > .table-bordered {*/
+/*    border: 0;*/
+/*  }*/
+/*}*/
+
+/*@media (max-width: 1199.98px) {*/
+/*  .table-responsive-xl {*/
+/*    display: block;*/
+/*    width: 100%;*/
+/*    overflow-x: auto;*/
+/*    -webkit-overflow-scrolling: touch;*/
+/*  }*/
+
+/*  .table-responsive-xl > .table-bordered {*/
+/*    border: 0;*/
+/*  }*/
+/*}*/
 
 .table-responsive {
   display: block;
   width: 100%;
   overflow-x: auto;
-  -webkit-overflow-scrolling: touch; }
+  -webkit-overflow-scrolling: touch;
+}
 
-.table-responsive > .table-bordered {
-  border: 0; }
+/*.table-responsive > .table-bordered {*/
+/*  border: 0;*/
+/*}*/
 
 .form-control {
   display: block;
@@ -1612,412 +2102,483 @@ pre code {
   background-clip: padding-box;
   border: 1px solid #ced4da;
   border-radius: 0.25rem;
-  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
 
-@media (prefers-reduced-motion: reduce) {
-  .form-control {
-    transition: none; } }
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .form-control {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
 
-.form-control::-ms-expand {
-  background-color: transparent;
-  border: 0; }
+/*.form-control::/*-ms-expand {*/
+/*  background-color: transparent;*/
+/*  border: 0;*/
+/*}*/
 
-.form-control:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #495057; }
+/*.form-control:-moz-focusring {*/
+/*  color: transparent;*/
+/*  text-shadow: 0 0 0 #495057;*/
+/*}*/
 
-.form-control:focus {
-  color: #495057;
-  background-color: #fff;
-  border-color: #80bdff;
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
+/*.form-control:focus {*/
+/*  color: #495057;*/
+/*  background-color: #fff;*/
+/*  border-color: #80bdff;*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
 
 .form-control::-webkit-input-placeholder {
   color: #6c757d;
-  opacity: 1; }
+  opacity: 1;
+}
 
-.form-control::-moz-placeholder {
-  color: #6c757d;
-  opacity: 1; }
+/*.form-control::-moz-placeholder {*/
+/*  color: #6c757d;*/
+/*  opacity: 1;*/
+/*}*/
 
-.form-control:-ms-input-placeholder {
-  color: #6c757d;
-  opacity: 1; }
+/*.form-control:-ms-input-placeholder {*/
+/*  color: #6c757d;*/
+/*  opacity: 1;*/
+/*}*/
 
-.form-control::-ms-input-placeholder {
-  color: #6c757d;
-  opacity: 1; }
+/*.form-control::-ms-input-placeholder {*/
+/*  color: #6c757d;*/
+/*  opacity: 1;*/
+/*}*/
 
 .form-control::placeholder {
   color: #6c757d;
-  opacity: 1; }
+  opacity: 1;
+}
 
-.form-control:disabled, .form-control[readonly] {
-  background-color: #e9ecef;
-  opacity: 1; }
+/*.form-control:disabled, .form-control[readonly] {*/
+/*  background-color: #e9ecef;*/
+/*  opacity: 1;*/
+/*}*/
 
-input[type="date"].form-control,
-input[type="time"].form-control,
-input[type="datetime-local"].form-control,
-input[type="month"].form-control {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none; }
+/*input[type="date"].form-control, input[type="time"].form-control, input[type="datetime-local"].form-control, input[type="month"].form-control {*/
+/*  -webkit-appearance: none;*/
+/*  -moz-appearance: none;*/
+/*  appearance: none;*/
+/*}*/
 
-select.form-control:focus::-ms-value {
-  color: #495057;
-  background-color: #fff; }
+/*select.form-control:focus::-ms-value {*/
+/*  color: #495057;*/
+/*  background-color: #fff;*/
+/*}*/
 
-.form-control-file,
-.form-control-range {
-  display: block;
-  width: 100%; }
+/*.form-control-file, .form-control-range {*/
+/*  display: block;*/
+/*  width: 100%;*/
+/*}*/
 
-.col-form-label {
-  padding-top: calc(0.375rem + 1px);
-  padding-bottom: calc(0.375rem + 1px);
-  margin-bottom: 0;
-  font-size: inherit;
-  line-height: 1.5; }
+/*.col-form-label {*/
+/*  padding-top: calc(0.375rem + 1px);*/
+/*  padding-bottom: calc(0.375rem + 1px);*/
+/*  margin-bottom: 0;*/
+/*  font-size: inherit;*/
+/*  line-height: 1.5;*/
+/*}*/
 
-.col-form-label-lg {
-  padding-top: calc(0.5rem + 1px);
-  padding-bottom: calc(0.5rem + 1px);
-  font-size: 1.25rem;
-  line-height: 1.5; }
+/*.col-form-label-lg {*/
+/*  padding-top: calc(0.5rem + 1px);*/
+/*  padding-bottom: calc(0.5rem + 1px);*/
+/*  font-size: 1.25rem;*/
+/*  line-height: 1.5;*/
+/*}*/
 
-.col-form-label-sm {
-  padding-top: calc(0.25rem + 1px);
-  padding-bottom: calc(0.25rem + 1px);
-  font-size: 0.875rem;
-  line-height: 1.5; }
+/*.col-form-label-sm {*/
+/*  padding-top: calc(0.25rem + 1px);*/
+/*  padding-bottom: calc(0.25rem + 1px);*/
+/*  font-size: 0.875rem;*/
+/*  line-height: 1.5;*/
+/*}*/
 
-.form-control-plaintext {
-  display: block;
-  width: 100%;
-  padding: 0.375rem 0;
-  margin-bottom: 0;
-  font-size: 1rem;
-  line-height: 1.5;
-  color: #212529;
-  background-color: transparent;
-  border: solid transparent;
-  border-width: 1px 0; }
+/*.form-control-plaintext {*/
+/*  display: block;*/
+/*  width: 100%;*/
+/*  padding: 0.375rem 0;*/
+/*  margin-bottom: 0;*/
+/*  font-size: 1rem;*/
+/*  line-height: 1.5;*/
+/*  color: #212529;*/
+/*  background-color: transparent;*/
+/*  border: solid transparent;*/
+/*  border-width: 1px 0;*/
+/*}*/
 
-.form-control-plaintext.form-control-sm, .form-control-plaintext.form-control-lg {
-  padding-right: 0;
-  padding-left: 0; }
+/*.form-control-plaintext.form-control-sm, .form-control-plaintext.form-control-lg {*/
+/*  padding-right: 0;*/
+/*  padding-left: 0;*/
+/*}*/
 
-.form-control-sm {
-  height: calc(1.5em + 0.5rem + 2px);
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  border-radius: 0.2rem; }
+/*.form-control-sm {*/
+/*  height: calc(1.5em + 0.5rem + 2px);*/
+/*  padding: 0.25rem 0.5rem;*/
+/*  font-size: 0.875rem;*/
+/*  line-height: 1.5;*/
+/*  border-radius: 0.2rem;*/
+/*}*/
 
-.form-control-lg {
-  height: calc(1.5em + 1rem + 2px);
-  padding: 0.5rem 1rem;
-  font-size: 1.25rem;
-  line-height: 1.5;
-  border-radius: 0.3rem; }
+/*.form-control-lg {*/
+/*  height: calc(1.5em + 1rem + 2px);*/
+/*  padding: 0.5rem 1rem;*/
+/*  font-size: 1.25rem;*/
+/*  line-height: 1.5;*/
+/*  border-radius: 0.3rem;*/
+/*}*/
 
-select.form-control[size], select.form-control[multiple] {
-  height: auto; }
+/*select.form-control[size], select.form-control[multiple] {*/
+/*  height: auto;*/
+/*}*/
 
-textarea.form-control {
-  height: auto; }
+/*textarea.form-control {*/
+/*  height: auto;*/
+/*}*/
 
-.form-group {
-  margin-bottom: 1rem; }
+/*.form-group {*/
+/*  margin-bottom: 1rem;*/
+/*}*/
 
-.form-text {
-  display: block;
-  margin-top: 0.25rem; }
+/*.form-text {*/
+/*  display: block;*/
+/*  margin-top: 0.25rem;*/
+/*}*/
 
-.form-row {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  margin-right: -5px;
-  margin-left: -5px; }
+/*.form-row {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-wrap: wrap;*/
+/*  flex-wrap: wrap;*/
+/*  margin-right: -5px;*/
+/*  margin-left: -5px;*/
+/*}*/
 
-.form-row > .col,
-.form-row > [class*="col-"] {
-  padding-right: 5px;
-  padding-left: 5px; }
+/*.form-row > .col, .form-row > [class*="col-"] {*/
+/*  padding-right: 5px;*/
+/*  padding-left: 5px;*/
+/*}*/
 
-.form-check {
-  position: relative;
-  display: block;
-  padding-left: 1.25rem; }
+/*.form-check {*/
+/*  position: relative;*/
+/*  display: block;*/
+/*  padding-left: 1.25rem;*/
+/*}*/
 
-.form-check-input {
-  position: absolute;
-  margin-top: 0.3rem;
-  margin-left: -1.25rem; }
+/*.form-check-input {*/
+/*  position: absolute;*/
+/*  margin-top: 0.3rem;*/
+/*  margin-left: -1.25rem;*/
+/*}*/
 
-.form-check-input[disabled] ~ .form-check-label,
-.form-check-input:disabled ~ .form-check-label {
-  color: #6c757d; }
+/*.form-check-input[disabled] ~ .form-check-label, .form-check-input:disabled ~ .form-check-label {*/
+/*  color: #6c757d;*/
+/*}*/
 
-.form-check-label {
-  margin-bottom: 0; }
+/*.form-check-label {*/
+/*  margin-bottom: 0;*/
+/*}*/
 
-.form-check-inline {
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  -ms-flex-align: center;
-  align-items: center;
-  padding-left: 0;
-  margin-right: 0.75rem; }
+/*.form-check-inline {*/
+/*  display: -ms-inline-flexbox;*/
+/*  display: inline-flex;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  padding-left: 0;*/
+/*  margin-right: 0.75rem;*/
+/*}*/
 
-.form-check-inline .form-check-input {
-  position: static;
-  margin-top: 0;
-  margin-right: 0.3125rem;
-  margin-left: 0; }
+/*.form-check-inline .form-check-input {*/
+/*  position: static;*/
+/*  margin-top: 0;*/
+/*  margin-right: 0.3125rem;*/
+/*  margin-left: 0;*/
+/*}*/
 
-.valid-feedback {
-  display: none;
-  width: 100%;
-  margin-top: 0.25rem;
-  font-size: 80%;
-  color: #28a745; }
+/*.valid-feedback {*/
+/*  display: none;*/
+/*  width: 100%;*/
+/*  margin-top: 0.25rem;*/
+/*  font-size: 80%;*/
+/*  color: #28a745;*/
+/*}*/
 
-.valid-tooltip {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 5;
-  display: none;
-  max-width: 100%;
-  padding: 0.25rem 0.5rem;
-  margin-top: .1rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  color: #fff;
-  background-color: rgba(40, 167, 69, 0.9);
-  border-radius: 0.25rem; }
+/*.valid-tooltip {*/
+/*  position: absolute;*/
+/*  top: 100%;*/
+/*  left: 0;*/
+/*  z-index: 5;*/
+/*  display: none;*/
+/*  max-width: 100%;*/
+/*  padding: 0.25rem 0.5rem;*/
+/*  margin-top: .1rem;*/
+/*  font-size: 0.875rem;*/
+/*  line-height: 1.5;*/
+/*  color: #fff;*/
+/*  background-color: rgba(40, 167, 69, 0.9);*/
+/*  border-radius: 0.25rem;*/
+/*}*/
 
-.form-row > .col > .valid-tooltip,
-.form-row > [class*="col-"] > .valid-tooltip {
-  left: 5px; }
+/*.form-row > .col > .valid-tooltip, .form-row > [class*="col-"] > .valid-tooltip {*/
+/*  left: 5px;*/
+/*}*/
 
-.was-validated :valid ~ .valid-feedback,
-.was-validated :valid ~ .valid-tooltip,
-.is-valid ~ .valid-feedback,
-.is-valid ~ .valid-tooltip {
-  display: block; }
+/*.was-validated :valid ~ .valid-feedback, .was-validated :valid ~ .valid-tooltip, .is-valid ~ .valid-feedback, .is-valid ~ .valid-tooltip {*/
+/*  display: block;*/
+/*}*/
 
-.was-validated .form-control:valid, .form-control.is-valid {
-  border-color: #28a745;
-  padding-right: calc(1.5em + 0.75rem);
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right calc(0.375em + 0.1875rem) center;
-  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem); }
+/*.was-validated .form-control:valid, .form-control.is-valid {*/
+/*  border-color: #28a745;*/
+/*  padding-right: calc(1.5em + 0.75rem);*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e");*/
+/*  background-repeat: no-repeat;*/
+/*  background-position: right calc(0.375em + 0.1875rem) center;*/
+/*  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);*/
+/*}*/
 
-.was-validated .form-control:valid:focus, .form-control.is-valid:focus {
-  border-color: #28a745;
-  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+/*.was-validated .form-control:valid:focus, .form-control.is-valid:focus {*/
+/*  border-color: #28a745;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);*/
+/*}*/
 
-.was-validated textarea.form-control:valid, textarea.form-control.is-valid {
-  padding-right: calc(1.5em + 0.75rem);
-  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem); }
+/*.was-validated textarea.form-control:valid, textarea.form-control.is-valid {*/
+/*  padding-right: calc(1.5em + 0.75rem);*/
+/*  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);*/
+/*}*/
 
-.was-validated .custom-select:valid, .custom-select.is-valid {
-  border-color: #28a745;
-  padding-right: calc(0.75em + 2.3125rem);
-  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat; }
+/*.was-validated .custom-select:valid, .custom-select.is-valid {*/
+/*  border-color: #28a745;*/
+/*  padding-right: calc(0.75em + 2.3125rem);*/
+/*  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%2328a745' d='M2.3 6.73L.6 4.53c-.4-1.04.46-1.4 1.1-.8l1.1 1.4 3.4-3.8c.6-.63 1.6-.27 1.2.7l-4 4.6c-.43.5-.8.4-1.1.1z'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat;*/
+/*}*/
 
-.was-validated .custom-select:valid:focus, .custom-select.is-valid:focus {
-  border-color: #28a745;
-  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+/*.was-validated .custom-select:valid:focus, .custom-select.is-valid:focus {*/
+/*  border-color: #28a745;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);*/
+/*}*/
 
-.was-validated .form-check-input:valid ~ .form-check-label, .form-check-input.is-valid ~ .form-check-label {
-  color: #28a745; }
+/*.was-validated .form-check-input:valid ~ .form-check-label, .form-check-input.is-valid ~ .form-check-label {*/
+/*  color: #28a745;*/
+/*}*/
 
-.was-validated .form-check-input:valid ~ .valid-feedback,
-.was-validated .form-check-input:valid ~ .valid-tooltip, .form-check-input.is-valid ~ .valid-feedback,
-.form-check-input.is-valid ~ .valid-tooltip {
-  display: block; }
+/*.was-validated .form-check-input:valid ~ .valid-feedback, .was-validated .form-check-input:valid ~ .valid-tooltip, .form-check-input.is-valid ~ .valid-feedback, .form-check-input.is-valid ~ .valid-tooltip {*/
+/*  display: block;*/
+/*}*/
 
-.was-validated .custom-control-input:valid ~ .custom-control-label, .custom-control-input.is-valid ~ .custom-control-label {
-  color: #28a745; }
+/*.was-validated .custom-control-input:valid ~ .custom-control-label, .custom-control-input.is-valid ~ .custom-control-label {*/
+/*  color: #28a745;*/
+/*}*/
 
-.was-validated .custom-control-input:valid ~ .custom-control-label::before, .custom-control-input.is-valid ~ .custom-control-label::before {
-  border-color: #28a745; }
+/*.was-validated .custom-control-input:valid ~ .custom-control-label::before, .custom-control-input.is-valid ~ .custom-control-label::before {*/
+/*  border-color: #28a745;*/
+/*}*/
 
-.was-validated .custom-control-input:valid:checked ~ .custom-control-label::before, .custom-control-input.is-valid:checked ~ .custom-control-label::before {
-  border-color: #34ce57;
-  background-color: #34ce57; }
+/*.was-validated .custom-control-input:valid:checked ~ .custom-control-label::before, .custom-control-input.is-valid:checked ~ .custom-control-label::before {*/
+/*  border-color: #34ce57;*/
+/*  background-color: #34ce57;*/
+/*}*/
 
-.was-validated .custom-control-input:valid:focus ~ .custom-control-label::before, .custom-control-input.is-valid:focus ~ .custom-control-label::before {
-  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+/*.was-validated .custom-control-input:valid:focus ~ .custom-control-label::before, .custom-control-input.is-valid:focus ~ .custom-control-label::before {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);*/
+/*}*/
 
-.was-validated .custom-control-input:valid:focus:not(:checked) ~ .custom-control-label::before, .custom-control-input.is-valid:focus:not(:checked) ~ .custom-control-label::before {
-  border-color: #28a745; }
+/*.was-validated .custom-control-input:valid:focus:not(:checked) ~ .custom-control-label::before, .custom-control-input.is-valid:focus:not(:checked) ~ .custom-control-label::before {*/
+/*  border-color: #28a745;*/
+/*}*/
 
-.was-validated .custom-file-input:valid ~ .custom-file-label, .custom-file-input.is-valid ~ .custom-file-label {
-  border-color: #28a745; }
+/*.was-validated .custom-file-input:valid ~ .custom-file-label, .custom-file-input.is-valid ~ .custom-file-label {*/
+/*  border-color: #28a745;*/
+/*}*/
 
-.was-validated .custom-file-input:valid:focus ~ .custom-file-label, .custom-file-input.is-valid:focus ~ .custom-file-label {
-  border-color: #28a745;
-  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25); }
+/*.was-validated .custom-file-input:valid:focus ~ .custom-file-label, .custom-file-input.is-valid:focus ~ .custom-file-label {*/
+/*  border-color: #28a745;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);*/
+/*}*/
 
-.invalid-feedback {
-  display: none;
-  width: 100%;
-  margin-top: 0.25rem;
-  font-size: 80%;
-  color: #dc3545; }
+/*.invalid-feedback {*/
+/*  display: none;*/
+/*  width: 100%;*/
+/*  margin-top: 0.25rem;*/
+/*  font-size: 80%;*/
+/*  color: #dc3545;*/
+/*}*/
 
-.invalid-tooltip {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 5;
-  display: none;
-  max-width: 100%;
-  padding: 0.25rem 0.5rem;
-  margin-top: .1rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  color: #fff;
-  background-color: rgba(220, 53, 69, 0.9);
-  border-radius: 0.25rem; }
+/*.invalid-tooltip {*/
+/*  position: absolute;*/
+/*  top: 100%;*/
+/*  left: 0;*/
+/*  z-index: 5;*/
+/*  display: none;*/
+/*  max-width: 100%;*/
+/*  padding: 0.25rem 0.5rem;*/
+/*  margin-top: .1rem;*/
+/*  font-size: 0.875rem;*/
+/*  line-height: 1.5;*/
+/*  color: #fff;*/
+/*  background-color: rgba(220, 53, 69, 0.9);*/
+/*  border-radius: 0.25rem;*/
+/*}*/
 
-.form-row > .col > .invalid-tooltip,
-.form-row > [class*="col-"] > .invalid-tooltip {
-  left: 5px; }
+/*.form-row > .col > .invalid-tooltip, .form-row > [class*="col-"] > .invalid-tooltip {*/
+/*  left: 5px;*/
+/*}*/
 
-.was-validated :invalid ~ .invalid-feedback,
-.was-validated :invalid ~ .invalid-tooltip,
-.is-invalid ~ .invalid-feedback,
-.is-invalid ~ .invalid-tooltip {
-  display: block; }
+/*.was-validated :invalid ~ .invalid-feedback, .was-validated :invalid ~ .invalid-tooltip, .is-invalid ~ .invalid-feedback, .is-invalid ~ .invalid-tooltip {*/
+/*  display: block;*/
+/*}*/
 
-.was-validated .form-control:invalid, .form-control.is-invalid {
-  border-color: #dc3545;
-  padding-right: calc(1.5em + 0.75rem);
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");
-  background-repeat: no-repeat;
-  background-position: right calc(0.375em + 0.1875rem) center;
-  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem); }
+/*.was-validated .form-control:invalid, .form-control.is-invalid {*/
+/*  border-color: #dc3545;*/
+/*  padding-right: calc(1.5em + 0.75rem);*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e");*/
+/*  background-repeat: no-repeat;*/
+/*  background-position: right calc(0.375em + 0.1875rem) center;*/
+/*  background-size: calc(0.75em + 0.375rem) calc(0.75em + 0.375rem);*/
+/*}*/
 
-.was-validated .form-control:invalid:focus, .form-control.is-invalid:focus {
-  border-color: #dc3545;
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+/*.was-validated .form-control:invalid:focus, .form-control.is-invalid:focus {*/
+/*  border-color: #dc3545;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);*/
+/*}*/
 
-.was-validated textarea.form-control:invalid, textarea.form-control.is-invalid {
-  padding-right: calc(1.5em + 0.75rem);
-  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem); }
+/*.was-validated textarea.form-control:invalid, textarea.form-control.is-invalid {*/
+/*  padding-right: calc(1.5em + 0.75rem);*/
+/*  background-position: top calc(0.375em + 0.1875rem) right calc(0.375em + 0.1875rem);*/
+/*}*/
 
-.was-validated .custom-select:invalid, .custom-select.is-invalid {
-  border-color: #dc3545;
-  padding-right: calc(0.75em + 2.3125rem);
-  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat; }
+/*.was-validated .custom-select:invalid, .custom-select.is-invalid {*/
+/*  border-color: #dc3545;*/
+/*  padding-right: calc(0.75em + 2.3125rem);*/
+/*  background: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat, #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' stroke='%23dc3545' viewBox='0 0 12 12'%3e%3ccircle cx='6' cy='6' r='4.5'/%3e%3cpath stroke-linejoin='round' d='M5.8 3.6h.4L6 6.5z'/%3e%3ccircle cx='6' cy='8.2' r='.6' fill='%23dc3545' stroke='none'/%3e%3c/svg%3e") center right 1.75rem/calc(0.75em + 0.375rem) calc(0.75em + 0.375rem) no-repeat;*/
+/*}*/
 
-.was-validated .custom-select:invalid:focus, .custom-select.is-invalid:focus {
-  border-color: #dc3545;
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+/*.was-validated .custom-select:invalid:focus, .custom-select.is-invalid:focus {*/
+/*  border-color: #dc3545;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);*/
+/*}*/
 
-.was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {
-  color: #dc3545; }
+/*.was-validated .form-check-input:invalid ~ .form-check-label, .form-check-input.is-invalid ~ .form-check-label {*/
+/*  color: #dc3545;*/
+/*}*/
 
-.was-validated .form-check-input:invalid ~ .invalid-feedback,
-.was-validated .form-check-input:invalid ~ .invalid-tooltip, .form-check-input.is-invalid ~ .invalid-feedback,
-.form-check-input.is-invalid ~ .invalid-tooltip {
-  display: block; }
+/*.was-validated .form-check-input:invalid ~ .invalid-feedback, .was-validated .form-check-input:invalid ~ .invalid-tooltip, .form-check-input.is-invalid ~ .invalid-feedback, .form-check-input.is-invalid ~ .invalid-tooltip {*/
+/*  display: block;*/
+/*}*/
 
-.was-validated .custom-control-input:invalid ~ .custom-control-label, .custom-control-input.is-invalid ~ .custom-control-label {
-  color: #dc3545; }
+/*.was-validated .custom-control-input:invalid ~ .custom-control-label, .custom-control-input.is-invalid ~ .custom-control-label {*/
+/*  color: #dc3545;*/
+/*}*/
 
-.was-validated .custom-control-input:invalid ~ .custom-control-label::before, .custom-control-input.is-invalid ~ .custom-control-label::before {
-  border-color: #dc3545; }
+/*.was-validated .custom-control-input:invalid ~ .custom-control-label::before, .custom-control-input.is-invalid ~ .custom-control-label::before {*/
+/*  border-color: #dc3545;*/
+/*}*/
 
-.was-validated .custom-control-input:invalid:checked ~ .custom-control-label::before, .custom-control-input.is-invalid:checked ~ .custom-control-label::before {
-  border-color: #e4606d;
-  background-color: #e4606d; }
+/*.was-validated .custom-control-input:invalid:checked ~ .custom-control-label::before, .custom-control-input.is-invalid:checked ~ .custom-control-label::before {*/
+/*  border-color: #e4606d;*/
+/*  background-color: #e4606d;*/
+/*}*/
 
-.was-validated .custom-control-input:invalid:focus ~ .custom-control-label::before, .custom-control-input.is-invalid:focus ~ .custom-control-label::before {
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+/*.was-validated .custom-control-input:invalid:focus ~ .custom-control-label::before, .custom-control-input.is-invalid:focus ~ .custom-control-label::before {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);*/
+/*}*/
 
-.was-validated .custom-control-input:invalid:focus:not(:checked) ~ .custom-control-label::before, .custom-control-input.is-invalid:focus:not(:checked) ~ .custom-control-label::before {
-  border-color: #dc3545; }
+/*.was-validated .custom-control-input:invalid:focus:not(:checked) ~ .custom-control-label::before, .custom-control-input.is-invalid:focus:not(:checked) ~ .custom-control-label::before {*/
+/*  border-color: #dc3545;*/
+/*}*/
 
-.was-validated .custom-file-input:invalid ~ .custom-file-label, .custom-file-input.is-invalid ~ .custom-file-label {
-  border-color: #dc3545; }
+/*.was-validated .custom-file-input:invalid ~ .custom-file-label, .custom-file-input.is-invalid ~ .custom-file-label {*/
+/*  border-color: #dc3545;*/
+/*}*/
 
-.was-validated .custom-file-input:invalid:focus ~ .custom-file-label, .custom-file-input.is-invalid:focus ~ .custom-file-label {
-  border-color: #dc3545;
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25); }
+/*.was-validated .custom-file-input:invalid:focus ~ .custom-file-label, .custom-file-input.is-invalid:focus ~ .custom-file-label {*/
+/*  border-color: #dc3545;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.25);*/
+/*}*/
 
 .form-inline {
-  display: -ms-flexbox;
+  /*display: -ms-flexbox;*/
   display: flex;
-  -ms-flex-flow: row wrap;
+  /*-ms-flex-flow: row wrap;*/
   flex-flow: row wrap;
-  -ms-flex-align: center;
-  align-items: center; }
+  /*-ms-flex-align: center;*/
+  align-items: center;
+}
 
-.form-inline .form-check {
-  width: 100%; }
+/*.form-inline .form-check {*/
+/*  width: 100%;*/
+/*}*/
 
-@media (min-width: 576px) {
-  .form-inline label {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-align: center;
-    align-items: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-    margin-bottom: 0; }
-  .form-inline .form-group {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex: 0 0 auto;
-    flex: 0 0 auto;
-    -ms-flex-flow: row wrap;
-    flex-flow: row wrap;
-    -ms-flex-align: center;
-    align-items: center;
-    margin-bottom: 0; }
-  .form-inline .form-control {
-    display: inline-block;
-    width: auto;
-    vertical-align: middle; }
-  .form-inline .form-control-plaintext {
-    display: inline-block; }
-  .form-inline .input-group,
-  .form-inline .custom-select {
-    width: auto; }
-  .form-inline .form-check {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-align: center;
-    align-items: center;
-    -ms-flex-pack: center;
-    justify-content: center;
-    width: auto;
-    padding-left: 0; }
-  .form-inline .form-check-input {
-    position: relative;
-    -ms-flex-negative: 0;
-    flex-shrink: 0;
-    margin-top: 0;
-    margin-right: 0.25rem;
-    margin-left: 0; }
-  .form-inline .custom-control {
-    -ms-flex-align: center;
-    align-items: center;
-    -ms-flex-pack: center;
-    justify-content: center; }
-  .form-inline .custom-control-label {
-    margin-bottom: 0; } }
+/*@media (min-width: 576px) {*/
+/*  .form-inline label {*/
+/*    display: -ms-flexbox;*/
+/*    display: flex;*/
+/*    -ms-flex-align: center;*/
+/*    align-items: center;*/
+/*    -ms-flex-pack: center;*/
+/*    justify-content: center;*/
+/*    margin-bottom: 0;*/
+/*  }*/
+
+/*  .form-inline .form-group {*/
+/*    display: -ms-flexbox;*/
+/*    display: flex;*/
+/*    -ms-flex: 0 0 auto;*/
+/*    flex: 0 0 auto;*/
+/*    -ms-flex-flow: row wrap;*/
+/*    flex-flow: row wrap;*/
+/*    -ms-flex-align: center;*/
+/*    align-items: center;*/
+/*    margin-bottom: 0;*/
+/*  }*/
+
+/*  .form-inline .form-control {*/
+/*    display: inline-block;*/
+/*    width: auto;*/
+/*    vertical-align: middle;*/
+/*  }*/
+
+/*  .form-inline .form-control-plaintext {*/
+/*    display: inline-block;*/
+/*  }*/
+
+/*  .form-inline .input-group, .form-inline .custom-select {*/
+/*    width: auto;*/
+/*  }*/
+
+/*  .form-inline .form-check {*/
+/*    display: -ms-flexbox;*/
+/*    display: flex;*/
+/*    -ms-flex-align: center;*/
+/*    align-items: center;*/
+/*    -ms-flex-pack: center;*/
+/*    justify-content: center;*/
+/*    width: auto;*/
+/*    padding-left: 0;*/
+/*  }*/
+
+/*  .form-inline .form-check-input {*/
+/*    position: relative;*/
+/*    -ms-flex-negative: 0;*/
+/*    flex-shrink: 0;*/
+/*    margin-top: 0;*/
+/*    margin-right: 0.25rem;*/
+/*    margin-left: 0;*/
+/*  }*/
+
+/*  .form-inline .custom-control {*/
+/*    -ms-flex-align: center;*/
+/*    align-items: center;*/
+/*    -ms-flex-pack: center;*/
+/*    justify-content: center;*/
+/*  }*/
+
+/*  .form-inline .custom-control-label {*/
+/*    margin-bottom: 0;*/
+/*  }*/
+/*}*/
 
 .btn {
   display: inline-block;
@@ -2027,7 +2588,7 @@ textarea.form-control {
   vertical-align: middle;
   -webkit-user-select: none;
   -moz-user-select: none;
-  -ms-user-select: none;
+  /*-ms-user-select: none;*/
   user-select: none;
   background-color: transparent;
   border: 1px solid transparent;
@@ -2035,557 +2596,642 @@ textarea.form-control {
   font-size: 1rem;
   line-height: 1.5;
   border-radius: 0.25rem;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
 
-@media (prefers-reduced-motion: reduce) {
-  .btn {
-    transition: none; } }
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .btn {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
 
-.btn:hover {
-  color: #212529;
-  text-decoration: none; }
+/*.btn:hover {*/
+/*  color: #212529;*/
+/*  text-decoration: none;*/
+/*}*/
 
-.btn:focus, .btn.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
+/*.btn:focus, .btn.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
 
-.btn.disabled, .btn:disabled {
-  opacity: 0.65; }
+/*.btn.disabled, .btn:disabled {*/
+/*  opacity: 0.65;*/
+/*}*/
 
 .btn:not(:disabled):not(.disabled) {
-  cursor: pointer; }
-
-a.btn.disabled,
-fieldset:disabled a.btn {
-  pointer-events: none; }
-
-.btn-primary {
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff; }
-
-.btn-primary:hover {
-  color: #fff;
-  background-color: #0069d9;
-  border-color: #0062cc; }
-
-.btn-primary:focus, .btn-primary.focus {
-  color: #fff;
-  background-color: #0069d9;
-  border-color: #0062cc;
-  box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5); }
-
-.btn-primary.disabled, .btn-primary:disabled {
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff; }
-
-.btn-primary:not(:disabled):not(.disabled):active, .btn-primary:not(:disabled):not(.disabled).active,
-.show > .btn-primary.dropdown-toggle {
-  color: #fff;
-  background-color: #0062cc;
-  border-color: #005cbf; }
-
-.btn-primary:not(:disabled):not(.disabled):active:focus, .btn-primary:not(:disabled):not(.disabled).active:focus,
-.show > .btn-primary.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5); }
-
-.btn-secondary {
-  color: #fff;
-  background-color: #6c757d;
-  border-color: #6c757d; }
-
-.btn-secondary:hover {
-  color: #fff;
-  background-color: #5a6268;
-  border-color: #545b62; }
-
-.btn-secondary:focus, .btn-secondary.focus {
-  color: #fff;
-  background-color: #5a6268;
-  border-color: #545b62;
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5); }
-
-.btn-secondary.disabled, .btn-secondary:disabled {
-  color: #fff;
-  background-color: #6c757d;
-  border-color: #6c757d; }
-
-.btn-secondary:not(:disabled):not(.disabled):active, .btn-secondary:not(:disabled):not(.disabled).active,
-.show > .btn-secondary.dropdown-toggle {
-  color: #fff;
-  background-color: #545b62;
-  border-color: #4e555b; }
-
-.btn-secondary:not(:disabled):not(.disabled):active:focus, .btn-secondary:not(:disabled):not(.disabled).active:focus,
-.show > .btn-secondary.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5); }
-
-.btn-success {
-  color: #fff;
-  background-color: #28a745;
-  border-color: #28a745; }
-
-.btn-success:hover {
-  color: #fff;
-  background-color: #218838;
-  border-color: #1e7e34; }
-
-.btn-success:focus, .btn-success.focus {
-  color: #fff;
-  background-color: #218838;
-  border-color: #1e7e34;
-  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5); }
-
-.btn-success.disabled, .btn-success:disabled {
-  color: #fff;
-  background-color: #28a745;
-  border-color: #28a745; }
-
-.btn-success:not(:disabled):not(.disabled):active, .btn-success:not(:disabled):not(.disabled).active,
-.show > .btn-success.dropdown-toggle {
-  color: #fff;
-  background-color: #1e7e34;
-  border-color: #1c7430; }
-
-.btn-success:not(:disabled):not(.disabled):active:focus, .btn-success:not(:disabled):not(.disabled).active:focus,
-.show > .btn-success.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5); }
-
-.btn-info {
-  color: #fff;
-  background-color: #17a2b8;
-  border-color: #17a2b8; }
-
-.btn-info:hover {
-  color: #fff;
-  background-color: #138496;
-  border-color: #117a8b; }
-
-.btn-info:focus, .btn-info.focus {
-  color: #fff;
-  background-color: #138496;
-  border-color: #117a8b;
-  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5); }
-
-.btn-info.disabled, .btn-info:disabled {
-  color: #fff;
-  background-color: #17a2b8;
-  border-color: #17a2b8; }
-
-.btn-info:not(:disabled):not(.disabled):active, .btn-info:not(:disabled):not(.disabled).active,
-.show > .btn-info.dropdown-toggle {
-  color: #fff;
-  background-color: #117a8b;
-  border-color: #10707f; }
-
-.btn-info:not(:disabled):not(.disabled):active:focus, .btn-info:not(:disabled):not(.disabled).active:focus,
-.show > .btn-info.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5); }
-
-.btn-warning {
-  color: #212529;
-  background-color: #ffc107;
-  border-color: #ffc107; }
-
-.btn-warning:hover {
-  color: #212529;
-  background-color: #e0a800;
-  border-color: #d39e00; }
-
-.btn-warning:focus, .btn-warning.focus {
-  color: #212529;
-  background-color: #e0a800;
-  border-color: #d39e00;
-  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5); }
-
-.btn-warning.disabled, .btn-warning:disabled {
-  color: #212529;
-  background-color: #ffc107;
-  border-color: #ffc107; }
-
-.btn-warning:not(:disabled):not(.disabled):active, .btn-warning:not(:disabled):not(.disabled).active,
-.show > .btn-warning.dropdown-toggle {
-  color: #212529;
-  background-color: #d39e00;
-  border-color: #c69500; }
-
-.btn-warning:not(:disabled):not(.disabled):active:focus, .btn-warning:not(:disabled):not(.disabled).active:focus,
-.show > .btn-warning.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5); }
-
-.btn-danger {
-  color: #fff;
-  background-color: #dc3545;
-  border-color: #dc3545; }
-
-.btn-danger:hover {
-  color: #fff;
-  background-color: #c82333;
-  border-color: #bd2130; }
-
-.btn-danger:focus, .btn-danger.focus {
-  color: #fff;
-  background-color: #c82333;
-  border-color: #bd2130;
-  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5); }
-
-.btn-danger.disabled, .btn-danger:disabled {
-  color: #fff;
-  background-color: #dc3545;
-  border-color: #dc3545; }
-
-.btn-danger:not(:disabled):not(.disabled):active, .btn-danger:not(:disabled):not(.disabled).active,
-.show > .btn-danger.dropdown-toggle {
-  color: #fff;
-  background-color: #bd2130;
-  border-color: #b21f2d; }
-
-.btn-danger:not(:disabled):not(.disabled):active:focus, .btn-danger:not(:disabled):not(.disabled).active:focus,
-.show > .btn-danger.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5); }
-
-.btn-light {
-  color: #212529;
-  background-color: #f8f9fa;
-  border-color: #f8f9fa; }
-
-.btn-light:hover {
-  color: #212529;
-  background-color: #e2e6ea;
-  border-color: #dae0e5; }
-
-.btn-light:focus, .btn-light.focus {
-  color: #212529;
-  background-color: #e2e6ea;
-  border-color: #dae0e5;
-  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5); }
-
-.btn-light.disabled, .btn-light:disabled {
-  color: #212529;
-  background-color: #f8f9fa;
-  border-color: #f8f9fa; }
-
-.btn-light:not(:disabled):not(.disabled):active, .btn-light:not(:disabled):not(.disabled).active,
-.show > .btn-light.dropdown-toggle {
-  color: #212529;
-  background-color: #dae0e5;
-  border-color: #d3d9df; }
-
-.btn-light:not(:disabled):not(.disabled):active:focus, .btn-light:not(:disabled):not(.disabled).active:focus,
-.show > .btn-light.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5); }
-
-.btn-dark {
-  color: #fff;
-  background-color: #343a40;
-  border-color: #343a40; }
-
-.btn-dark:hover {
-  color: #fff;
-  background-color: #23272b;
-  border-color: #1d2124; }
-
-.btn-dark:focus, .btn-dark.focus {
-  color: #fff;
-  background-color: #23272b;
-  border-color: #1d2124;
-  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5); }
-
-.btn-dark.disabled, .btn-dark:disabled {
-  color: #fff;
-  background-color: #343a40;
-  border-color: #343a40; }
-
-.btn-dark:not(:disabled):not(.disabled):active, .btn-dark:not(:disabled):not(.disabled).active,
-.show > .btn-dark.dropdown-toggle {
-  color: #fff;
-  background-color: #1d2124;
-  border-color: #171a1d; }
-
-.btn-dark:not(:disabled):not(.disabled):active:focus, .btn-dark:not(:disabled):not(.disabled).active:focus,
-.show > .btn-dark.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5); }
-
-.btn-outline-primary {
-  color: #007bff;
-  border-color: #007bff; }
-
-.btn-outline-primary:hover {
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff; }
-
-.btn-outline-primary:focus, .btn-outline-primary.focus {
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5); }
-
-.btn-outline-primary.disabled, .btn-outline-primary:disabled {
-  color: #007bff;
-  background-color: transparent; }
-
-.btn-outline-primary:not(:disabled):not(.disabled):active, .btn-outline-primary:not(:disabled):not(.disabled).active,
-.show > .btn-outline-primary.dropdown-toggle {
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff; }
-
-.btn-outline-primary:not(:disabled):not(.disabled):active:focus, .btn-outline-primary:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-primary.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5); }
-
-.btn-outline-secondary {
-  color: #6c757d;
-  border-color: #6c757d; }
-
-.btn-outline-secondary:hover {
-  color: #fff;
-  background-color: #6c757d;
-  border-color: #6c757d; }
-
-.btn-outline-secondary:focus, .btn-outline-secondary.focus {
-  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
-
-.btn-outline-secondary.disabled, .btn-outline-secondary:disabled {
-  color: #6c757d;
-  background-color: transparent; }
-
-.btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active,
-.show > .btn-outline-secondary.dropdown-toggle {
-  color: #fff;
-  background-color: #6c757d;
-  border-color: #6c757d; }
-
-.btn-outline-secondary:not(:disabled):not(.disabled):active:focus, .btn-outline-secondary:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-secondary.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
-
-.btn-outline-success {
-  color: #28a745;
-  border-color: #28a745; }
-
-.btn-outline-success:hover {
-  color: #fff;
-  background-color: #28a745;
-  border-color: #28a745; }
-
-.btn-outline-success:focus, .btn-outline-success.focus {
-  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
-
-.btn-outline-success.disabled, .btn-outline-success:disabled {
-  color: #28a745;
-  background-color: transparent; }
-
-.btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success:not(:disabled):not(.disabled).active,
-.show > .btn-outline-success.dropdown-toggle {
-  color: #fff;
-  background-color: #28a745;
-  border-color: #28a745; }
-
-.btn-outline-success:not(:disabled):not(.disabled):active:focus, .btn-outline-success:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-success.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
-
-.btn-outline-info {
-  color: #17a2b8;
-  border-color: #17a2b8; }
-
-.btn-outline-info:hover {
-  color: #fff;
-  background-color: #17a2b8;
-  border-color: #17a2b8; }
-
-.btn-outline-info:focus, .btn-outline-info.focus {
-  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
-
-.btn-outline-info.disabled, .btn-outline-info:disabled {
-  color: #17a2b8;
-  background-color: transparent; }
-
-.btn-outline-info:not(:disabled):not(.disabled):active, .btn-outline-info:not(:disabled):not(.disabled).active,
-.show > .btn-outline-info.dropdown-toggle {
-  color: #fff;
-  background-color: #17a2b8;
-  border-color: #17a2b8; }
-
-.btn-outline-info:not(:disabled):not(.disabled):active:focus, .btn-outline-info:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-info.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
-
-.btn-outline-warning {
-  color: #ffc107;
-  border-color: #ffc107; }
-
-.btn-outline-warning:hover {
-  color: #212529;
-  background-color: #ffc107;
-  border-color: #ffc107; }
-
-.btn-outline-warning:focus, .btn-outline-warning.focus {
-  box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5); }
-
-.btn-outline-warning.disabled, .btn-outline-warning:disabled {
-  color: #ffc107;
-  background-color: transparent; }
-
-.btn-outline-warning:not(:disabled):not(.disabled):active, .btn-outline-warning:not(:disabled):not(.disabled).active,
-.show > .btn-outline-warning.dropdown-toggle {
-  color: #212529;
-  background-color: #ffc107;
-  border-color: #ffc107; }
-
-.btn-outline-warning:not(:disabled):not(.disabled):active:focus, .btn-outline-warning:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-warning.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5); }
-
-.btn-outline-danger {
-  color: #dc3545;
-  border-color: #dc3545; }
-
-.btn-outline-danger:hover {
-  color: #fff;
-  background-color: #dc3545;
-  border-color: #dc3545; }
-
-.btn-outline-danger:focus, .btn-outline-danger.focus {
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
-
-.btn-outline-danger.disabled, .btn-outline-danger:disabled {
-  color: #dc3545;
-  background-color: transparent; }
-
-.btn-outline-danger:not(:disabled):not(.disabled):active, .btn-outline-danger:not(:disabled):not(.disabled).active,
-.show > .btn-outline-danger.dropdown-toggle {
-  color: #fff;
-  background-color: #dc3545;
-  border-color: #dc3545; }
-
-.btn-outline-danger:not(:disabled):not(.disabled):active:focus, .btn-outline-danger:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-danger.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
-
-.btn-outline-light {
-  color: #f8f9fa;
-  border-color: #f8f9fa; }
-
-.btn-outline-light:hover {
-  color: #212529;
-  background-color: #f8f9fa;
-  border-color: #f8f9fa; }
-
-.btn-outline-light:focus, .btn-outline-light.focus {
-  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
-
-.btn-outline-light.disabled, .btn-outline-light:disabled {
-  color: #f8f9fa;
-  background-color: transparent; }
-
-.btn-outline-light:not(:disabled):not(.disabled):active, .btn-outline-light:not(:disabled):not(.disabled).active,
-.show > .btn-outline-light.dropdown-toggle {
-  color: #212529;
-  background-color: #f8f9fa;
-  border-color: #f8f9fa; }
-
-.btn-outline-light:not(:disabled):not(.disabled):active:focus, .btn-outline-light:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-light.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
-
-.btn-outline-dark {
-  color: #343a40;
-  border-color: #343a40; }
-
-.btn-outline-dark:hover {
-  color: #fff;
-  background-color: #343a40;
-  border-color: #343a40; }
-
-.btn-outline-dark:focus, .btn-outline-dark.focus {
-  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
-
-.btn-outline-dark.disabled, .btn-outline-dark:disabled {
-  color: #343a40;
-  background-color: transparent; }
-
-.btn-outline-dark:not(:disabled):not(.disabled):active, .btn-outline-dark:not(:disabled):not(.disabled).active,
-.show > .btn-outline-dark.dropdown-toggle {
-  color: #fff;
-  background-color: #343a40;
-  border-color: #343a40; }
-
-.btn-outline-dark:not(:disabled):not(.disabled):active:focus, .btn-outline-dark:not(:disabled):not(.disabled).active:focus,
-.show > .btn-outline-dark.dropdown-toggle:focus {
-  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
-
-.btn-link {
-  font-weight: 400;
-  color: #007bff;
-  text-decoration: none; }
-
-.btn-link:hover {
-  color: #0056b3;
-  text-decoration: underline; }
-
-.btn-link:focus, .btn-link.focus {
-  text-decoration: underline; }
-
-.btn-link:disabled, .btn-link.disabled {
-  color: #6c757d;
-  pointer-events: none; }
+  cursor: pointer;
+}
+
+/*a.btn.disabled, fieldset:disabled a.btn {*/
+/*  pointer-events: none;*/
+/*}*/
+
+/*.btn-primary {*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*  border-color: #007bff;*/
+/*}*/
+
+/*.btn-primary:hover {*/
+/*  color: #fff;*/
+/*  background-color: #0069d9;*/
+/*  border-color: #0062cc;*/
+/*}*/
+
+/*.btn-primary:focus, .btn-primary.focus {*/
+/*  color: #fff;*/
+/*  background-color: #0069d9;*/
+/*  border-color: #0062cc;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);*/
+/*}*/
+
+/*.btn-primary.disabled, .btn-primary:disabled {*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*  border-color: #007bff;*/
+/*}*/
+
+/*.btn-primary:not(:disabled):not(.disabled):active, .btn-primary:not(:disabled):not(.disabled).active, .show > .btn-primary.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #0062cc;*/
+/*  border-color: #005cbf;*/
+/*}*/
+
+/*.btn-primary:not(:disabled):not(.disabled):active:focus, .btn-primary:not(:disabled):not(.disabled).active:focus, .show > .btn-primary.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(38, 143, 255, 0.5);*/
+/*}*/
+
+/*.btn-secondary {*/
+/*  color: #fff;*/
+/*  background-color: #6c757d;*/
+/*  border-color: #6c757d;*/
+/*}*/
+
+/*.btn-secondary:hover {*/
+/*  color: #fff;*/
+/*  background-color: #5a6268;*/
+/*  border-color: #545b62;*/
+/*}*/
+
+/*.btn-secondary:focus, .btn-secondary.focus {*/
+/*  color: #fff;*/
+/*  background-color: #5a6268;*/
+/*  border-color: #545b62;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);*/
+/*}*/
+
+/*.btn-secondary.disabled, .btn-secondary:disabled {*/
+/*  color: #fff;*/
+/*  background-color: #6c757d;*/
+/*  border-color: #6c757d;*/
+/*}*/
+
+/*.btn-secondary:not(:disabled):not(.disabled):active, .btn-secondary:not(:disabled):not(.disabled).active, .show > .btn-secondary.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #545b62;*/
+/*  border-color: #4e555b;*/
+/*}*/
+
+/*.btn-secondary:not(:disabled):not(.disabled):active:focus, .btn-secondary:not(:disabled):not(.disabled).active:focus, .show > .btn-secondary.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(130, 138, 145, 0.5);*/
+/*}*/
+
+/*.btn-success {*/
+/*  color: #fff;*/
+/*  background-color: #28a745;*/
+/*  border-color: #28a745;*/
+/*}*/
+
+/*.btn-success:hover {*/
+/*  color: #fff;*/
+/*  background-color: #218838;*/
+/*  border-color: #1e7e34;*/
+/*}*/
+
+/*.btn-success:focus, .btn-success.focus {*/
+/*  color: #fff;*/
+/*  background-color: #218838;*/
+/*  border-color: #1e7e34;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);*/
+/*}*/
+
+/*.btn-success.disabled, .btn-success:disabled {*/
+/*  color: #fff;*/
+/*  background-color: #28a745;*/
+/*  border-color: #28a745;*/
+/*}*/
+
+/*.btn-success:not(:disabled):not(.disabled):active, .btn-success:not(:disabled):not(.disabled).active, .show > .btn-success.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #1e7e34;*/
+/*  border-color: #1c7430;*/
+/*}*/
+
+/*.btn-success:not(:disabled):not(.disabled):active:focus, .btn-success:not(:disabled):not(.disabled).active:focus, .show > .btn-success.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(72, 180, 97, 0.5);*/
+/*}*/
+
+/*.btn-info {*/
+/*  color: #fff;*/
+/*  background-color: #17a2b8;*/
+/*  border-color: #17a2b8;*/
+/*}*/
+
+/*.btn-info:hover {*/
+/*  color: #fff;*/
+/*  background-color: #138496;*/
+/*  border-color: #117a8b;*/
+/*}*/
+
+/*.btn-info:focus, .btn-info.focus {*/
+/*  color: #fff;*/
+/*  background-color: #138496;*/
+/*  border-color: #117a8b;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);*/
+/*}*/
+
+/*.btn-info.disabled, .btn-info:disabled {*/
+/*  color: #fff;*/
+/*  background-color: #17a2b8;*/
+/*  border-color: #17a2b8;*/
+/*}*/
+
+/*.btn-info:not(:disabled):not(.disabled):active, .btn-info:not(:disabled):not(.disabled).active, .show > .btn-info.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #117a8b;*/
+/*  border-color: #10707f;*/
+/*}*/
+
+/*.btn-info:not(:disabled):not(.disabled):active:focus, .btn-info:not(:disabled):not(.disabled).active:focus, .show > .btn-info.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(58, 176, 195, 0.5);*/
+/*}*/
+
+/*.btn-warning {*/
+/*  color: #212529;*/
+/*  background-color: #ffc107;*/
+/*  border-color: #ffc107;*/
+/*}*/
+
+/*.btn-warning:hover {*/
+/*  color: #212529;*/
+/*  background-color: #e0a800;*/
+/*  border-color: #d39e00;*/
+/*}*/
+
+/*.btn-warning:focus, .btn-warning.focus {*/
+/*  color: #212529;*/
+/*  background-color: #e0a800;*/
+/*  border-color: #d39e00;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);*/
+/*}*/
+
+/*.btn-warning.disabled, .btn-warning:disabled {*/
+/*  color: #212529;*/
+/*  background-color: #ffc107;*/
+/*  border-color: #ffc107;*/
+/*}*/
+
+/*.btn-warning:not(:disabled):not(.disabled):active, .btn-warning:not(:disabled):not(.disabled).active, .show > .btn-warning.dropdown-toggle {*/
+/*  color: #212529;*/
+/*  background-color: #d39e00;*/
+/*  border-color: #c69500;*/
+/*}*/
+
+/*.btn-warning:not(:disabled):not(.disabled):active:focus, .btn-warning:not(:disabled):not(.disabled).active:focus, .show > .btn-warning.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(222, 170, 12, 0.5);*/
+/*}*/
+
+/*.btn-danger {*/
+/*  color: #fff;*/
+/*  background-color: #dc3545;*/
+/*  border-color: #dc3545;*/
+/*}*/
+
+/*.btn-danger:hover {*/
+/*  color: #fff;*/
+/*  background-color: #c82333;*/
+/*  border-color: #bd2130;*/
+/*}*/
+
+/*.btn-danger:focus, .btn-danger.focus {*/
+/*  color: #fff;*/
+/*  background-color: #c82333;*/
+/*  border-color: #bd2130;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5);*/
+/*}*/
+
+/*.btn-danger.disabled, .btn-danger:disabled {*/
+/*  color: #fff;*/
+/*  background-color: #dc3545;*/
+/*  border-color: #dc3545;*/
+/*}*/
+
+/*.btn-danger:not(:disabled):not(.disabled):active, .btn-danger:not(:disabled):not(.disabled).active, .show > .btn-danger.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #bd2130;*/
+/*  border-color: #b21f2d;*/
+/*}*/
+
+/*.btn-danger:not(:disabled):not(.disabled):active:focus, .btn-danger:not(:disabled):not(.disabled).active:focus, .show > .btn-danger.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(225, 83, 97, 0.5);*/
+/*}*/
+
+/*.btn-light {*/
+/*  color: #212529;*/
+/*  background-color: #f8f9fa;*/
+/*  border-color: #f8f9fa;*/
+/*}*/
+
+/*.btn-light:hover {*/
+/*  color: #212529;*/
+/*  background-color: #e2e6ea;*/
+/*  border-color: #dae0e5;*/
+/*}*/
+
+/*.btn-light:focus, .btn-light.focus {*/
+/*  color: #212529;*/
+/*  background-color: #e2e6ea;*/
+/*  border-color: #dae0e5;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5);*/
+/*}*/
+
+/*.btn-light.disabled, .btn-light:disabled {*/
+/*  color: #212529;*/
+/*  background-color: #f8f9fa;*/
+/*  border-color: #f8f9fa;*/
+/*}*/
+
+/*.btn-light:not(:disabled):not(.disabled):active, .btn-light:not(:disabled):not(.disabled).active, .show > .btn-light.dropdown-toggle {*/
+/*  color: #212529;*/
+/*  background-color: #dae0e5;*/
+/*  border-color: #d3d9df;*/
+/*}*/
+
+/*.btn-light:not(:disabled):not(.disabled):active:focus, .btn-light:not(:disabled):not(.disabled).active:focus, .show > .btn-light.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(216, 217, 219, 0.5);*/
+/*}*/
+
+/*.btn-dark {*/
+/*  color: #fff;*/
+/*  background-color: #343a40;*/
+/*  border-color: #343a40;*/
+/*}*/
+
+/*.btn-dark:hover {*/
+/*  color: #fff;*/
+/*  background-color: #23272b;*/
+/*  border-color: #1d2124;*/
+/*}*/
+
+/*.btn-dark:focus, .btn-dark.focus {*/
+/*  color: #fff;*/
+/*  background-color: #23272b;*/
+/*  border-color: #1d2124;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5);*/
+/*}*/
+
+/*.btn-dark.disabled, .btn-dark:disabled {*/
+/*  color: #fff;*/
+/*  background-color: #343a40;*/
+/*  border-color: #343a40;*/
+/*}*/
+
+/*.btn-dark:not(:disabled):not(.disabled):active, .btn-dark:not(:disabled):not(.disabled).active, .show > .btn-dark.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #1d2124;*/
+/*  border-color: #171a1d;*/
+/*}*/
+
+/*.btn-dark:not(:disabled):not(.disabled):active:focus, .btn-dark:not(:disabled):not(.disabled).active:focus, .show > .btn-dark.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(82, 88, 93, 0.5);*/
+/*}*/
+
+/*.btn-outline-primary {*/
+/*  color: #007bff;*/
+/*  border-color: #007bff;*/
+/*}*/
+
+/*.btn-outline-primary:hover {*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*  border-color: #007bff;*/
+/*}*/
+
+/*.btn-outline-primary:focus, .btn-outline-primary.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);*/
+/*}*/
+
+/*.btn-outline-primary.disabled, .btn-outline-primary:disabled {*/
+/*  color: #007bff;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-primary:not(:disabled):not(.disabled):active, .btn-outline-primary:not(:disabled):not(.disabled).active, .show > .btn-outline-primary.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*  border-color: #007bff;*/
+/*}*/
+
+/*.btn-outline-primary:not(:disabled):not(.disabled):active:focus, .btn-outline-primary:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-primary.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);*/
+/*}*/
+
+/*.btn-outline-secondary {*/
+/*  color: #6c757d;*/
+/*  border-color: #6c757d;*/
+/*}*/
+
+/*.btn-outline-secondary:hover {*/
+/*  color: #fff;*/
+/*  background-color: #6c757d;*/
+/*  border-color: #6c757d;*/
+/*}*/
+
+/*.btn-outline-secondary:focus, .btn-outline-secondary.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5);*/
+/*}*/
+
+/*.btn-outline-secondary.disabled, .btn-outline-secondary:disabled {*/
+/*  color: #6c757d;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-secondary:not(:disabled):not(.disabled):active, .btn-outline-secondary:not(:disabled):not(.disabled).active, .show > .btn-outline-secondary.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #6c757d;*/
+/*  border-color: #6c757d;*/
+/*}*/
+
+/*.btn-outline-secondary:not(:disabled):not(.disabled):active:focus, .btn-outline-secondary:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-secondary.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5);*/
+/*}*/
+
+/*.btn-outline-success {*/
+/*  color: #28a745;*/
+/*  border-color: #28a745;*/
+/*}*/
+
+/*.btn-outline-success:hover {*/
+/*  color: #fff;*/
+/*  background-color: #28a745;*/
+/*  border-color: #28a745;*/
+/*}*/
+
+/*.btn-outline-success:focus, .btn-outline-success.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5);*/
+/*}*/
+
+/*.btn-outline-success.disabled, .btn-outline-success:disabled {*/
+/*  color: #28a745;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-success:not(:disabled):not(.disabled):active, .btn-outline-success:not(:disabled):not(.disabled).active, .show > .btn-outline-success.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #28a745;*/
+/*  border-color: #28a745;*/
+/*}*/
+
+/*.btn-outline-success:not(:disabled):not(.disabled):active:focus, .btn-outline-success:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-success.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5);*/
+/*}*/
+
+/*.btn-outline-info {*/
+/*  color: #17a2b8;*/
+/*  border-color: #17a2b8;*/
+/*}*/
+
+/*.btn-outline-info:hover {*/
+/*  color: #fff;*/
+/*  background-color: #17a2b8;*/
+/*  border-color: #17a2b8;*/
+/*}*/
+
+/*.btn-outline-info:focus, .btn-outline-info.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5);*/
+/*}*/
+
+/*.btn-outline-info.disabled, .btn-outline-info:disabled {*/
+/*  color: #17a2b8;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-info:not(:disabled):not(.disabled):active, .btn-outline-info:not(:disabled):not(.disabled).active, .show > .btn-outline-info.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #17a2b8;*/
+/*  border-color: #17a2b8;*/
+/*}*/
+
+/*.btn-outline-info:not(:disabled):not(.disabled):active:focus, .btn-outline-info:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-info.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5);*/
+/*}*/
+
+/*.btn-outline-warning {*/
+/*  color: #ffc107;*/
+/*  border-color: #ffc107;*/
+/*}*/
+
+/*.btn-outline-warning:hover {*/
+/*  color: #212529;*/
+/*  background-color: #ffc107;*/
+/*  border-color: #ffc107;*/
+/*}*/
+
+/*.btn-outline-warning:focus, .btn-outline-warning.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5);*/
+/*}*/
+
+/*.btn-outline-warning.disabled, .btn-outline-warning:disabled {*/
+/*  color: #ffc107;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-warning:not(:disabled):not(.disabled):active, .btn-outline-warning:not(:disabled):not(.disabled).active, .show > .btn-outline-warning.dropdown-toggle {*/
+/*  color: #212529;*/
+/*  background-color: #ffc107;*/
+/*  border-color: #ffc107;*/
+/*}*/
+
+/*.btn-outline-warning:not(:disabled):not(.disabled):active:focus, .btn-outline-warning:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-warning.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5);*/
+/*}*/
+
+/*.btn-outline-danger {*/
+/*  color: #dc3545;*/
+/*  border-color: #dc3545;*/
+/*}*/
+
+/*.btn-outline-danger:hover {*/
+/*  color: #fff;*/
+/*  background-color: #dc3545;*/
+/*  border-color: #dc3545;*/
+/*}*/
+
+/*.btn-outline-danger:focus, .btn-outline-danger.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5);*/
+/*}*/
+
+/*.btn-outline-danger.disabled, .btn-outline-danger:disabled {*/
+/*  color: #dc3545;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-danger:not(:disabled):not(.disabled):active, .btn-outline-danger:not(:disabled):not(.disabled).active, .show > .btn-outline-danger.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #dc3545;*/
+/*  border-color: #dc3545;*/
+/*}*/
+
+/*.btn-outline-danger:not(:disabled):not(.disabled):active:focus, .btn-outline-danger:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-danger.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5);*/
+/*}*/
+
+/*.btn-outline-light {*/
+/*  color: #f8f9fa;*/
+/*  border-color: #f8f9fa;*/
+/*}*/
+
+/*.btn-outline-light:hover {*/
+/*  color: #212529;*/
+/*  background-color: #f8f9fa;*/
+/*  border-color: #f8f9fa;*/
+/*}*/
+
+/*.btn-outline-light:focus, .btn-outline-light.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5);*/
+/*}*/
+
+/*.btn-outline-light.disabled, .btn-outline-light:disabled {*/
+/*  color: #f8f9fa;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-light:not(:disabled):not(.disabled):active, .btn-outline-light:not(:disabled):not(.disabled).active, .show > .btn-outline-light.dropdown-toggle {*/
+/*  color: #212529;*/
+/*  background-color: #f8f9fa;*/
+/*  border-color: #f8f9fa;*/
+/*}*/
+
+/*.btn-outline-light:not(:disabled):not(.disabled):active:focus, .btn-outline-light:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-light.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5);*/
+/*}*/
+
+/*.btn-outline-dark {*/
+/*  color: #343a40;*/
+/*  border-color: #343a40;*/
+/*}*/
+
+/*.btn-outline-dark:hover {*/
+/*  color: #fff;*/
+/*  background-color: #343a40;*/
+/*  border-color: #343a40;*/
+/*}*/
+
+/*.btn-outline-dark:focus, .btn-outline-dark.focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5);*/
+/*}*/
+
+/*.btn-outline-dark.disabled, .btn-outline-dark:disabled {*/
+/*  color: #343a40;*/
+/*  background-color: transparent;*/
+/*}*/
+
+/*.btn-outline-dark:not(:disabled):not(.disabled):active, .btn-outline-dark:not(:disabled):not(.disabled).active, .show > .btn-outline-dark.dropdown-toggle {*/
+/*  color: #fff;*/
+/*  background-color: #343a40;*/
+/*  border-color: #343a40;*/
+/*}*/
+
+/*.btn-outline-dark:not(:disabled):not(.disabled):active:focus, .btn-outline-dark:not(:disabled):not(.disabled).active:focus, .show > .btn-outline-dark.dropdown-toggle:focus {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5);*/
+/*}*/
+
+/*.btn-link {*/
+/*  font-weight: 400;*/
+/*  color: #007bff;*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.btn-link:hover {*/
+/*  color: #0056b3;*/
+/*  text-decoration: underline;*/
+/*}*/
+
+/*.btn-link:focus, .btn-link.focus {*/
+/*  text-decoration: underline;*/
+/*}*/
+
+/*.btn-link:disabled, .btn-link.disabled {*/
+/*  color: #6c757d;*/
+/*  pointer-events: none;*/
+/*}*/
 
 .btn-lg, .btn-group-lg > .btn {
   padding: 0.5rem 1rem;
   font-size: 1.25rem;
   line-height: 1.5;
-  border-radius: 0.3rem; }
+  border-radius: 0.3rem;
+}
 
-.btn-sm, .btn-group-sm > .btn {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  border-radius: 0.2rem; }
+/*.btn-sm, .btn-group-sm > .btn {*/
+/*  padding: 0.25rem 0.5rem;*/
+/*  font-size: 0.875rem;*/
+/*  line-height: 1.5;*/
+/*  border-radius: 0.2rem;*/
+/*}*/
 
-.btn-block {
-  display: block;
-  width: 100%; }
+/*.btn-block {*/
+/*  display: block;*/
+/*  width: 100%;*/
+/*}*/
 
-.btn-block + .btn-block {
-  margin-top: 0.5rem; }
+/*.btn-block + .btn-block {*/
+/*  margin-top: 0.5rem;*/
+/*}*/
 
-input[type="submit"].btn-block,
-input[type="reset"].btn-block,
-input[type="button"].btn-block {
-  width: 100%; }
+/*input[type="submit"].btn-block, input[type="reset"].btn-block, input[type="button"].btn-block {*/
+/*  width: 100%;*/
+/*}*/
 
 .fade {
-  transition: opacity 0.15s linear; }
+  transition: opacity 0.15s linear;
+}
 
-@media (prefers-reduced-motion: reduce) {
-  .fade {
-    transition: none; } }
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .fade {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
 
 .fade:not(.show) {
-  opacity: 0; }
+  opacity: 0;
+}
 
-.collapse:not(.show) {
-  display: none; }
+/*.collapse:not(.show) {*/
+/*  display: none;*/
+/*}*/
 
-.collapsing {
-  position: relative;
-  height: 0;
-  overflow: hidden;
-  transition: height 0.35s ease; }
+/*.collapsing {*/
+/*  position: relative;*/
+/*  height: 0;*/
+/*  overflow: hidden;*/
+/*  transition: height 0.35s ease;*/
+/*}*/
 
-@media (prefers-reduced-motion: reduce) {
-  .collapsing {
-    transition: none; } }
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .collapsing {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
 
-.dropup,
-.dropright,
-.dropdown,
-.dropleft {
-  position: relative; }
+/*.dropup, .dropright, .dropdown, .dropleft {*/
+/*  position: relative;*/
+/*}*/
 
 .dropdown-toggle {
-  white-space: nowrap; }
+  white-space: nowrap;
+}
 
 .dropdown-toggle::after {
   display: inline-block;
@@ -2595,152 +3241,188 @@ input[type="button"].btn-block {
   border-top: 0.3em solid;
   border-right: 0.3em solid transparent;
   border-bottom: 0;
-  border-left: 0.3em solid transparent; }
+  border-left: 0.3em solid transparent;
+}
 
-.dropdown-toggle:empty::after {
-  margin-left: 0; }
+/*.dropdown-toggle:empty::after {*/
+/*  margin-left: 0;*/
+/*}*/
 
-.dropdown-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 1000;
-  display: none;
-  float: left;
-  min-width: 10rem;
-  padding: 0.5rem 0;
-  margin: 0.125rem 0 0;
-  font-size: 1rem;
-  color: #212529;
-  text-align: left;
-  list-style: none;
-  background-color: #fff;
-  background-clip: padding-box;
-  border: 1px solid rgba(0, 0, 0, 0.15);
-  border-radius: 0.25rem; }
+/*.dropdown-menu {*/
+/*  position: absolute;*/
+/*  top: 100%;*/
+/*  left: 0;*/
+/*  z-index: 1000;*/
+/*  display: none;*/
+/*  float: left;*/
+/*  min-width: 10rem;*/
+/*  padding: 0.5rem 0;*/
+/*  margin: 0.125rem 0 0;*/
+/*  font-size: 1rem;*/
+/*  color: #212529;*/
+/*  text-align: left;*/
+/*  list-style: none;*/
+/*  background-color: #fff;*/
+/*  background-clip: padding-box;*/
+/*  border: 1px solid rgba(0, 0, 0, 0.15);*/
+/*  border-radius: 0.25rem;*/
+/*}*/
 
-.dropdown-menu-left {
-  right: auto;
-  left: 0; }
+/*.dropdown-menu-left {*/
+/*  right: auto;*/
+/*  left: 0;*/
+/*}*/
 
-.dropdown-menu-right {
-  right: 0;
-  left: auto; }
+/*.dropdown-menu-right {*/
+/*  right: 0;*/
+/*  left: auto;*/
+/*}*/
 
-@media (min-width: 576px) {
-  .dropdown-menu-sm-left {
-    right: auto;
-    left: 0; }
-  .dropdown-menu-sm-right {
-    right: 0;
-    left: auto; } }
+/*@media (min-width: 576px) {*/
+/*  .dropdown-menu-sm-left {*/
+/*    right: auto;*/
+/*    left: 0;*/
+/*  }*/
 
-@media (min-width: 768px) {
-  .dropdown-menu-md-left {
-    right: auto;
-    left: 0; }
-  .dropdown-menu-md-right {
-    right: 0;
-    left: auto; } }
+/*  .dropdown-menu-sm-right {*/
+/*    right: 0;*/
+/*    left: auto;*/
+/*  }*/
+/*}*/
 
-@media (min-width: 992px) {
-  .dropdown-menu-lg-left {
-    right: auto;
-    left: 0; }
-  .dropdown-menu-lg-right {
-    right: 0;
-    left: auto; } }
+/*@media (min-width: 768px) {*/
+/*  .dropdown-menu-md-left {*/
+/*    right: auto;*/
+/*    left: 0;*/
+/*  }*/
 
-@media (min-width: 1200px) {
-  .dropdown-menu-xl-left {
-    right: auto;
-    left: 0; }
-  .dropdown-menu-xl-right {
-    right: 0;
-    left: auto; } }
+/*  .dropdown-menu-md-right {*/
+/*    right: 0;*/
+/*    left: auto;*/
+/*  }*/
+/*}*/
 
-.dropup .dropdown-menu {
-  top: auto;
-  bottom: 100%;
-  margin-top: 0;
-  margin-bottom: 0.125rem; }
+/*@media (min-width: 992px) {*/
+/*  .dropdown-menu-lg-left {*/
+/*    right: auto;*/
+/*    left: 0;*/
+/*  }*/
 
-.dropup .dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0;
-  border-right: 0.3em solid transparent;
-  border-bottom: 0.3em solid;
-  border-left: 0.3em solid transparent; }
+/*  .dropdown-menu-lg-right {*/
+/*    right: 0;*/
+/*    left: auto;*/
+/*  }*/
+/*}*/
 
-.dropup .dropdown-toggle:empty::after {
-  margin-left: 0; }
+/*@media (min-width: 1200px) {*/
+/*  .dropdown-menu-xl-left {*/
+/*    right: auto;*/
+/*    left: 0;*/
+/*  }*/
 
-.dropright .dropdown-menu {
-  top: 0;
-  right: auto;
-  left: 100%;
-  margin-top: 0;
-  margin-left: 0.125rem; }
+/*  .dropdown-menu-xl-right {*/
+/*    right: 0;*/
+/*    left: auto;*/
+/*  }*/
+/*}*/
 
-.dropright .dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0.3em solid transparent;
-  border-right: 0;
-  border-bottom: 0.3em solid transparent;
-  border-left: 0.3em solid; }
+/*.dropup .dropdown-menu {*/
+/*  top: auto;*/
+/*  bottom: 100%;*/
+/*  margin-top: 0;*/
+/*  margin-bottom: 0.125rem;*/
+/*}*/
 
-.dropright .dropdown-toggle:empty::after {
-  margin-left: 0; }
+/*.dropup .dropdown-toggle::after {*/
+/*  display: inline-block;*/
+/*  margin-left: 0.255em;*/
+/*  vertical-align: 0.255em;*/
+/*  content: "";*/
+/*  border-top: 0;*/
+/*  border-right: 0.3em solid transparent;*/
+/*  border-bottom: 0.3em solid;*/
+/*  border-left: 0.3em solid transparent;*/
+/*}*/
 
-.dropright .dropdown-toggle::after {
-  vertical-align: 0; }
+/*.dropup .dropdown-toggle:empty::after {*/
+/*  margin-left: 0;*/
+/*}*/
 
-.dropleft .dropdown-menu {
-  top: 0;
-  right: 100%;
-  left: auto;
-  margin-top: 0;
-  margin-right: 0.125rem; }
+/*.dropright .dropdown-menu {*/
+/*  top: 0;*/
+/*  right: auto;*/
+/*  left: 100%;*/
+/*  margin-top: 0;*/
+/*  margin-left: 0.125rem;*/
+/*}*/
 
-.dropleft .dropdown-toggle::after {
-  display: inline-block;
-  margin-left: 0.255em;
-  vertical-align: 0.255em;
-  content: ""; }
+/*.dropright .dropdown-toggle::after {*/
+/*  display: inline-block;*/
+/*  margin-left: 0.255em;*/
+/*  vertical-align: 0.255em;*/
+/*  content: "";*/
+/*  border-top: 0.3em solid transparent;*/
+/*  border-right: 0;*/
+/*  border-bottom: 0.3em solid transparent;*/
+/*  border-left: 0.3em solid;*/
+/*}*/
 
-.dropleft .dropdown-toggle::after {
-  display: none; }
+/*.dropright .dropdown-toggle:empty::after {*/
+/*  margin-left: 0;*/
+/*}*/
 
-.dropleft .dropdown-toggle::before {
-  display: inline-block;
-  margin-right: 0.255em;
-  vertical-align: 0.255em;
-  content: "";
-  border-top: 0.3em solid transparent;
-  border-right: 0.3em solid;
-  border-bottom: 0.3em solid transparent; }
+/*.dropright .dropdown-toggle::after {*/
+/*  vertical-align: 0;*/
+/*}*/
 
-.dropleft .dropdown-toggle:empty::after {
-  margin-left: 0; }
+/*.dropleft .dropdown-menu {*/
+/*  top: 0;*/
+/*  right: 100%;*/
+/*  left: auto;*/
+/*  margin-top: 0;*/
+/*  margin-right: 0.125rem;*/
+/*}*/
 
-.dropleft .dropdown-toggle::before {
-  vertical-align: 0; }
+/*.dropleft .dropdown-toggle::after {*/
+/*  display: inline-block;*/
+/*  margin-left: 0.255em;*/
+/*  vertical-align: 0.255em;*/
+/*  content: "";*/
+/*}*/
 
-.dropdown-menu[x-placement^="top"], .dropdown-menu[x-placement^="right"], .dropdown-menu[x-placement^="bottom"], .dropdown-menu[x-placement^="left"] {
-  right: auto;
-  bottom: auto; }
+/*.dropleft .dropdown-toggle::after {*/
+/*  display: none;*/
+/*}*/
 
-.dropdown-divider {
-  height: 0;
-  margin: 0.5rem 0;
-  overflow: hidden;
-  border-top: 1px solid #e9ecef; }
+/*.dropleft .dropdown-toggle::before {*/
+/*  display: inline-block;*/
+/*  margin-right: 0.255em;*/
+/*  vertical-align: 0.255em;*/
+/*  content: "";*/
+/*  border-top: 0.3em solid transparent;*/
+/*  border-right: 0.3em solid;*/
+/*  border-bottom: 0.3em solid transparent;*/
+/*}*/
+
+/*.dropleft .dropdown-toggle:empty::after {*/
+/*  margin-left: 0;*/
+/*}*/
+
+/*.dropleft .dropdown-toggle::before {*/
+/*  vertical-align: 0;*/
+/*}*/
+
+/*.dropdown-menu[x-placement^="top"], .dropdown-menu[x-placement^="right"], .dropdown-menu[x-placement^="bottom"], .dropdown-menu[x-placement^="left"] {*/
+/*  right: auto;*/
+/*  bottom: auto;*/
+/*}*/
+
+/*.dropdown-divider {*/
+/*  height: 0;*/
+/*  margin: 0.5rem 0;*/
+/*  overflow: hidden;*/
+/*  border-top: 1px solid #e9ecef;*/
+/*}*/
 
 .dropdown-item {
   display: block;
@@ -2752,2279 +3434,2733 @@ input[type="button"].btn-block {
   text-align: inherit;
   white-space: nowrap;
   background-color: transparent;
-  border: 0; }
+  border: 0;
+}
 
-.dropdown-item:hover, .dropdown-item:focus {
-  color: #16181b;
-  text-decoration: none;
-  background-color: #e9ecef; }
+/*.dropdown-item:hover, .dropdown-item:focus {*/
+/*  color: #16181b;*/
+/*  text-decoration: none;*/
+/*  background-color: #e9ecef;*/
+/*}*/
 
-.dropdown-item.active, .dropdown-item:active {
-  color: #fff;
-  text-decoration: none;
-  background-color: #007bff; }
+/*.dropdown-item.active, .dropdown-item:active {*/
+/*  color: #fff;*/
+/*  text-decoration: none;*/
+/*  background-color: #007bff;*/
+/*}*/
 
-.dropdown-item.disabled, .dropdown-item:disabled {
-  color: #adb5bd;
-  pointer-events: none;
-  background-color: transparent; }
+/*.dropdown-item.disabled, .dropdown-item:disabled {*/
+/*  color: #adb5bd;*/
+/*  pointer-events: none;*/
+/*  background-color: transparent;*/
+/*}*/
 
-.dropdown-menu.show {
-  display: block; }
+/*.dropdown-menu.show {*/
+/*  display: block;*/
+/*}*/
 
-.dropdown-header {
-  display: block;
-  padding: 0.5rem 1.5rem;
-  margin-bottom: 0;
-  font-size: 0.875rem;
-  color: #6c757d;
-  white-space: nowrap; }
+/*.dropdown-header {*/
+/*  display: block;*/
+/*  padding: 0.5rem 1.5rem;*/
+/*  margin-bottom: 0;*/
+/*  font-size: 0.875rem;*/
+/*  color: #6c757d;*/
+/*  white-space: nowrap;*/
+/*}*/
 
-.dropdown-item-text {
-  display: block;
-  padding: 0.25rem 1.5rem;
-  color: #212529; }
+/*.dropdown-item-text {*/
+/*  display: block;*/
+/*  padding: 0.25rem 1.5rem;*/
+/*  color: #212529;*/
+/*}*/
 
-.btn-group,
-.btn-group-vertical {
-  position: relative;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  vertical-align: middle; }
+/*.btn-group, .btn-group-vertical {*/
+/*  position: relative;*/
+/*  display: -ms-inline-flexbox;*/
+/*  display: inline-flex;*/
+/*  vertical-align: middle;*/
+/*}*/
 
-.btn-group > .btn,
-.btn-group-vertical > .btn {
-  position: relative;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto; }
+/*.btn-group > .btn, .btn-group-vertical > .btn {*/
+/*  position: relative;*/
+/*  -ms-flex: 1 1 auto;*/
+/*  flex: 1 1 auto;*/
+/*}*/
 
-.btn-group > .btn:hover,
-.btn-group-vertical > .btn:hover {
-  z-index: 1; }
+/*.btn-group > .btn:hover, .btn-group-vertical > .btn:hover {*/
+/*  z-index: 1;*/
+/*}*/
 
-.btn-group > .btn:focus, .btn-group > .btn:active, .btn-group > .btn.active,
-.btn-group-vertical > .btn:focus,
-.btn-group-vertical > .btn:active,
-.btn-group-vertical > .btn.active {
-  z-index: 1; }
+/*.btn-group > .btn:focus, .btn-group > .btn:active, .btn-group > .btn.active, .btn-group-vertical > .btn:focus, .btn-group-vertical > .btn:active, .btn-group-vertical > .btn.active {*/
+/*  z-index: 1;*/
+/*}*/
 
 .btn-toolbar {
-  display: -ms-flexbox;
+  /*display: -ms-flexbox;*/
   display: flex;
-  -ms-flex-wrap: wrap;
+  /*-ms-flex-wrap: wrap;*/
   flex-wrap: wrap;
-  -ms-flex-pack: start;
-  justify-content: flex-start; }
+  /*-ms-flex-pack: start;*/
+  justify-content: flex-start;
+}
 
-.btn-toolbar .input-group {
-  width: auto; }
+/*.btn-toolbar .input-group {*/
+/*  width: auto;*/
+/*}*/
 
-.btn-group > .btn:not(:first-child),
-.btn-group > .btn-group:not(:first-child) {
-  margin-left: -1px; }
+/*.btn-group > .btn:not(:first-child), .btn-group > .btn-group:not(:first-child) {*/
+/*  margin-left: -1px;*/
+/*}*/
 
-.btn-group > .btn:not(:last-child):not(.dropdown-toggle),
-.btn-group > .btn-group:not(:last-child) > .btn {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0; }
+/*.btn-group > .btn:not(:last-child):not(.dropdown-toggle), .btn-group > .btn-group:not(:last-child) > .btn {*/
+/*  border-top-right-radius: 0;*/
+/*  border-bottom-right-radius: 0;*/
+/*}*/
 
-.btn-group > .btn:not(:first-child),
-.btn-group > .btn-group:not(:first-child) > .btn {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0; }
+/*.btn-group > .btn:not(:first-child), .btn-group > .btn-group:not(:first-child) > .btn {*/
+/*  border-top-left-radius: 0;*/
+/*  border-bottom-left-radius: 0;*/
+/*}*/
 
 .dropdown-toggle-split {
   padding-right: 0.5625rem;
-  padding-left: 0.5625rem; }
-
-.dropdown-toggle-split::after,
-.dropup .dropdown-toggle-split::after,
-.dropright .dropdown-toggle-split::after {
-  margin-left: 0; }
-
-.dropleft .dropdown-toggle-split::before {
-  margin-right: 0; }
-
-.btn-sm + .dropdown-toggle-split, .btn-group-sm > .btn + .dropdown-toggle-split {
-  padding-right: 0.375rem;
-  padding-left: 0.375rem; }
-
-.btn-lg + .dropdown-toggle-split, .btn-group-lg > .btn + .dropdown-toggle-split {
-  padding-right: 0.75rem;
-  padding-left: 0.75rem; }
-
-.btn-group-vertical {
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -ms-flex-align: start;
-  align-items: flex-start;
-  -ms-flex-pack: center;
-  justify-content: center; }
-
-.btn-group-vertical > .btn,
-.btn-group-vertical > .btn-group {
-  width: 100%; }
-
-.btn-group-vertical > .btn:not(:first-child),
-.btn-group-vertical > .btn-group:not(:first-child) {
-  margin-top: -1px; }
-
-.btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle),
-.btn-group-vertical > .btn-group:not(:last-child) > .btn {
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.btn-group-vertical > .btn:not(:first-child),
-.btn-group-vertical > .btn-group:not(:first-child) > .btn {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0; }
-
-.btn-group-toggle > .btn,
-.btn-group-toggle > .btn-group > .btn {
-  margin-bottom: 0; }
-
-.btn-group-toggle > .btn input[type="radio"],
-.btn-group-toggle > .btn input[type="checkbox"],
-.btn-group-toggle > .btn-group > .btn input[type="radio"],
-.btn-group-toggle > .btn-group > .btn input[type="checkbox"] {
-  position: absolute;
-  clip: rect(0, 0, 0, 0);
-  pointer-events: none; }
-
-.input-group {
-  position: relative;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -ms-flex-align: stretch;
-  align-items: stretch;
-  width: 100%; }
-
-.input-group > .form-control,
-.input-group > .form-control-plaintext,
-.input-group > .custom-select,
-.input-group > .custom-file {
-  position: relative;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  width: 1%;
-  min-width: 0;
-  margin-bottom: 0; }
-
-.input-group > .form-control + .form-control,
-.input-group > .form-control + .custom-select,
-.input-group > .form-control + .custom-file,
-.input-group > .form-control-plaintext + .form-control,
-.input-group > .form-control-plaintext + .custom-select,
-.input-group > .form-control-plaintext + .custom-file,
-.input-group > .custom-select + .form-control,
-.input-group > .custom-select + .custom-select,
-.input-group > .custom-select + .custom-file,
-.input-group > .custom-file + .form-control,
-.input-group > .custom-file + .custom-select,
-.input-group > .custom-file + .custom-file {
-  margin-left: -1px; }
-
-.input-group > .form-control:focus,
-.input-group > .custom-select:focus,
-.input-group > .custom-file .custom-file-input:focus ~ .custom-file-label {
-  z-index: 3; }
-
-.input-group > .custom-file .custom-file-input:focus {
-  z-index: 4; }
-
-.input-group > .form-control:not(:first-child),
-.input-group > .custom-select:not(:first-child) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.input-group > .custom-file {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: center;
-  align-items: center; }
-
-.input-group > .custom-file:not(:last-child) .custom-file-label,
-.input-group > .custom-file:not(:first-child) .custom-file-label {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.input-group:not(.has-validation) > .form-control:not(:last-child),
-.input-group:not(.has-validation) > .custom-select:not(:last-child),
-.input-group:not(.has-validation) > .custom-file:not(:last-child) .custom-file-label::after {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0; }
-
-.input-group.has-validation > .form-control:nth-last-child(n + 3),
-.input-group.has-validation > .custom-select:nth-last-child(n + 3),
-.input-group.has-validation > .custom-file:nth-last-child(n + 3) .custom-file-label::after {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0; }
-
-.input-group-prepend,
-.input-group-append {
-  display: -ms-flexbox;
-  display: flex; }
-
-.input-group-prepend .btn,
-.input-group-append .btn {
-  position: relative;
-  z-index: 2; }
-
-.input-group-prepend .btn:focus,
-.input-group-append .btn:focus {
-  z-index: 3; }
-
-.input-group-prepend .btn + .btn,
-.input-group-prepend .btn + .input-group-text,
-.input-group-prepend .input-group-text + .input-group-text,
-.input-group-prepend .input-group-text + .btn,
-.input-group-append .btn + .btn,
-.input-group-append .btn + .input-group-text,
-.input-group-append .input-group-text + .input-group-text,
-.input-group-append .input-group-text + .btn {
-  margin-left: -1px; }
-
-.input-group-prepend {
-  margin-right: -1px; }
-
-.input-group-append {
-  margin-left: -1px; }
-
-.input-group-text {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 0.375rem 0.75rem;
-  margin-bottom: 0;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #495057;
-  text-align: center;
-  white-space: nowrap;
-  background-color: #e9ecef;
-  border: 1px solid #ced4da;
-  border-radius: 0.25rem; }
-
-.input-group-text input[type="radio"],
-.input-group-text input[type="checkbox"] {
-  margin-top: 0; }
-
-.input-group-lg > .form-control:not(textarea),
-.input-group-lg > .custom-select {
-  height: calc(1.5em + 1rem + 2px); }
-
-.input-group-lg > .form-control,
-.input-group-lg > .custom-select,
-.input-group-lg > .input-group-prepend > .input-group-text,
-.input-group-lg > .input-group-append > .input-group-text,
-.input-group-lg > .input-group-prepend > .btn,
-.input-group-lg > .input-group-append > .btn {
-  padding: 0.5rem 1rem;
-  font-size: 1.25rem;
-  line-height: 1.5;
-  border-radius: 0.3rem; }
-
-.input-group-sm > .form-control:not(textarea),
-.input-group-sm > .custom-select {
-  height: calc(1.5em + 0.5rem + 2px); }
-
-.input-group-sm > .form-control,
-.input-group-sm > .custom-select,
-.input-group-sm > .input-group-prepend > .input-group-text,
-.input-group-sm > .input-group-append > .input-group-text,
-.input-group-sm > .input-group-prepend > .btn,
-.input-group-sm > .input-group-append > .btn {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  border-radius: 0.2rem; }
-
-.input-group-lg > .custom-select,
-.input-group-sm > .custom-select {
-  padding-right: 1.75rem; }
-
-.input-group > .input-group-prepend > .btn,
-.input-group > .input-group-prepend > .input-group-text,
-.input-group:not(.has-validation) > .input-group-append:not(:last-child) > .btn,
-.input-group:not(.has-validation) > .input-group-append:not(:last-child) > .input-group-text,
-.input-group.has-validation > .input-group-append:nth-last-child(n + 3) > .btn,
-.input-group.has-validation > .input-group-append:nth-last-child(n + 3) > .input-group-text,
-.input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
-.input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0; }
-
-.input-group > .input-group-append > .btn,
-.input-group > .input-group-append > .input-group-text,
-.input-group > .input-group-prepend:not(:first-child) > .btn,
-.input-group > .input-group-prepend:not(:first-child) > .input-group-text,
-.input-group > .input-group-prepend:first-child > .btn:not(:first-child),
-.input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.custom-control {
-  position: relative;
-  z-index: 1;
-  display: block;
-  min-height: 1.5rem;
-  padding-left: 1.5rem;
-  -webkit-print-color-adjust: exact;
-  color-adjust: exact; }
-
-.custom-control-inline {
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  margin-right: 1rem; }
-
-.custom-control-input {
-  position: absolute;
-  left: 0;
-  z-index: -1;
-  width: 1rem;
-  height: 1.25rem;
-  opacity: 0; }
-
-.custom-control-input:checked ~ .custom-control-label::before {
-  color: #fff;
-  border-color: #007bff;
-  background-color: #007bff; }
-
-.custom-control-input:focus ~ .custom-control-label::before {
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
-
-.custom-control-input:focus:not(:checked) ~ .custom-control-label::before {
-  border-color: #80bdff; }
-
-.custom-control-input:not(:disabled):active ~ .custom-control-label::before {
-  color: #fff;
-  background-color: #b3d7ff;
-  border-color: #b3d7ff; }
-
-.custom-control-input[disabled] ~ .custom-control-label, .custom-control-input:disabled ~ .custom-control-label {
-  color: #6c757d; }
-
-.custom-control-input[disabled] ~ .custom-control-label::before, .custom-control-input:disabled ~ .custom-control-label::before {
-  background-color: #e9ecef; }
-
-.custom-control-label {
-  position: relative;
-  margin-bottom: 0;
-  vertical-align: top; }
-
-.custom-control-label::before {
-  position: absolute;
-  top: 0.25rem;
-  left: -1.5rem;
-  display: block;
-  width: 1rem;
-  height: 1rem;
-  pointer-events: none;
-  content: "";
-  background-color: #fff;
-  border: #adb5bd solid 1px; }
-
-.custom-control-label::after {
-  position: absolute;
-  top: 0.25rem;
-  left: -1.5rem;
-  display: block;
-  width: 1rem;
-  height: 1rem;
-  content: "";
-  background: 50% / 50% 50% no-repeat; }
-
-.custom-checkbox .custom-control-label::before {
-  border-radius: 0.25rem; }
-
-.custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/%3e%3c/svg%3e"); }
-
-.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {
-  border-color: #007bff;
-  background-color: #007bff; }
-
-.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3e%3cpath stroke='%23fff' d='M0 2h4'/%3e%3c/svg%3e"); }
-
-.custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {
-  background-color: rgba(0, 123, 255, 0.5); }
-
-.custom-checkbox .custom-control-input:disabled:indeterminate ~ .custom-control-label::before {
-  background-color: rgba(0, 123, 255, 0.5); }
-
-.custom-radio .custom-control-label::before {
-  border-radius: 50%; }
-
-.custom-radio .custom-control-input:checked ~ .custom-control-label::after {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e"); }
-
-.custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {
-  background-color: rgba(0, 123, 255, 0.5); }
-
-.custom-switch {
-  padding-left: 2.25rem; }
-
-.custom-switch .custom-control-label::before {
-  left: -2.25rem;
-  width: 1.75rem;
-  pointer-events: all;
-  border-radius: 0.5rem; }
-
-.custom-switch .custom-control-label::after {
-  top: calc(0.25rem + 2px);
-  left: calc(-2.25rem + 2px);
-  width: calc(1rem - 4px);
-  height: calc(1rem - 4px);
-  background-color: #adb5bd;
-  border-radius: 0.5rem;
-  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out;
-  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out; }
-
-@media (prefers-reduced-motion: reduce) {
-  .custom-switch .custom-control-label::after {
-    transition: none; } }
-
-.custom-switch .custom-control-input:checked ~ .custom-control-label::after {
-  background-color: #fff;
-  -webkit-transform: translateX(0.75rem);
-  transform: translateX(0.75rem); }
-
-.custom-switch .custom-control-input:disabled:checked ~ .custom-control-label::before {
-  background-color: rgba(0, 123, 255, 0.5); }
-
-.custom-select {
-  display: inline-block;
-  width: 100%;
-  height: calc(1.5em + 0.75rem + 2px);
-  padding: 0.375rem 1.75rem 0.375rem 0.75rem;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #495057;
-  vertical-align: middle;
-  background: #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat;
-  border: 1px solid #ced4da;
-  border-radius: 0.25rem;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none; }
-
-.custom-select:focus {
-  border-color: #80bdff;
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
-
-.custom-select:focus::-ms-value {
-  color: #495057;
-  background-color: #fff; }
-
-.custom-select[multiple], .custom-select[size]:not([size="1"]) {
-  height: auto;
-  padding-right: 0.75rem;
-  background-image: none; }
-
-.custom-select:disabled {
-  color: #6c757d;
-  background-color: #e9ecef; }
-
-.custom-select::-ms-expand {
-  display: none; }
-
-.custom-select:-moz-focusring {
-  color: transparent;
-  text-shadow: 0 0 0 #495057; }
-
-.custom-select-sm {
-  height: calc(1.5em + 0.5rem + 2px);
-  padding-top: 0.25rem;
-  padding-bottom: 0.25rem;
-  padding-left: 0.5rem;
-  font-size: 0.875rem; }
-
-.custom-select-lg {
-  height: calc(1.5em + 1rem + 2px);
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem;
-  padding-left: 1rem;
-  font-size: 1.25rem; }
-
-.custom-file {
-  position: relative;
-  display: inline-block;
-  width: 100%;
-  height: calc(1.5em + 0.75rem + 2px);
-  margin-bottom: 0; }
-
-.custom-file-input {
-  position: relative;
-  z-index: 2;
-  width: 100%;
-  height: calc(1.5em + 0.75rem + 2px);
-  margin: 0;
-  overflow: hidden;
-  opacity: 0; }
-
-.custom-file-input:focus ~ .custom-file-label {
-  border-color: #80bdff;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
-
-.custom-file-input[disabled] ~ .custom-file-label,
-.custom-file-input:disabled ~ .custom-file-label {
-  background-color: #e9ecef; }
-
-.custom-file-input:lang(en) ~ .custom-file-label::after {
-  content: "Browse"; }
-
-.custom-file-input ~ .custom-file-label[data-browse]::after {
-  content: attr(data-browse); }
-
-.custom-file-label {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 1;
-  height: calc(1.5em + 0.75rem + 2px);
-  padding: 0.375rem 0.75rem;
-  overflow: hidden;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #495057;
-  background-color: #fff;
-  border: 1px solid #ced4da;
-  border-radius: 0.25rem; }
-
-.custom-file-label::after {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 3;
-  display: block;
-  height: calc(1.5em + 0.75rem);
-  padding: 0.375rem 0.75rem;
-  line-height: 1.5;
-  color: #495057;
-  content: "Browse";
-  background-color: #e9ecef;
-  border-left: inherit;
-  border-radius: 0 0.25rem 0.25rem 0; }
-
-.custom-range {
-  width: 100%;
-  height: 1.4rem;
-  padding: 0;
-  background-color: transparent;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none; }
-
-.custom-range:focus {
-  outline: 0; }
-
-.custom-range:focus::-webkit-slider-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
-
-.custom-range:focus::-moz-range-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
-
-.custom-range:focus::-ms-thumb {
-  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
-
-.custom-range::-moz-focus-outer {
-  border: 0; }
-
-.custom-range::-webkit-slider-thumb {
-  width: 1rem;
-  height: 1rem;
-  margin-top: -0.25rem;
-  background-color: #007bff;
-  border: 0;
-  border-radius: 1rem;
-  -webkit-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  -webkit-appearance: none;
-  appearance: none; }
-
-@media (prefers-reduced-motion: reduce) {
-  .custom-range::-webkit-slider-thumb {
-    -webkit-transition: none;
-    transition: none; } }
-
-.custom-range::-webkit-slider-thumb:active {
-  background-color: #b3d7ff; }
-
-.custom-range::-webkit-slider-runnable-track {
-  width: 100%;
-  height: 0.5rem;
-  color: transparent;
-  cursor: pointer;
-  background-color: #dee2e6;
-  border-color: transparent;
-  border-radius: 1rem; }
-
-.custom-range::-moz-range-thumb {
-  width: 1rem;
-  height: 1rem;
-  background-color: #007bff;
-  border: 0;
-  border-radius: 1rem;
-  -moz-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  -moz-appearance: none;
-  appearance: none; }
-
-@media (prefers-reduced-motion: reduce) {
-  .custom-range::-moz-range-thumb {
-    -moz-transition: none;
-    transition: none; } }
-
-.custom-range::-moz-range-thumb:active {
-  background-color: #b3d7ff; }
-
-.custom-range::-moz-range-track {
-  width: 100%;
-  height: 0.5rem;
-  color: transparent;
-  cursor: pointer;
-  background-color: #dee2e6;
-  border-color: transparent;
-  border-radius: 1rem; }
-
-.custom-range::-ms-thumb {
-  width: 1rem;
-  height: 1rem;
-  margin-top: 0;
-  margin-right: 0.2rem;
-  margin-left: 0.2rem;
-  background-color: #007bff;
-  border: 0;
-  border-radius: 1rem;
-  -ms-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
-  appearance: none; }
-
-@media (prefers-reduced-motion: reduce) {
-  .custom-range::-ms-thumb {
-    -ms-transition: none;
-    transition: none; } }
-
-.custom-range::-ms-thumb:active {
-  background-color: #b3d7ff; }
-
-.custom-range::-ms-track {
-  width: 100%;
-  height: 0.5rem;
-  color: transparent;
-  cursor: pointer;
-  background-color: transparent;
-  border-color: transparent;
-  border-width: 0.5rem; }
-
-.custom-range::-ms-fill-lower {
-  background-color: #dee2e6;
-  border-radius: 1rem; }
-
-.custom-range::-ms-fill-upper {
-  margin-right: 15px;
-  background-color: #dee2e6;
-  border-radius: 1rem; }
-
-.custom-range:disabled::-webkit-slider-thumb {
-  background-color: #adb5bd; }
-
-.custom-range:disabled::-webkit-slider-runnable-track {
-  cursor: default; }
-
-.custom-range:disabled::-moz-range-thumb {
-  background-color: #adb5bd; }
-
-.custom-range:disabled::-moz-range-track {
-  cursor: default; }
-
-.custom-range:disabled::-ms-thumb {
-  background-color: #adb5bd; }
-
-.custom-control-label::before,
-.custom-file-label,
-.custom-select {
-  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
-
-@media (prefers-reduced-motion: reduce) {
-  .custom-control-label::before,
-  .custom-file-label,
-  .custom-select {
-    transition: none; } }
+  padding-left: 0.5625rem;
+}
+
+.dropdown-toggle-split::after, .dropup .dropdown-toggle-split::after, .dropright .dropdown-toggle-split::after {
+  margin-left: 0;
+}
+
+/*.dropleft .dropdown-toggle-split::before {*/
+/*  margin-right: 0;*/
+/*}*/
+
+/*.btn-sm + .dropdown-toggle-split, .btn-group-sm > .btn + .dropdown-toggle-split {*/
+/*  padding-right: 0.375rem;*/
+/*  padding-left: 0.375rem;*/
+/*}*/
+
+/*.btn-lg + .dropdown-toggle-split, .btn-group-lg > .btn + .dropdown-toggle-split {*/
+/*  padding-right: 0.75rem;*/
+/*  padding-left: 0.75rem;*/
+/*}*/
+
+/*.btn-group-vertical {*/
+/*  -ms-flex-direction: column;*/
+/*  flex-direction: column;*/
+/*  -ms-flex-align: start;*/
+/*  align-items: flex-start;*/
+/*  -ms-flex-pack: center;*/
+/*  justify-content: center;*/
+/*}*/
+
+/*.btn-group-vertical > .btn, .btn-group-vertical > .btn-group {*/
+/*  width: 100%;*/
+/*}*/
+
+/*.btn-group-vertical > .btn:not(:first-child), .btn-group-vertical > .btn-group:not(:first-child) {*/
+/*  margin-top: -1px;*/
+/*}*/
+
+/*.btn-group-vertical > .btn:not(:last-child):not(.dropdown-toggle), .btn-group-vertical > .btn-group:not(:last-child) > .btn {*/
+/*  border-bottom-right-radius: 0;*/
+/*  border-bottom-left-radius: 0;*/
+/*}*/
+
+/*.btn-group-vertical > .btn:not(:first-child), .btn-group-vertical > .btn-group:not(:first-child) > .btn {*/
+/*  border-top-left-radius: 0;*/
+/*  border-top-right-radius: 0;*/
+/*}*/
+
+/*.btn-group-toggle > .btn, .btn-group-toggle > .btn-group > .btn {*/
+/*  margin-bottom: 0;*/
+/*}*/
+
+/*.btn-group-toggle > .btn input[type="radio"], .btn-group-toggle > .btn input[type="checkbox"], .btn-group-toggle > .btn-group > .btn input[type="radio"], .btn-group-toggle > .btn-group > .btn input[type="checkbox"] {*/
+/*  position: absolute;*/
+/*  clip: rect(0, 0, 0, 0);*/
+/*  pointer-events: none;*/
+/*}*/
+
+/*.input-group {*/
+/*  position: relative;*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-wrap: wrap;*/
+/*  flex-wrap: wrap;*/
+/*  -ms-flex-align: stretch;*/
+/*  align-items: stretch;*/
+/*  width: 100%;*/
+/*}*/
+
+/*.input-group > .form-control, .input-group > .form-control-plaintext, .input-group > .custom-select, .input-group > .custom-file {*/
+/*  position: relative;*/
+/*  -ms-flex: 1 1 auto;*/
+/*  flex: 1 1 auto;*/
+/*  width: 1%;*/
+/*  min-width: 0;*/
+/*  margin-bottom: 0;*/
+/*}*/
+
+/*.input-group > .form-control + .form-control, .input-group > .form-control + .custom-select, .input-group > .form-control + .custom-file, .input-group > .form-control-plaintext + .form-control, .input-group > .form-control-plaintext + .custom-select, .input-group > .form-control-plaintext + .custom-file, .input-group > .custom-select + .form-control, .input-group > .custom-select + .custom-select, .input-group > .custom-select + .custom-file, .input-group > .custom-file + .form-control, .input-group > .custom-file + .custom-select, .input-group > .custom-file + .custom-file {*/
+/*  margin-left: -1px;*/
+/*}*/
+
+/*.input-group > .form-control:focus, .input-group > .custom-select:focus, .input-group > .custom-file .custom-file-input:focus ~ .custom-file-label {*/
+/*  z-index: 3;*/
+/*}*/
+
+/*.input-group > .custom-file .custom-file-input:focus {*/
+/*  z-index: 4;*/
+/*}*/
+
+/*.input-group > .form-control:not(:first-child), .input-group > .custom-select:not(:first-child) {*/
+/*  border-top-left-radius: 0;*/
+/*  border-bottom-left-radius: 0;*/
+/*}*/
+
+/*.input-group > .custom-file {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*}*/
+
+/*.input-group > .custom-file:not(:last-child) .custom-file-label, .input-group > .custom-file:not(:first-child) .custom-file-label {*/
+/*  border-top-left-radius: 0;*/
+/*  border-bottom-left-radius: 0;*/
+/*}*/
+
+/*.input-group:not(.has-validation) > .form-control:not(:last-child), .input-group:not(.has-validation) > .custom-select:not(:last-child), .input-group:not(.has-validation) > .custom-file:not(:last-child) .custom-file-label::after {*/
+/*  border-top-right-radius: 0;*/
+/*  border-bottom-right-radius: 0;*/
+/*}*/
+
+/*.input-group.has-validation > .form-control:nth-last-child(n + 3), .input-group.has-validation > .custom-select:nth-last-child(n + 3), .input-group.has-validation > .custom-file:nth-last-child(n + 3) .custom-file-label::after {*/
+/*  border-top-right-radius: 0;*/
+/*  border-bottom-right-radius: 0;*/
+/*}*/
+
+/*.input-group-prepend, .input-group-append {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*}*/
+
+/*.input-group-prepend .btn, .input-group-append .btn {*/
+/*  position: relative;*/
+/*  z-index: 2;*/
+/*}*/
+
+/*.input-group-prepend .btn:focus, .input-group-append .btn:focus {*/
+/*  z-index: 3;*/
+/*}*/
+
+/*.input-group-prepend .btn + .btn, .input-group-prepend .btn + .input-group-text, .input-group-prepend .input-group-text + .input-group-text, .input-group-prepend .input-group-text + .btn, .input-group-append .btn + .btn, .input-group-append .btn + .input-group-text, .input-group-append .input-group-text + .input-group-text, .input-group-append .input-group-text + .btn {*/
+/*  margin-left: -1px;*/
+/*}*/
+
+/*.input-group-prepend {*/
+/*  margin-right: -1px;*/
+/*}*/
+
+/*.input-group-append {*/
+/*  margin-left: -1px;*/
+/*}*/
+
+/*.input-group-text {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  padding: 0.375rem 0.75rem;*/
+/*  margin-bottom: 0;*/
+/*  font-size: 1rem;*/
+/*  font-weight: 400;*/
+/*  line-height: 1.5;*/
+/*  color: #495057;*/
+/*  text-align: center;*/
+/*  white-space: nowrap;*/
+/*  background-color: #e9ecef;*/
+/*  border: 1px solid #ced4da;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.input-group-text input[type="radio"], .input-group-text input[type="checkbox"] {*/
+/*  margin-top: 0;*/
+/*}*/
+
+/*.input-group-lg > .form-control:not(textarea), .input-group-lg > .custom-select {*/
+/*  height: calc(1.5em + 1rem + 2px);*/
+/*}*/
+
+/*.input-group-lg > .form-control, .input-group-lg > .custom-select, .input-group-lg > .input-group-prepend > .input-group-text, .input-group-lg > .input-group-append > .input-group-text, .input-group-lg > .input-group-prepend > .btn, .input-group-lg > .input-group-append > .btn {*/
+/*  padding: 0.5rem 1rem;*/
+/*  font-size: 1.25rem;*/
+/*  line-height: 1.5;*/
+/*  border-radius: 0.3rem;*/
+/*}*/
+
+/*.input-group-sm > .form-control:not(textarea), .input-group-sm > .custom-select {*/
+/*  height: calc(1.5em + 0.5rem + 2px);*/
+/*}*/
+
+/*.input-group-sm > .form-control, .input-group-sm > .custom-select, .input-group-sm > .input-group-prepend > .input-group-text, .input-group-sm > .input-group-append > .input-group-text, .input-group-sm > .input-group-prepend > .btn, .input-group-sm > .input-group-append > .btn {*/
+/*  padding: 0.25rem 0.5rem;*/
+/*  font-size: 0.875rem;*/
+/*  line-height: 1.5;*/
+/*  border-radius: 0.2rem;*/
+/*}*/
+
+/*.input-group-lg > .custom-select, .input-group-sm > .custom-select {*/
+/*  padding-right: 1.75rem;*/
+/*}*/
+
+/*.input-group > .input-group-prepend > .btn, .input-group > .input-group-prepend > .input-group-text, .input-group:not(.has-validation) > .input-group-append:not(:last-child) > .btn, .input-group:not(.has-validation) > .input-group-append:not(:last-child) > .input-group-text, .input-group.has-validation > .input-group-append:nth-last-child(n + 3) > .btn, .input-group.has-validation > .input-group-append:nth-last-child(n + 3) > .input-group-text, .input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle), .input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {*/
+/*  border-top-right-radius: 0;*/
+/*  border-bottom-right-radius: 0;*/
+/*}*/
+
+/*.input-group > .input-group-append > .btn, .input-group > .input-group-append > .input-group-text, .input-group > .input-group-prepend:not(:first-child) > .btn, .input-group > .input-group-prepend:not(:first-child) > .input-group-text, .input-group > .input-group-prepend:first-child > .btn:not(:first-child), .input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {*/
+/*  border-top-left-radius: 0;*/
+/*  border-bottom-left-radius: 0;*/
+/*}*/
+
+/*.custom-control {*/
+/*  position: relative;*/
+/*  z-index: 1;*/
+/*  display: block;*/
+/*  min-height: 1.5rem;*/
+/*  padding-left: 1.5rem;*/
+/*  -webkit-print-color-adjust: exact;*/
+/*  color-adjust: exact;*/
+/*}*/
+
+/*.custom-control-inline {*/
+/*  display: -ms-inline-flexbox;*/
+/*  display: inline-flex;*/
+/*  margin-right: 1rem;*/
+/*}*/
+
+/*.custom-control-input {*/
+/*  position: absolute;*/
+/*  left: 0;*/
+/*  z-index: -1;*/
+/*  width: 1rem;*/
+/*  height: 1.25rem;*/
+/*  opacity: 0;*/
+/*}*/
+
+/*.custom-control-input:checked ~ .custom-control-label::before {*/
+/*  color: #fff;*/
+/*  border-color: #007bff;*/
+/*  background-color: #007bff;*/
+/*}*/
+
+/*.custom-control-input:focus ~ .custom-control-label::before {*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
+
+/*.custom-control-input:focus:not(:checked) ~ .custom-control-label::before {*/
+/*  border-color: #80bdff;*/
+/*}*/
+
+/*.custom-control-input:not(:disabled):active ~ .custom-control-label::before {*/
+/*  color: #fff;*/
+/*  background-color: #b3d7ff;*/
+/*  border-color: #b3d7ff;*/
+/*}*/
+
+/*.custom-control-input[disabled] ~ .custom-control-label, .custom-control-input:disabled ~ .custom-control-label {*/
+/*  color: #6c757d;*/
+/*}*/
+
+/*.custom-control-input[disabled] ~ .custom-control-label::before, .custom-control-input:disabled ~ .custom-control-label::before {*/
+/*  background-color: #e9ecef;*/
+/*}*/
+
+/*.custom-control-label {*/
+/*  position: relative;*/
+/*  margin-bottom: 0;*/
+/*  vertical-align: top;*/
+/*}*/
+
+/*.custom-control-label::before {*/
+/*  position: absolute;*/
+/*  top: 0.25rem;*/
+/*  left: -1.5rem;*/
+/*  display: block;*/
+/*  width: 1rem;*/
+/*  height: 1rem;*/
+/*  pointer-events: none;*/
+/*  content: "";*/
+/*  background-color: #fff;*/
+/*  border: #adb5bd solid 1px;*/
+/*}*/
+
+/*.custom-control-label::after {*/
+/*  position: absolute;*/
+/*  top: 0.25rem;*/
+/*  left: -1.5rem;*/
+/*  display: block;*/
+/*  width: 1rem;*/
+/*  height: 1rem;*/
+/*  content: "";*/
+/*  background: 50% / 50% 50% no-repeat;*/
+/*}*/
+
+/*.custom-checkbox .custom-control-label::before {*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.custom-checkbox .custom-control-input:checked ~ .custom-control-label::after {*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath fill='%23fff' d='M6.564.75l-3.59 3.612-1.538-1.55L0 4.26l2.974 2.99L8 2.193z'/%3e%3c/svg%3e");*/
+/*}*/
+
+/*.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::before {*/
+/*  border-color: #007bff;*/
+/*  background-color: #007bff;*/
+/*}*/
+
+/*.custom-checkbox .custom-control-input:indeterminate ~ .custom-control-label::after {*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3e%3cpath stroke='%23fff' d='M0 2h4'/%3e%3c/svg%3e");*/
+/*}*/
+
+/*.custom-checkbox .custom-control-input:disabled:checked ~ .custom-control-label::before {*/
+/*  background-color: rgba(0, 123, 255, 0.5);*/
+/*}*/
+
+/*.custom-checkbox .custom-control-input:disabled:indeterminate ~ .custom-control-label::before {*/
+/*  background-color: rgba(0, 123, 255, 0.5);*/
+/*}*/
+
+/*.custom-radio .custom-control-label::before {*/
+/*  border-radius: 50%;*/
+/*}*/
+
+/*.custom-radio .custom-control-input:checked ~ .custom-control-label::after {*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='-4 -4 8 8'%3e%3ccircle r='3' fill='%23fff'/%3e%3c/svg%3e");*/
+/*}*/
+
+/*.custom-radio .custom-control-input:disabled:checked ~ .custom-control-label::before {*/
+/*  background-color: rgba(0, 123, 255, 0.5);*/
+/*}*/
+
+/*.custom-switch {*/
+/*  padding-left: 2.25rem;*/
+/*}*/
+
+/*.custom-switch .custom-control-label::before {*/
+/*  left: -2.25rem;*/
+/*  width: 1.75rem;*/
+/*  pointer-events: all;*/
+/*  border-radius: 0.5rem;*/
+/*}*/
+
+/*.custom-switch .custom-control-label::after {*/
+/*  top: calc(0.25rem + 2px);*/
+/*  left: calc(-2.25rem + 2px);*/
+/*  width: calc(1rem - 4px);*/
+/*  height: calc(1rem - 4px);*/
+/*  background-color: #adb5bd;*/
+/*  border-radius: 0.5rem;*/
+/*  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out;*/
+/*  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*  transition: transform 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out, -webkit-transform 0.15s ease-in-out;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .custom-switch .custom-control-label::after {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.custom-switch .custom-control-input:checked ~ .custom-control-label::after {*/
+/*  background-color: #fff;*/
+/*  -webkit-transform: translateX(0.75rem);*/
+/*  transform: translateX(0.75rem);*/
+/*}*/
+
+/*.custom-switch .custom-control-input:disabled:checked ~ .custom-control-label::before {*/
+/*  background-color: rgba(0, 123, 255, 0.5);*/
+/*}*/
+
+/*.custom-select {*/
+/*  display: inline-block;*/
+/*  width: 100%;*/
+/*  height: calc(1.5em + 0.75rem + 2px);*/
+/*  padding: 0.375rem 1.75rem 0.375rem 0.75rem;*/
+/*  font-size: 1rem;*/
+/*  font-weight: 400;*/
+/*  line-height: 1.5;*/
+/*  color: #495057;*/
+/*  vertical-align: middle;*/
+/*  background: #fff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='4' height='5' viewBox='0 0 4 5'%3e%3cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3e%3c/svg%3e") right 0.75rem center/8px 10px no-repeat;*/
+/*  border: 1px solid #ced4da;*/
+/*  border-radius: 0.25rem;*/
+/*  -webkit-appearance: none;*/
+/*  -moz-appearance: none;*/
+/*  appearance: none;*/
+/*}*/
+
+/*.custom-select:focus {*/
+/*  border-color: #80bdff;*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
+
+/*.custom-select:focus::-ms-value {*/
+/*  color: #495057;*/
+/*  background-color: #fff;*/
+/*}*/
+
+/*.custom-select[multiple], .custom-select[size]:not([size="1"]) {*/
+/*  height: auto;*/
+/*  padding-right: 0.75rem;*/
+/*  background-image: none;*/
+/*}*/
+
+/*.custom-select:disabled {*/
+/*  color: #6c757d;*/
+/*  background-color: #e9ecef;*/
+/*}*/
+
+/*.custom-select::-ms-expand {*/
+/*  display: none;*/
+/*}*/
+
+/*.custom-select:-moz-focusring {*/
+/*  color: transparent;*/
+/*  text-shadow: 0 0 0 #495057;*/
+/*}*/
+
+/*.custom-select-sm {*/
+/*  height: calc(1.5em + 0.5rem + 2px);*/
+/*  padding-top: 0.25rem;*/
+/*  padding-bottom: 0.25rem;*/
+/*  padding-left: 0.5rem;*/
+/*  font-size: 0.875rem;*/
+/*}*/
+
+/*.custom-select-lg {*/
+/*  height: calc(1.5em + 1rem + 2px);*/
+/*  padding-top: 0.5rem;*/
+/*  padding-bottom: 0.5rem;*/
+/*  padding-left: 1rem;*/
+/*  font-size: 1.25rem;*/
+/*}*/
+
+/*.custom-file {*/
+/*  position: relative;*/
+/*  display: inline-block;*/
+/*  width: 100%;*/
+/*  height: calc(1.5em + 0.75rem + 2px);*/
+/*  margin-bottom: 0;*/
+/*}*/
+
+/*.custom-file-input {*/
+/*  position: relative;*/
+/*  z-index: 2;*/
+/*  width: 100%;*/
+/*  height: calc(1.5em + 0.75rem + 2px);*/
+/*  margin: 0;*/
+/*  overflow: hidden;*/
+/*  opacity: 0;*/
+/*}*/
+
+/*.custom-file-input:focus ~ .custom-file-label {*/
+/*  border-color: #80bdff;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
+
+/*.custom-file-input[disabled] ~ .custom-file-label, .custom-file-input:disabled ~ .custom-file-label {*/
+/*  background-color: #e9ecef;*/
+/*}*/
+
+/*.custom-file-input:lang(en) ~ .custom-file-label::after {*/
+/*  content: "Browse";*/
+/*}*/
+
+/*.custom-file-input ~ .custom-file-label[data-browse]::after {*/
+/*  content: attr(data-browse);*/
+/*}*/
+
+/*.custom-file-label {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  left: 0;*/
+/*  z-index: 1;*/
+/*  height: calc(1.5em + 0.75rem + 2px);*/
+/*  padding: 0.375rem 0.75rem;*/
+/*  overflow: hidden;*/
+/*  font-weight: 400;*/
+/*  line-height: 1.5;*/
+/*  color: #495057;*/
+/*  background-color: #fff;*/
+/*  border: 1px solid #ced4da;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.custom-file-label::after {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  bottom: 0;*/
+/*  z-index: 3;*/
+/*  display: block;*/
+/*  height: calc(1.5em + 0.75rem);*/
+/*  padding: 0.375rem 0.75rem;*/
+/*  line-height: 1.5;*/
+/*  color: #495057;*/
+/*  content: "Browse";*/
+/*  background-color: #e9ecef;*/
+/*  border-left: inherit;*/
+/*  border-radius: 0 0.25rem 0.25rem 0;*/
+/*}*/
+
+/*.custom-range {*/
+/*  width: 100%;*/
+/*  height: 1.4rem;*/
+/*  padding: 0;*/
+/*  background-color: transparent;*/
+/*  -webkit-appearance: none;*/
+/*  -moz-appearance: none;*/
+/*  appearance: none;*/
+/*}*/
+
+/*.custom-range:focus {*/
+/*  outline: 0;*/
+/*}*/
+
+/*.custom-range:focus::-webkit-slider-thumb {*/
+/*  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
+
+/*.custom-range:focus::-moz-range-thumb {*/
+/*  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
+
+/*.custom-range:focus::-ms-thumb {*/
+/*  box-shadow: 0 0 0 1px #fff, 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
+
+/*.custom-range::-moz-focus-outer {*/
+/*  border: 0;*/
+/*}*/
+
+/*.custom-range::-webkit-slider-thumb {*/
+/*  width: 1rem;*/
+/*  height: 1rem;*/
+/*  margin-top: -0.25rem;*/
+/*  background-color: #007bff;*/
+/*  border: 0;*/
+/*  border-radius: 1rem;*/
+/*  -webkit-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*  -webkit-appearance: none;*/
+/*  appearance: none;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .custom-range::-webkit-slider-thumb {*/
+/*    -webkit-transition: none;*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.custom-range::-webkit-slider-thumb:active {*/
+/*  background-color: #b3d7ff;*/
+/*}*/
+
+/*.custom-range::-webkit-slider-runnable-track {*/
+/*  width: 100%;*/
+/*  height: 0.5rem;*/
+/*  color: transparent;*/
+/*  cursor: pointer;*/
+/*  background-color: #dee2e6;*/
+/*  border-color: transparent;*/
+/*  border-radius: 1rem;*/
+/*}*/
+
+/*.custom-range::-moz-range-thumb {*/
+/*  width: 1rem;*/
+/*  height: 1rem;*/
+/*  background-color: #007bff;*/
+/*  border: 0;*/
+/*  border-radius: 1rem;*/
+/*  -moz-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*  -moz-appearance: none;*/
+/*  appearance: none;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .custom-range::-moz-range-thumb {*/
+/*    -moz-transition: none;*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.custom-range::-moz-range-thumb:active {*/
+/*  background-color: #b3d7ff;*/
+/*}*/
+
+/*.custom-range::-moz-range-track {*/
+/*  width: 100%;*/
+/*  height: 0.5rem;*/
+/*  color: transparent;*/
+/*  cursor: pointer;*/
+/*  background-color: #dee2e6;*/
+/*  border-color: transparent;*/
+/*  border-radius: 1rem;*/
+/*}*/
+
+/*.custom-range::-ms-thumb {*/
+/*  width: 1rem;*/
+/*  height: 1rem;*/
+/*  margin-top: 0;*/
+/*  margin-right: 0.2rem;*/
+/*  margin-left: 0.2rem;*/
+/*  background-color: #007bff;*/
+/*  border: 0;*/
+/*  border-radius: 1rem;*/
+/*  -ms-transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*  appearance: none;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .custom-range::-ms-thumb {*/
+/*    -ms-transition: none;*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.custom-range::-ms-thumb:active {*/
+/*  background-color: #b3d7ff;*/
+/*}*/
+
+/*.custom-range::-ms-track {*/
+/*  width: 100%;*/
+/*  height: 0.5rem;*/
+/*  color: transparent;*/
+/*  cursor: pointer;*/
+/*  background-color: transparent;*/
+/*  border-color: transparent;*/
+/*  border-width: 0.5rem;*/
+/*}*/
+
+/*.custom-range::-ms-fill-lower {*/
+/*  background-color: #dee2e6;*/
+/*  border-radius: 1rem;*/
+/*}*/
+
+/*.custom-range::-ms-fill-upper {*/
+/*  margin-right: 15px;*/
+/*  background-color: #dee2e6;*/
+/*  border-radius: 1rem;*/
+/*}*/
+
+/*.custom-range:disabled::-webkit-slider-thumb {*/
+/*  background-color: #adb5bd;*/
+/*}*/
+
+/*.custom-range:disabled::-webkit-slider-runnable-track {*/
+/*  cursor: default;*/
+/*}*/
+
+/*.custom-range:disabled::-moz-range-thumb {*/
+/*  background-color: #adb5bd;*/
+/*}*/
+
+/*.custom-range:disabled::-moz-range-track {*/
+/*  cursor: default;*/
+/*}*/
+
+/*.custom-range:disabled::-ms-thumb {*/
+/*  background-color: #adb5bd;*/
+/*}*/
+
+/*.custom-control-label::before, .custom-file-label, .custom-select {*/
+/*  transition: background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .custom-control-label::before, .custom-file-label, .custom-select {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
 
 .nav {
-  display: -ms-flexbox;
+  /*display: /*-ms-flexbox;*/
   display: flex;
-  -ms-flex-wrap: wrap;
+  /*-ms-flex-wrap: wrap;*/
   flex-wrap: wrap;
   padding-left: 0;
   margin-bottom: 0;
-  list-style: none; }
-
-.nav-link {
-  display: block;
-  padding: 0.5rem 1rem; }
-
-.nav-link:hover, .nav-link:focus {
-  text-decoration: none; }
-
-.nav-link.disabled {
-  color: #6c757d;
-  pointer-events: none;
-  cursor: default; }
-
-.nav-tabs {
-  border-bottom: 1px solid #dee2e6; }
-
-.nav-tabs .nav-link {
-  margin-bottom: -1px;
-  border: 1px solid transparent;
-  border-top-left-radius: 0.25rem;
-  border-top-right-radius: 0.25rem; }
-
-.nav-tabs .nav-link:hover, .nav-tabs .nav-link:focus {
-  border-color: #e9ecef #e9ecef #dee2e6; }
-
-.nav-tabs .nav-link.disabled {
-  color: #6c757d;
-  background-color: transparent;
-  border-color: transparent; }
-
-.nav-tabs .nav-link.active,
-.nav-tabs .nav-item.show .nav-link {
-  color: #495057;
-  background-color: #fff;
-  border-color: #dee2e6 #dee2e6 #fff; }
-
-.nav-tabs .dropdown-menu {
-  margin-top: -1px;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0; }
-
-.nav-pills .nav-link {
-  border-radius: 0.25rem; }
-
-.nav-pills .nav-link.active,
-.nav-pills .show > .nav-link {
-  color: #fff;
-  background-color: #007bff; }
-
-.nav-fill > .nav-link,
-.nav-fill .nav-item {
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  text-align: center; }
-
-.nav-justified > .nav-link,
-.nav-justified .nav-item {
-  -ms-flex-preferred-size: 0;
-  flex-basis: 0;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  text-align: center; }
-
-.tab-content > .tab-pane {
-  display: none; }
-
-.tab-content > .active {
-  display: block; }
-
-.navbar {
-  position: relative;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -ms-flex-align: center;
-  align-items: center;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding: 0.5rem 1rem; }
-
-.navbar .container,
-.navbar .container-fluid, .navbar .container-sm, .navbar .container-md, .navbar .container-lg, .navbar .container-xl {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -ms-flex-align: center;
-  align-items: center;
-  -ms-flex-pack: justify;
-  justify-content: space-between; }
-
-.navbar-brand {
-  display: inline-block;
-  padding-top: 0.3125rem;
-  padding-bottom: 0.3125rem;
-  margin-right: 1rem;
-  font-size: 1.25rem;
-  line-height: inherit;
-  white-space: nowrap; }
-
-.navbar-brand:hover, .navbar-brand:focus {
-  text-decoration: none; }
-
-.navbar-nav {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 0;
-  margin-bottom: 0;
-  list-style: none; }
-
-.navbar-nav .nav-link {
-  padding-right: 0;
-  padding-left: 0; }
-
-.navbar-nav .dropdown-menu {
-  position: static;
-  float: none; }
-
-.navbar-text {
-  display: inline-block;
-  padding-top: 0.5rem;
-  padding-bottom: 0.5rem; }
-
-.navbar-collapse {
-  -ms-flex-preferred-size: 100%;
-  flex-basis: 100%;
-  -ms-flex-positive: 1;
-  flex-grow: 1;
-  -ms-flex-align: center;
-  align-items: center; }
-
-.navbar-toggler {
-  padding: 0.25rem 0.75rem;
-  font-size: 1.25rem;
-  line-height: 1;
-  background-color: transparent;
-  border: 1px solid transparent;
-  border-radius: 0.25rem; }
-
-.navbar-toggler:hover, .navbar-toggler:focus {
-  text-decoration: none; }
-
-.navbar-toggler-icon {
-  display: inline-block;
-  width: 1.5em;
-  height: 1.5em;
-  vertical-align: middle;
-  content: "";
-  background: 50% / 100% 100% no-repeat; }
-
-.navbar-nav-scroll {
-  max-height: 75vh;
-  overflow-y: auto; }
-
-@media (max-width: 575.98px) {
-  .navbar-expand-sm > .container,
-  .navbar-expand-sm > .container-fluid, .navbar-expand-sm > .container-sm, .navbar-expand-sm > .container-md, .navbar-expand-sm > .container-lg, .navbar-expand-sm > .container-xl {
-    padding-right: 0;
-    padding-left: 0; } }
-
-@media (min-width: 576px) {
-  .navbar-expand-sm {
-    -ms-flex-flow: row nowrap;
-    flex-flow: row nowrap;
-    -ms-flex-pack: start;
-    justify-content: flex-start; }
-  .navbar-expand-sm .navbar-nav {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .navbar-expand-sm .navbar-nav .dropdown-menu {
-    position: absolute; }
-  .navbar-expand-sm .navbar-nav .nav-link {
-    padding-right: 0.5rem;
-    padding-left: 0.5rem; }
-  .navbar-expand-sm > .container,
-  .navbar-expand-sm > .container-fluid, .navbar-expand-sm > .container-sm, .navbar-expand-sm > .container-md, .navbar-expand-sm > .container-lg, .navbar-expand-sm > .container-xl {
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap; }
-  .navbar-expand-sm .navbar-nav-scroll {
-    overflow: visible; }
-  .navbar-expand-sm .navbar-collapse {
-    display: -ms-flexbox !important;
-    display: flex !important;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto; }
-  .navbar-expand-sm .navbar-toggler {
-    display: none; } }
-
-@media (max-width: 767.98px) {
-  .navbar-expand-md > .container,
-  .navbar-expand-md > .container-fluid, .navbar-expand-md > .container-sm, .navbar-expand-md > .container-md, .navbar-expand-md > .container-lg, .navbar-expand-md > .container-xl {
-    padding-right: 0;
-    padding-left: 0; } }
-
-@media (min-width: 768px) {
-  .navbar-expand-md {
-    -ms-flex-flow: row nowrap;
-    flex-flow: row nowrap;
-    -ms-flex-pack: start;
-    justify-content: flex-start; }
-  .navbar-expand-md .navbar-nav {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .navbar-expand-md .navbar-nav .dropdown-menu {
-    position: absolute; }
-  .navbar-expand-md .navbar-nav .nav-link {
-    padding-right: 0.5rem;
-    padding-left: 0.5rem; }
-  .navbar-expand-md > .container,
-  .navbar-expand-md > .container-fluid, .navbar-expand-md > .container-sm, .navbar-expand-md > .container-md, .navbar-expand-md > .container-lg, .navbar-expand-md > .container-xl {
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap; }
-  .navbar-expand-md .navbar-nav-scroll {
-    overflow: visible; }
-  .navbar-expand-md .navbar-collapse {
-    display: -ms-flexbox !important;
-    display: flex !important;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto; }
-  .navbar-expand-md .navbar-toggler {
-    display: none; } }
-
-@media (max-width: 991.98px) {
-  .navbar-expand-lg > .container,
-  .navbar-expand-lg > .container-fluid, .navbar-expand-lg > .container-sm, .navbar-expand-lg > .container-md, .navbar-expand-lg > .container-lg, .navbar-expand-lg > .container-xl {
-    padding-right: 0;
-    padding-left: 0; } }
-
-@media (min-width: 992px) {
-  .navbar-expand-lg {
-    -ms-flex-flow: row nowrap;
-    flex-flow: row nowrap;
-    -ms-flex-pack: start;
-    justify-content: flex-start; }
-  .navbar-expand-lg .navbar-nav {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .navbar-expand-lg .navbar-nav .dropdown-menu {
-    position: absolute; }
-  .navbar-expand-lg .navbar-nav .nav-link {
-    padding-right: 0.5rem;
-    padding-left: 0.5rem; }
-  .navbar-expand-lg > .container,
-  .navbar-expand-lg > .container-fluid, .navbar-expand-lg > .container-sm, .navbar-expand-lg > .container-md, .navbar-expand-lg > .container-lg, .navbar-expand-lg > .container-xl {
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap; }
-  .navbar-expand-lg .navbar-nav-scroll {
-    overflow: visible; }
-  .navbar-expand-lg .navbar-collapse {
-    display: -ms-flexbox !important;
-    display: flex !important;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto; }
-  .navbar-expand-lg .navbar-toggler {
-    display: none; } }
-
-@media (max-width: 1199.98px) {
-  .navbar-expand-xl > .container,
-  .navbar-expand-xl > .container-fluid, .navbar-expand-xl > .container-sm, .navbar-expand-xl > .container-md, .navbar-expand-xl > .container-lg, .navbar-expand-xl > .container-xl {
-    padding-right: 0;
-    padding-left: 0; } }
-
-@media (min-width: 1200px) {
-  .navbar-expand-xl {
-    -ms-flex-flow: row nowrap;
-    flex-flow: row nowrap;
-    -ms-flex-pack: start;
-    justify-content: flex-start; }
-  .navbar-expand-xl .navbar-nav {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .navbar-expand-xl .navbar-nav .dropdown-menu {
-    position: absolute; }
-  .navbar-expand-xl .navbar-nav .nav-link {
-    padding-right: 0.5rem;
-    padding-left: 0.5rem; }
-  .navbar-expand-xl > .container,
-  .navbar-expand-xl > .container-fluid, .navbar-expand-xl > .container-sm, .navbar-expand-xl > .container-md, .navbar-expand-xl > .container-lg, .navbar-expand-xl > .container-xl {
-    -ms-flex-wrap: nowrap;
-    flex-wrap: nowrap; }
-  .navbar-expand-xl .navbar-nav-scroll {
-    overflow: visible; }
-  .navbar-expand-xl .navbar-collapse {
-    display: -ms-flexbox !important;
-    display: flex !important;
-    -ms-flex-preferred-size: auto;
-    flex-basis: auto; }
-  .navbar-expand-xl .navbar-toggler {
-    display: none; } }
-
-.navbar-expand {
-  -ms-flex-flow: row nowrap;
-  flex-flow: row nowrap;
-  -ms-flex-pack: start;
-  justify-content: flex-start; }
-
-.navbar-expand > .container,
-.navbar-expand > .container-fluid, .navbar-expand > .container-sm, .navbar-expand > .container-md, .navbar-expand > .container-lg, .navbar-expand > .container-xl {
-  padding-right: 0;
-  padding-left: 0; }
-
-.navbar-expand .navbar-nav {
-  -ms-flex-direction: row;
-  flex-direction: row; }
-
-.navbar-expand .navbar-nav .dropdown-menu {
-  position: absolute; }
-
-.navbar-expand .navbar-nav .nav-link {
-  padding-right: 0.5rem;
-  padding-left: 0.5rem; }
-
-.navbar-expand > .container,
-.navbar-expand > .container-fluid, .navbar-expand > .container-sm, .navbar-expand > .container-md, .navbar-expand > .container-lg, .navbar-expand > .container-xl {
-  -ms-flex-wrap: nowrap;
-  flex-wrap: nowrap; }
-
-.navbar-expand .navbar-nav-scroll {
-  overflow: visible; }
-
-.navbar-expand .navbar-collapse {
-  display: -ms-flexbox !important;
-  display: flex !important;
-  -ms-flex-preferred-size: auto;
-  flex-basis: auto; }
-
-.navbar-expand .navbar-toggler {
-  display: none; }
-
-.navbar-light .navbar-brand {
-  color: rgba(0, 0, 0, 0.9); }
-
-.navbar-light .navbar-brand:hover, .navbar-light .navbar-brand:focus {
-  color: rgba(0, 0, 0, 0.9); }
-
-.navbar-light .navbar-nav .nav-link {
-  color: rgba(0, 0, 0, 0.5); }
-
-.navbar-light .navbar-nav .nav-link:hover, .navbar-light .navbar-nav .nav-link:focus {
-  color: rgba(0, 0, 0, 0.7); }
-
-.navbar-light .navbar-nav .nav-link.disabled {
-  color: rgba(0, 0, 0, 0.3); }
-
-.navbar-light .navbar-nav .show > .nav-link,
-.navbar-light .navbar-nav .active > .nav-link,
-.navbar-light .navbar-nav .nav-link.show,
-.navbar-light .navbar-nav .nav-link.active {
-  color: rgba(0, 0, 0, 0.9); }
-
-.navbar-light .navbar-toggler {
-  color: rgba(0, 0, 0, 0.5);
-  border-color: rgba(0, 0, 0, 0.1); }
-
-.navbar-light .navbar-toggler-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%280, 0, 0, 0.5%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"); }
-
-.navbar-light .navbar-text {
-  color: rgba(0, 0, 0, 0.5); }
-
-.navbar-light .navbar-text a {
-  color: rgba(0, 0, 0, 0.9); }
-
-.navbar-light .navbar-text a:hover, .navbar-light .navbar-text a:focus {
-  color: rgba(0, 0, 0, 0.9); }
-
-.navbar-dark .navbar-brand {
-  color: #fff; }
-
-.navbar-dark .navbar-brand:hover, .navbar-dark .navbar-brand:focus {
-  color: #fff; }
-
-.navbar-dark .navbar-nav .nav-link {
-  color: rgba(255, 255, 255, 0.5); }
-
-.navbar-dark .navbar-nav .nav-link:hover, .navbar-dark .navbar-nav .nav-link:focus {
-  color: rgba(255, 255, 255, 0.75); }
-
-.navbar-dark .navbar-nav .nav-link.disabled {
-  color: rgba(255, 255, 255, 0.25); }
-
-.navbar-dark .navbar-nav .show > .nav-link,
-.navbar-dark .navbar-nav .active > .nav-link,
-.navbar-dark .navbar-nav .nav-link.show,
-.navbar-dark .navbar-nav .nav-link.active {
-  color: #fff; }
-
-.navbar-dark .navbar-toggler {
-  color: rgba(255, 255, 255, 0.5);
-  border-color: rgba(255, 255, 255, 0.1); }
-
-.navbar-dark .navbar-toggler-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.5%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e"); }
-
-.navbar-dark .navbar-text {
-  color: rgba(255, 255, 255, 0.5); }
-
-.navbar-dark .navbar-text a {
-  color: #fff; }
-
-.navbar-dark .navbar-text a:hover, .navbar-dark .navbar-text a:focus {
-  color: #fff; }
+  list-style: none;
+}
+
+/*.nav-link {*/
+/*  display: block;*/
+/*  padding: 0.5rem 1rem;*/
+/*}*/
+
+/*.nav-link:hover, .nav-link:focus {*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.nav-link.disabled {*/
+/*  color: #6c757d;*/
+/*  pointer-events: none;*/
+/*  cursor: default;*/
+/*}*/
+
+/*.nav-tabs {*/
+/*  border-bottom: 1px solid #dee2e6;*/
+/*}*/
+
+/*.nav-tabs .nav-link {*/
+/*  margin-bottom: -1px;*/
+/*  border: 1px solid transparent;*/
+/*  border-top-left-radius: 0.25rem;*/
+/*  border-top-right-radius: 0.25rem;*/
+/*}*/
+
+/*.nav-tabs .nav-link:hover, .nav-tabs .nav-link:focus {*/
+/*  border-color: #e9ecef #e9ecef #dee2e6;*/
+/*}*/
+
+/*.nav-tabs .nav-link.disabled {*/
+/*  color: #6c757d;*/
+/*  background-color: transparent;*/
+/*  border-color: transparent;*/
+/*}*/
+
+/*.nav-tabs .nav-link.active, .nav-tabs .nav-item.show .nav-link {*/
+/*  color: #495057;*/
+/*  background-color: #fff;*/
+/*  border-color: #dee2e6 #dee2e6 #fff;*/
+/*}*/
+
+/*.nav-tabs .dropdown-menu {*/
+/*  margin-top: -1px;*/
+/*  border-top-left-radius: 0;*/
+/*  border-top-right-radius: 0;*/
+/*}*/
+
+/*.nav-pills .nav-link {*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.nav-pills .nav-link.active, .nav-pills .show > .nav-link {*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*}*/
+
+/*.nav-fill > .nav-link, .nav-fill .nav-item {*/
+/*  -ms-flex: 1 1 auto;*/
+/*  flex: 1 1 auto;*/
+/*  text-align: center;*/
+/*}*/
+
+/*.nav-justified > .nav-link, .nav-justified .nav-item {*/
+/*  -ms-flex-preferred-size: 0;*/
+/*  flex-basis: 0;*/
+/*  -ms-flex-positive: 1;*/
+/*  flex-grow: 1;*/
+/*  text-align: center;*/
+/*}*/
+
+/*.tab-content > .tab-pane {*/
+/*  display: none;*/
+/*}*/
+
+/*.tab-content > .active {*/
+/*  display: block;*/
+/*}*/
+
+/*.navbar {*/
+/*  position: relative;*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-wrap: wrap;*/
+/*  flex-wrap: wrap;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  -ms-flex-pack: justify;*/
+/*  justify-content: space-between;*/
+/*  padding: 0.5rem 1rem;*/
+/*}*/
+
+/*.navbar .container, .navbar .container-fluid, .navbar .container-sm, .navbar .container-md, .navbar .container-lg, .navbar .container-xl {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-wrap: wrap;*/
+/*  flex-wrap: wrap;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  -ms-flex-pack: justify;*/
+/*  justify-content: space-between;*/
+/*}*/
+
+/*.navbar-brand {*/
+/*  display: inline-block;*/
+/*  padding-top: 0.3125rem;*/
+/*  padding-bottom: 0.3125rem;*/
+/*  margin-right: 1rem;*/
+/*  font-size: 1.25rem;*/
+/*  line-height: inherit;*/
+/*  white-space: nowrap;*/
+/*}*/
+
+/*.navbar-brand:hover, .navbar-brand:focus {*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.navbar-nav {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-direction: column;*/
+/*  flex-direction: column;*/
+/*  padding-left: 0;*/
+/*  margin-bottom: 0;*/
+/*  list-style: none;*/
+/*}*/
+
+/*.navbar-nav .nav-link {*/
+/*  padding-right: 0;*/
+/*  padding-left: 0;*/
+/*}*/
+
+/*.navbar-nav .dropdown-menu {*/
+/*  position: static;*/
+/*  float: none;*/
+/*}*/
+
+/*.navbar-text {*/
+/*  display: inline-block;*/
+/*  padding-top: 0.5rem;*/
+/*  padding-bottom: 0.5rem;*/
+/*}*/
+
+/*.navbar-collapse {*/
+/*  -ms-flex-preferred-size: 100%;*/
+/*  flex-basis: 100%;*/
+/*  -ms-flex-positive: 1;*/
+/*  flex-grow: 1;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*}*/
+
+/*.navbar-toggler {*/
+/*  padding: 0.25rem 0.75rem;*/
+/*  font-size: 1.25rem;*/
+/*  line-height: 1;*/
+/*  background-color: transparent;*/
+/*  border: 1px solid transparent;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.navbar-toggler:hover, .navbar-toggler:focus {*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.navbar-toggler-icon {*/
+/*  display: inline-block;*/
+/*  width: 1.5em;*/
+/*  height: 1.5em;*/
+/*  vertical-align: middle;*/
+/*  content: "";*/
+/*  background: 50% / 100% 100% no-repeat;*/
+/*}*/
+
+/*.navbar-nav-scroll {*/
+/*  max-height: 75vh;*/
+/*  overflow-y: auto;*/
+/*}*/
+
+/*@media (max-width: 575.98px) {*/
+/*  .navbar-expand-sm > .container, .navbar-expand-sm > .container-fluid, .navbar-expand-sm > .container-sm, .navbar-expand-sm > .container-md, .navbar-expand-sm > .container-lg, .navbar-expand-sm > .container-xl {*/
+/*    padding-right: 0;*/
+/*    padding-left: 0;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .navbar-expand-sm {*/
+/*    -ms-flex-flow: row nowrap;*/
+/*    flex-flow: row nowrap;*/
+/*    -ms-flex-pack: start;*/
+/*    justify-content: flex-start;*/
+/*  }*/
+
+/*  .navbar-expand-sm .navbar-nav {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .navbar-expand-sm .navbar-nav .dropdown-menu {*/
+/*    position: absolute;*/
+/*  }*/
+
+/*  .navbar-expand-sm .navbar-nav .nav-link {*/
+/*    padding-right: 0.5rem;*/
+/*    padding-left: 0.5rem;*/
+/*  }*/
+
+/*  .navbar-expand-sm > .container, .navbar-expand-sm > .container-fluid, .navbar-expand-sm > .container-sm, .navbar-expand-sm > .container-md, .navbar-expand-sm > .container-lg, .navbar-expand-sm > .container-xl {*/
+/*    -ms-flex-wrap: nowrap;*/
+/*    flex-wrap: nowrap;*/
+/*  }*/
+
+/*  .navbar-expand-sm .navbar-nav-scroll {*/
+/*    overflow: visible;*/
+/*  }*/
+
+/*  .navbar-expand-sm .navbar-collapse {*/
+/*    display: -ms-flexbox !important;*/
+/*    display: flex !important;*/
+/*    -ms-flex-preferred-size: auto;*/
+/*    flex-basis: auto;*/
+/*  }*/
+
+/*  .navbar-expand-sm .navbar-toggler {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*@media (max-width: 767.98px) {*/
+/*  .navbar-expand-md > .container, .navbar-expand-md > .container-fluid, .navbar-expand-md > .container-sm, .navbar-expand-md > .container-md, .navbar-expand-md > .container-lg, .navbar-expand-md > .container-xl {*/
+/*    padding-right: 0;*/
+/*    padding-left: 0;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 768px) {*/
+/*  .navbar-expand-md {*/
+/*    -ms-flex-flow: row nowrap;*/
+/*    flex-flow: row nowrap;*/
+/*    -ms-flex-pack: start;*/
+/*    justify-content: flex-start;*/
+/*  }*/
+
+/*  .navbar-expand-md .navbar-nav {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .navbar-expand-md .navbar-nav .dropdown-menu {*/
+/*    position: absolute;*/
+/*  }*/
+
+/*  .navbar-expand-md .navbar-nav .nav-link {*/
+/*    padding-right: 0.5rem;*/
+/*    padding-left: 0.5rem;*/
+/*  }*/
+
+/*  .navbar-expand-md > .container, .navbar-expand-md > .container-fluid, .navbar-expand-md > .container-sm, .navbar-expand-md > .container-md, .navbar-expand-md > .container-lg, .navbar-expand-md > .container-xl {*/
+/*    -ms-flex-wrap: nowrap;*/
+/*    flex-wrap: nowrap;*/
+/*  }*/
+
+/*  .navbar-expand-md .navbar-nav-scroll {*/
+/*    overflow: visible;*/
+/*  }*/
+
+/*  .navbar-expand-md .navbar-collapse {*/
+/*    display: -ms-flexbox !important;*/
+/*    display: flex !important;*/
+/*    -ms-flex-preferred-size: auto;*/
+/*    flex-basis: auto;*/
+/*  }*/
+
+/*  .navbar-expand-md .navbar-toggler {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*@media (max-width: 991.98px) {*/
+/*  .navbar-expand-lg > .container, .navbar-expand-lg > .container-fluid, .navbar-expand-lg > .container-sm, .navbar-expand-lg > .container-md, .navbar-expand-lg > .container-lg, .navbar-expand-lg > .container-xl {*/
+/*    padding-right: 0;*/
+/*    padding-left: 0;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 992px) {*/
+/*  .navbar-expand-lg {*/
+/*    -ms-flex-flow: row nowrap;*/
+/*    flex-flow: row nowrap;*/
+/*    -ms-flex-pack: start;*/
+/*    justify-content: flex-start;*/
+/*  }*/
+
+/*  .navbar-expand-lg .navbar-nav {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .navbar-expand-lg .navbar-nav .dropdown-menu {*/
+/*    position: absolute;*/
+/*  }*/
+
+/*  .navbar-expand-lg .navbar-nav .nav-link {*/
+/*    padding-right: 0.5rem;*/
+/*    padding-left: 0.5rem;*/
+/*  }*/
+
+/*  .navbar-expand-lg > .container, .navbar-expand-lg > .container-fluid, .navbar-expand-lg > .container-sm, .navbar-expand-lg > .container-md, .navbar-expand-lg > .container-lg, .navbar-expand-lg > .container-xl {*/
+/*    -ms-flex-wrap: nowrap;*/
+/*    flex-wrap: nowrap;*/
+/*  }*/
+
+/*  .navbar-expand-lg .navbar-nav-scroll {*/
+/*    overflow: visible;*/
+/*  }*/
+
+/*  .navbar-expand-lg .navbar-collapse {*/
+/*    display: -ms-flexbox !important;*/
+/*    display: flex !important;*/
+/*    -ms-flex-preferred-size: auto;*/
+/*    flex-basis: auto;*/
+/*  }*/
+
+/*  .navbar-expand-lg .navbar-toggler {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*@media (max-width: 1199.98px) {*/
+/*  .navbar-expand-xl > .container, .navbar-expand-xl > .container-fluid, .navbar-expand-xl > .container-sm, .navbar-expand-xl > .container-md, .navbar-expand-xl > .container-lg, .navbar-expand-xl > .container-xl {*/
+/*    padding-right: 0;*/
+/*    padding-left: 0;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 1200px) {*/
+/*  .navbar-expand-xl {*/
+/*    -ms-flex-flow: row nowrap;*/
+/*    flex-flow: row nowrap;*/
+/*    -ms-flex-pack: start;*/
+/*    justify-content: flex-start;*/
+/*  }*/
+
+/*  .navbar-expand-xl .navbar-nav {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .navbar-expand-xl .navbar-nav .dropdown-menu {*/
+/*    position: absolute;*/
+/*  }*/
+
+/*  .navbar-expand-xl .navbar-nav .nav-link {*/
+/*    padding-right: 0.5rem;*/
+/*    padding-left: 0.5rem;*/
+/*  }*/
+
+/*  .navbar-expand-xl > .container, .navbar-expand-xl > .container-fluid, .navbar-expand-xl > .container-sm, .navbar-expand-xl > .container-md, .navbar-expand-xl > .container-lg, .navbar-expand-xl > .container-xl {*/
+/*    -ms-flex-wrap: nowrap;*/
+/*    flex-wrap: nowrap;*/
+/*  }*/
+
+/*  .navbar-expand-xl .navbar-nav-scroll {*/
+/*    overflow: visible;*/
+/*  }*/
+
+/*  .navbar-expand-xl .navbar-collapse {*/
+/*    display: -ms-flexbox !important;*/
+/*    display: flex !important;*/
+/*    -ms-flex-preferred-size: auto;*/
+/*    flex-basis: auto;*/
+/*  }*/
+
+/*  .navbar-expand-xl .navbar-toggler {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*.navbar-expand {*/
+/*  -ms-flex-flow: row nowrap;*/
+/*  flex-flow: row nowrap;*/
+/*  -ms-flex-pack: start;*/
+/*  justify-content: flex-start;*/
+/*}*/
+
+/*.navbar-expand > .container, .navbar-expand > .container-fluid, .navbar-expand > .container-sm, .navbar-expand > .container-md, .navbar-expand > .container-lg, .navbar-expand > .container-xl {*/
+/*  padding-right: 0;*/
+/*  padding-left: 0;*/
+/*}*/
+
+/*.navbar-expand .navbar-nav {*/
+/*  -ms-flex-direction: row;*/
+/*  flex-direction: row;*/
+/*}*/
+
+/*.navbar-expand .navbar-nav .dropdown-menu {*/
+/*  position: absolute;*/
+/*}*/
+
+/*.navbar-expand .navbar-nav .nav-link {*/
+/*  padding-right: 0.5rem;*/
+/*  padding-left: 0.5rem;*/
+/*}*/
+
+/*.navbar-expand > .container, .navbar-expand > .container-fluid, .navbar-expand > .container-sm, .navbar-expand > .container-md, .navbar-expand > .container-lg, .navbar-expand > .container-xl {*/
+/*  -ms-flex-wrap: nowrap;*/
+/*  flex-wrap: nowrap;*/
+/*}*/
+
+/*.navbar-expand .navbar-nav-scroll {*/
+/*  overflow: visible;*/
+/*}*/
+
+/*.navbar-expand .navbar-collapse {*/
+/*  display: -ms-flexbox !important;*/
+/*  display: flex !important;*/
+/*  -ms-flex-preferred-size: auto;*/
+/*  flex-basis: auto;*/
+/*}*/
+
+/*.navbar-expand .navbar-toggler {*/
+/*  display: none;*/
+/*}*/
+
+/*.navbar-light .navbar-brand {*/
+/*  color: rgba(0, 0, 0, 0.9);*/
+/*}*/
+
+/*.navbar-light .navbar-brand:hover, .navbar-light .navbar-brand:focus {*/
+/*  color: rgba(0, 0, 0, 0.9);*/
+/*}*/
+
+/*.navbar-light .navbar-nav .nav-link {*/
+/*  color: rgba(0, 0, 0, 0.5);*/
+/*}*/
+
+/*.navbar-light .navbar-nav .nav-link:hover, .navbar-light .navbar-nav .nav-link:focus {*/
+/*  color: rgba(0, 0, 0, 0.7);*/
+/*}*/
+
+/*.navbar-light .navbar-nav .nav-link.disabled {*/
+/*  color: rgba(0, 0, 0, 0.3);*/
+/*}*/
+
+/*.navbar-light .navbar-nav .show > .nav-link, .navbar-light .navbar-nav .active > .nav-link, .navbar-light .navbar-nav .nav-link.show, .navbar-light .navbar-nav .nav-link.active {*/
+/*  color: rgba(0, 0, 0, 0.9);*/
+/*}*/
+
+/*.navbar-light .navbar-toggler {*/
+/*  color: rgba(0, 0, 0, 0.5);*/
+/*  border-color: rgba(0, 0, 0, 0.1);*/
+/*}*/
+
+/*.navbar-light .navbar-toggler-icon {*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%280, 0, 0, 0.5%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");*/
+/*}*/
+
+/*.navbar-light .navbar-text {*/
+/*  color: rgba(0, 0, 0, 0.5);*/
+/*}*/
+
+/*.navbar-light .navbar-text a {*/
+/*  color: rgba(0, 0, 0, 0.9);*/
+/*}*/
+
+/*.navbar-light .navbar-text a:hover, .navbar-light .navbar-text a:focus {*/
+/*  color: rgba(0, 0, 0, 0.9);*/
+/*}*/
+
+/*.navbar-dark .navbar-brand {*/
+/*  color: #fff;*/
+/*}*/
+
+/*.navbar-dark .navbar-brand:hover, .navbar-dark .navbar-brand:focus {*/
+/*  color: #fff;*/
+/*}*/
+
+/*.navbar-dark .navbar-nav .nav-link {*/
+/*  color: rgba(255, 255, 255, 0.5);*/
+/*}*/
+
+/*.navbar-dark .navbar-nav .nav-link:hover, .navbar-dark .navbar-nav .nav-link:focus {*/
+/*  color: rgba(255, 255, 255, 0.75);*/
+/*}*/
+
+/*.navbar-dark .navbar-nav .nav-link.disabled {*/
+/*  color: rgba(255, 255, 255, 0.25);*/
+/*}*/
+
+/*.navbar-dark .navbar-nav .show > .nav-link, .navbar-dark .navbar-nav .active > .nav-link, .navbar-dark .navbar-nav .nav-link.show, .navbar-dark .navbar-nav .nav-link.active {*/
+/*  color: #fff;*/
+/*}*/
+
+/*.navbar-dark .navbar-toggler {*/
+/*  color: rgba(255, 255, 255, 0.5);*/
+/*  border-color: rgba(255, 255, 255, 0.1);*/
+/*}*/
+
+/*.navbar-dark .navbar-toggler-icon {*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='30' height='30' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255, 255, 255, 0.5%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");*/
+/*}*/
+
+/*.navbar-dark .navbar-text {*/
+/*  color: rgba(255, 255, 255, 0.5);*/
+/*}*/
+
+/*.navbar-dark .navbar-text a {*/
+/*  color: #fff;*/
+/*}*/
+
+/*.navbar-dark .navbar-text a:hover, .navbar-dark .navbar-text a:focus {*/
+/*  color: #fff;*/
+/*}*/
 
 .card {
   position: relative;
-  display: -ms-flexbox;
+  /*display: -ms-flexbox;*/
   display: flex;
-  -ms-flex-direction: column;
+  /*-ms-flex-direction: column;*/
   flex-direction: column;
   min-width: 0;
   word-wrap: break-word;
   background-color: #fff;
   background-clip: border-box;
   border: 1px solid rgba(0, 0, 0, 0.125);
-  border-radius: 0.25rem; }
-
-.card > hr {
-  margin-right: 0;
-  margin-left: 0; }
-
-.card > .list-group {
-  border-top: inherit;
-  border-bottom: inherit; }
-
-.card > .list-group:first-child {
-  border-top-width: 0;
-  border-top-left-radius: calc(0.25rem - 1px);
-  border-top-right-radius: calc(0.25rem - 1px); }
-
-.card > .list-group:last-child {
-  border-bottom-width: 0;
-  border-bottom-right-radius: calc(0.25rem - 1px);
-  border-bottom-left-radius: calc(0.25rem - 1px); }
-
-.card > .card-header + .list-group,
-.card > .list-group + .card-footer {
-  border-top: 0; }
-
-.card-body {
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  min-height: 1px;
-  padding: 1.25rem; }
-
-.card-title {
-  margin-bottom: 0.75rem; }
-
-.card-subtitle {
-  margin-top: -0.375rem;
-  margin-bottom: 0; }
-
-.card-text:last-child {
-  margin-bottom: 0; }
-
-.card-link:hover {
-  text-decoration: none; }
-
-.card-link + .card-link {
-  margin-left: 1.25rem; }
-
-.card-header {
-  padding: 0.75rem 1.25rem;
-  margin-bottom: 0;
-  background-color: rgba(0, 0, 0, 0.03);
-  border-bottom: 1px solid rgba(0, 0, 0, 0.125); }
-
-.card-header:first-child {
-  border-radius: calc(0.25rem - 1px) calc(0.25rem - 1px) 0 0; }
-
-.card-footer {
-  padding: 0.75rem 1.25rem;
-  background-color: rgba(0, 0, 0, 0.03);
-  border-top: 1px solid rgba(0, 0, 0, 0.125); }
-
-.card-footer:last-child {
-  border-radius: 0 0 calc(0.25rem - 1px) calc(0.25rem - 1px); }
-
-.card-header-tabs {
-  margin-right: -0.625rem;
-  margin-bottom: -0.75rem;
-  margin-left: -0.625rem;
-  border-bottom: 0; }
-
-.card-header-pills {
-  margin-right: -0.625rem;
-  margin-left: -0.625rem; }
-
-.card-img-overlay {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  padding: 1.25rem;
-  border-radius: calc(0.25rem - 1px); }
-
-.card-img,
-.card-img-top,
-.card-img-bottom {
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  width: 100%; }
-
-.card-img,
-.card-img-top {
-  border-top-left-radius: calc(0.25rem - 1px);
-  border-top-right-radius: calc(0.25rem - 1px); }
-
-.card-img,
-.card-img-bottom {
-  border-bottom-right-radius: calc(0.25rem - 1px);
-  border-bottom-left-radius: calc(0.25rem - 1px); }
-
-.card-deck .card {
-  margin-bottom: 15px; }
-
-@media (min-width: 576px) {
-  .card-deck {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-flow: row wrap;
-    flex-flow: row wrap;
-    margin-right: -15px;
-    margin-left: -15px; }
-  .card-deck .card {
-    -ms-flex: 1 0 0%;
-    flex: 1 0 0%;
-    margin-right: 15px;
-    margin-bottom: 0;
-    margin-left: 15px; } }
-
-.card-group > .card {
-  margin-bottom: 15px; }
-
-@media (min-width: 576px) {
-  .card-group {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-flow: row wrap;
-    flex-flow: row wrap; }
-  .card-group > .card {
-    -ms-flex: 1 0 0%;
-    flex: 1 0 0%;
-    margin-bottom: 0; }
-  .card-group > .card + .card {
-    margin-left: 0;
-    border-left: 0; }
-  .card-group > .card:not(:last-child) {
-    border-top-right-radius: 0;
-    border-bottom-right-radius: 0; }
-  .card-group > .card:not(:last-child) .card-img-top,
-  .card-group > .card:not(:last-child) .card-header {
-    border-top-right-radius: 0; }
-  .card-group > .card:not(:last-child) .card-img-bottom,
-  .card-group > .card:not(:last-child) .card-footer {
-    border-bottom-right-radius: 0; }
-  .card-group > .card:not(:first-child) {
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0; }
-  .card-group > .card:not(:first-child) .card-img-top,
-  .card-group > .card:not(:first-child) .card-header {
-    border-top-left-radius: 0; }
-  .card-group > .card:not(:first-child) .card-img-bottom,
-  .card-group > .card:not(:first-child) .card-footer {
-    border-bottom-left-radius: 0; } }
-
-.card-columns .card {
-  margin-bottom: 0.75rem; }
-
-@media (min-width: 576px) {
-  .card-columns {
-    -webkit-column-count: 3;
-    -moz-column-count: 3;
-    column-count: 3;
-    -webkit-column-gap: 1.25rem;
-    -moz-column-gap: 1.25rem;
-    column-gap: 1.25rem;
-    orphans: 1;
-    widows: 1; }
-  .card-columns .card {
-    display: inline-block;
-    width: 100%; } }
-
-.accordion {
-  overflow-anchor: none; }
-
-.accordion > .card {
-  overflow: hidden; }
-
-.accordion > .card:not(:last-of-type) {
-  border-bottom: 0;
-  border-bottom-right-radius: 0;
-  border-bottom-left-radius: 0; }
-
-.accordion > .card:not(:first-of-type) {
-  border-top-left-radius: 0;
-  border-top-right-radius: 0; }
-
-.accordion > .card > .card-header {
-  border-radius: 0;
-  margin-bottom: -1px; }
-
-.breadcrumb {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
-  list-style: none;
-  background-color: #e9ecef;
-  border-radius: 0.25rem; }
-
-.breadcrumb-item + .breadcrumb-item {
-  padding-left: 0.5rem; }
-
-.breadcrumb-item + .breadcrumb-item::before {
-  float: left;
-  padding-right: 0.5rem;
-  color: #6c757d;
-  content: "/"; }
-
-.breadcrumb-item + .breadcrumb-item:hover::before {
-  text-decoration: underline; }
-
-.breadcrumb-item + .breadcrumb-item:hover::before {
-  text-decoration: none; }
-
-.breadcrumb-item.active {
-  color: #6c757d; }
-
-.pagination {
-  display: -ms-flexbox;
-  display: flex;
-  padding-left: 0;
-  list-style: none;
-  border-radius: 0.25rem; }
-
-.page-link {
-  position: relative;
-  display: block;
-  padding: 0.5rem 0.75rem;
-  margin-left: -1px;
-  line-height: 1.25;
-  color: #007bff;
-  background-color: #fff;
-  border: 1px solid #dee2e6; }
-
-.page-link:hover {
-  z-index: 2;
-  color: #0056b3;
-  text-decoration: none;
-  background-color: #e9ecef;
-  border-color: #dee2e6; }
-
-.page-link:focus {
-  z-index: 3;
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25); }
-
-.page-item:first-child .page-link {
-  margin-left: 0;
-  border-top-left-radius: 0.25rem;
-  border-bottom-left-radius: 0.25rem; }
-
-.page-item:last-child .page-link {
-  border-top-right-radius: 0.25rem;
-  border-bottom-right-radius: 0.25rem; }
-
-.page-item.active .page-link {
-  z-index: 3;
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff; }
-
-.page-item.disabled .page-link {
-  color: #6c757d;
-  pointer-events: none;
-  cursor: auto;
-  background-color: #fff;
-  border-color: #dee2e6; }
-
-.pagination-lg .page-link {
-  padding: 0.75rem 1.5rem;
-  font-size: 1.25rem;
-  line-height: 1.5; }
-
-.pagination-lg .page-item:first-child .page-link {
-  border-top-left-radius: 0.3rem;
-  border-bottom-left-radius: 0.3rem; }
-
-.pagination-lg .page-item:last-child .page-link {
-  border-top-right-radius: 0.3rem;
-  border-bottom-right-radius: 0.3rem; }
-
-.pagination-sm .page-link {
-  padding: 0.25rem 0.5rem;
-  font-size: 0.875rem;
-  line-height: 1.5; }
-
-.pagination-sm .page-item:first-child .page-link {
-  border-top-left-radius: 0.2rem;
-  border-bottom-left-radius: 0.2rem; }
-
-.pagination-sm .page-item:last-child .page-link {
-  border-top-right-radius: 0.2rem;
-  border-bottom-right-radius: 0.2rem; }
-
-.badge {
-  display: inline-block;
-  padding: 0.25em 0.4em;
-  font-size: 75%;
-  font-weight: 700;
-  line-height: 1;
-  text-align: center;
-  white-space: nowrap;
-  vertical-align: baseline;
   border-radius: 0.25rem;
-  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out; }
-
-@media (prefers-reduced-motion: reduce) {
-  .badge {
-    transition: none; } }
-
-a.badge:hover, a.badge:focus {
-  text-decoration: none; }
-
-.badge:empty {
-  display: none; }
-
-.btn .badge {
-  position: relative;
-  top: -1px; }
-
-.badge-pill {
-  padding-right: 0.6em;
-  padding-left: 0.6em;
-  border-radius: 10rem; }
-
-.badge-primary {
-  color: #fff;
-  background-color: #007bff; }
-
-a.badge-primary:hover, a.badge-primary:focus {
-  color: #fff;
-  background-color: #0062cc; }
-
-a.badge-primary:focus, a.badge-primary.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5); }
-
-.badge-secondary {
-  color: #fff;
-  background-color: #6c757d; }
-
-a.badge-secondary:hover, a.badge-secondary:focus {
-  color: #fff;
-  background-color: #545b62; }
-
-a.badge-secondary:focus, a.badge-secondary.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5); }
-
-.badge-success {
-  color: #fff;
-  background-color: #28a745; }
-
-a.badge-success:hover, a.badge-success:focus {
-  color: #fff;
-  background-color: #1e7e34; }
-
-a.badge-success:focus, a.badge-success.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5); }
-
-.badge-info {
-  color: #fff;
-  background-color: #17a2b8; }
-
-a.badge-info:hover, a.badge-info:focus {
-  color: #fff;
-  background-color: #117a8b; }
-
-a.badge-info:focus, a.badge-info.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5); }
-
-.badge-warning {
-  color: #212529;
-  background-color: #ffc107; }
-
-a.badge-warning:hover, a.badge-warning:focus {
-  color: #212529;
-  background-color: #d39e00; }
-
-a.badge-warning:focus, a.badge-warning.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5); }
-
-.badge-danger {
-  color: #fff;
-  background-color: #dc3545; }
-
-a.badge-danger:hover, a.badge-danger:focus {
-  color: #fff;
-  background-color: #bd2130; }
-
-a.badge-danger:focus, a.badge-danger.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5); }
-
-.badge-light {
-  color: #212529;
-  background-color: #f8f9fa; }
-
-a.badge-light:hover, a.badge-light:focus {
-  color: #212529;
-  background-color: #dae0e5; }
-
-a.badge-light:focus, a.badge-light.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5); }
-
-.badge-dark {
-  color: #fff;
-  background-color: #343a40; }
-
-a.badge-dark:hover, a.badge-dark:focus {
-  color: #fff;
-  background-color: #1d2124; }
-
-a.badge-dark:focus, a.badge-dark.focus {
-  outline: 0;
-  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5); }
-
-.jumbotron {
-  padding: 2rem 1rem;
-  margin-bottom: 2rem;
-  background-color: #e9ecef;
-  border-radius: 0.3rem; }
-
-@media (min-width: 576px) {
-  .jumbotron {
-    padding: 4rem 2rem; } }
-
-.jumbotron-fluid {
-  padding-right: 0;
-  padding-left: 0;
-  border-radius: 0; }
-
-.alert {
-  position: relative;
-  padding: 0.75rem 1.25rem;
-  margin-bottom: 1rem;
-  border: 1px solid transparent;
-  border-radius: 0.25rem; }
-
-.alert-heading {
-  color: inherit; }
-
-.alert-link {
-  font-weight: 700; }
-
-.alert-dismissible {
-  padding-right: 4rem; }
-
-.alert-dismissible .close {
-  position: absolute;
-  top: 0;
-  right: 0;
-  z-index: 2;
-  padding: 0.75rem 1.25rem;
-  color: inherit; }
-
-.alert-primary {
-  color: #004085;
-  background-color: #cce5ff;
-  border-color: #b8daff; }
-
-.alert-primary hr {
-  border-top-color: #9fcdff; }
-
-.alert-primary .alert-link {
-  color: #002752; }
-
-.alert-secondary {
-  color: #383d41;
-  background-color: #e2e3e5;
-  border-color: #d6d8db; }
-
-.alert-secondary hr {
-  border-top-color: #c8cbcf; }
-
-.alert-secondary .alert-link {
-  color: #202326; }
-
-.alert-success {
-  color: #155724;
-  background-color: #d4edda;
-  border-color: #c3e6cb; }
-
-.alert-success hr {
-  border-top-color: #b1dfbb; }
-
-.alert-success .alert-link {
-  color: #0b2e13; }
-
-.alert-info {
-  color: #0c5460;
-  background-color: #d1ecf1;
-  border-color: #bee5eb; }
-
-.alert-info hr {
-  border-top-color: #abdde5; }
-
-.alert-info .alert-link {
-  color: #062c33; }
-
-.alert-warning {
-  color: #856404;
-  background-color: #fff3cd;
-  border-color: #ffeeba; }
-
-.alert-warning hr {
-  border-top-color: #ffe8a1; }
-
-.alert-warning .alert-link {
-  color: #533f03; }
-
-.alert-danger {
-  color: #721c24;
-  background-color: #f8d7da;
-  border-color: #f5c6cb; }
-
-.alert-danger hr {
-  border-top-color: #f1b0b7; }
-
-.alert-danger .alert-link {
-  color: #491217; }
-
-.alert-light {
-  color: #818182;
-  background-color: #fefefe;
-  border-color: #fdfdfe; }
-
-.alert-light hr {
-  border-top-color: #ececf6; }
-
-.alert-light .alert-link {
-  color: #686868; }
-
-.alert-dark {
-  color: #1b1e21;
-  background-color: #d6d8d9;
-  border-color: #c6c8ca; }
-
-.alert-dark hr {
-  border-top-color: #b9bbbe; }
-
-.alert-dark .alert-link {
-  color: #040505; }
-
-@-webkit-keyframes progress-bar-stripes {
-  from {
-    background-position: 1rem 0; }
-  to {
-    background-position: 0 0; } }
-
-@keyframes progress-bar-stripes {
-  from {
-    background-position: 1rem 0; }
-  to {
-    background-position: 0 0; } }
-
-.progress {
-  display: -ms-flexbox;
-  display: flex;
-  height: 1rem;
-  overflow: hidden;
-  line-height: 0;
-  font-size: 0.75rem;
-  background-color: #e9ecef;
-  border-radius: 0.25rem; }
-
-.progress-bar {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -ms-flex-pack: center;
-  justify-content: center;
-  overflow: hidden;
-  color: #fff;
-  text-align: center;
-  white-space: nowrap;
-  background-color: #007bff;
-  transition: width 0.6s ease; }
-
-@media (prefers-reduced-motion: reduce) {
-  .progress-bar {
-    transition: none; } }
-
-.progress-bar-striped {
-  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);
-  background-size: 1rem 1rem; }
-
-.progress-bar-animated {
-  -webkit-animation: 1s linear infinite progress-bar-stripes;
-  animation: 1s linear infinite progress-bar-stripes; }
-
-@media (prefers-reduced-motion: reduce) {
-  .progress-bar-animated {
-    -webkit-animation: none;
-    animation: none; } }
-
-.media {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: start;
-  align-items: flex-start; }
-
-.media-body {
-  -ms-flex: 1;
-  flex: 1; }
-
-.list-group {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  padding-left: 0;
-  margin-bottom: 0;
-  border-radius: 0.25rem; }
-
-.list-group-item-action {
-  width: 100%;
-  color: #495057;
-  text-align: inherit; }
-
-.list-group-item-action:hover, .list-group-item-action:focus {
-  z-index: 1;
-  color: #495057;
-  text-decoration: none;
-  background-color: #f8f9fa; }
-
-.list-group-item-action:active {
-  color: #212529;
-  background-color: #e9ecef; }
-
-.list-group-item {
-  position: relative;
-  display: block;
-  padding: 0.75rem 1.25rem;
-  background-color: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.125); }
-
-.list-group-item:first-child {
-  border-top-left-radius: inherit;
-  border-top-right-radius: inherit; }
-
-.list-group-item:last-child {
-  border-bottom-right-radius: inherit;
-  border-bottom-left-radius: inherit; }
-
-.list-group-item.disabled, .list-group-item:disabled {
-  color: #6c757d;
-  pointer-events: none;
-  background-color: #fff; }
-
-.list-group-item.active {
-  z-index: 2;
-  color: #fff;
-  background-color: #007bff;
-  border-color: #007bff; }
-
-.list-group-item + .list-group-item {
-  border-top-width: 0; }
-
-.list-group-item + .list-group-item.active {
-  margin-top: -1px;
-  border-top-width: 1px; }
-
-.list-group-horizontal {
-  -ms-flex-direction: row;
-  flex-direction: row; }
-
-.list-group-horizontal > .list-group-item:first-child {
-  border-bottom-left-radius: 0.25rem;
-  border-top-right-radius: 0; }
-
-.list-group-horizontal > .list-group-item:last-child {
-  border-top-right-radius: 0.25rem;
-  border-bottom-left-radius: 0; }
-
-.list-group-horizontal > .list-group-item.active {
-  margin-top: 0; }
-
-.list-group-horizontal > .list-group-item + .list-group-item {
-  border-top-width: 1px;
-  border-left-width: 0; }
-
-.list-group-horizontal > .list-group-item + .list-group-item.active {
-  margin-left: -1px;
-  border-left-width: 1px; }
-
-@media (min-width: 576px) {
-  .list-group-horizontal-sm {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .list-group-horizontal-sm > .list-group-item:first-child {
-    border-bottom-left-radius: 0.25rem;
-    border-top-right-radius: 0; }
-  .list-group-horizontal-sm > .list-group-item:last-child {
-    border-top-right-radius: 0.25rem;
-    border-bottom-left-radius: 0; }
-  .list-group-horizontal-sm > .list-group-item.active {
-    margin-top: 0; }
-  .list-group-horizontal-sm > .list-group-item + .list-group-item {
-    border-top-width: 1px;
-    border-left-width: 0; }
-  .list-group-horizontal-sm > .list-group-item + .list-group-item.active {
-    margin-left: -1px;
-    border-left-width: 1px; } }
-
-@media (min-width: 768px) {
-  .list-group-horizontal-md {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .list-group-horizontal-md > .list-group-item:first-child {
-    border-bottom-left-radius: 0.25rem;
-    border-top-right-radius: 0; }
-  .list-group-horizontal-md > .list-group-item:last-child {
-    border-top-right-radius: 0.25rem;
-    border-bottom-left-radius: 0; }
-  .list-group-horizontal-md > .list-group-item.active {
-    margin-top: 0; }
-  .list-group-horizontal-md > .list-group-item + .list-group-item {
-    border-top-width: 1px;
-    border-left-width: 0; }
-  .list-group-horizontal-md > .list-group-item + .list-group-item.active {
-    margin-left: -1px;
-    border-left-width: 1px; } }
-
-@media (min-width: 992px) {
-  .list-group-horizontal-lg {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .list-group-horizontal-lg > .list-group-item:first-child {
-    border-bottom-left-radius: 0.25rem;
-    border-top-right-radius: 0; }
-  .list-group-horizontal-lg > .list-group-item:last-child {
-    border-top-right-radius: 0.25rem;
-    border-bottom-left-radius: 0; }
-  .list-group-horizontal-lg > .list-group-item.active {
-    margin-top: 0; }
-  .list-group-horizontal-lg > .list-group-item + .list-group-item {
-    border-top-width: 1px;
-    border-left-width: 0; }
-  .list-group-horizontal-lg > .list-group-item + .list-group-item.active {
-    margin-left: -1px;
-    border-left-width: 1px; } }
-
-@media (min-width: 1200px) {
-  .list-group-horizontal-xl {
-    -ms-flex-direction: row;
-    flex-direction: row; }
-  .list-group-horizontal-xl > .list-group-item:first-child {
-    border-bottom-left-radius: 0.25rem;
-    border-top-right-radius: 0; }
-  .list-group-horizontal-xl > .list-group-item:last-child {
-    border-top-right-radius: 0.25rem;
-    border-bottom-left-radius: 0; }
-  .list-group-horizontal-xl > .list-group-item.active {
-    margin-top: 0; }
-  .list-group-horizontal-xl > .list-group-item + .list-group-item {
-    border-top-width: 1px;
-    border-left-width: 0; }
-  .list-group-horizontal-xl > .list-group-item + .list-group-item.active {
-    margin-left: -1px;
-    border-left-width: 1px; } }
-
-.list-group-flush {
-  border-radius: 0; }
-
-.list-group-flush > .list-group-item {
-  border-width: 0 0 1px; }
-
-.list-group-flush > .list-group-item:last-child {
-  border-bottom-width: 0; }
-
-.list-group-item-primary {
-  color: #004085;
-  background-color: #b8daff; }
-
-.list-group-item-primary.list-group-item-action:hover, .list-group-item-primary.list-group-item-action:focus {
-  color: #004085;
-  background-color: #9fcdff; }
-
-.list-group-item-primary.list-group-item-action.active {
-  color: #fff;
-  background-color: #004085;
-  border-color: #004085; }
-
-.list-group-item-secondary {
-  color: #383d41;
-  background-color: #d6d8db; }
-
-.list-group-item-secondary.list-group-item-action:hover, .list-group-item-secondary.list-group-item-action:focus {
-  color: #383d41;
-  background-color: #c8cbcf; }
-
-.list-group-item-secondary.list-group-item-action.active {
-  color: #fff;
-  background-color: #383d41;
-  border-color: #383d41; }
-
-.list-group-item-success {
-  color: #155724;
-  background-color: #c3e6cb; }
-
-.list-group-item-success.list-group-item-action:hover, .list-group-item-success.list-group-item-action:focus {
-  color: #155724;
-  background-color: #b1dfbb; }
-
-.list-group-item-success.list-group-item-action.active {
-  color: #fff;
-  background-color: #155724;
-  border-color: #155724; }
-
-.list-group-item-info {
-  color: #0c5460;
-  background-color: #bee5eb; }
-
-.list-group-item-info.list-group-item-action:hover, .list-group-item-info.list-group-item-action:focus {
-  color: #0c5460;
-  background-color: #abdde5; }
-
-.list-group-item-info.list-group-item-action.active {
-  color: #fff;
-  background-color: #0c5460;
-  border-color: #0c5460; }
-
-.list-group-item-warning {
-  color: #856404;
-  background-color: #ffeeba; }
-
-.list-group-item-warning.list-group-item-action:hover, .list-group-item-warning.list-group-item-action:focus {
-  color: #856404;
-  background-color: #ffe8a1; }
-
-.list-group-item-warning.list-group-item-action.active {
-  color: #fff;
-  background-color: #856404;
-  border-color: #856404; }
-
-.list-group-item-danger {
-  color: #721c24;
-  background-color: #f5c6cb; }
-
-.list-group-item-danger.list-group-item-action:hover, .list-group-item-danger.list-group-item-action:focus {
-  color: #721c24;
-  background-color: #f1b0b7; }
-
-.list-group-item-danger.list-group-item-action.active {
-  color: #fff;
-  background-color: #721c24;
-  border-color: #721c24; }
-
-.list-group-item-light {
-  color: #818182;
-  background-color: #fdfdfe; }
-
-.list-group-item-light.list-group-item-action:hover, .list-group-item-light.list-group-item-action:focus {
-  color: #818182;
-  background-color: #ececf6; }
-
-.list-group-item-light.list-group-item-action.active {
-  color: #fff;
-  background-color: #818182;
-  border-color: #818182; }
-
-.list-group-item-dark {
-  color: #1b1e21;
-  background-color: #c6c8ca; }
-
-.list-group-item-dark.list-group-item-action:hover, .list-group-item-dark.list-group-item-action:focus {
-  color: #1b1e21;
-  background-color: #b9bbbe; }
-
-.list-group-item-dark.list-group-item-action.active {
-  color: #fff;
-  background-color: #1b1e21;
-  border-color: #1b1e21; }
-
-.close {
-  float: right;
-  font-size: 1.5rem;
-  font-weight: 700;
-  line-height: 1;
-  color: #000;
-  text-shadow: 0 1px 0 #fff;
-  opacity: .5; }
-
-.close:hover {
-  color: #000;
-  text-decoration: none; }
-
-.close:not(:disabled):not(.disabled):hover, .close:not(:disabled):not(.disabled):focus {
-  opacity: .75; }
-
-button.close {
-  padding: 0;
-  background-color: transparent;
-  border: 0; }
-
-a.close.disabled {
-  pointer-events: none; }
-
-.toast {
-  -ms-flex-preferred-size: 350px;
-  flex-basis: 350px;
-  max-width: 350px;
-  font-size: 0.875rem;
-  background-color: rgba(255, 255, 255, 0.85);
-  background-clip: padding-box;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);
-  opacity: 0;
-  border-radius: 0.25rem; }
-
-.toast:not(:last-child) {
-  margin-bottom: 0.75rem; }
-
-.toast.showing {
-  opacity: 1; }
-
-.toast.show {
-  display: block;
-  opacity: 1; }
-
-.toast.hide {
-  display: none; }
-
-.toast-header {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: center;
-  align-items: center;
-  padding: 0.25rem 0.75rem;
-  color: #6c757d;
-  background-color: rgba(255, 255, 255, 0.85);
-  background-clip: padding-box;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-  border-top-left-radius: calc(0.25rem - 1px);
-  border-top-right-radius: calc(0.25rem - 1px); }
-
-.toast-body {
-  padding: 0.75rem; }
-
-.modal-open {
-  overflow: hidden; }
-
-.modal-open .modal {
-  overflow-x: hidden;
-  overflow-y: auto; }
-
-.modal {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 1050;
-  display: none;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  outline: 0; }
-
-.modal-dialog {
-  position: relative;
-  width: auto;
-  margin: 0.5rem;
-  pointer-events: none; }
-
-.modal.fade .modal-dialog {
-  transition: -webkit-transform 0.3s ease-out;
-  transition: transform 0.3s ease-out;
-  transition: transform 0.3s ease-out, -webkit-transform 0.3s ease-out;
-  -webkit-transform: translate(0, -50px);
-  transform: translate(0, -50px); }
-
-@media (prefers-reduced-motion: reduce) {
-  .modal.fade .modal-dialog {
-    transition: none; } }
-
-.modal.show .modal-dialog {
-  -webkit-transform: none;
-  transform: none; }
-
-.modal.modal-static .modal-dialog {
-  -webkit-transform: scale(1.02);
-  transform: scale(1.02); }
-
-.modal-dialog-scrollable {
-  display: -ms-flexbox;
-  display: flex;
-  max-height: calc(100% - 1rem); }
-
-.modal-dialog-scrollable .modal-content {
-  max-height: calc(100vh - 1rem);
-  overflow: hidden; }
-
-.modal-dialog-scrollable .modal-header,
-.modal-dialog-scrollable .modal-footer {
-  -ms-flex-negative: 0;
-  flex-shrink: 0; }
-
-.modal-dialog-scrollable .modal-body {
-  overflow-y: auto; }
-
-.modal-dialog-centered {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: center;
-  align-items: center;
-  min-height: calc(100% - 1rem); }
-
-.modal-dialog-centered::before {
-  display: block;
-  height: calc(100vh - 1rem);
-  height: -webkit-min-content;
-  height: -moz-min-content;
-  height: min-content;
-  content: ""; }
-
-.modal-dialog-centered.modal-dialog-scrollable {
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -ms-flex-pack: center;
-  justify-content: center;
-  height: 100%; }
-
-.modal-dialog-centered.modal-dialog-scrollable .modal-content {
-  max-height: none; }
-
-.modal-dialog-centered.modal-dialog-scrollable::before {
-  content: none; }
-
-.modal-content {
-  position: relative;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  width: 100%;
-  pointer-events: auto;
-  background-color: #fff;
-  background-clip: padding-box;
-  border: 1px solid rgba(0, 0, 0, 0.2);
-  border-radius: 0.3rem;
-  outline: 0; }
-
-.modal-backdrop {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 1040;
-  width: 100vw;
-  height: 100vh;
-  background-color: #000; }
-
-.modal-backdrop.fade {
-  opacity: 0; }
-
-.modal-backdrop.show {
-  opacity: 0.5; }
-
-.modal-header {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: start;
-  align-items: flex-start;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
-  padding: 1rem 1rem;
-  border-bottom: 1px solid #dee2e6;
-  border-top-left-radius: calc(0.3rem - 1px);
-  border-top-right-radius: calc(0.3rem - 1px); }
-
-.modal-header .close {
-  padding: 1rem 1rem;
-  margin: -1rem -1rem -1rem auto; }
-
-.modal-title {
-  margin-bottom: 0;
-  line-height: 1.5; }
-
-.modal-body {
-  position: relative;
-  -ms-flex: 1 1 auto;
-  flex: 1 1 auto;
-  padding: 1rem; }
-
-.modal-footer {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-wrap: wrap;
-  flex-wrap: wrap;
-  -ms-flex-align: center;
-  align-items: center;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  padding: 0.75rem;
-  border-top: 1px solid #dee2e6;
-  border-bottom-right-radius: calc(0.3rem - 1px);
-  border-bottom-left-radius: calc(0.3rem - 1px); }
-
-.modal-footer > * {
-  margin: 0.25rem; }
-
-.modal-scrollbar-measure {
-  position: absolute;
-  top: -9999px;
-  width: 50px;
-  height: 50px;
-  overflow: scroll; }
-
-@media (min-width: 576px) {
-  .modal-dialog {
-    max-width: 500px;
-    margin: 1.75rem auto; }
-  .modal-dialog-scrollable {
-    max-height: calc(100% - 3.5rem); }
-  .modal-dialog-scrollable .modal-content {
-    max-height: calc(100vh - 3.5rem); }
-  .modal-dialog-centered {
-    min-height: calc(100% - 3.5rem); }
-  .modal-dialog-centered::before {
-    height: calc(100vh - 3.5rem);
-    height: -webkit-min-content;
-    height: -moz-min-content;
-    height: min-content; }
-  .modal-sm {
-    max-width: 300px; } }
-
-@media (min-width: 992px) {
-  .modal-lg,
-  .modal-xl {
-    max-width: 800px; } }
-
-@media (min-width: 1200px) {
-  .modal-xl {
-    max-width: 1140px; } }
+}
+
+/*.card > hr {*/
+/*  margin-right: 0;*/
+/*  margin-left: 0;*/
+/*}*/
+
+/*.card > .list-group {*/
+/*  border-top: inherit;*/
+/*  border-bottom: inherit;*/
+/*}*/
+
+/*.card > .list-group:first-child {*/
+/*  border-top-width: 0;*/
+/*  border-top-left-radius: calc(0.25rem - 1px);*/
+/*  border-top-right-radius: calc(0.25rem - 1px);*/
+/*}*/
+
+/*.card > .list-group:last-child {*/
+/*  border-bottom-width: 0;*/
+/*  border-bottom-right-radius: calc(0.25rem - 1px);*/
+/*  border-bottom-left-radius: calc(0.25rem - 1px);*/
+/*}*/
+
+/*.card > .card-header + .list-group, .card > .list-group + .card-footer {*/
+/*  border-top: 0;*/
+/*}*/
+
+/*.card-body {*/
+/*  -ms-flex: 1 1 auto;*/
+/*  flex: 1 1 auto;*/
+/*  min-height: 1px;*/
+/*  padding: 1.25rem;*/
+/*}*/
+
+/*.card-title {*/
+/*  margin-bottom: 0.75rem;*/
+/*}*/
+
+/*.card-subtitle {*/
+/*  margin-top: -0.375rem;*/
+/*  margin-bottom: 0;*/
+/*}*/
+
+/*.card-text:last-child {*/
+/*  margin-bottom: 0;*/
+/*}*/
+
+/*.card-link:hover {*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.card-link + .card-link {*/
+/*  margin-left: 1.25rem;*/
+/*}*/
+
+/*.card-header {*/
+/*  padding: 0.75rem 1.25rem;*/
+/*  margin-bottom: 0;*/
+/*  background-color: rgba(0, 0, 0, 0.03);*/
+/*  border-bottom: 1px solid rgba(0, 0, 0, 0.125);*/
+/*}*/
+
+/*.card-header:first-child {*/
+/*  border-radius: calc(0.25rem - 1px) calc(0.25rem - 1px) 0 0;*/
+/*}*/
+
+/*.card-footer {*/
+/*  padding: 0.75rem 1.25rem;*/
+/*  background-color: rgba(0, 0, 0, 0.03);*/
+/*  border-top: 1px solid rgba(0, 0, 0, 0.125);*/
+/*}*/
+
+/*.card-footer:last-child {*/
+/*  border-radius: 0 0 calc(0.25rem - 1px) calc(0.25rem - 1px);*/
+/*}*/
+
+/*.card-header-tabs {*/
+/*  margin-right: -0.625rem;*/
+/*  margin-bottom: -0.75rem;*/
+/*  margin-left: -0.625rem;*/
+/*  border-bottom: 0;*/
+/*}*/
+
+/*.card-header-pills {*/
+/*  margin-right: -0.625rem;*/
+/*  margin-left: -0.625rem;*/
+/*}*/
+
+/*.card-img-overlay {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  bottom: 0;*/
+/*  left: 0;*/
+/*  padding: 1.25rem;*/
+/*  border-radius: calc(0.25rem - 1px);*/
+/*}*/
+
+/*.card-img, .card-img-top, .card-img-bottom {*/
+/*  -ms-flex-negative: 0;*/
+/*  flex-shrink: 0;*/
+/*  width: 100%;*/
+/*}*/
+
+/*.card-img, .card-img-top {*/
+/*  border-top-left-radius: calc(0.25rem - 1px);*/
+/*  border-top-right-radius: calc(0.25rem - 1px);*/
+/*}*/
+
+/*.card-img, .card-img-bottom {*/
+/*  border-bottom-right-radius: calc(0.25rem - 1px);*/
+/*  border-bottom-left-radius: calc(0.25rem - 1px);*/
+/*}*/
+
+/*.card-deck .card {*/
+/*  margin-bottom: 15px;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .card-deck {*/
+/*    display: -ms-flexbox;*/
+/*    display: flex;*/
+/*    -ms-flex-flow: row wrap;*/
+/*    flex-flow: row wrap;*/
+/*    margin-right: -15px;*/
+/*    margin-left: -15px;*/
+/*  }*/
+
+/*  .card-deck .card {*/
+/*    -ms-flex: 1 0 0%;*/
+/*    flex: 1 0 0%;*/
+/*    margin-right: 15px;*/
+/*    margin-bottom: 0;*/
+/*    margin-left: 15px;*/
+/*  }*/
+/*}*/
+
+/*.card-group > .card {*/
+/*  margin-bottom: 15px;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .card-group {*/
+/*    display: -ms-flexbox;*/
+/*    display: flex;*/
+/*    -ms-flex-flow: row wrap;*/
+/*    flex-flow: row wrap;*/
+/*  }*/
+
+/*  .card-group > .card {*/
+/*    -ms-flex: 1 0 0%;*/
+/*    flex: 1 0 0%;*/
+/*    margin-bottom: 0;*/
+/*  }*/
+
+/*  .card-group > .card + .card {*/
+/*    margin-left: 0;*/
+/*    border-left: 0;*/
+/*  }*/
+
+/*  .card-group > .card:not(:last-child) {*/
+/*    border-top-right-radius: 0;*/
+/*    border-bottom-right-radius: 0;*/
+/*  }*/
+
+/*  .card-group > .card:not(:last-child) .card-img-top, .card-group > .card:not(:last-child) .card-header {*/
+/*    border-top-right-radius: 0;*/
+/*  }*/
+
+/*  .card-group > .card:not(:last-child) .card-img-bottom, .card-group > .card:not(:last-child) .card-footer {*/
+/*    border-bottom-right-radius: 0;*/
+/*  }*/
+
+/*  .card-group > .card:not(:first-child) {*/
+/*    border-top-left-radius: 0;*/
+/*    border-bottom-left-radius: 0;*/
+/*  }*/
+
+/*  .card-group > .card:not(:first-child) .card-img-top, .card-group > .card:not(:first-child) .card-header {*/
+/*    border-top-left-radius: 0;*/
+/*  }*/
+
+/*  .card-group > .card:not(:first-child) .card-img-bottom, .card-group > .card:not(:first-child) .card-footer {*/
+/*    border-bottom-left-radius: 0;*/
+/*  }*/
+/*}*/
+
+/*.card-columns .card {*/
+/*  margin-bottom: 0.75rem;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .card-columns {*/
+/*    -webkit-column-count: 3;*/
+/*    -moz-column-count: 3;*/
+/*    column-count: 3;*/
+/*    -webkit-column-gap: 1.25rem;*/
+/*    -moz-column-gap: 1.25rem;*/
+/*    column-gap: 1.25rem;*/
+/*    orphans: 1;*/
+/*    widows: 1;*/
+/*  }*/
+
+/*  .card-columns .card {*/
+/*    display: inline-block;*/
+/*    width: 100%;*/
+/*  }*/
+/*}*/
+
+/*.accordion {*/
+/*  overflow-anchor: none;*/
+/*}*/
+
+/*.accordion > .card {*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.accordion > .card:not(:last-of-type) {*/
+/*  border-bottom: 0;*/
+/*  border-bottom-right-radius: 0;*/
+/*  border-bottom-left-radius: 0;*/
+/*}*/
+
+/*.accordion > .card:not(:first-of-type) {*/
+/*  border-top-left-radius: 0;*/
+/*  border-top-right-radius: 0;*/
+/*}*/
+
+/*.accordion > .card > .card-header {*/
+/*  border-radius: 0;*/
+/*  margin-bottom: -1px;*/
+/*}*/
+
+/*.breadcrumb {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-wrap: wrap;*/
+/*  flex-wrap: wrap;*/
+/*  padding: 0.75rem 1rem;*/
+/*  margin-bottom: 1rem;*/
+/*  list-style: none;*/
+/*  background-color: #e9ecef;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.breadcrumb-item + .breadcrumb-item {*/
+/*  padding-left: 0.5rem;*/
+/*}*/
+
+/*.breadcrumb-item + .breadcrumb-item::before {*/
+/*  float: left;*/
+/*  padding-right: 0.5rem;*/
+/*  color: #6c757d;*/
+/*  content: "/";*/
+/*}*/
+
+/*.breadcrumb-item + .breadcrumb-item:hover::before {*/
+/*  text-decoration: underline;*/
+/*}*/
+
+/*.breadcrumb-item + .breadcrumb-item:hover::before {*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.breadcrumb-item.active {*/
+/*  color: #6c757d;*/
+/*}*/
+
+/*.pagination {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  padding-left: 0;*/
+/*  list-style: none;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.page-link {*/
+/*  position: relative;*/
+/*  display: block;*/
+/*  padding: 0.5rem 0.75rem;*/
+/*  margin-left: -1px;*/
+/*  line-height: 1.25;*/
+/*  color: #007bff;*/
+/*  background-color: #fff;*/
+/*  border: 1px solid #dee2e6;*/
+/*}*/
+
+/*.page-link:hover {*/
+/*  z-index: 2;*/
+/*  color: #0056b3;*/
+/*  text-decoration: none;*/
+/*  background-color: #e9ecef;*/
+/*  border-color: #dee2e6;*/
+/*}*/
+
+/*.page-link:focus {*/
+/*  z-index: 3;*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);*/
+/*}*/
+
+/*.page-item:first-child .page-link {*/
+/*  margin-left: 0;*/
+/*  border-top-left-radius: 0.25rem;*/
+/*  border-bottom-left-radius: 0.25rem;*/
+/*}*/
+
+/*.page-item:last-child .page-link {*/
+/*  border-top-right-radius: 0.25rem;*/
+/*  border-bottom-right-radius: 0.25rem;*/
+/*}*/
+
+/*.page-item.active .page-link {*/
+/*  z-index: 3;*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*  border-color: #007bff;*/
+/*}*/
+
+/*.page-item.disabled .page-link {*/
+/*  color: #6c757d;*/
+/*  pointer-events: none;*/
+/*  cursor: auto;*/
+/*  background-color: #fff;*/
+/*  border-color: #dee2e6;*/
+/*}*/
+
+/*.pagination-lg .page-link {*/
+/*  padding: 0.75rem 1.5rem;*/
+/*  font-size: 1.25rem;*/
+/*  line-height: 1.5;*/
+/*}*/
+
+/*.pagination-lg .page-item:first-child .page-link {*/
+/*  border-top-left-radius: 0.3rem;*/
+/*  border-bottom-left-radius: 0.3rem;*/
+/*}*/
+
+/*.pagination-lg .page-item:last-child .page-link {*/
+/*  border-top-right-radius: 0.3rem;*/
+/*  border-bottom-right-radius: 0.3rem;*/
+/*}*/
+
+/*.pagination-sm .page-link {*/
+/*  padding: 0.25rem 0.5rem;*/
+/*  font-size: 0.875rem;*/
+/*  line-height: 1.5;*/
+/*}*/
+
+/*.pagination-sm .page-item:first-child .page-link {*/
+/*  border-top-left-radius: 0.2rem;*/
+/*  border-bottom-left-radius: 0.2rem;*/
+/*}*/
+
+/*.pagination-sm .page-item:last-child .page-link {*/
+/*  border-top-right-radius: 0.2rem;*/
+/*  border-bottom-right-radius: 0.2rem;*/
+/*}*/
+
+/*.badge {*/
+/*  display: inline-block;*/
+/*  padding: 0.25em 0.4em;*/
+/*  font-size: 75%;*/
+/*  font-weight: 700;*/
+/*  line-height: 1;*/
+/*  text-align: center;*/
+/*  white-space: nowrap;*/
+/*  vertical-align: baseline;*/
+/*  border-radius: 0.25rem;*/
+/*  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out, border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .badge {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*a.badge:hover, a.badge:focus {*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.badge:empty {*/
+/*  display: none;*/
+/*}*/
+
+/*.btn .badge {*/
+/*  position: relative;*/
+/*  top: -1px;*/
+/*}*/
+
+/*.badge-pill {*/
+/*  padding-right: 0.6em;*/
+/*  padding-left: 0.6em;*/
+/*  border-radius: 10rem;*/
+/*}*/
+
+/*.badge-primary {*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*}*/
+
+/*a.badge-primary:hover, a.badge-primary:focus {*/
+/*  color: #fff;*/
+/*  background-color: #0062cc;*/
+/*}*/
+
+/*a.badge-primary:focus, a.badge-primary.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.5);*/
+/*}*/
+
+/*.badge-secondary {*/
+/*  color: #fff;*/
+/*  background-color: #6c757d;*/
+/*}*/
+
+/*a.badge-secondary:hover, a.badge-secondary:focus {*/
+/*  color: #fff;*/
+/*  background-color: #545b62;*/
+/*}*/
+
+/*a.badge-secondary:focus, a.badge-secondary.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(108, 117, 125, 0.5);*/
+/*}*/
+
+/*.badge-success {*/
+/*  color: #fff;*/
+/*  background-color: #28a745;*/
+/*}*/
+
+/*a.badge-success:hover, a.badge-success:focus {*/
+/*  color: #fff;*/
+/*  background-color: #1e7e34;*/
+/*}*/
+
+/*a.badge-success:focus, a.badge-success.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.5);*/
+/*}*/
+
+/*.badge-info {*/
+/*  color: #fff;*/
+/*  background-color: #17a2b8;*/
+/*}*/
+
+/*a.badge-info:hover, a.badge-info:focus {*/
+/*  color: #fff;*/
+/*  background-color: #117a8b;*/
+/*}*/
+
+/*a.badge-info:focus, a.badge-info.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(23, 162, 184, 0.5);*/
+/*}*/
+
+/*.badge-warning {*/
+/*  color: #212529;*/
+/*  background-color: #ffc107;*/
+/*}*/
+
+/*a.badge-warning:hover, a.badge-warning:focus {*/
+/*  color: #212529;*/
+/*  background-color: #d39e00;*/
+/*}*/
+
+/*a.badge-warning:focus, a.badge-warning.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(255, 193, 7, 0.5);*/
+/*}*/
+
+/*.badge-danger {*/
+/*  color: #fff;*/
+/*  background-color: #dc3545;*/
+/*}*/
+
+/*a.badge-danger:hover, a.badge-danger:focus {*/
+/*  color: #fff;*/
+/*  background-color: #bd2130;*/
+/*}*/
+
+/*a.badge-danger:focus, a.badge-danger.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.5);*/
+/*}*/
+
+/*.badge-light {*/
+/*  color: #212529;*/
+/*  background-color: #f8f9fa;*/
+/*}*/
+
+/*a.badge-light:hover, a.badge-light:focus {*/
+/*  color: #212529;*/
+/*  background-color: #dae0e5;*/
+/*}*/
+
+/*a.badge-light:focus, a.badge-light.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(248, 249, 250, 0.5);*/
+/*}*/
+
+/*.badge-dark {*/
+/*  color: #fff;*/
+/*  background-color: #343a40;*/
+/*}*/
+
+/*a.badge-dark:hover, a.badge-dark:focus {*/
+/*  color: #fff;*/
+/*  background-color: #1d2124;*/
+/*}*/
+
+/*a.badge-dark:focus, a.badge-dark.focus {*/
+/*  outline: 0;*/
+/*  box-shadow: 0 0 0 0.2rem rgba(52, 58, 64, 0.5);*/
+/*}*/
+
+/*.jumbotron {*/
+/*  padding: 2rem 1rem;*/
+/*  margin-bottom: 2rem;*/
+/*  background-color: #e9ecef;*/
+/*  border-radius: 0.3rem;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .jumbotron {*/
+/*    padding: 4rem 2rem;*/
+/*  }*/
+/*}*/
+
+/*.jumbotron-fluid {*/
+/*  padding-right: 0;*/
+/*  padding-left: 0;*/
+/*  border-radius: 0;*/
+/*}*/
+
+/*.alert {*/
+/*  position: relative;*/
+/*  padding: 0.75rem 1.25rem;*/
+/*  margin-bottom: 1rem;*/
+/*  border: 1px solid transparent;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.alert-heading {*/
+/*  color: inherit;*/
+/*}*/
+
+/*.alert-link {*/
+/*  font-weight: 700;*/
+/*}*/
+
+/*.alert-dismissible {*/
+/*  padding-right: 4rem;*/
+/*}*/
+
+/*.alert-dismissible .close {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  z-index: 2;*/
+/*  padding: 0.75rem 1.25rem;*/
+/*  color: inherit;*/
+/*}*/
+
+/*.alert-primary {*/
+/*  color: #004085;*/
+/*  background-color: #cce5ff;*/
+/*  border-color: #b8daff;*/
+/*}*/
+
+/*.alert-primary hr {*/
+/*  border-top-color: #9fcdff;*/
+/*}*/
+
+/*.alert-primary .alert-link {*/
+/*  color: #002752;*/
+/*}*/
+
+/*.alert-secondary {*/
+/*  color: #383d41;*/
+/*  background-color: #e2e3e5;*/
+/*  border-color: #d6d8db;*/
+/*}*/
+
+/*.alert-secondary hr {*/
+/*  border-top-color: #c8cbcf;*/
+/*}*/
+
+/*.alert-secondary .alert-link {*/
+/*  color: #202326;*/
+/*}*/
+
+/*.alert-success {*/
+/*  color: #155724;*/
+/*  background-color: #d4edda;*/
+/*  border-color: #c3e6cb;*/
+/*}*/
+
+/*.alert-success hr {*/
+/*  border-top-color: #b1dfbb;*/
+/*}*/
+
+/*.alert-success .alert-link {*/
+/*  color: #0b2e13;*/
+/*}*/
+
+/*.alert-info {*/
+/*  color: #0c5460;*/
+/*  background-color: #d1ecf1;*/
+/*  border-color: #bee5eb;*/
+/*}*/
+
+/*.alert-info hr {*/
+/*  border-top-color: #abdde5;*/
+/*}*/
+
+/*.alert-info .alert-link {*/
+/*  color: #062c33;*/
+/*}*/
+
+/*.alert-warning {*/
+/*  color: #856404;*/
+/*  background-color: #fff3cd;*/
+/*  border-color: #ffeeba;*/
+/*}*/
+
+/*.alert-warning hr {*/
+/*  border-top-color: #ffe8a1;*/
+/*}*/
+
+/*.alert-warning .alert-link {*/
+/*  color: #533f03;*/
+/*}*/
+
+/*.alert-danger {*/
+/*  color: #721c24;*/
+/*  background-color: #f8d7da;*/
+/*  border-color: #f5c6cb;*/
+/*}*/
+
+/*.alert-danger hr {*/
+/*  border-top-color: #f1b0b7;*/
+/*}*/
+
+/*.alert-danger .alert-link {*/
+/*  color: #491217;*/
+/*}*/
+
+/*.alert-light {*/
+/*  color: #818182;*/
+/*  background-color: #fefefe;*/
+/*  border-color: #fdfdfe;*/
+/*}*/
+
+/*.alert-light hr {*/
+/*  border-top-color: #ececf6;*/
+/*}*/
+
+/*.alert-light .alert-link {*/
+/*  color: #686868;*/
+/*}*/
+
+/*.alert-dark {*/
+/*  color: #1b1e21;*/
+/*  background-color: #d6d8d9;*/
+/*  border-color: #c6c8ca;*/
+/*}*/
+
+/*.alert-dark hr {*/
+/*  border-top-color: #b9bbbe;*/
+/*}*/
+
+/*.alert-dark .alert-link {*/
+/*  color: #040505;*/
+/*}*/
+
+/*@-webkit-keyframes progress-bar-stripes {*/
+/*  from {*/
+/*    background-position: 1rem 0;*/
+/*  }*/
+
+/*  to {*/
+/*    background-position: 0 0;*/
+/*  }*/
+/*}*/
+
+/*@keyframes progress-bar-stripes {*/
+/*  from {*/
+/*    background-position: 1rem 0;*/
+/*  }*/
+
+/*  to {*/
+/*    background-position: 0 0;*/
+/*  }*/
+/*}*/
+
+/*.progress {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  height: 1rem;*/
+/*  overflow: hidden;*/
+/*  line-height: 0;*/
+/*  font-size: 0.75rem;*/
+/*  background-color: #e9ecef;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.progress-bar {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-direction: column;*/
+/*  flex-direction: column;*/
+/*  -ms-flex-pack: center;*/
+/*  justify-content: center;*/
+/*  overflow: hidden;*/
+/*  color: #fff;*/
+/*  text-align: center;*/
+/*  white-space: nowrap;*/
+/*  background-color: #007bff;*/
+/*  transition: width 0.6s ease;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .progress-bar {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.progress-bar-striped {*/
+/*  background-image: linear-gradient(45deg, rgba(255, 255, 255, 0.15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, 0.15) 50%, rgba(255, 255, 255, 0.15) 75%, transparent 75%, transparent);*/
+/*  background-size: 1rem 1rem;*/
+/*}*/
+
+/*.progress-bar-animated {*/
+/*  -webkit-animation: 1s linear infinite progress-bar-stripes;*/
+/*  animation: 1s linear infinite progress-bar-stripes;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .progress-bar-animated {*/
+/*    -webkit-animation: none;*/
+/*    animation: none;*/
+/*  }*/
+/*}*/
+
+/*.media {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-align: start;*/
+/*  align-items: flex-start;*/
+/*}*/
+
+/*.media-body {*/
+/*  -ms-flex: 1;*/
+/*  flex: 1;*/
+/*}*/
+
+/*.list-group {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-direction: column;*/
+/*  flex-direction: column;*/
+/*  padding-left: 0;*/
+/*  margin-bottom: 0;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.list-group-item-action {*/
+/*  width: 100%;*/
+/*  color: #495057;*/
+/*  text-align: inherit;*/
+/*}*/
+
+/*.list-group-item-action:hover, .list-group-item-action:focus {*/
+/*  z-index: 1;*/
+/*  color: #495057;*/
+/*  text-decoration: none;*/
+/*  background-color: #f8f9fa;*/
+/*}*/
+
+/*.list-group-item-action:active {*/
+/*  color: #212529;*/
+/*  background-color: #e9ecef;*/
+/*}*/
+
+/*.list-group-item {*/
+/*  position: relative;*/
+/*  display: block;*/
+/*  padding: 0.75rem 1.25rem;*/
+/*  background-color: #fff;*/
+/*  border: 1px solid rgba(0, 0, 0, 0.125);*/
+/*}*/
+
+/*.list-group-item:first-child {*/
+/*  border-top-left-radius: inherit;*/
+/*  border-top-right-radius: inherit;*/
+/*}*/
+
+/*.list-group-item:last-child {*/
+/*  border-bottom-right-radius: inherit;*/
+/*  border-bottom-left-radius: inherit;*/
+/*}*/
+
+/*.list-group-item.disabled, .list-group-item:disabled {*/
+/*  color: #6c757d;*/
+/*  pointer-events: none;*/
+/*  background-color: #fff;*/
+/*}*/
+
+/*.list-group-item.active {*/
+/*  z-index: 2;*/
+/*  color: #fff;*/
+/*  background-color: #007bff;*/
+/*  border-color: #007bff;*/
+/*}*/
+
+/*.list-group-item + .list-group-item {*/
+/*  border-top-width: 0;*/
+/*}*/
+
+/*.list-group-item + .list-group-item.active {*/
+/*  margin-top: -1px;*/
+/*  border-top-width: 1px;*/
+/*}*/
+
+/*.list-group-horizontal {*/
+/*  -ms-flex-direction: row;*/
+/*  flex-direction: row;*/
+/*}*/
+
+/*.list-group-horizontal > .list-group-item:first-child {*/
+/*  border-bottom-left-radius: 0.25rem;*/
+/*  border-top-right-radius: 0;*/
+/*}*/
+
+/*.list-group-horizontal > .list-group-item:last-child {*/
+/*  border-top-right-radius: 0.25rem;*/
+/*  border-bottom-left-radius: 0;*/
+/*}*/
+
+/*.list-group-horizontal > .list-group-item.active {*/
+/*  margin-top: 0;*/
+/*}*/
+
+/*.list-group-horizontal > .list-group-item + .list-group-item {*/
+/*  border-top-width: 1px;*/
+/*  border-left-width: 0;*/
+/*}*/
+
+/*.list-group-horizontal > .list-group-item + .list-group-item.active {*/
+/*  margin-left: -1px;*/
+/*  border-left-width: 1px;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .list-group-horizontal-sm {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .list-group-horizontal-sm > .list-group-item:first-child {*/
+/*    border-bottom-left-radius: 0.25rem;*/
+/*    border-top-right-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-sm > .list-group-item:last-child {*/
+/*    border-top-right-radius: 0.25rem;*/
+/*    border-bottom-left-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-sm > .list-group-item.active {*/
+/*    margin-top: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-sm > .list-group-item + .list-group-item {*/
+/*    border-top-width: 1px;*/
+/*    border-left-width: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-sm > .list-group-item + .list-group-item.active {*/
+/*    margin-left: -1px;*/
+/*    border-left-width: 1px;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 768px) {*/
+/*  .list-group-horizontal-md {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .list-group-horizontal-md > .list-group-item:first-child {*/
+/*    border-bottom-left-radius: 0.25rem;*/
+/*    border-top-right-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-md > .list-group-item:last-child {*/
+/*    border-top-right-radius: 0.25rem;*/
+/*    border-bottom-left-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-md > .list-group-item.active {*/
+/*    margin-top: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-md > .list-group-item + .list-group-item {*/
+/*    border-top-width: 1px;*/
+/*    border-left-width: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-md > .list-group-item + .list-group-item.active {*/
+/*    margin-left: -1px;*/
+/*    border-left-width: 1px;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 992px) {*/
+/*  .list-group-horizontal-lg {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .list-group-horizontal-lg > .list-group-item:first-child {*/
+/*    border-bottom-left-radius: 0.25rem;*/
+/*    border-top-right-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-lg > .list-group-item:last-child {*/
+/*    border-top-right-radius: 0.25rem;*/
+/*    border-bottom-left-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-lg > .list-group-item.active {*/
+/*    margin-top: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-lg > .list-group-item + .list-group-item {*/
+/*    border-top-width: 1px;*/
+/*    border-left-width: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-lg > .list-group-item + .list-group-item.active {*/
+/*    margin-left: -1px;*/
+/*    border-left-width: 1px;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 1200px) {*/
+/*  .list-group-horizontal-xl {*/
+/*    -ms-flex-direction: row;*/
+/*    flex-direction: row;*/
+/*  }*/
+
+/*  .list-group-horizontal-xl > .list-group-item:first-child {*/
+/*    border-bottom-left-radius: 0.25rem;*/
+/*    border-top-right-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-xl > .list-group-item:last-child {*/
+/*    border-top-right-radius: 0.25rem;*/
+/*    border-bottom-left-radius: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-xl > .list-group-item.active {*/
+/*    margin-top: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-xl > .list-group-item + .list-group-item {*/
+/*    border-top-width: 1px;*/
+/*    border-left-width: 0;*/
+/*  }*/
+
+/*  .list-group-horizontal-xl > .list-group-item + .list-group-item.active {*/
+/*    margin-left: -1px;*/
+/*    border-left-width: 1px;*/
+/*  }*/
+/*}*/
+
+/*.list-group-flush {*/
+/*  border-radius: 0;*/
+/*}*/
+
+/*.list-group-flush > .list-group-item {*/
+/*  border-width: 0 0 1px;*/
+/*}*/
+
+/*.list-group-flush > .list-group-item:last-child {*/
+/*  border-bottom-width: 0;*/
+/*}*/
+
+/*.list-group-item-primary {*/
+/*  color: #004085;*/
+/*  background-color: #b8daff;*/
+/*}*/
+
+/*.list-group-item-primary.list-group-item-action:hover, .list-group-item-primary.list-group-item-action:focus {*/
+/*  color: #004085;*/
+/*  background-color: #9fcdff;*/
+/*}*/
+
+/*.list-group-item-primary.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #004085;*/
+/*  border-color: #004085;*/
+/*}*/
+
+/*.list-group-item-secondary {*/
+/*  color: #383d41;*/
+/*  background-color: #d6d8db;*/
+/*}*/
+
+/*.list-group-item-secondary.list-group-item-action:hover, .list-group-item-secondary.list-group-item-action:focus {*/
+/*  color: #383d41;*/
+/*  background-color: #c8cbcf;*/
+/*}*/
+
+/*.list-group-item-secondary.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #383d41;*/
+/*  border-color: #383d41;*/
+/*}*/
+
+/*.list-group-item-success {*/
+/*  color: #155724;*/
+/*  background-color: #c3e6cb;*/
+/*}*/
+
+/*.list-group-item-success.list-group-item-action:hover, .list-group-item-success.list-group-item-action:focus {*/
+/*  color: #155724;*/
+/*  background-color: #b1dfbb;*/
+/*}*/
+
+/*.list-group-item-success.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #155724;*/
+/*  border-color: #155724;*/
+/*}*/
+
+/*.list-group-item-info {*/
+/*  color: #0c5460;*/
+/*  background-color: #bee5eb;*/
+/*}*/
+
+/*.list-group-item-info.list-group-item-action:hover, .list-group-item-info.list-group-item-action:focus {*/
+/*  color: #0c5460;*/
+/*  background-color: #abdde5;*/
+/*}*/
+
+/*.list-group-item-info.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #0c5460;*/
+/*  border-color: #0c5460;*/
+/*}*/
+
+/*.list-group-item-warning {*/
+/*  color: #856404;*/
+/*  background-color: #ffeeba;*/
+/*}*/
+
+/*.list-group-item-warning.list-group-item-action:hover, .list-group-item-warning.list-group-item-action:focus {*/
+/*  color: #856404;*/
+/*  background-color: #ffe8a1;*/
+/*}*/
+
+/*.list-group-item-warning.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #856404;*/
+/*  border-color: #856404;*/
+/*}*/
+
+/*.list-group-item-danger {*/
+/*  color: #721c24;*/
+/*  background-color: #f5c6cb;*/
+/*}*/
+
+/*.list-group-item-danger.list-group-item-action:hover, .list-group-item-danger.list-group-item-action:focus {*/
+/*  color: #721c24;*/
+/*  background-color: #f1b0b7;*/
+/*}*/
+
+/*.list-group-item-danger.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #721c24;*/
+/*  border-color: #721c24;*/
+/*}*/
+
+/*.list-group-item-light {*/
+/*  color: #818182;*/
+/*  background-color: #fdfdfe;*/
+/*}*/
+
+/*.list-group-item-light.list-group-item-action:hover, .list-group-item-light.list-group-item-action:focus {*/
+/*  color: #818182;*/
+/*  background-color: #ececf6;*/
+/*}*/
+
+/*.list-group-item-light.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #818182;*/
+/*  border-color: #818182;*/
+/*}*/
+
+/*.list-group-item-dark {*/
+/*  color: #1b1e21;*/
+/*  background-color: #c6c8ca;*/
+/*}*/
+
+/*.list-group-item-dark.list-group-item-action:hover, .list-group-item-dark.list-group-item-action:focus {*/
+/*  color: #1b1e21;*/
+/*  background-color: #b9bbbe;*/
+/*}*/
+
+/*.list-group-item-dark.list-group-item-action.active {*/
+/*  color: #fff;*/
+/*  background-color: #1b1e21;*/
+/*  border-color: #1b1e21;*/
+/*}*/
+
+/*.close {*/
+/*  float: right;*/
+/*  font-size: 1.5rem;*/
+/*  font-weight: 700;*/
+/*  line-height: 1;*/
+/*  color: #000;*/
+/*  text-shadow: 0 1px 0 #fff;*/
+/*  opacity: .5;*/
+/*}*/
+
+/*.close:hover {*/
+/*  color: #000;*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.close:not(:disabled):not(.disabled):hover, .close:not(:disabled):not(.disabled):focus {*/
+/*  opacity: .75;*/
+/*}*/
+
+/*button.close {*/
+/*  padding: 0;*/
+/*  background-color: transparent;*/
+/*  border: 0;*/
+/*}*/
+
+/*a.close.disabled {*/
+/*  pointer-events: none;*/
+/*}*/
+
+/*.toast {*/
+/*  -ms-flex-preferred-size: 350px;*/
+/*  flex-basis: 350px;*/
+/*  max-width: 350px;*/
+/*  font-size: 0.875rem;*/
+/*  background-color: rgba(255, 255, 255, 0.85);*/
+/*  background-clip: padding-box;*/
+/*  border: 1px solid rgba(0, 0, 0, 0.1);*/
+/*  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.1);*/
+/*  opacity: 0;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
+
+/*.toast:not(:last-child) {*/
+/*  margin-bottom: 0.75rem;*/
+/*}*/
+
+/*.toast.showing {*/
+/*  opacity: 1;*/
+/*}*/
+
+/*.toast.show {*/
+/*  display: block;*/
+/*  opacity: 1;*/
+/*}*/
+
+/*.toast.hide {*/
+/*  display: none;*/
+/*}*/
+
+/*.toast-header {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  padding: 0.25rem 0.75rem;*/
+/*  color: #6c757d;*/
+/*  background-color: rgba(255, 255, 255, 0.85);*/
+/*  background-clip: padding-box;*/
+/*  border-bottom: 1px solid rgba(0, 0, 0, 0.05);*/
+/*  border-top-left-radius: calc(0.25rem - 1px);*/
+/*  border-top-right-radius: calc(0.25rem - 1px);*/
+/*}*/
+
+/*.toast-body {*/
+/*  padding: 0.75rem;*/
+/*}*/
+
+/*.modal-open {*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.modal-open .modal {*/
+/*  overflow-x: hidden;*/
+/*  overflow-y: auto;*/
+/*}*/
+
+/*.modal {*/
+/*  position: fixed;*/
+/*  top: 0;*/
+/*  left: 0;*/
+/*  z-index: 1050;*/
+/*  display: none;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  overflow: hidden;*/
+/*  outline: 0;*/
+/*}*/
+
+/*.modal-dialog {*/
+/*  position: relative;*/
+/*  width: auto;*/
+/*  margin: 0.5rem;*/
+/*  pointer-events: none;*/
+/*}*/
+
+/*.modal.fade .modal-dialog {*/
+/*  transition: -webkit-transform 0.3s ease-out;*/
+/*  transition: transform 0.3s ease-out;*/
+/*  transition: transform 0.3s ease-out, -webkit-transform 0.3s ease-out;*/
+/*  -webkit-transform: translate(0, -50px);*/
+/*  transform: translate(0, -50px);*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .modal.fade .modal-dialog {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.modal.show .modal-dialog {*/
+/*  -webkit-transform: none;*/
+/*  transform: none;*/
+/*}*/
+
+/*.modal.modal-static .modal-dialog {*/
+/*  -webkit-transform: scale(1.02);*/
+/*  transform: scale(1.02);*/
+/*}*/
+
+/*.modal-dialog-scrollable {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  max-height: calc(100% - 1rem);*/
+/*}*/
+
+/*.modal-dialog-scrollable .modal-content {*/
+/*  max-height: calc(100vh - 1rem);*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.modal-dialog-scrollable .modal-header, .modal-dialog-scrollable .modal-footer {*/
+/*  -ms-flex-negative: 0;*/
+/*  flex-shrink: 0;*/
+/*}*/
+
+/*.modal-dialog-scrollable .modal-body {*/
+/*  overflow-y: auto;*/
+/*}*/
+
+/*.modal-dialog-centered {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  min-height: calc(100% - 1rem);*/
+/*}*/
+
+/*.modal-dialog-centered::before {*/
+/*  display: block;*/
+/*  height: calc(100vh - 1rem);*/
+/*  height: -webkit-min-content;*/
+/*  height: -moz-min-content;*/
+/*  height: min-content;*/
+/*  content: "";*/
+/*}*/
+
+/*.modal-dialog-centered.modal-dialog-scrollable {*/
+/*  -ms-flex-direction: column;*/
+/*  flex-direction: column;*/
+/*  -ms-flex-pack: center;*/
+/*  justify-content: center;*/
+/*  height: 100%;*/
+/*}*/
+
+/*.modal-dialog-centered.modal-dialog-scrollable .modal-content {*/
+/*  max-height: none;*/
+/*}*/
+
+/*.modal-dialog-centered.modal-dialog-scrollable::before {*/
+/*  content: none;*/
+/*}*/
+
+/*.modal-content {*/
+/*  position: relative;*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-direction: column;*/
+/*  flex-direction: column;*/
+/*  width: 100%;*/
+/*  pointer-events: auto;*/
+/*  background-color: #fff;*/
+/*  background-clip: padding-box;*/
+/*  border: 1px solid rgba(0, 0, 0, 0.2);*/
+/*  border-radius: 0.3rem;*/
+/*  outline: 0;*/
+/*}*/
+
+/*.modal-backdrop {*/
+/*  position: fixed;*/
+/*  top: 0;*/
+/*  left: 0;*/
+/*  z-index: 1040;*/
+/*  width: 100vw;*/
+/*  height: 100vh;*/
+/*  background-color: #000;*/
+/*}*/
+
+/*.modal-backdrop.fade {*/
+/*  opacity: 0;*/
+/*}*/
+
+/*.modal-backdrop.show {*/
+/*  opacity: 0.5;*/
+/*}*/
+
+/*.modal-header {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-align: start;*/
+/*  align-items: flex-start;*/
+/*  -ms-flex-pack: justify;*/
+/*  justify-content: space-between;*/
+/*  padding: 1rem 1rem;*/
+/*  border-bottom: 1px solid #dee2e6;*/
+/*  border-top-left-radius: calc(0.3rem - 1px);*/
+/*  border-top-right-radius: calc(0.3rem - 1px);*/
+/*}*/
+
+/*.modal-header .close {*/
+/*  padding: 1rem 1rem;*/
+/*  margin: -1rem -1rem -1rem auto;*/
+/*}*/
+
+/*.modal-title {*/
+/*  margin-bottom: 0;*/
+/*  line-height: 1.5;*/
+/*}*/
+
+/*.modal-body {*/
+/*  position: relative;*/
+/*  -ms-flex: 1 1 auto;*/
+/*  flex: 1 1 auto;*/
+/*  padding: 1rem;*/
+/*}*/
+
+/*.modal-footer {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-wrap: wrap;*/
+/*  flex-wrap: wrap;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  -ms-flex-pack: end;*/
+/*  justify-content: flex-end;*/
+/*  padding: 0.75rem;*/
+/*  border-top: 1px solid #dee2e6;*/
+/*  border-bottom-right-radius: calc(0.3rem - 1px);*/
+/*  border-bottom-left-radius: calc(0.3rem - 1px);*/
+/*}*/
+
+/*.modal-footer > * {*/
+/*  margin: 0.25rem;*/
+/*}*/
+
+/*.modal-scrollbar-measure {*/
+/*  position: absolute;*/
+/*  top: -9999px;*/
+/*  width: 50px;*/
+/*  height: 50px;*/
+/*  overflow: scroll;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .modal-dialog {*/
+/*    max-width: 500px;*/
+/*    margin: 1.75rem auto;*/
+/*  }*/
+
+/*  .modal-dialog-scrollable {*/
+/*    max-height: calc(100% - 3.5rem);*/
+/*  }*/
+
+/*  .modal-dialog-scrollable .modal-content {*/
+/*    max-height: calc(100vh - 3.5rem);*/
+/*  }*/
+
+/*  .modal-dialog-centered {*/
+/*    min-height: calc(100% - 3.5rem);*/
+/*  }*/
+
+/*  .modal-dialog-centered::before {*/
+/*    height: calc(100vh - 3.5rem);*/
+/*    height: -webkit-min-content;*/
+/*    height: -moz-min-content;*/
+/*    height: min-content;*/
+/*  }*/
+
+/*  .modal-sm {*/
+/*    max-width: 300px;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 992px) {*/
+/*  .modal-lg, .modal-xl {*/
+/*    max-width: 800px;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 1200px) {*/
+/*  .modal-xl {*/
+/*    max-width: 1140px;*/
+/*  }*/
+/*}*/
 
 .tooltip {
   position: absolute;
@@ -5047,70 +6183,86 @@ a.close.disabled {
   line-break: auto;
   font-size: 0.875rem;
   word-wrap: break-word;
-  opacity: 0; }
+  opacity: 0;
+}
 
 .tooltip.show {
-  opacity: 0.9; }
+  opacity: 0.9;
+}
 
 .tooltip .arrow {
   position: absolute;
   display: block;
   width: 0.8rem;
-  height: 0.4rem; }
+  height: 0.4rem;
+}
 
 .tooltip .arrow::before {
   position: absolute;
   content: "";
   border-color: transparent;
-  border-style: solid; }
+  border-style: solid;
+}
 
 .bs-tooltip-top, .bs-tooltip-auto[x-placement^="top"] {
-  padding: 0.4rem 0; }
+  padding: 0.4rem 0;
+}
 
 .bs-tooltip-top .arrow, .bs-tooltip-auto[x-placement^="top"] .arrow {
-  bottom: 0; }
+  bottom: 0;
+}
 
 .bs-tooltip-top .arrow::before, .bs-tooltip-auto[x-placement^="top"] .arrow::before {
   top: 0;
   border-width: 0.4rem 0.4rem 0;
-  border-top-color: #000; }
+  border-top-color: #000;
+}
 
-.bs-tooltip-right, .bs-tooltip-auto[x-placement^="right"] {
-  padding: 0 0.4rem; }
+/*.bs-tooltip-right, .bs-tooltip-auto[x-placement^="right"] {*/
+/*  padding: 0 0.4rem;*/
+/*}*/
 
-.bs-tooltip-right .arrow, .bs-tooltip-auto[x-placement^="right"] .arrow {
-  left: 0;
-  width: 0.4rem;
-  height: 0.8rem; }
+/*.bs-tooltip-right .arrow, .bs-tooltip-auto[x-placement^="right"] .arrow {*/
+/*  left: 0;*/
+/*  width: 0.4rem;*/
+/*  height: 0.8rem;*/
+/*}*/
 
-.bs-tooltip-right .arrow::before, .bs-tooltip-auto[x-placement^="right"] .arrow::before {
-  right: 0;
-  border-width: 0.4rem 0.4rem 0.4rem 0;
-  border-right-color: #000; }
+/*.bs-tooltip-right .arrow::before, .bs-tooltip-auto[x-placement^="right"] .arrow::before {*/
+/*  right: 0;*/
+/*  border-width: 0.4rem 0.4rem 0.4rem 0;*/
+/*  border-right-color: #000;*/
+/*}*/
 
-.bs-tooltip-bottom, .bs-tooltip-auto[x-placement^="bottom"] {
-  padding: 0.4rem 0; }
+/*.bs-tooltip-bottom, .bs-tooltip-auto[x-placement^="bottom"] {*/
+/*  padding: 0.4rem 0;*/
+/*}*/
 
-.bs-tooltip-bottom .arrow, .bs-tooltip-auto[x-placement^="bottom"] .arrow {
-  top: 0; }
+/*.bs-tooltip-bottom .arrow, .bs-tooltip-auto[x-placement^="bottom"] .arrow {*/
+/*  top: 0;*/
+/*}*/
 
-.bs-tooltip-bottom .arrow::before, .bs-tooltip-auto[x-placement^="bottom"] .arrow::before {
-  bottom: 0;
-  border-width: 0 0.4rem 0.4rem;
-  border-bottom-color: #000; }
+/*.bs-tooltip-bottom .arrow::before, .bs-tooltip-auto[x-placement^="bottom"] .arrow::before {*/
+/*  bottom: 0;*/
+/*  border-width: 0 0.4rem 0.4rem;*/
+/*  border-bottom-color: #000;*/
+/*}*/
 
-.bs-tooltip-left, .bs-tooltip-auto[x-placement^="left"] {
-  padding: 0 0.4rem; }
+/*.bs-tooltip-left, .bs-tooltip-auto[x-placement^="left"] {*/
+/*  padding: 0 0.4rem;*/
+/*}*/
 
-.bs-tooltip-left .arrow, .bs-tooltip-auto[x-placement^="left"] .arrow {
-  right: 0;
-  width: 0.4rem;
-  height: 0.8rem; }
+/*.bs-tooltip-left .arrow, .bs-tooltip-auto[x-placement^="left"] .arrow {*/
+/*  right: 0;*/
+/*  width: 0.4rem;*/
+/*  height: 0.8rem;*/
+/*}*/
 
-.bs-tooltip-left .arrow::before, .bs-tooltip-auto[x-placement^="left"] .arrow::before {
-  left: 0;
-  border-width: 0.4rem 0 0.4rem 0.4rem;
-  border-left-color: #000; }
+/*.bs-tooltip-left .arrow::before, .bs-tooltip-auto[x-placement^="left"] .arrow::before {*/
+/*  left: 0;*/
+/*  border-width: 0.4rem 0 0.4rem 0.4rem;*/
+/*  border-left-color: #000;*/
+/*}*/
 
 .tooltip-inner {
   max-width: 200px;
@@ -5118,7 +6270,8 @@ a.close.disabled {
   color: #fff;
   text-align: center;
   background-color: #000;
-  border-radius: 0.25rem; }
+  border-radius: 0.25rem;
+}
 
 .popover {
   position: absolute;
@@ -5145,1365 +6298,1907 @@ a.close.disabled {
   background-color: #fff;
   background-clip: padding-box;
   border: 1px solid rgba(0, 0, 0, 0.2);
-  border-radius: 0.3rem; }
+  border-radius: 0.3rem;
+}
 
 .popover .arrow {
   position: absolute;
   display: block;
   width: 1rem;
   height: 0.5rem;
-  margin: 0 0.3rem; }
+  margin: 0 0.3rem;
+}
 
 .popover .arrow::before, .popover .arrow::after {
   position: absolute;
   display: block;
   content: "";
   border-color: transparent;
-  border-style: solid; }
+  border-style: solid;
+}
 
-.bs-popover-top, .bs-popover-auto[x-placement^="top"] {
-  margin-bottom: 0.5rem; }
+/*.bs-popover-top, .bs-popover-auto[x-placement^="top"] {*/
+/*  margin-bottom: 0.5rem;*/
+/*}*/
 
-.bs-popover-top > .arrow, .bs-popover-auto[x-placement^="top"] > .arrow {
-  bottom: calc(-0.5rem - 1px); }
+/*.bs-popover-top > .arrow, .bs-popover-auto[x-placement^="top"] > .arrow {*/
+/*  bottom: calc(-0.5rem - 1px);*/
+/*}*/
 
-.bs-popover-top > .arrow::before, .bs-popover-auto[x-placement^="top"] > .arrow::before {
-  bottom: 0;
-  border-width: 0.5rem 0.5rem 0;
-  border-top-color: rgba(0, 0, 0, 0.25); }
+/*.bs-popover-top > .arrow::before, .bs-popover-auto[x-placement^="top"] > .arrow::before {*/
+/*  bottom: 0;*/
+/*  border-width: 0.5rem 0.5rem 0;*/
+/*  border-top-color: rgba(0, 0, 0, 0.25);*/
+/*}*/
 
-.bs-popover-top > .arrow::after, .bs-popover-auto[x-placement^="top"] > .arrow::after {
-  bottom: 1px;
-  border-width: 0.5rem 0.5rem 0;
-  border-top-color: #fff; }
+/*.bs-popover-top > .arrow::after, .bs-popover-auto[x-placement^="top"] > .arrow::after {*/
+/*  bottom: 1px;*/
+/*  border-width: 0.5rem 0.5rem 0;*/
+/*  border-top-color: #fff;*/
+/*}*/
 
 .bs-popover-right, .bs-popover-auto[x-placement^="right"] {
-  margin-left: 0.5rem; }
+  margin-left: 0.5rem;
+}
 
 .bs-popover-right > .arrow, .bs-popover-auto[x-placement^="right"] > .arrow {
   left: calc(-0.5rem - 1px);
   width: 0.5rem;
   height: 1rem;
-  margin: 0.3rem 0; }
+  margin: 0.3rem 0;
+}
 
 .bs-popover-right > .arrow::before, .bs-popover-auto[x-placement^="right"] > .arrow::before {
   left: 0;
   border-width: 0.5rem 0.5rem 0.5rem 0;
-  border-right-color: rgba(0, 0, 0, 0.25); }
+  border-right-color: rgba(0, 0, 0, 0.25);
+}
 
 .bs-popover-right > .arrow::after, .bs-popover-auto[x-placement^="right"] > .arrow::after {
   left: 1px;
   border-width: 0.5rem 0.5rem 0.5rem 0;
-  border-right-color: #fff; }
+  border-right-color: #fff;
+}
 
 .bs-popover-bottom, .bs-popover-auto[x-placement^="bottom"] {
-  margin-top: 0.5rem; }
+  margin-top: 0.5rem;
+}
 
 .bs-popover-bottom > .arrow, .bs-popover-auto[x-placement^="bottom"] > .arrow {
-  top: calc(-0.5rem - 1px); }
+  top: calc(-0.5rem - 1px);
+}
 
 .bs-popover-bottom > .arrow::before, .bs-popover-auto[x-placement^="bottom"] > .arrow::before {
   top: 0;
   border-width: 0 0.5rem 0.5rem 0.5rem;
-  border-bottom-color: rgba(0, 0, 0, 0.25); }
+  border-bottom-color: rgba(0, 0, 0, 0.25);
+}
 
 .bs-popover-bottom > .arrow::after, .bs-popover-auto[x-placement^="bottom"] > .arrow::after {
   top: 1px;
   border-width: 0 0.5rem 0.5rem 0.5rem;
-  border-bottom-color: #fff; }
-
-.bs-popover-bottom .popover-header::before, .bs-popover-auto[x-placement^="bottom"] .popover-header::before {
-  position: absolute;
-  top: 0;
-  left: 50%;
-  display: block;
-  width: 1rem;
-  margin-left: -0.5rem;
-  content: "";
-  border-bottom: 1px solid #f7f7f7; }
-
-.bs-popover-left, .bs-popover-auto[x-placement^="left"] {
-  margin-right: 0.5rem; }
-
-.bs-popover-left > .arrow, .bs-popover-auto[x-placement^="left"] > .arrow {
-  right: calc(-0.5rem - 1px);
-  width: 0.5rem;
-  height: 1rem;
-  margin: 0.3rem 0; }
-
-.bs-popover-left > .arrow::before, .bs-popover-auto[x-placement^="left"] > .arrow::before {
-  right: 0;
-  border-width: 0.5rem 0 0.5rem 0.5rem;
-  border-left-color: rgba(0, 0, 0, 0.25); }
-
-.bs-popover-left > .arrow::after, .bs-popover-auto[x-placement^="left"] > .arrow::after {
-  right: 1px;
-  border-width: 0.5rem 0 0.5rem 0.5rem;
-  border-left-color: #fff; }
-
-.popover-header {
-  padding: 0.5rem 0.75rem;
-  margin-bottom: 0;
-  font-size: 1rem;
-  background-color: #f7f7f7;
-  border-bottom: 1px solid #ebebeb;
-  border-top-left-radius: calc(0.3rem - 1px);
-  border-top-right-radius: calc(0.3rem - 1px); }
-
-.popover-header:empty {
-  display: none; }
-
-.popover-body {
-  padding: 0.5rem 0.75rem;
-  color: #212529; }
-
-.carousel {
-  position: relative; }
-
-.carousel.pointer-event {
-  -ms-touch-action: pan-y;
-  touch-action: pan-y; }
-
-.carousel-inner {
-  position: relative;
-  width: 100%;
-  overflow: hidden; }
-
-.carousel-inner::after {
-  display: block;
-  clear: both;
-  content: ""; }
-
-.carousel-item {
-  position: relative;
-  display: none;
-  float: left;
-  width: 100%;
-  margin-right: -100%;
-  -webkit-backface-visibility: hidden;
-  backface-visibility: hidden;
-  transition: -webkit-transform 0.6s ease-in-out;
-  transition: transform 0.6s ease-in-out;
-  transition: transform 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out; }
-
-@media (prefers-reduced-motion: reduce) {
-  .carousel-item {
-    transition: none; } }
-
-.carousel-item.active,
-.carousel-item-next,
-.carousel-item-prev {
-  display: block; }
-
-.carousel-item-next:not(.carousel-item-left),
-.active.carousel-item-right {
-  -webkit-transform: translateX(100%);
-  transform: translateX(100%); }
-
-.carousel-item-prev:not(.carousel-item-right),
-.active.carousel-item-left {
-  -webkit-transform: translateX(-100%);
-  transform: translateX(-100%); }
-
-.carousel-fade .carousel-item {
-  opacity: 0;
-  transition-property: opacity;
-  -webkit-transform: none;
-  transform: none; }
-
-.carousel-fade .carousel-item.active,
-.carousel-fade .carousel-item-next.carousel-item-left,
-.carousel-fade .carousel-item-prev.carousel-item-right {
-  z-index: 1;
-  opacity: 1; }
-
-.carousel-fade .active.carousel-item-left,
-.carousel-fade .active.carousel-item-right {
-  z-index: 0;
-  opacity: 0;
-  transition: opacity 0s 0.6s; }
-
-@media (prefers-reduced-motion: reduce) {
-  .carousel-fade .active.carousel-item-left,
-  .carousel-fade .active.carousel-item-right {
-    transition: none; } }
-
-.carousel-control-prev,
-.carousel-control-next {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  z-index: 1;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: center;
-  align-items: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-  width: 15%;
-  color: #fff;
-  text-align: center;
-  opacity: 0.5;
-  transition: opacity 0.15s ease; }
-
-@media (prefers-reduced-motion: reduce) {
-  .carousel-control-prev,
-  .carousel-control-next {
-    transition: none; } }
-
-.carousel-control-prev:hover, .carousel-control-prev:focus,
-.carousel-control-next:hover,
-.carousel-control-next:focus {
-  color: #fff;
-  text-decoration: none;
-  outline: 0;
-  opacity: 0.9; }
-
-.carousel-control-prev {
-  left: 0; }
-
-.carousel-control-next {
-  right: 0; }
-
-.carousel-control-prev-icon,
-.carousel-control-next-icon {
-  display: inline-block;
-  width: 20px;
-  height: 20px;
-  background: 50% / 100% 100% no-repeat; }
-
-.carousel-control-prev-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5L4.25 4l2.5-2.5L5.25 0z'/%3e%3c/svg%3e"); }
-
-.carousel-control-next-icon {
-  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5L3.75 4l-2.5 2.5L2.75 8l4-4-4-4z'/%3e%3c/svg%3e"); }
-
-.carousel-indicators {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 15;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-pack: center;
-  justify-content: center;
-  padding-left: 0;
-  margin-right: 15%;
-  margin-left: 15%;
-  list-style: none; }
-
-.carousel-indicators li {
-  box-sizing: content-box;
-  -ms-flex: 0 1 auto;
-  flex: 0 1 auto;
-  width: 30px;
-  height: 3px;
-  margin-right: 3px;
-  margin-left: 3px;
-  text-indent: -999px;
-  cursor: pointer;
-  background-color: #fff;
-  background-clip: padding-box;
-  border-top: 10px solid transparent;
-  border-bottom: 10px solid transparent;
-  opacity: .5;
-  transition: opacity 0.6s ease; }
-
-@media (prefers-reduced-motion: reduce) {
-  .carousel-indicators li {
-    transition: none; } }
-
-.carousel-indicators .active {
-  opacity: 1; }
-
-.carousel-caption {
-  position: absolute;
-  right: 15%;
-  bottom: 20px;
-  left: 15%;
-  z-index: 10;
-  padding-top: 20px;
-  padding-bottom: 20px;
-  color: #fff;
-  text-align: center; }
-
-@-webkit-keyframes spinner-border {
-  to {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg); } }
-
-@keyframes spinner-border {
-  to {
-    -webkit-transform: rotate(360deg);
-    transform: rotate(360deg); } }
-
-.spinner-border {
-  display: inline-block;
-  width: 2rem;
-  height: 2rem;
-  vertical-align: text-bottom;
-  border: 0.25em solid currentColor;
-  border-right-color: transparent;
-  border-radius: 50%;
-  -webkit-animation: .75s linear infinite spinner-border;
-  animation: .75s linear infinite spinner-border; }
-
-.spinner-border-sm {
-  width: 1rem;
-  height: 1rem;
-  border-width: 0.2em; }
-
-@-webkit-keyframes spinner-grow {
-  0% {
-    -webkit-transform: scale(0);
-    transform: scale(0); }
-  50% {
-    opacity: 1;
-    -webkit-transform: none;
-    transform: none; } }
-
-@keyframes spinner-grow {
-  0% {
-    -webkit-transform: scale(0);
-    transform: scale(0); }
-  50% {
-    opacity: 1;
-    -webkit-transform: none;
-    transform: none; } }
-
-.spinner-grow {
-  display: inline-block;
-  width: 2rem;
-  height: 2rem;
-  vertical-align: text-bottom;
-  background-color: currentColor;
-  border-radius: 50%;
-  opacity: 0;
-  -webkit-animation: .75s linear infinite spinner-grow;
-  animation: .75s linear infinite spinner-grow; }
-
-.spinner-grow-sm {
-  width: 1rem;
-  height: 1rem; }
-
-@media (prefers-reduced-motion: reduce) {
-  .spinner-border,
-  .spinner-grow {
-    -webkit-animation-duration: 1.5s;
-    animation-duration: 1.5s; } }
-
-.align-baseline {
-  vertical-align: baseline !important; }
-
-.align-top {
-  vertical-align: top !important; }
-
-.align-middle {
-  vertical-align: middle !important; }
-
-.align-bottom {
-  vertical-align: bottom !important; }
-
-.align-text-bottom {
-  vertical-align: text-bottom !important; }
-
-.align-text-top {
-  vertical-align: text-top !important; }
-
-.bg-primary {
-  background-color: #007bff !important; }
-
-a.bg-primary:hover, a.bg-primary:focus,
-button.bg-primary:hover,
-button.bg-primary:focus {
-  background-color: #0062cc !important; }
-
-.bg-secondary {
-  background-color: #6c757d !important; }
-
-a.bg-secondary:hover, a.bg-secondary:focus,
-button.bg-secondary:hover,
-button.bg-secondary:focus {
-  background-color: #545b62 !important; }
-
-.bg-success {
-  background-color: #28a745 !important; }
-
-a.bg-success:hover, a.bg-success:focus,
-button.bg-success:hover,
-button.bg-success:focus {
-  background-color: #1e7e34 !important; }
-
-.bg-info {
-  background-color: #17a2b8 !important; }
-
-a.bg-info:hover, a.bg-info:focus,
-button.bg-info:hover,
-button.bg-info:focus {
-  background-color: #117a8b !important; }
-
-.bg-warning {
-  background-color: #ffc107 !important; }
-
-a.bg-warning:hover, a.bg-warning:focus,
-button.bg-warning:hover,
-button.bg-warning:focus {
-  background-color: #d39e00 !important; }
-
-.bg-danger {
-  background-color: #dc3545 !important; }
-
-a.bg-danger:hover, a.bg-danger:focus,
-button.bg-danger:hover,
-button.bg-danger:focus {
-  background-color: #bd2130 !important; }
-
-.bg-light {
-  background-color: #f8f9fa !important; }
-
-a.bg-light:hover, a.bg-light:focus,
-button.bg-light:hover,
-button.bg-light:focus {
-  background-color: #dae0e5 !important; }
-
-.bg-dark {
-  background-color: #343a40 !important; }
-
-a.bg-dark:hover, a.bg-dark:focus,
-button.bg-dark:hover,
-button.bg-dark:focus {
-  background-color: #1d2124 !important; }
-
-.bg-white {
-  background-color: #fff !important; }
-
-.bg-transparent {
-  background-color: transparent !important; }
-
-.border {
-  border: 1px solid #dee2e6 !important; }
-
-.border-top {
-  border-top: 1px solid #dee2e6 !important; }
-
-.border-right {
-  border-right: 1px solid #dee2e6 !important; }
-
-.border-bottom {
-  border-bottom: 1px solid #dee2e6 !important; }
-
-.border-left {
-  border-left: 1px solid #dee2e6 !important; }
-
-.border-0 {
-  border: 0 !important; }
-
-.border-top-0 {
-  border-top: 0 !important; }
-
-.border-right-0 {
-  border-right: 0 !important; }
-
-.border-bottom-0 {
-  border-bottom: 0 !important; }
-
-.border-left-0 {
-  border-left: 0 !important; }
-
-.border-primary {
-  border-color: #007bff !important; }
-
-.border-secondary {
-  border-color: #6c757d !important; }
-
-.border-success {
-  border-color: #28a745 !important; }
-
-.border-info {
-  border-color: #17a2b8 !important; }
-
-.border-warning {
-  border-color: #ffc107 !important; }
-
-.border-danger {
-  border-color: #dc3545 !important; }
-
-.border-light {
-  border-color: #f8f9fa !important; }
-
-.border-dark {
-  border-color: #343a40 !important; }
-
-.border-white {
-  border-color: #fff !important; }
-
-.rounded-sm {
-  border-radius: 0.2rem !important; }
-
-.rounded {
-  border-radius: 0.25rem !important; }
-
-.rounded-top {
-  border-top-left-radius: 0.25rem !important;
-  border-top-right-radius: 0.25rem !important; }
-
-.rounded-right {
-  border-top-right-radius: 0.25rem !important;
-  border-bottom-right-radius: 0.25rem !important; }
-
-.rounded-bottom {
-  border-bottom-right-radius: 0.25rem !important;
-  border-bottom-left-radius: 0.25rem !important; }
-
-.rounded-left {
-  border-top-left-radius: 0.25rem !important;
-  border-bottom-left-radius: 0.25rem !important; }
-
-.rounded-lg {
-  border-radius: 0.3rem !important; }
-
-.rounded-circle {
-  border-radius: 50% !important; }
-
-.rounded-pill {
-  border-radius: 50rem !important; }
-
-.rounded-0 {
-  border-radius: 0 !important; }
-
-.clearfix::after {
-  display: block;
-  clear: both;
-  content: ""; }
-
-.d-none {
-  display: none !important; }
-
-.d-inline {
-  display: inline !important; }
-
-.d-inline-block {
-  display: inline-block !important; }
+  border-bottom-color: #fff;
+}
+
+/*.bs-popover-bottom .popover-header::before, .bs-popover-auto[x-placement^="bottom"] .popover-header::before {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  left: 50%;*/
+/*  display: block;*/
+/*  width: 1rem;*/
+/*  margin-left: -0.5rem;*/
+/*  content: "";*/
+/*  border-bottom: 1px solid #f7f7f7;*/
+/*}*/
+
+/*.bs-popover-left, .bs-popover-auto[x-placement^="left"] {*/
+/*  margin-right: 0.5rem;*/
+/*}*/
+
+/*.bs-popover-left > .arrow, .bs-popover-auto[x-placement^="left"] > .arrow {*/
+/*  right: calc(-0.5rem - 1px);*/
+/*  width: 0.5rem;*/
+/*  height: 1rem;*/
+/*  margin: 0.3rem 0;*/
+/*}*/
+
+/*.bs-popover-left > .arrow::before, .bs-popover-auto[x-placement^="left"] > .arrow::before {*/
+/*  right: 0;*/
+/*  border-width: 0.5rem 0 0.5rem 0.5rem;*/
+/*  border-left-color: rgba(0, 0, 0, 0.25);*/
+/*}*/
+
+/*.bs-popover-left > .arrow::after, .bs-popover-auto[x-placement^="left"] > .arrow::after {*/
+/*  right: 1px;*/
+/*  border-width: 0.5rem 0 0.5rem 0.5rem;*/
+/*  border-left-color: #fff;*/
+/*}*/
+
+/*.popover-header {*/
+/*  padding: 0.5rem 0.75rem;*/
+/*  margin-bottom: 0;*/
+/*  font-size: 1rem;*/
+/*  background-color: #f7f7f7;*/
+/*  border-bottom: 1px solid #ebebeb;*/
+/*  border-top-left-radius: calc(0.3rem - 1px);*/
+/*  border-top-right-radius: calc(0.3rem - 1px);*/
+/*}*/
+
+/*.popover-header:empty {*/
+/*  display: none;*/
+/*}*/
+
+/*.popover-body {*/
+/*  padding: 0.5rem 0.75rem;*/
+/*  color: #212529;*/
+/*}*/
+
+/*.carousel {*/
+/*  position: relative;*/
+/*}*/
+
+/*.carousel.pointer-event {*/
+/*  -ms-touch-action: pan-y;*/
+/*  touch-action: pan-y;*/
+/*}*/
+
+/*.carousel-inner {*/
+/*  position: relative;*/
+/*  width: 100%;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.carousel-inner::after {*/
+/*  display: block;*/
+/*  clear: both;*/
+/*  content: "";*/
+/*}*/
+
+/*.carousel-item {*/
+/*  position: relative;*/
+/*  display: none;*/
+/*  float: left;*/
+/*  width: 100%;*/
+/*  margin-right: -100%;*/
+/*  -webkit-backface-visibility: hidden;*/
+/*  backface-visibility: hidden;*/
+/*  transition: -webkit-transform 0.6s ease-in-out;*/
+/*  transition: transform 0.6s ease-in-out;*/
+/*  transition: transform 0.6s ease-in-out, -webkit-transform 0.6s ease-in-out;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .carousel-item {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.carousel-item.active, .carousel-item-next, .carousel-item-prev {*/
+/*  display: block;*/
+/*}*/
+
+/*.carousel-item-next:not(.carousel-item-left), .active.carousel-item-right {*/
+/*  -webkit-transform: translateX(100%);*/
+/*  transform: translateX(100%);*/
+/*}*/
+
+/*.carousel-item-prev:not(.carousel-item-right), .active.carousel-item-left {*/
+/*  -webkit-transform: translateX(-100%);*/
+/*  transform: translateX(-100%);*/
+/*}*/
+
+/*.carousel-fade .carousel-item {*/
+/*  opacity: 0;*/
+/*  transition-property: opacity;*/
+/*  -webkit-transform: none;*/
+/*  transform: none;*/
+/*}*/
+
+/*.carousel-fade .carousel-item.active, .carousel-fade .carousel-item-next.carousel-item-left, .carousel-fade .carousel-item-prev.carousel-item-right {*/
+/*  z-index: 1;*/
+/*  opacity: 1;*/
+/*}*/
+
+/*.carousel-fade .active.carousel-item-left, .carousel-fade .active.carousel-item-right {*/
+/*  z-index: 0;*/
+/*  opacity: 0;*/
+/*  transition: opacity 0s 0.6s;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .carousel-fade .active.carousel-item-left, .carousel-fade .active.carousel-item-right {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.carousel-control-prev, .carousel-control-next {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  bottom: 0;*/
+/*  z-index: 1;*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-align: center;*/
+/*  align-items: center;*/
+/*  -ms-flex-pack: center;*/
+/*  justify-content: center;*/
+/*  width: 15%;*/
+/*  color: #fff;*/
+/*  text-align: center;*/
+/*  opacity: 0.5;*/
+/*  transition: opacity 0.15s ease;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .carousel-control-prev, .carousel-control-next {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.carousel-control-prev:hover, .carousel-control-prev:focus, .carousel-control-next:hover, .carousel-control-next:focus {*/
+/*  color: #fff;*/
+/*  text-decoration: none;*/
+/*  outline: 0;*/
+/*  opacity: 0.9;*/
+/*}*/
+
+/*.carousel-control-prev {*/
+/*  left: 0;*/
+/*}*/
+
+/*.carousel-control-next {*/
+/*  right: 0;*/
+/*}*/
+
+/*.carousel-control-prev-icon, .carousel-control-next-icon {*/
+/*  display: inline-block;*/
+/*  width: 20px;*/
+/*  height: 20px;*/
+/*  background: 50% / 100% 100% no-repeat;*/
+/*}*/
+
+/*.carousel-control-prev-icon {*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath d='M5.25 0l-4 4 4 4 1.5-1.5L4.25 4l2.5-2.5L5.25 0z'/%3e%3c/svg%3e");*/
+/*}*/
+
+/*.carousel-control-next-icon {*/
+/*  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='%23fff' width='8' height='8' viewBox='0 0 8 8'%3e%3cpath d='M2.75 0l-1.5 1.5L3.75 4l-2.5 2.5L2.75 8l4-4-4-4z'/%3e%3c/svg%3e");*/
+/*}*/
+
+/*.carousel-indicators {*/
+/*  position: absolute;*/
+/*  right: 0;*/
+/*  bottom: 0;*/
+/*  left: 0;*/
+/*  z-index: 15;*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-pack: center;*/
+/*  justify-content: center;*/
+/*  padding-left: 0;*/
+/*  margin-right: 15%;*/
+/*  margin-left: 15%;*/
+/*  list-style: none;*/
+/*}*/
+
+/*.carousel-indicators li {*/
+/*  box-sizing: content-box;*/
+/*  -ms-flex: 0 1 auto;*/
+/*  flex: 0 1 auto;*/
+/*  width: 30px;*/
+/*  height: 3px;*/
+/*  margin-right: 3px;*/
+/*  margin-left: 3px;*/
+/*  text-indent: -999px;*/
+/*  cursor: pointer;*/
+/*  background-color: #fff;*/
+/*  background-clip: padding-box;*/
+/*  border-top: 10px solid transparent;*/
+/*  border-bottom: 10px solid transparent;*/
+/*  opacity: .5;*/
+/*  transition: opacity 0.6s ease;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .carousel-indicators li {*/
+/*    transition: none;*/
+/*  }*/
+/*}*/
+
+/*.carousel-indicators .active {*/
+/*  opacity: 1;*/
+/*}*/
+
+/*.carousel-caption {*/
+/*  position: absolute;*/
+/*  right: 15%;*/
+/*  bottom: 20px;*/
+/*  left: 15%;*/
+/*  z-index: 10;*/
+/*  padding-top: 20px;*/
+/*  padding-bottom: 20px;*/
+/*  color: #fff;*/
+/*  text-align: center;*/
+/*}*/
+
+/*@-webkit-keyframes spinner-border {*/
+/*  to {*/
+/*    -webkit-transform: rotate(360deg);*/
+/*    transform: rotate(360deg);*/
+/*  }*/
+/*}*/
+
+/*@keyframes spinner-border {*/
+/*  to {*/
+/*    -webkit-transform: rotate(360deg);*/
+/*    transform: rotate(360deg);*/
+/*  }*/
+/*}*/
+
+/*.spinner-border {*/
+/*  display: inline-block;*/
+/*  width: 2rem;*/
+/*  height: 2rem;*/
+/*  vertical-align: text-bottom;*/
+/*  border: 0.25em solid currentColor;*/
+/*  border-right-color: transparent;*/
+/*  border-radius: 50%;*/
+/*  -webkit-animation: .75s linear infinite spinner-border;*/
+/*  animation: .75s linear infinite spinner-border;*/
+/*}*/
+
+/*.spinner-border-sm {*/
+/*  width: 1rem;*/
+/*  height: 1rem;*/
+/*  border-width: 0.2em;*/
+/*}*/
+
+/*@-webkit-keyframes spinner-grow {*/
+/*  0% {*/
+/*    -webkit-transform: scale(0);*/
+/*    transform: scale(0);*/
+/*  }*/
+
+/*  50% {*/
+/*    opacity: 1;*/
+/*    -webkit-transform: none;*/
+/*    transform: none;*/
+/*  }*/
+/*}*/
+
+/*@keyframes spinner-grow {*/
+/*  0% {*/
+/*    -webkit-transform: scale(0);*/
+/*    transform: scale(0);*/
+/*  }*/
+
+/*  50% {*/
+/*    opacity: 1;*/
+/*    -webkit-transform: none;*/
+/*    transform: none;*/
+/*  }*/
+/*}*/
+
+/*.spinner-grow {*/
+/*  display: inline-block;*/
+/*  width: 2rem;*/
+/*  height: 2rem;*/
+/*  vertical-align: text-bottom;*/
+/*  background-color: currentColor;*/
+/*  border-radius: 50%;*/
+/*  opacity: 0;*/
+/*  -webkit-animation: .75s linear infinite spinner-grow;*/
+/*  animation: .75s linear infinite spinner-grow;*/
+/*}*/
+
+/*.spinner-grow-sm {*/
+/*  width: 1rem;*/
+/*  height: 1rem;*/
+/*}*/
+
+/*@media (prefers-reduced-motion: reduce) {*/
+/*  .spinner-border, .spinner-grow {*/
+/*    -webkit-animation-duration: 1.5s;*/
+/*    animation-duration: 1.5s;*/
+/*  }*/
+/*}*/
+
+/*.align-baseline {*/
+/*  vertical-align: baseline !important;*/
+/*}*/
+
+/*.align-top {*/
+/*  vertical-align: top !important;*/
+/*}*/
+
+/*.align-middle {*/
+/*  vertical-align: middle !important;*/
+/*}*/
+
+/*.align-bottom {*/
+/*  vertical-align: bottom !important;*/
+/*}*/
+
+/*.align-text-bottom {*/
+/*  vertical-align: text-bottom !important;*/
+/*}*/
+
+/*.align-text-top {*/
+/*  vertical-align: text-top !important;*/
+/*}*/
+
+/*.bg-primary {*/
+/*  background-color: #007bff !important;*/
+/*}*/
+
+/*a.bg-primary:hover, a.bg-primary:focus, button.bg-primary:hover, button.bg-primary:focus {*/
+/*  background-color: #0062cc !important;*/
+/*}*/
+
+/*.bg-secondary {*/
+/*  background-color: #6c757d !important;*/
+/*}*/
+
+/*a.bg-secondary:hover, a.bg-secondary:focus, button.bg-secondary:hover, button.bg-secondary:focus {*/
+/*  background-color: #545b62 !important;*/
+/*}*/
+
+/*.bg-success {*/
+/*  background-color: #28a745 !important;*/
+/*}*/
+
+/*a.bg-success:hover, a.bg-success:focus, button.bg-success:hover, button.bg-success:focus {*/
+/*  background-color: #1e7e34 !important;*/
+/*}*/
+
+/*.bg-info {*/
+/*  background-color: #17a2b8 !important;*/
+/*}*/
+
+/*a.bg-info:hover, a.bg-info:focus, button.bg-info:hover, button.bg-info:focus {*/
+/*  background-color: #117a8b !important;*/
+/*}*/
+
+/*.bg-warning {*/
+/*  background-color: #ffc107 !important;*/
+/*}*/
+
+/*a.bg-warning:hover, a.bg-warning:focus, button.bg-warning:hover, button.bg-warning:focus {*/
+/*  background-color: #d39e00 !important;*/
+/*}*/
+
+/*.bg-danger {*/
+/*  background-color: #dc3545 !important;*/
+/*}*/
+
+/*a.bg-danger:hover, a.bg-danger:focus, button.bg-danger:hover, button.bg-danger:focus {*/
+/*  background-color: #bd2130 !important;*/
+/*}*/
+
+/*.bg-light {*/
+/*  background-color: #f8f9fa !important;*/
+/*}*/
+
+/*a.bg-light:hover, a.bg-light:focus, button.bg-light:hover, button.bg-light:focus {*/
+/*  background-color: #dae0e5 !important;*/
+/*}*/
+
+/*.bg-dark {*/
+/*  background-color: #343a40 !important;*/
+/*}*/
+
+/*a.bg-dark:hover, a.bg-dark:focus, button.bg-dark:hover, button.bg-dark:focus {*/
+/*  background-color: #1d2124 !important;*/
+/*}*/
+
+/*.bg-white {*/
+/*  background-color: #fff !important;*/
+/*}*/
+
+/*.bg-transparent {*/
+/*  background-color: transparent !important;*/
+/*}*/
+
+/*.border {*/
+/*  border: 1px solid #dee2e6 !important;*/
+/*}*/
+
+/*.border-top {*/
+/*  border-top: 1px solid #dee2e6 !important;*/
+/*}*/
+
+/*.border-right {*/
+/*  border-right: 1px solid #dee2e6 !important;*/
+/*}*/
+
+/*.border-bottom {*/
+/*  border-bottom: 1px solid #dee2e6 !important;*/
+/*}*/
+
+/*.border-left {*/
+/*  border-left: 1px solid #dee2e6 !important;*/
+/*}*/
+
+/*.border-0 {*/
+/*  border: 0 !important;*/
+/*}*/
+
+/*.border-top-0 {*/
+/*  border-top: 0 !important;*/
+/*}*/
+
+/*.border-right-0 {*/
+/*  border-right: 0 !important;*/
+/*}*/
+
+/*.border-bottom-0 {*/
+/*  border-bottom: 0 !important;*/
+/*}*/
+
+/*.border-left-0 {*/
+/*  border-left: 0 !important;*/
+/*}*/
+
+/*.border-primary {*/
+/*  border-color: #007bff !important;*/
+/*}*/
+
+/*.border-secondary {*/
+/*  border-color: #6c757d !important;*/
+/*}*/
+
+/*.border-success {*/
+/*  border-color: #28a745 !important;*/
+/*}*/
+
+/*.border-info {*/
+/*  border-color: #17a2b8 !important;*/
+/*}*/
+
+/*.border-warning {*/
+/*  border-color: #ffc107 !important;*/
+/*}*/
+
+/*.border-danger {*/
+/*  border-color: #dc3545 !important;*/
+/*}*/
+
+/*.border-light {*/
+/*  border-color: #f8f9fa !important;*/
+/*}*/
+
+/*.border-dark {*/
+/*  border-color: #343a40 !important;*/
+/*}*/
+
+/*.border-white {*/
+/*  border-color: #fff !important;*/
+/*}*/
+
+/*.rounded-sm {*/
+/*  border-radius: 0.2rem !important;*/
+/*}*/
+
+/*.rounded {*/
+/*  border-radius: 0.25rem !important;*/
+/*}*/
+
+/*.rounded-top {*/
+/*  border-top-left-radius: 0.25rem !important;*/
+/*  border-top-right-radius: 0.25rem !important;*/
+/*}*/
+
+/*.rounded-right {*/
+/*  border-top-right-radius: 0.25rem !important;*/
+/*  border-bottom-right-radius: 0.25rem !important;*/
+/*}*/
+
+/*.rounded-bottom {*/
+/*  border-bottom-right-radius: 0.25rem !important;*/
+/*  border-bottom-left-radius: 0.25rem !important;*/
+/*}*/
+
+/*.rounded-left {*/
+/*  border-top-left-radius: 0.25rem !important;*/
+/*  border-bottom-left-radius: 0.25rem !important;*/
+/*}*/
+
+/*.rounded-lg {*/
+/*  border-radius: 0.3rem !important;*/
+/*}*/
+
+/*.rounded-circle {*/
+/*  border-radius: 50% !important;*/
+/*}*/
+
+/*.rounded-pill {*/
+/*  border-radius: 50rem !important;*/
+/*}*/
+
+/*.rounded-0 {*/
+/*  border-radius: 0 !important;*/
+/*}*/
+
+/*.clearfix::after {*/
+/*  display: block;*/
+/*  clear: both;*/
+/*  content: "";*/
+/*}*/
+
+/*.d-none {*/
+/*  display: none !important;*/
+/*}*/
+
+/*.d-inline {*/
+/*  display: inline !important;*/
+/*}*/
+
+/*.d-inline-block {*/
+/*  display: inline-block !important;*/
+/*}*/
 
 .d-block {
-  display: block !important; }
+  display: block !important;
+}
 
-.d-table {
-  display: table !important; }
+/*.d-table {*/
+/*  display: table !important;*/
+/*}*/
 
-.d-table-row {
-  display: table-row !important; }
+/*.d-table-row {*/
+/*  display: table-row !important;*/
+/*}*/
 
-.d-table-cell {
-  display: table-cell !important; }
+/*.d-table-cell {*/
+/*  display: table-cell !important;*/
+/*}*/
 
-.d-flex {
-  display: -ms-flexbox !important;
-  display: flex !important; }
+/*.d-flex {*/
+/*  display: -ms-flexbox !important;*/
+/*  display: flex !important;*/
+/*}*/
 
-.d-inline-flex {
-  display: -ms-inline-flexbox !important;
-  display: inline-flex !important; }
+/*.d-inline-flex {*/
+/*  display: -ms-inline-flexbox !important;*/
+/*  display: inline-flex !important;*/
+/*}*/
 
 @media (min-width: 576px) {
   .d-sm-none {
-    display: none !important; }
+    display: none !important;
+  }
+
   .d-sm-inline {
-    display: inline !important; }
+    display: inline !important;
+  }
+
   .d-sm-inline-block {
-    display: inline-block !important; }
+    display: inline-block !important;
+  }
+
   .d-sm-block {
-    display: block !important; }
-  .d-sm-table {
-    display: table !important; }
-  .d-sm-table-row {
-    display: table-row !important; }
-  .d-sm-table-cell {
-    display: table-cell !important; }
-  .d-sm-flex {
-    display: -ms-flexbox !important;
-    display: flex !important; }
-  .d-sm-inline-flex {
-    display: -ms-inline-flexbox !important;
-    display: inline-flex !important; } }
-
-@media (min-width: 768px) {
-  .d-md-none {
-    display: none !important; }
-  .d-md-inline {
-    display: inline !important; }
-  .d-md-inline-block {
-    display: inline-block !important; }
-  .d-md-block {
-    display: block !important; }
-  .d-md-table {
-    display: table !important; }
-  .d-md-table-row {
-    display: table-row !important; }
-  .d-md-table-cell {
-    display: table-cell !important; }
-  .d-md-flex {
-    display: -ms-flexbox !important;
-    display: flex !important; }
-  .d-md-inline-flex {
-    display: -ms-inline-flexbox !important;
-    display: inline-flex !important; } }
-
-@media (min-width: 992px) {
-  .d-lg-none {
-    display: none !important; }
-  .d-lg-inline {
-    display: inline !important; }
-  .d-lg-inline-block {
-    display: inline-block !important; }
-  .d-lg-block {
-    display: block !important; }
-  .d-lg-table {
-    display: table !important; }
-  .d-lg-table-row {
-    display: table-row !important; }
-  .d-lg-table-cell {
-    display: table-cell !important; }
-  .d-lg-flex {
-    display: -ms-flexbox !important;
-    display: flex !important; }
-  .d-lg-inline-flex {
-    display: -ms-inline-flexbox !important;
-    display: inline-flex !important; } }
-
-@media (min-width: 1200px) {
-  .d-xl-none {
-    display: none !important; }
-  .d-xl-inline {
-    display: inline !important; }
-  .d-xl-inline-block {
-    display: inline-block !important; }
-  .d-xl-block {
-    display: block !important; }
-  .d-xl-table {
-    display: table !important; }
-  .d-xl-table-row {
-    display: table-row !important; }
-  .d-xl-table-cell {
-    display: table-cell !important; }
-  .d-xl-flex {
-    display: -ms-flexbox !important;
-    display: flex !important; }
-  .d-xl-inline-flex {
-    display: -ms-inline-flexbox !important;
-    display: inline-flex !important; } }
-
-@media print {
-  .d-print-none {
-    display: none !important; }
-  .d-print-inline {
-    display: inline !important; }
-  .d-print-inline-block {
-    display: inline-block !important; }
-  .d-print-block {
-    display: block !important; }
-  .d-print-table {
-    display: table !important; }
-  .d-print-table-row {
-    display: table-row !important; }
-  .d-print-table-cell {
-    display: table-cell !important; }
-  .d-print-flex {
-    display: -ms-flexbox !important;
-    display: flex !important; }
-  .d-print-inline-flex {
-    display: -ms-inline-flexbox !important;
-    display: inline-flex !important; } }
-
-.embed-responsive {
-  position: relative;
-  display: block;
-  width: 100%;
-  padding: 0;
-  overflow: hidden; }
-
-.embed-responsive::before {
-  display: block;
-  content: ""; }
-
-.embed-responsive .embed-responsive-item,
-.embed-responsive iframe,
-.embed-responsive embed,
-.embed-responsive object,
-.embed-responsive video {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  border: 0; }
-
-.embed-responsive-21by9::before {
-  padding-top: 42.857143%; }
-
-.embed-responsive-16by9::before {
-  padding-top: 56.25%; }
-
-.embed-responsive-4by3::before {
-  padding-top: 75%; }
-
-.embed-responsive-1by1::before {
-  padding-top: 100%; }
-
-.flex-row {
-  -ms-flex-direction: row !important;
-  flex-direction: row !important; }
-
-.flex-column {
-  -ms-flex-direction: column !important;
-  flex-direction: column !important; }
-
-.flex-row-reverse {
-  -ms-flex-direction: row-reverse !important;
-  flex-direction: row-reverse !important; }
-
-.flex-column-reverse {
-  -ms-flex-direction: column-reverse !important;
-  flex-direction: column-reverse !important; }
-
-.flex-wrap {
-  -ms-flex-wrap: wrap !important;
-  flex-wrap: wrap !important; }
-
-.flex-nowrap {
-  -ms-flex-wrap: nowrap !important;
-  flex-wrap: nowrap !important; }
-
-.flex-wrap-reverse {
-  -ms-flex-wrap: wrap-reverse !important;
-  flex-wrap: wrap-reverse !important; }
-
-.flex-fill {
-  -ms-flex: 1 1 auto !important;
-  flex: 1 1 auto !important; }
-
-.flex-grow-0 {
-  -ms-flex-positive: 0 !important;
-  flex-grow: 0 !important; }
-
-.flex-grow-1 {
-  -ms-flex-positive: 1 !important;
-  flex-grow: 1 !important; }
-
-.flex-shrink-0 {
-  -ms-flex-negative: 0 !important;
-  flex-shrink: 0 !important; }
-
-.flex-shrink-1 {
-  -ms-flex-negative: 1 !important;
-  flex-shrink: 1 !important; }
-
-.justify-content-start {
-  -ms-flex-pack: start !important;
-  justify-content: flex-start !important; }
-
-.justify-content-end {
-  -ms-flex-pack: end !important;
-  justify-content: flex-end !important; }
-
-.justify-content-center {
-  -ms-flex-pack: center !important;
-  justify-content: center !important; }
-
-.justify-content-between {
-  -ms-flex-pack: justify !important;
-  justify-content: space-between !important; }
-
-.justify-content-around {
-  -ms-flex-pack: distribute !important;
-  justify-content: space-around !important; }
-
-.align-items-start {
-  -ms-flex-align: start !important;
-  align-items: flex-start !important; }
-
-.align-items-end {
-  -ms-flex-align: end !important;
-  align-items: flex-end !important; }
-
-.align-items-center {
-  -ms-flex-align: center !important;
-  align-items: center !important; }
-
-.align-items-baseline {
-  -ms-flex-align: baseline !important;
-  align-items: baseline !important; }
-
-.align-items-stretch {
-  -ms-flex-align: stretch !important;
-  align-items: stretch !important; }
-
-.align-content-start {
-  -ms-flex-line-pack: start !important;
-  align-content: flex-start !important; }
-
-.align-content-end {
-  -ms-flex-line-pack: end !important;
-  align-content: flex-end !important; }
-
-.align-content-center {
-  -ms-flex-line-pack: center !important;
-  align-content: center !important; }
-
-.align-content-between {
-  -ms-flex-line-pack: justify !important;
-  align-content: space-between !important; }
-
-.align-content-around {
-  -ms-flex-line-pack: distribute !important;
-  align-content: space-around !important; }
-
-.align-content-stretch {
-  -ms-flex-line-pack: stretch !important;
-  align-content: stretch !important; }
-
-.align-self-auto {
-  -ms-flex-item-align: auto !important;
-  align-self: auto !important; }
-
-.align-self-start {
-  -ms-flex-item-align: start !important;
-  align-self: flex-start !important; }
-
-.align-self-end {
-  -ms-flex-item-align: end !important;
-  align-self: flex-end !important; }
-
-.align-self-center {
-  -ms-flex-item-align: center !important;
-  align-self: center !important; }
-
-.align-self-baseline {
-  -ms-flex-item-align: baseline !important;
-  align-self: baseline !important; }
-
-.align-self-stretch {
-  -ms-flex-item-align: stretch !important;
-  align-self: stretch !important; }
-
-@media (min-width: 576px) {
-  .flex-sm-row {
-    -ms-flex-direction: row !important;
-    flex-direction: row !important; }
-  .flex-sm-column {
-    -ms-flex-direction: column !important;
-    flex-direction: column !important; }
-  .flex-sm-row-reverse {
-    -ms-flex-direction: row-reverse !important;
-    flex-direction: row-reverse !important; }
-  .flex-sm-column-reverse {
-    -ms-flex-direction: column-reverse !important;
-    flex-direction: column-reverse !important; }
-  .flex-sm-wrap {
-    -ms-flex-wrap: wrap !important;
-    flex-wrap: wrap !important; }
-  .flex-sm-nowrap {
-    -ms-flex-wrap: nowrap !important;
-    flex-wrap: nowrap !important; }
-  .flex-sm-wrap-reverse {
-    -ms-flex-wrap: wrap-reverse !important;
-    flex-wrap: wrap-reverse !important; }
-  .flex-sm-fill {
-    -ms-flex: 1 1 auto !important;
-    flex: 1 1 auto !important; }
-  .flex-sm-grow-0 {
-    -ms-flex-positive: 0 !important;
-    flex-grow: 0 !important; }
-  .flex-sm-grow-1 {
-    -ms-flex-positive: 1 !important;
-    flex-grow: 1 !important; }
-  .flex-sm-shrink-0 {
-    -ms-flex-negative: 0 !important;
-    flex-shrink: 0 !important; }
-  .flex-sm-shrink-1 {
-    -ms-flex-negative: 1 !important;
-    flex-shrink: 1 !important; }
-  .justify-content-sm-start {
-    -ms-flex-pack: start !important;
-    justify-content: flex-start !important; }
-  .justify-content-sm-end {
-    -ms-flex-pack: end !important;
-    justify-content: flex-end !important; }
-  .justify-content-sm-center {
-    -ms-flex-pack: center !important;
-    justify-content: center !important; }
-  .justify-content-sm-between {
-    -ms-flex-pack: justify !important;
-    justify-content: space-between !important; }
-  .justify-content-sm-around {
-    -ms-flex-pack: distribute !important;
-    justify-content: space-around !important; }
-  .align-items-sm-start {
-    -ms-flex-align: start !important;
-    align-items: flex-start !important; }
-  .align-items-sm-end {
-    -ms-flex-align: end !important;
-    align-items: flex-end !important; }
-  .align-items-sm-center {
-    -ms-flex-align: center !important;
-    align-items: center !important; }
-  .align-items-sm-baseline {
-    -ms-flex-align: baseline !important;
-    align-items: baseline !important; }
-  .align-items-sm-stretch {
-    -ms-flex-align: stretch !important;
-    align-items: stretch !important; }
-  .align-content-sm-start {
-    -ms-flex-line-pack: start !important;
-    align-content: flex-start !important; }
-  .align-content-sm-end {
-    -ms-flex-line-pack: end !important;
-    align-content: flex-end !important; }
-  .align-content-sm-center {
-    -ms-flex-line-pack: center !important;
-    align-content: center !important; }
-  .align-content-sm-between {
-    -ms-flex-line-pack: justify !important;
-    align-content: space-between !important; }
-  .align-content-sm-around {
-    -ms-flex-line-pack: distribute !important;
-    align-content: space-around !important; }
-  .align-content-sm-stretch {
-    -ms-flex-line-pack: stretch !important;
-    align-content: stretch !important; }
-  .align-self-sm-auto {
-    -ms-flex-item-align: auto !important;
-    align-self: auto !important; }
-  .align-self-sm-start {
-    -ms-flex-item-align: start !important;
-    align-self: flex-start !important; }
-  .align-self-sm-end {
-    -ms-flex-item-align: end !important;
-    align-self: flex-end !important; }
-  .align-self-sm-center {
-    -ms-flex-item-align: center !important;
-    align-self: center !important; }
-  .align-self-sm-baseline {
-    -ms-flex-item-align: baseline !important;
-    align-self: baseline !important; }
-  .align-self-sm-stretch {
-    -ms-flex-item-align: stretch !important;
-    align-self: stretch !important; } }
-
-@media (min-width: 768px) {
-  .flex-md-row {
-    -ms-flex-direction: row !important;
-    flex-direction: row !important; }
-  .flex-md-column {
-    -ms-flex-direction: column !important;
-    flex-direction: column !important; }
-  .flex-md-row-reverse {
-    -ms-flex-direction: row-reverse !important;
-    flex-direction: row-reverse !important; }
-  .flex-md-column-reverse {
-    -ms-flex-direction: column-reverse !important;
-    flex-direction: column-reverse !important; }
-  .flex-md-wrap {
-    -ms-flex-wrap: wrap !important;
-    flex-wrap: wrap !important; }
-  .flex-md-nowrap {
-    -ms-flex-wrap: nowrap !important;
-    flex-wrap: nowrap !important; }
-  .flex-md-wrap-reverse {
-    -ms-flex-wrap: wrap-reverse !important;
-    flex-wrap: wrap-reverse !important; }
-  .flex-md-fill {
-    -ms-flex: 1 1 auto !important;
-    flex: 1 1 auto !important; }
-  .flex-md-grow-0 {
-    -ms-flex-positive: 0 !important;
-    flex-grow: 0 !important; }
-  .flex-md-grow-1 {
-    -ms-flex-positive: 1 !important;
-    flex-grow: 1 !important; }
-  .flex-md-shrink-0 {
-    -ms-flex-negative: 0 !important;
-    flex-shrink: 0 !important; }
-  .flex-md-shrink-1 {
-    -ms-flex-negative: 1 !important;
-    flex-shrink: 1 !important; }
-  .justify-content-md-start {
-    -ms-flex-pack: start !important;
-    justify-content: flex-start !important; }
-  .justify-content-md-end {
-    -ms-flex-pack: end !important;
-    justify-content: flex-end !important; }
-  .justify-content-md-center {
-    -ms-flex-pack: center !important;
-    justify-content: center !important; }
-  .justify-content-md-between {
-    -ms-flex-pack: justify !important;
-    justify-content: space-between !important; }
-  .justify-content-md-around {
-    -ms-flex-pack: distribute !important;
-    justify-content: space-around !important; }
-  .align-items-md-start {
-    -ms-flex-align: start !important;
-    align-items: flex-start !important; }
-  .align-items-md-end {
-    -ms-flex-align: end !important;
-    align-items: flex-end !important; }
-  .align-items-md-center {
-    -ms-flex-align: center !important;
-    align-items: center !important; }
-  .align-items-md-baseline {
-    -ms-flex-align: baseline !important;
-    align-items: baseline !important; }
-  .align-items-md-stretch {
-    -ms-flex-align: stretch !important;
-    align-items: stretch !important; }
-  .align-content-md-start {
-    -ms-flex-line-pack: start !important;
-    align-content: flex-start !important; }
-  .align-content-md-end {
-    -ms-flex-line-pack: end !important;
-    align-content: flex-end !important; }
-  .align-content-md-center {
-    -ms-flex-line-pack: center !important;
-    align-content: center !important; }
-  .align-content-md-between {
-    -ms-flex-line-pack: justify !important;
-    align-content: space-between !important; }
-  .align-content-md-around {
-    -ms-flex-line-pack: distribute !important;
-    align-content: space-around !important; }
-  .align-content-md-stretch {
-    -ms-flex-line-pack: stretch !important;
-    align-content: stretch !important; }
-  .align-self-md-auto {
-    -ms-flex-item-align: auto !important;
-    align-self: auto !important; }
-  .align-self-md-start {
-    -ms-flex-item-align: start !important;
-    align-self: flex-start !important; }
-  .align-self-md-end {
-    -ms-flex-item-align: end !important;
-    align-self: flex-end !important; }
-  .align-self-md-center {
-    -ms-flex-item-align: center !important;
-    align-self: center !important; }
-  .align-self-md-baseline {
-    -ms-flex-item-align: baseline !important;
-    align-self: baseline !important; }
-  .align-self-md-stretch {
-    -ms-flex-item-align: stretch !important;
-    align-self: stretch !important; } }
-
-@media (min-width: 992px) {
-  .flex-lg-row {
-    -ms-flex-direction: row !important;
-    flex-direction: row !important; }
-  .flex-lg-column {
-    -ms-flex-direction: column !important;
-    flex-direction: column !important; }
-  .flex-lg-row-reverse {
-    -ms-flex-direction: row-reverse !important;
-    flex-direction: row-reverse !important; }
-  .flex-lg-column-reverse {
-    -ms-flex-direction: column-reverse !important;
-    flex-direction: column-reverse !important; }
-  .flex-lg-wrap {
-    -ms-flex-wrap: wrap !important;
-    flex-wrap: wrap !important; }
-  .flex-lg-nowrap {
-    -ms-flex-wrap: nowrap !important;
-    flex-wrap: nowrap !important; }
-  .flex-lg-wrap-reverse {
-    -ms-flex-wrap: wrap-reverse !important;
-    flex-wrap: wrap-reverse !important; }
-  .flex-lg-fill {
-    -ms-flex: 1 1 auto !important;
-    flex: 1 1 auto !important; }
-  .flex-lg-grow-0 {
-    -ms-flex-positive: 0 !important;
-    flex-grow: 0 !important; }
-  .flex-lg-grow-1 {
-    -ms-flex-positive: 1 !important;
-    flex-grow: 1 !important; }
-  .flex-lg-shrink-0 {
-    -ms-flex-negative: 0 !important;
-    flex-shrink: 0 !important; }
-  .flex-lg-shrink-1 {
-    -ms-flex-negative: 1 !important;
-    flex-shrink: 1 !important; }
-  .justify-content-lg-start {
-    -ms-flex-pack: start !important;
-    justify-content: flex-start !important; }
-  .justify-content-lg-end {
-    -ms-flex-pack: end !important;
-    justify-content: flex-end !important; }
-  .justify-content-lg-center {
-    -ms-flex-pack: center !important;
-    justify-content: center !important; }
-  .justify-content-lg-between {
-    -ms-flex-pack: justify !important;
-    justify-content: space-between !important; }
-  .justify-content-lg-around {
-    -ms-flex-pack: distribute !important;
-    justify-content: space-around !important; }
-  .align-items-lg-start {
-    -ms-flex-align: start !important;
-    align-items: flex-start !important; }
-  .align-items-lg-end {
-    -ms-flex-align: end !important;
-    align-items: flex-end !important; }
-  .align-items-lg-center {
-    -ms-flex-align: center !important;
-    align-items: center !important; }
-  .align-items-lg-baseline {
-    -ms-flex-align: baseline !important;
-    align-items: baseline !important; }
-  .align-items-lg-stretch {
-    -ms-flex-align: stretch !important;
-    align-items: stretch !important; }
-  .align-content-lg-start {
-    -ms-flex-line-pack: start !important;
-    align-content: flex-start !important; }
-  .align-content-lg-end {
-    -ms-flex-line-pack: end !important;
-    align-content: flex-end !important; }
-  .align-content-lg-center {
-    -ms-flex-line-pack: center !important;
-    align-content: center !important; }
-  .align-content-lg-between {
-    -ms-flex-line-pack: justify !important;
-    align-content: space-between !important; }
-  .align-content-lg-around {
-    -ms-flex-line-pack: distribute !important;
-    align-content: space-around !important; }
-  .align-content-lg-stretch {
-    -ms-flex-line-pack: stretch !important;
-    align-content: stretch !important; }
-  .align-self-lg-auto {
-    -ms-flex-item-align: auto !important;
-    align-self: auto !important; }
-  .align-self-lg-start {
-    -ms-flex-item-align: start !important;
-    align-self: flex-start !important; }
-  .align-self-lg-end {
-    -ms-flex-item-align: end !important;
-    align-self: flex-end !important; }
-  .align-self-lg-center {
-    -ms-flex-item-align: center !important;
-    align-self: center !important; }
-  .align-self-lg-baseline {
-    -ms-flex-item-align: baseline !important;
-    align-self: baseline !important; }
-  .align-self-lg-stretch {
-    -ms-flex-item-align: stretch !important;
-    align-self: stretch !important; } }
-
-@media (min-width: 1200px) {
-  .flex-xl-row {
-    -ms-flex-direction: row !important;
-    flex-direction: row !important; }
-  .flex-xl-column {
-    -ms-flex-direction: column !important;
-    flex-direction: column !important; }
-  .flex-xl-row-reverse {
-    -ms-flex-direction: row-reverse !important;
-    flex-direction: row-reverse !important; }
-  .flex-xl-column-reverse {
-    -ms-flex-direction: column-reverse !important;
-    flex-direction: column-reverse !important; }
-  .flex-xl-wrap {
-    -ms-flex-wrap: wrap !important;
-    flex-wrap: wrap !important; }
-  .flex-xl-nowrap {
-    -ms-flex-wrap: nowrap !important;
-    flex-wrap: nowrap !important; }
-  .flex-xl-wrap-reverse {
-    -ms-flex-wrap: wrap-reverse !important;
-    flex-wrap: wrap-reverse !important; }
-  .flex-xl-fill {
-    -ms-flex: 1 1 auto !important;
-    flex: 1 1 auto !important; }
-  .flex-xl-grow-0 {
-    -ms-flex-positive: 0 !important;
-    flex-grow: 0 !important; }
-  .flex-xl-grow-1 {
-    -ms-flex-positive: 1 !important;
-    flex-grow: 1 !important; }
-  .flex-xl-shrink-0 {
-    -ms-flex-negative: 0 !important;
-    flex-shrink: 0 !important; }
-  .flex-xl-shrink-1 {
-    -ms-flex-negative: 1 !important;
-    flex-shrink: 1 !important; }
-  .justify-content-xl-start {
-    -ms-flex-pack: start !important;
-    justify-content: flex-start !important; }
-  .justify-content-xl-end {
-    -ms-flex-pack: end !important;
-    justify-content: flex-end !important; }
-  .justify-content-xl-center {
-    -ms-flex-pack: center !important;
-    justify-content: center !important; }
-  .justify-content-xl-between {
-    -ms-flex-pack: justify !important;
-    justify-content: space-between !important; }
-  .justify-content-xl-around {
-    -ms-flex-pack: distribute !important;
-    justify-content: space-around !important; }
-  .align-items-xl-start {
-    -ms-flex-align: start !important;
-    align-items: flex-start !important; }
-  .align-items-xl-end {
-    -ms-flex-align: end !important;
-    align-items: flex-end !important; }
-  .align-items-xl-center {
-    -ms-flex-align: center !important;
-    align-items: center !important; }
-  .align-items-xl-baseline {
-    -ms-flex-align: baseline !important;
-    align-items: baseline !important; }
-  .align-items-xl-stretch {
-    -ms-flex-align: stretch !important;
-    align-items: stretch !important; }
-  .align-content-xl-start {
-    -ms-flex-line-pack: start !important;
-    align-content: flex-start !important; }
-  .align-content-xl-end {
-    -ms-flex-line-pack: end !important;
-    align-content: flex-end !important; }
-  .align-content-xl-center {
-    -ms-flex-line-pack: center !important;
-    align-content: center !important; }
-  .align-content-xl-between {
-    -ms-flex-line-pack: justify !important;
-    align-content: space-between !important; }
-  .align-content-xl-around {
-    -ms-flex-line-pack: distribute !important;
-    align-content: space-around !important; }
-  .align-content-xl-stretch {
-    -ms-flex-line-pack: stretch !important;
-    align-content: stretch !important; }
-  .align-self-xl-auto {
-    -ms-flex-item-align: auto !important;
-    align-self: auto !important; }
-  .align-self-xl-start {
-    -ms-flex-item-align: start !important;
-    align-self: flex-start !important; }
-  .align-self-xl-end {
-    -ms-flex-item-align: end !important;
-    align-self: flex-end !important; }
-  .align-self-xl-center {
-    -ms-flex-item-align: center !important;
-    align-self: center !important; }
-  .align-self-xl-baseline {
-    -ms-flex-item-align: baseline !important;
-    align-self: baseline !important; }
-  .align-self-xl-stretch {
-    -ms-flex-item-align: stretch !important;
-    align-self: stretch !important; } }
-
-.float-left {
-  float: left !important; }
-
-.float-right {
-  float: right !important; }
-
-.float-none {
-  float: none !important; }
-
-@media (min-width: 576px) {
-  .float-sm-left {
-    float: left !important; }
-  .float-sm-right {
-    float: right !important; }
-  .float-sm-none {
-    float: none !important; } }
-
-@media (min-width: 768px) {
-  .float-md-left {
-    float: left !important; }
-  .float-md-right {
-    float: right !important; }
-  .float-md-none {
-    float: none !important; } }
-
-@media (min-width: 992px) {
-  .float-lg-left {
-    float: left !important; }
-  .float-lg-right {
-    float: right !important; }
-  .float-lg-none {
-    float: none !important; } }
-
-@media (min-width: 1200px) {
-  .float-xl-left {
-    float: left !important; }
-  .float-xl-right {
-    float: right !important; }
-  .float-xl-none {
-    float: none !important; } }
-
-.user-select-all {
-  -webkit-user-select: all !important;
-  -moz-user-select: all !important;
-  user-select: all !important; }
-
-.user-select-auto {
-  -webkit-user-select: auto !important;
-  -moz-user-select: auto !important;
-  -ms-user-select: auto !important;
-  user-select: auto !important; }
-
-.user-select-none {
-  -webkit-user-select: none !important;
-  -moz-user-select: none !important;
-  -ms-user-select: none !important;
-  user-select: none !important; }
-
-.overflow-auto {
-  overflow: auto !important; }
-
-.overflow-hidden {
-  overflow: hidden !important; }
-
-.position-static {
-  position: static !important; }
-
-.position-relative {
-  position: relative !important; }
-
-.position-absolute {
-  position: absolute !important; }
-
-.position-fixed {
-  position: fixed !important; }
-
-.position-sticky {
-  position: -webkit-sticky !important;
-  position: sticky !important; }
-
-.fixed-top {
-  position: fixed;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 1030; }
-
-.fixed-bottom {
-  position: fixed;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1030; }
-
-@supports (position: -webkit-sticky) or (position: sticky) {
-  .sticky-top {
-    position: -webkit-sticky;
-    position: sticky;
-    top: 0;
-    z-index: 1020; } }
+    display: block !important;
+  }
+
+  /*  .d-sm-table {*/
+  /*    display: table !important;*/
+  /*  }*/
+
+  /*  .d-sm-table-row {*/
+  /*    display: table-row !important;*/
+  /*  }*/
+
+  /*  .d-sm-table-cell {*/
+  /*    display: table-cell !important;*/
+  /*  }*/
+
+  /*  .d-sm-flex {*/
+  /*    display: -ms-flexbox !important;*/
+  /*    display: flex !important;*/
+  /*  }*/
+
+  /*  .d-sm-inline-flex {*/
+  /*    display: -ms-inline-flexbox !important;*/
+  /*    display: inline-flex !important;*/
+  /*  }*/
+  /*}*/
+
+  @media (min-width: 768px) {
+    .d-md-none {
+      display: none !important;
+    }
+
+    /*.d-md-inline {*/
+    /*  display: inline !important;*/
+    /*}*/
+    /*.d-md-inline-block {*/
+    /*  display: inline-block !important;*/
+    /*}*/
+    .d-md-block {
+      display: block !important;
+    }
+  }
+  /*  .d-md-table {*/
+  /*    display: table !important;*/
+  /*  }*/
+
+  /*  .d-md-table-row {*/
+  /*    display: table-row !important;*/
+  /*  }*/
+
+  /*  .d-md-table-cell {*/
+  /*    display: table-cell !important;*/
+  /*  }*/
+
+  /*  .d-md-flex {*/
+  /*    display: -ms-flexbox !important;*/
+  /*    display: flex !important;*/
+  /*  }*/
+
+  /*  .d-md-inline-flex {*/
+  /*    display: -ms-inline-flexbox !important;*/
+  /*    display: inline-flex !important;*/
+  /*  }*/
+  /*}*/
+
+  /*@media (min-width: 992px) {*/
+  /*  .d-lg-none {*/
+  /*    display: none !important;*/
+  /*  }*/
+
+  /*  .d-lg-inline {*/
+  /*    display: inline !important;*/
+  /*  }*/
+
+  /*  .d-lg-inline-block {*/
+  /*    display: inline-block !important;*/
+  /*  }*/
+
+  /*  .d-lg-block {*/
+  /*    display: block !important;*/
+  /*  }*/
+
+  /*  .d-lg-table {*/
+  /*    display: table !important;*/
+  /*  }*/
+
+  /*  .d-lg-table-row {*/
+  /*    display: table-row !important;*/
+  /*  }*/
+
+  /*  .d-lg-table-cell {*/
+  /*    display: table-cell !important;*/
+  /*  }*/
+
+  /*  .d-lg-flex {*/
+  /*    display: -ms-flexbox !important;*/
+  /*    display: flex !important;*/
+  /*  }*/
+
+  /*  .d-lg-inline-flex {*/
+  /*    display: -ms-inline-flexbox !important;*/
+  /*    display: inline-flex !important;*/
+  /*  }*/
+  /*}*/
+
+  @media (min-width: 1200px) {
+    .d-xl-none {
+      display: none !important;
+    }
+  }
+  /* Temporary Feb 1, 2022 */
+  /*  .d-xl-inline {*/
+  /*    display: inline !important;*/
+  /*  }*/
+  /*  .d-xl-inline-block {*/
+  /*    display: inline-block !important;*/
+  /*  }*/
+
+  /*  .d-xl-block {*/
+  /*    display: block !important;*/
+  /*  }*/
+
+  /*  .d-xl-table {*/
+  /*    display: table !important;*/
+  /*  }*/
+
+  /*  .d-xl-table-row {*/
+  /*    display: table-row !important;*/
+  /*  }*/
+
+  /*  .d-xl-table-cell {*/
+  /*    display: table-cell !important;*/
+  /*  }*/
+
+  /*  .d-xl-flex {*/
+  /*    display: -ms-flexbox !important;*/
+  /*    display: flex !important;*/
+  /*  }*/
+
+  /*  .d-xl-inline-flex {*/
+  /*    display: -ms-inline-flexbox !important;*/
+  /*    display: inline-flex !important;*/
+  /*  }*/
+  /*}*/
+
+  /*@media print {*/
+  /*  .d-print-none {*/
+  /*    display: none !important;*/
+  /*  }*/
+
+  /*  .d-print-inline {*/
+  /*    display: inline !important;*/
+  /*  }*/
+
+  /*  .d-print-inline-block {*/
+  /*    display: inline-block !important;*/
+  /*  }*/
+
+  /*  .d-print-block {*/
+  /*    display: block !important;*/
+  /*  }*/
+
+  /*  .d-print-table {*/
+  /*    display: table !important;*/
+  /*  }*/
+
+  /*  .d-print-table-row {*/
+  /*    display: table-row !important;*/
+  /*  }*/
+
+  /*  .d-print-table-cell {*/
+  /*    display: table-cell !important;*/
+  /*  }*/
+
+  /*  .d-print-flex {*/
+  /*    display: -ms-flexbox !important;*/
+  /*    display: flex !important;*/
+  /*  }*/
+
+  /*  .d-print-inline-flex {*/
+  /*    display: -ms-inline-flexbox !important;*/
+  /*    display: inline-flex !important;*/
+  /*  }*/
+}
+
+/*.embed-responsive {*/
+/*  position: relative;*/
+/*  display: block;*/
+/*  width: 100%;*/
+/*  padding: 0;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.embed-responsive::before {*/
+/*  display: block;*/
+/*  content: "";*/
+/*}*/
+
+/*.embed-responsive .embed-responsive-item, .embed-responsive iframe, .embed-responsive embed, .embed-responsive object, .embed-responsive video {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  bottom: 0;*/
+/*  left: 0;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  border: 0;*/
+/*}*/
+
+/*.embed-responsive-21by9::before {*/
+/*  padding-top: 42.857143%;*/
+/*}*/
+
+/*.embed-responsive-16by9::before {*/
+/*  padding-top: 56.25%;*/
+/*}*/
+
+/*.embed-responsive-4by3::before {*/
+/*  padding-top: 75%;*/
+/*}*/
+
+/*.embed-responsive-1by1::before {*/
+/*  padding-top: 100%;*/
+/*}*/
+
+/*.flex-row {*/
+/*  -ms-flex-direction: row !important;*/
+/*  flex-direction: row !important;*/
+/*}*/
+
+/*.flex-column {*/
+/*  -ms-flex-direction: column !important;*/
+/*  flex-direction: column !important;*/
+/*}*/
+
+/*.flex-row-reverse {*/
+/*  -ms-flex-direction: row-reverse !important;*/
+/*  flex-direction: row-reverse !important;*/
+/*}*/
+
+/*.flex-column-reverse {*/
+/*  -ms-flex-direction: column-reverse !important;*/
+/*  flex-direction: column-reverse !important;*/
+/*}*/
+
+/*.flex-wrap {*/
+/*  -ms-flex-wrap: wrap !important;*/
+/*  flex-wrap: wrap !important;*/
+/*}*/
+
+/*.flex-nowrap {*/
+/*  -ms-flex-wrap: nowrap !important;*/
+/*  flex-wrap: nowrap !important;*/
+/*}*/
+
+/*.flex-wrap-reverse {*/
+/*  -ms-flex-wrap: wrap-reverse !important;*/
+/*  flex-wrap: wrap-reverse !important;*/
+/*}*/
+
+/*.flex-fill {*/
+/*  -ms-flex: 1 1 auto !important;*/
+/*  flex: 1 1 auto !important;*/
+/*}*/
+
+/*.flex-grow-0 {*/
+/*  -ms-flex-positive: 0 !important;*/
+/*  flex-grow: 0 !important;*/
+/*}*/
+
+/*.flex-grow-1 {*/
+/*  -ms-flex-positive: 1 !important;*/
+/*  flex-grow: 1 !important;*/
+/*}*/
+
+/*.flex-shrink-0 {*/
+/*  -ms-flex-negative: 0 !important;*/
+/*  flex-shrink: 0 !important;*/
+/*}*/
+
+/*.flex-shrink-1 {*/
+/*  -ms-flex-negative: 1 !important;*/
+/*  flex-shrink: 1 !important;*/
+/*}*/
+
+/*.justify-content-start {*/
+/*  -ms-flex-pack: start !important;*/
+/*  justify-content: flex-start !important;*/
+/*}*/
+
+/*.justify-content-end {*/
+/*  -ms-flex-pack: end !important;*/
+/*  justify-content: flex-end !important;*/
+/*}*/
+
+/*.justify-content-center {*/
+/*  -ms-flex-pack: center !important;*/
+/*  justify-content: center !important;*/
+/*}*/
+
+/*.justify-content-between {*/
+/*  -ms-flex-pack: justify !important;*/
+/*  justify-content: space-between !important;*/
+/*}*/
+
+/*.justify-content-around {*/
+/*  -ms-flex-pack: distribute !important;*/
+/*  justify-content: space-around !important;*/
+/*}*/
+
+/*.align-items-start {*/
+/*  -ms-flex-align: start !important;*/
+/*  align-items: flex-start !important;*/
+/*}*/
+
+/*.align-items-end {*/
+/*  -ms-flex-align: end !important;*/
+/*  align-items: flex-end !important;*/
+/*}*/
+
+/*.align-items-center {*/
+/*  -ms-flex-align: center !important;*/
+/*  align-items: center !important;*/
+/*}*/
+
+/*.align-items-baseline {*/
+/*  -ms-flex-align: baseline !important;*/
+/*  align-items: baseline !important;*/
+/*}*/
+
+/*.align-items-stretch {*/
+/*  -ms-flex-align: stretch !important;*/
+/*  align-items: stretch !important;*/
+/*}*/
+
+/*.align-content-start {*/
+/*  -ms-flex-line-pack: start !important;*/
+/*  align-content: flex-start !important;*/
+/*}*/
+
+/*.align-content-end {*/
+/*  -ms-flex-line-pack: end !important;*/
+/*  align-content: flex-end !important;*/
+/*}*/
+
+/*.align-content-center {*/
+/*  -ms-flex-line-pack: center !important;*/
+/*  align-content: center !important;*/
+/*}*/
+
+/*.align-content-between {*/
+/*  -ms-flex-line-pack: justify !important;*/
+/*  align-content: space-between !important;*/
+/*}*/
+
+/*.align-content-around {*/
+/*  -ms-flex-line-pack: distribute !important;*/
+/*  align-content: space-around !important;*/
+/*}*/
+
+/*.align-content-stretch {*/
+/*  -ms-flex-line-pack: stretch !important;*/
+/*  align-content: stretch !important;*/
+/*}*/
+
+/*.align-self-auto {*/
+/*  -ms-flex-item-align: auto !important;*/
+/*  align-self: auto !important;*/
+/*}*/
+
+/*.align-self-start {*/
+/*  -ms-flex-item-align: start !important;*/
+/*  align-self: flex-start !important;*/
+/*}*/
+
+/*.align-self-end {*/
+/*  -ms-flex-item-align: end !important;*/
+/*  align-self: flex-end !important;*/
+/*}*/
+
+/*.align-self-center {*/
+/*  -ms-flex-item-align: center !important;*/
+/*  align-self: center !important;*/
+/*}*/
+
+/*.align-self-baseline {*/
+/*  -ms-flex-item-align: baseline !important;*/
+/*  align-self: baseline !important;*/
+/*}*/
+
+/*.align-self-stretch {*/
+/*  -ms-flex-item-align: stretch !important;*/
+/*  align-self: stretch !important;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .flex-sm-row {*/
+/*    -ms-flex-direction: row !important;*/
+/*    flex-direction: row !important;*/
+/*  }*/
+
+/*  .flex-sm-column {*/
+/*    -ms-flex-direction: column !important;*/
+/*    flex-direction: column !important;*/
+/*  }*/
+
+/*  .flex-sm-row-reverse {*/
+/*    -ms-flex-direction: row-reverse !important;*/
+/*    flex-direction: row-reverse !important;*/
+/*  }*/
+
+/*  .flex-sm-column-reverse {*/
+/*    -ms-flex-direction: column-reverse !important;*/
+/*    flex-direction: column-reverse !important;*/
+/*  }*/
+
+/*  .flex-sm-wrap {*/
+/*    -ms-flex-wrap: wrap !important;*/
+/*    flex-wrap: wrap !important;*/
+/*  }*/
+
+/*  .flex-sm-nowrap {*/
+/*    -ms-flex-wrap: nowrap !important;*/
+/*    flex-wrap: nowrap !important;*/
+/*  }*/
+
+/*  .flex-sm-wrap-reverse {*/
+/*    -ms-flex-wrap: wrap-reverse !important;*/
+/*    flex-wrap: wrap-reverse !important;*/
+/*  }*/
+
+/*  .flex-sm-fill {*/
+/*    -ms-flex: 1 1 auto !important;*/
+/*    flex: 1 1 auto !important;*/
+/*  }*/
+
+/*  .flex-sm-grow-0 {*/
+/*    -ms-flex-positive: 0 !important;*/
+/*    flex-grow: 0 !important;*/
+/*  }*/
+
+/*  .flex-sm-grow-1 {*/
+/*    -ms-flex-positive: 1 !important;*/
+/*    flex-grow: 1 !important;*/
+/*  }*/
+
+/*  .flex-sm-shrink-0 {*/
+/*    -ms-flex-negative: 0 !important;*/
+/*    flex-shrink: 0 !important;*/
+/*  }*/
+
+/*  .flex-sm-shrink-1 {*/
+/*    -ms-flex-negative: 1 !important;*/
+/*    flex-shrink: 1 !important;*/
+/*  }*/
+
+/*  .justify-content-sm-start {*/
+/*    -ms-flex-pack: start !important;*/
+/*    justify-content: flex-start !important;*/
+/*  }*/
+
+/*  .justify-content-sm-end {*/
+/*    -ms-flex-pack: end !important;*/
+/*    justify-content: flex-end !important;*/
+/*  }*/
+
+/*  .justify-content-sm-center {*/
+/*    -ms-flex-pack: center !important;*/
+/*    justify-content: center !important;*/
+/*  }*/
+
+/*  .justify-content-sm-between {*/
+/*    -ms-flex-pack: justify !important;*/
+/*    justify-content: space-between !important;*/
+/*  }*/
+
+/*  .justify-content-sm-around {*/
+/*    -ms-flex-pack: distribute !important;*/
+/*    justify-content: space-around !important;*/
+/*  }*/
+
+/*  .align-items-sm-start {*/
+/*    -ms-flex-align: start !important;*/
+/*    align-items: flex-start !important;*/
+/*  }*/
+
+/*  .align-items-sm-end {*/
+/*    -ms-flex-align: end !important;*/
+/*    align-items: flex-end !important;*/
+/*  }*/
+
+/*  .align-items-sm-center {*/
+/*    -ms-flex-align: center !important;*/
+/*    align-items: center !important;*/
+/*  }*/
+
+/*  .align-items-sm-baseline {*/
+/*    -ms-flex-align: baseline !important;*/
+/*    align-items: baseline !important;*/
+/*  }*/
+
+/*  .align-items-sm-stretch {*/
+/*    -ms-flex-align: stretch !important;*/
+/*    align-items: stretch !important;*/
+/*  }*/
+
+/*  .align-content-sm-start {*/
+/*    -ms-flex-line-pack: start !important;*/
+/*    align-content: flex-start !important;*/
+/*  }*/
+
+/*  .align-content-sm-end {*/
+/*    -ms-flex-line-pack: end !important;*/
+/*    align-content: flex-end !important;*/
+/*  }*/
+
+/*  .align-content-sm-center {*/
+/*    -ms-flex-line-pack: center !important;*/
+/*    align-content: center !important;*/
+/*  }*/
+
+/*  .align-content-sm-between {*/
+/*    -ms-flex-line-pack: justify !important;*/
+/*    align-content: space-between !important;*/
+/*  }*/
+
+/*  .align-content-sm-around {*/
+/*    -ms-flex-line-pack: distribute !important;*/
+/*    align-content: space-around !important;*/
+/*  }*/
+
+/*  .align-content-sm-stretch {*/
+/*    -ms-flex-line-pack: stretch !important;*/
+/*    align-content: stretch !important;*/
+/*  }*/
+
+/*  .align-self-sm-auto {*/
+/*    -ms-flex-item-align: auto !important;*/
+/*    align-self: auto !important;*/
+/*  }*/
+
+/*  .align-self-sm-start {*/
+/*    -ms-flex-item-align: start !important;*/
+/*    align-self: flex-start !important;*/
+/*  }*/
+
+/*  .align-self-sm-end {*/
+/*    -ms-flex-item-align: end !important;*/
+/*    align-self: flex-end !important;*/
+/*  }*/
+
+/*  .align-self-sm-center {*/
+/*    -ms-flex-item-align: center !important;*/
+/*    align-self: center !important;*/
+/*  }*/
+
+/*  .align-self-sm-baseline {*/
+/*    -ms-flex-item-align: baseline !important;*/
+/*    align-self: baseline !important;*/
+/*  }*/
+
+/*  .align-self-sm-stretch {*/
+/*    -ms-flex-item-align: stretch !important;*/
+/*    align-self: stretch !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 768px) {*/
+/*  .flex-md-row {*/
+/*    -ms-flex-direction: row !important;*/
+/*    flex-direction: row !important;*/
+/*  }*/
+
+/*  .flex-md-column {*/
+/*    -ms-flex-direction: column !important;*/
+/*    flex-direction: column !important;*/
+/*  }*/
+
+/*  .flex-md-row-reverse {*/
+/*    -ms-flex-direction: row-reverse !important;*/
+/*    flex-direction: row-reverse !important;*/
+/*  }*/
+
+/*  .flex-md-column-reverse {*/
+/*    -ms-flex-direction: column-reverse !important;*/
+/*    flex-direction: column-reverse !important;*/
+/*  }*/
+
+/*  .flex-md-wrap {*/
+/*    -ms-flex-wrap: wrap !important;*/
+/*    flex-wrap: wrap !important;*/
+/*  }*/
+
+/*  .flex-md-nowrap {*/
+/*    -ms-flex-wrap: nowrap !important;*/
+/*    flex-wrap: nowrap !important;*/
+/*  }*/
+
+/*  .flex-md-wrap-reverse {*/
+/*    -ms-flex-wrap: wrap-reverse !important;*/
+/*    flex-wrap: wrap-reverse !important;*/
+/*  }*/
+
+/*  .flex-md-fill {*/
+/*    -ms-flex: 1 1 auto !important;*/
+/*    flex: 1 1 auto !important;*/
+/*  }*/
+
+/*  .flex-md-grow-0 {*/
+/*    -ms-flex-positive: 0 !important;*/
+/*    flex-grow: 0 !important;*/
+/*  }*/
+
+/*  .flex-md-grow-1 {*/
+/*    -ms-flex-positive: 1 !important;*/
+/*    flex-grow: 1 !important;*/
+/*  }*/
+
+/*  .flex-md-shrink-0 {*/
+/*    -ms-flex-negative: 0 !important;*/
+/*    flex-shrink: 0 !important;*/
+/*  }*/
+
+/*  .flex-md-shrink-1 {*/
+/*    -ms-flex-negative: 1 !important;*/
+/*    flex-shrink: 1 !important;*/
+/*  }*/
+
+/*  .justify-content-md-start {*/
+/*    -ms-flex-pack: start !important;*/
+/*    justify-content: flex-start !important;*/
+/*  }*/
+
+/*  .justify-content-md-end {*/
+/*    -ms-flex-pack: end !important;*/
+/*    justify-content: flex-end !important;*/
+/*  }*/
+
+/*  .justify-content-md-center {*/
+/*    -ms-flex-pack: center !important;*/
+/*    justify-content: center !important;*/
+/*  }*/
+
+/*  .justify-content-md-between {*/
+/*    -ms-flex-pack: justify !important;*/
+/*    justify-content: space-between !important;*/
+/*  }*/
+
+/*  .justify-content-md-around {*/
+/*    -ms-flex-pack: distribute !important;*/
+/*    justify-content: space-around !important;*/
+/*  }*/
+
+/*  .align-items-md-start {*/
+/*    -ms-flex-align: start !important;*/
+/*    align-items: flex-start !important;*/
+/*  }*/
+
+/*  .align-items-md-end {*/
+/*    -ms-flex-align: end !important;*/
+/*    align-items: flex-end !important;*/
+/*  }*/
+
+/*  .align-items-md-center {*/
+/*    -ms-flex-align: center !important;*/
+/*    align-items: center !important;*/
+/*  }*/
+
+/*  .align-items-md-baseline {*/
+/*    -ms-flex-align: baseline !important;*/
+/*    align-items: baseline !important;*/
+/*  }*/
+
+/*  .align-items-md-stretch {*/
+/*    -ms-flex-align: stretch !important;*/
+/*    align-items: stretch !important;*/
+/*  }*/
+
+/*  .align-content-md-start {*/
+/*    -ms-flex-line-pack: start !important;*/
+/*    align-content: flex-start !important;*/
+/*  }*/
+
+/*  .align-content-md-end {*/
+/*    -ms-flex-line-pack: end !important;*/
+/*    align-content: flex-end !important;*/
+/*  }*/
+
+/*  .align-content-md-center {*/
+/*    -ms-flex-line-pack: center !important;*/
+/*    align-content: center !important;*/
+/*  }*/
+
+/*  .align-content-md-between {*/
+/*    -ms-flex-line-pack: justify !important;*/
+/*    align-content: space-between !important;*/
+/*  }*/
+
+/*  .align-content-md-around {*/
+/*    -ms-flex-line-pack: distribute !important;*/
+/*    align-content: space-around !important;*/
+/*  }*/
+
+/*  .align-content-md-stretch {*/
+/*    -ms-flex-line-pack: stretch !important;*/
+/*    align-content: stretch !important;*/
+/*  }*/
+
+/*  .align-self-md-auto {*/
+/*    -ms-flex-item-align: auto !important;*/
+/*    align-self: auto !important;*/
+/*  }*/
+
+/*  .align-self-md-start {*/
+/*    -ms-flex-item-align: start !important;*/
+/*    align-self: flex-start !important;*/
+/*  }*/
+
+/*  .align-self-md-end {*/
+/*    -ms-flex-item-align: end !important;*/
+/*    align-self: flex-end !important;*/
+/*  }*/
+
+/*  .align-self-md-center {*/
+/*    -ms-flex-item-align: center !important;*/
+/*    align-self: center !important;*/
+/*  }*/
+
+/*  .align-self-md-baseline {*/
+/*    -ms-flex-item-align: baseline !important;*/
+/*    align-self: baseline !important;*/
+/*  }*/
+
+/*  .align-self-md-stretch {*/
+/*    -ms-flex-item-align: stretch !important;*/
+/*    align-self: stretch !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 992px) {*/
+/*  .flex-lg-row {*/
+/*    -ms-flex-direction: row !important;*/
+/*    flex-direction: row !important;*/
+/*  }*/
+
+/*  .flex-lg-column {*/
+/*    -ms-flex-direction: column !important;*/
+/*    flex-direction: column !important;*/
+/*  }*/
+
+/*  .flex-lg-row-reverse {*/
+/*    -ms-flex-direction: row-reverse !important;*/
+/*    flex-direction: row-reverse !important;*/
+/*  }*/
+
+/*  .flex-lg-column-reverse {*/
+/*    -ms-flex-direction: column-reverse !important;*/
+/*    flex-direction: column-reverse !important;*/
+/*  }*/
+
+/*  .flex-lg-wrap {*/
+/*    -ms-flex-wrap: wrap !important;*/
+/*    flex-wrap: wrap !important;*/
+/*  }*/
+
+/*  .flex-lg-nowrap {*/
+/*    -ms-flex-wrap: nowrap !important;*/
+/*    flex-wrap: nowrap !important;*/
+/*  }*/
+
+/*  .flex-lg-wrap-reverse {*/
+/*    -ms-flex-wrap: wrap-reverse !important;*/
+/*    flex-wrap: wrap-reverse !important;*/
+/*  }*/
+
+/*  .flex-lg-fill {*/
+/*    -ms-flex: 1 1 auto !important;*/
+/*    flex: 1 1 auto !important;*/
+/*  }*/
+
+/*  .flex-lg-grow-0 {*/
+/*    -ms-flex-positive: 0 !important;*/
+/*    flex-grow: 0 !important;*/
+/*  }*/
+
+/*  .flex-lg-grow-1 {*/
+/*    -ms-flex-positive: 1 !important;*/
+/*    flex-grow: 1 !important;*/
+/*  }*/
+
+/*  .flex-lg-shrink-0 {*/
+/*    -ms-flex-negative: 0 !important;*/
+/*    flex-shrink: 0 !important;*/
+/*  }*/
+
+/*  .flex-lg-shrink-1 {*/
+/*    -ms-flex-negative: 1 !important;*/
+/*    flex-shrink: 1 !important;*/
+/*  }*/
+
+/*  .justify-content-lg-start {*/
+/*    -ms-flex-pack: start !important;*/
+/*    justify-content: flex-start !important;*/
+/*  }*/
+
+/*  .justify-content-lg-end {*/
+/*    -ms-flex-pack: end !important;*/
+/*    justify-content: flex-end !important;*/
+/*  }*/
+
+/*  .justify-content-lg-center {*/
+/*    -ms-flex-pack: center !important;*/
+/*    justify-content: center !important;*/
+/*  }*/
+
+/*  .justify-content-lg-between {*/
+/*    -ms-flex-pack: justify !important;*/
+/*    justify-content: space-between !important;*/
+/*  }*/
+
+/*  .justify-content-lg-around {*/
+/*    -ms-flex-pack: distribute !important;*/
+/*    justify-content: space-around !important;*/
+/*  }*/
+
+/*  .align-items-lg-start {*/
+/*    -ms-flex-align: start !important;*/
+/*    align-items: flex-start !important;*/
+/*  }*/
+
+/*  .align-items-lg-end {*/
+/*    -ms-flex-align: end !important;*/
+/*    align-items: flex-end !important;*/
+/*  }*/
+
+/*  .align-items-lg-center {*/
+/*    -ms-flex-align: center !important;*/
+/*    align-items: center !important;*/
+/*  }*/
+
+/*  .align-items-lg-baseline {*/
+/*    -ms-flex-align: baseline !important;*/
+/*    align-items: baseline !important;*/
+/*  }*/
+
+/*  .align-items-lg-stretch {*/
+/*    -ms-flex-align: stretch !important;*/
+/*    align-items: stretch !important;*/
+/*  }*/
+
+/*  .align-content-lg-start {*/
+/*    -ms-flex-line-pack: start !important;*/
+/*    align-content: flex-start !important;*/
+/*  }*/
+
+/*  .align-content-lg-end {*/
+/*    -ms-flex-line-pack: end !important;*/
+/*    align-content: flex-end !important;*/
+/*  }*/
+
+/*  .align-content-lg-center {*/
+/*    -ms-flex-line-pack: center !important;*/
+/*    align-content: center !important;*/
+/*  }*/
+
+/*  .align-content-lg-between {*/
+/*    -ms-flex-line-pack: justify !important;*/
+/*    align-content: space-between !important;*/
+/*  }*/
+
+/*  .align-content-lg-around {*/
+/*    -ms-flex-line-pack: distribute !important;*/
+/*    align-content: space-around !important;*/
+/*  }*/
+
+/*  .align-content-lg-stretch {*/
+/*    -ms-flex-line-pack: stretch !important;*/
+/*    align-content: stretch !important;*/
+/*  }*/
+
+/*  .align-self-lg-auto {*/
+/*    -ms-flex-item-align: auto !important;*/
+/*    align-self: auto !important;*/
+/*  }*/
+
+/*  .align-self-lg-start {*/
+/*    -ms-flex-item-align: start !important;*/
+/*    align-self: flex-start !important;*/
+/*  }*/
+
+/*  .align-self-lg-end {*/
+/*    -ms-flex-item-align: end !important;*/
+/*    align-self: flex-end !important;*/
+/*  }*/
+
+/*  .align-self-lg-center {*/
+/*    -ms-flex-item-align: center !important;*/
+/*    align-self: center !important;*/
+/*  }*/
+
+/*  .align-self-lg-baseline {*/
+/*    -ms-flex-item-align: baseline !important;*/
+/*    align-self: baseline !important;*/
+/*  }*/
+
+/*  .align-self-lg-stretch {*/
+/*    -ms-flex-item-align: stretch !important;*/
+/*    align-self: stretch !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 1200px) {*/
+/*  .flex-xl-row {*/
+/*    -ms-flex-direction: row !important;*/
+/*    flex-direction: row !important;*/
+/*  }*/
+
+/*  .flex-xl-column {*/
+/*    -ms-flex-direction: column !important;*/
+/*    flex-direction: column !important;*/
+/*  }*/
+
+/*  .flex-xl-row-reverse {*/
+/*    -ms-flex-direction: row-reverse !important;*/
+/*    flex-direction: row-reverse !important;*/
+/*  }*/
+
+/*  .flex-xl-column-reverse {*/
+/*    -ms-flex-direction: column-reverse !important;*/
+/*    flex-direction: column-reverse !important;*/
+/*  }*/
+
+/*  .flex-xl-wrap {*/
+/*    -ms-flex-wrap: wrap !important;*/
+/*    flex-wrap: wrap !important;*/
+/*  }*/
+
+/*  .flex-xl-nowrap {*/
+/*    -ms-flex-wrap: nowrap !important;*/
+/*    flex-wrap: nowrap !important;*/
+/*  }*/
+
+/*  .flex-xl-wrap-reverse {*/
+/*    -ms-flex-wrap: wrap-reverse !important;*/
+/*    flex-wrap: wrap-reverse !important;*/
+/*  }*/
+
+/*  .flex-xl-fill {*/
+/*    -ms-flex: 1 1 auto !important;*/
+/*    flex: 1 1 auto !important;*/
+/*  }*/
+
+/*  .flex-xl-grow-0 {*/
+/*    -ms-flex-positive: 0 !important;*/
+/*    flex-grow: 0 !important;*/
+/*  }*/
+
+/*  .flex-xl-grow-1 {*/
+/*    -ms-flex-positive: 1 !important;*/
+/*    flex-grow: 1 !important;*/
+/*  }*/
+
+/*  .flex-xl-shrink-0 {*/
+/*    -ms-flex-negative: 0 !important;*/
+/*    flex-shrink: 0 !important;*/
+/*  }*/
+
+/*  .flex-xl-shrink-1 {*/
+/*    -ms-flex-negative: 1 !important;*/
+/*    flex-shrink: 1 !important;*/
+/*  }*/
+
+/*  .justify-content-xl-start {*/
+/*    -ms-flex-pack: start !important;*/
+/*    justify-content: flex-start !important;*/
+/*  }*/
+
+/*  .justify-content-xl-end {*/
+/*    -ms-flex-pack: end !important;*/
+/*    justify-content: flex-end !important;*/
+/*  }*/
+
+/*  .justify-content-xl-center {*/
+/*    -ms-flex-pack: center !important;*/
+/*    justify-content: center !important;*/
+/*  }*/
+
+/*  .justify-content-xl-between {*/
+/*    -ms-flex-pack: justify !important;*/
+/*    justify-content: space-between !important;*/
+/*  }*/
+
+/*  .justify-content-xl-around {*/
+/*    -ms-flex-pack: distribute !important;*/
+/*    justify-content: space-around !important;*/
+/*  }*/
+
+/*  .align-items-xl-start {*/
+/*    -ms-flex-align: start !important;*/
+/*    align-items: flex-start !important;*/
+/*  }*/
+
+/*  .align-items-xl-end {*/
+/*    -ms-flex-align: end !important;*/
+/*    align-items: flex-end !important;*/
+/*  }*/
+
+/*  .align-items-xl-center {*/
+/*    -ms-flex-align: center !important;*/
+/*    align-items: center !important;*/
+/*  }*/
+
+/*  .align-items-xl-baseline {*/
+/*    -ms-flex-align: baseline !important;*/
+/*    align-items: baseline !important;*/
+/*  }*/
+
+/*  .align-items-xl-stretch {*/
+/*    -ms-flex-align: stretch !important;*/
+/*    align-items: stretch !important;*/
+/*  }*/
+
+/*  .align-content-xl-start {*/
+/*    -ms-flex-line-pack: start !important;*/
+/*    align-content: flex-start !important;*/
+/*  }*/
+
+/*  .align-content-xl-end {*/
+/*    -ms-flex-line-pack: end !important;*/
+/*    align-content: flex-end !important;*/
+/*  }*/
+
+/*  .align-content-xl-center {*/
+/*    -ms-flex-line-pack: center !important;*/
+/*    align-content: center !important;*/
+/*  }*/
+
+/*  .align-content-xl-between {*/
+/*    -ms-flex-line-pack: justify !important;*/
+/*    align-content: space-between !important;*/
+/*  }*/
+
+/*  .align-content-xl-around {*/
+/*    -ms-flex-line-pack: distribute !important;*/
+/*    align-content: space-around !important;*/
+/*  }*/
+
+/*  .align-content-xl-stretch {*/
+/*    -ms-flex-line-pack: stretch !important;*/
+/*    align-content: stretch !important;*/
+/*  }*/
+
+/*  .align-self-xl-auto {*/
+/*    -ms-flex-item-align: auto !important;*/
+/*    align-self: auto !important;*/
+/*  }*/
+
+/*  .align-self-xl-start {*/
+/*    -ms-flex-item-align: start !important;*/
+/*    align-self: flex-start !important;*/
+/*  }*/
+
+/*  .align-self-xl-end {*/
+/*    -ms-flex-item-align: end !important;*/
+/*    align-self: flex-end !important;*/
+/*  }*/
+
+/*  .align-self-xl-center {*/
+/*    -ms-flex-item-align: center !important;*/
+/*    align-self: center !important;*/
+/*  }*/
+
+/*  .align-self-xl-baseline {*/
+/*    -ms-flex-item-align: baseline !important;*/
+/*    align-self: baseline !important;*/
+/*  }*/
+
+/*  .align-self-xl-stretch {*/
+/*    -ms-flex-item-align: stretch !important;*/
+/*    align-self: stretch !important;*/
+/*  }*/
+/*}*/
+
+/*.float-left {*/
+/*  float: left !important;*/
+/*}*/
+
+/*.float-right {*/
+/*  float: right !important;*/
+/*}*/
+
+/*.float-none {*/
+/*  float: none !important;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .float-sm-left {*/
+/*    float: left !important;*/
+/*  }*/
+
+/*  .float-sm-right {*/
+/*    float: right !important;*/
+/*  }*/
+
+/*  .float-sm-none {*/
+/*    float: none !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 768px) {*/
+/*  .float-md-left {*/
+/*    float: left !important;*/
+/*  }*/
+
+/*  .float-md-right {*/
+/*    float: right !important;*/
+/*  }*/
+
+/*  .float-md-none {*/
+/*    float: none !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 992px) {*/
+/*  .float-lg-left {*/
+/*    float: left !important;*/
+/*  }*/
+
+/*  .float-lg-right {*/
+/*    float: right !important;*/
+/*  }*/
+
+/*  .float-lg-none {*/
+/*    float: none !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 1200px) {*/
+/*  .float-xl-left {*/
+/*    float: left !important;*/
+/*  }*/
+
+/*  .float-xl-right {*/
+/*    float: right !important;*/
+/*  }*/
+
+/*  .float-xl-none {*/
+/*    float: none !important;*/
+/*  }*/
+/*}*/
+
+/*.user-select-all {*/
+/*  -webkit-user-select: all !important;*/
+/*  -moz-user-select: all !important;*/
+/*  user-select: all !important;*/
+/*}*/
+
+/*.user-select-auto {*/
+/*  -webkit-user-select: auto !important;*/
+/*  -moz-user-select: auto !important;*/
+/*  -ms-user-select: auto !important;*/
+/*  user-select: auto !important;*/
+/*}*/
+
+/*.user-select-none {*/
+/*  -webkit-user-select: none !important;*/
+/*  -moz-user-select: none !important;*/
+/*  -ms-user-select: none !important;*/
+/*  user-select: none !important;*/
+/*}*/
+
+/*.overflow-auto {*/
+/*  overflow: auto !important;*/
+/*}*/
+
+/*.overflow-hidden {*/
+/*  overflow: hidden !important;*/
+/*}*/
+
+/*.position-static {*/
+/*  position: static !important;*/
+/*}*/
+
+/*.position-relative {*/
+/*  position: relative !important;*/
+/*}*/
+
+/*.position-absolute {*/
+/*  position: absolute !important;*/
+/*}*/
+
+/*.position-fixed {*/
+/*  position: fixed !important;*/
+/*}*/
+
+/*.position-sticky {*/
+/*  position: -webkit-sticky !important;*/
+/*  position: sticky !important;*/
+/*}*/
+
+/*.fixed-top {*/
+/*  position: fixed;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  left: 0;*/
+/*  z-index: 1030;*/
+/*}*/
+
+/*.fixed-bottom {*/
+/*  position: fixed;*/
+/*  right: 0;*/
+/*  bottom: 0;*/
+/*  left: 0;*/
+/*  z-index: 1030;*/
+/*}*/
+
+/*@supports (position: -webkit-sticky) or (position: sticky) {*/
+/*  .sticky-top {*/
+/*    position: -webkit-sticky;*/
+/*    position: sticky;*/
+/*    top: 0;*/
+/*    z-index: 1020;*/
+/*  }*/
+/*}*/
 
 .sr-only {
   position: absolute;
@@ -6514,1725 +8209,2282 @@ button.bg-dark:focus {
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
-  border: 0; }
-
-.sr-only-focusable:active, .sr-only-focusable:focus {
-  position: static;
-  width: auto;
-  height: auto;
-  overflow: visible;
-  clip: auto;
-  white-space: normal; }
-
-.shadow-sm {
-  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important; }
-
-.shadow {
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important; }
-
-.shadow-lg {
-  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175) !important; }
-
-.shadow-none {
-  box-shadow: none !important; }
-
-.w-25 {
-  width: 25% !important; }
-
-.w-50 {
-  width: 50% !important; }
-
-.w-75 {
-  width: 75% !important; }
-
-.w-100 {
-  width: 100% !important; }
-
-.w-auto {
-  width: auto !important; }
-
-.h-25 {
-  height: 25% !important; }
-
-.h-50 {
-  height: 50% !important; }
-
-.h-75 {
-  height: 75% !important; }
-
-.h-100 {
-  height: 100% !important; }
-
-.h-auto {
-  height: auto !important; }
-
-.mw-100 {
-  max-width: 100% !important; }
-
-.mh-100 {
-  max-height: 100% !important; }
-
-.min-vw-100 {
-  min-width: 100vw !important; }
-
-.min-vh-100 {
-  min-height: 100vh !important; }
-
-.vw-100 {
-  width: 100vw !important; }
-
-.vh-100 {
-  height: 100vh !important; }
-
-.m-0 {
-  margin: 0 !important; }
-
-.mt-0,
-.my-0 {
-  margin-top: 0 !important; }
-
-.mr-0,
-.mx-0 {
-  margin-right: 0 !important; }
-
-.mb-0,
-.my-0 {
-  margin-bottom: 0 !important; }
-
-.ml-0,
-.mx-0 {
-  margin-left: 0 !important; }
-
-.m-1 {
-  margin: 0.25rem !important; }
-
-.mt-1,
-.my-1 {
-  margin-top: 0.25rem !important; }
-
-.mr-1,
-.mx-1 {
-  margin-right: 0.25rem !important; }
-
-.mb-1,
-.my-1 {
-  margin-bottom: 0.25rem !important; }
-
-.ml-1,
-.mx-1 {
-  margin-left: 0.25rem !important; }
-
-.m-2 {
-  margin: 0.5rem !important; }
-
-.mt-2,
-.my-2 {
-  margin-top: 0.5rem !important; }
-
-.mr-2,
-.mx-2 {
-  margin-right: 0.5rem !important; }
-
-.mb-2,
-.my-2 {
-  margin-bottom: 0.5rem !important; }
-
-.ml-2,
-.mx-2 {
-  margin-left: 0.5rem !important; }
-
-.m-3 {
-  margin: 1rem !important; }
-
-.mt-3,
-.my-3 {
-  margin-top: 1rem !important; }
-
-.mr-3,
-.mx-3 {
-  margin-right: 1rem !important; }
-
-.mb-3,
-.my-3 {
-  margin-bottom: 1rem !important; }
-
-.ml-3,
-.mx-3 {
-  margin-left: 1rem !important; }
-
-.m-4 {
-  margin: 1.5rem !important; }
-
-.mt-4,
-.my-4 {
-  margin-top: 1.5rem !important; }
-
-.mr-4,
-.mx-4 {
-  margin-right: 1.5rem !important; }
-
-.mb-4,
-.my-4 {
-  margin-bottom: 1.5rem !important; }
-
-.ml-4,
-.mx-4 {
-  margin-left: 1.5rem !important; }
-
-.m-5 {
-  margin: 3rem !important; }
-
-.mt-5,
-.my-5 {
-  margin-top: 3rem !important; }
-
-.mr-5,
-.mx-5 {
-  margin-right: 3rem !important; }
-
-.mb-5,
-.my-5 {
-  margin-bottom: 3rem !important; }
-
-.ml-5,
-.mx-5 {
-  margin-left: 3rem !important; }
-
-.p-0 {
-  padding: 0 !important; }
-
-.pt-0,
-.py-0 {
-  padding-top: 0 !important; }
-
-.pr-0,
-.px-0 {
-  padding-right: 0 !important; }
-
-.pb-0,
-.py-0 {
-  padding-bottom: 0 !important; }
-
-.pl-0,
-.px-0 {
-  padding-left: 0 !important; }
-
-.p-1 {
-  padding: 0.25rem !important; }
-
-.pt-1,
-.py-1 {
-  padding-top: 0.25rem !important; }
-
-.pr-1,
-.px-1 {
-  padding-right: 0.25rem !important; }
-
-.pb-1,
-.py-1 {
-  padding-bottom: 0.25rem !important; }
-
-.pl-1,
-.px-1 {
-  padding-left: 0.25rem !important; }
-
-.p-2 {
-  padding: 0.5rem !important; }
-
-.pt-2,
-.py-2 {
-  padding-top: 0.5rem !important; }
-
-.pr-2,
-.px-2 {
-  padding-right: 0.5rem !important; }
-
-.pb-2,
-.py-2 {
-  padding-bottom: 0.5rem !important; }
-
-.pl-2,
-.px-2 {
-  padding-left: 0.5rem !important; }
-
-.p-3 {
-  padding: 1rem !important; }
-
-.pt-3,
-.py-3 {
-  padding-top: 1rem !important; }
-
-.pr-3,
-.px-3 {
-  padding-right: 1rem !important; }
-
-.pb-3,
-.py-3 {
-  padding-bottom: 1rem !important; }
-
-.pl-3,
-.px-3 {
-  padding-left: 1rem !important; }
-
-.p-4 {
-  padding: 1.5rem !important; }
-
-.pt-4,
-.py-4 {
-  padding-top: 1.5rem !important; }
-
-.pr-4,
-.px-4 {
-  padding-right: 1.5rem !important; }
-
-.pb-4,
-.py-4 {
-  padding-bottom: 1.5rem !important; }
-
-.pl-4,
-.px-4 {
-  padding-left: 1.5rem !important; }
-
-.p-5 {
-  padding: 3rem !important; }
-
-.pt-5,
-.py-5 {
-  padding-top: 3rem !important; }
-
-.pr-5,
-.px-5 {
-  padding-right: 3rem !important; }
-
-.pb-5,
-.py-5 {
-  padding-bottom: 3rem !important; }
-
-.pl-5,
-.px-5 {
-  padding-left: 3rem !important; }
-
-.m-n1 {
-  margin: -0.25rem !important; }
-
-.mt-n1,
-.my-n1 {
-  margin-top: -0.25rem !important; }
-
-.mr-n1,
-.mx-n1 {
-  margin-right: -0.25rem !important; }
-
-.mb-n1,
-.my-n1 {
-  margin-bottom: -0.25rem !important; }
-
-.ml-n1,
-.mx-n1 {
-  margin-left: -0.25rem !important; }
-
-.m-n2 {
-  margin: -0.5rem !important; }
-
-.mt-n2,
-.my-n2 {
-  margin-top: -0.5rem !important; }
-
-.mr-n2,
-.mx-n2 {
-  margin-right: -0.5rem !important; }
-
-.mb-n2,
-.my-n2 {
-  margin-bottom: -0.5rem !important; }
-
-.ml-n2,
-.mx-n2 {
-  margin-left: -0.5rem !important; }
-
-.m-n3 {
-  margin: -1rem !important; }
-
-.mt-n3,
-.my-n3 {
-  margin-top: -1rem !important; }
-
-.mr-n3,
-.mx-n3 {
-  margin-right: -1rem !important; }
-
-.mb-n3,
-.my-n3 {
-  margin-bottom: -1rem !important; }
-
-.ml-n3,
-.mx-n3 {
-  margin-left: -1rem !important; }
-
-.m-n4 {
-  margin: -1.5rem !important; }
-
-.mt-n4,
-.my-n4 {
-  margin-top: -1.5rem !important; }
-
-.mr-n4,
-.mx-n4 {
-  margin-right: -1.5rem !important; }
-
-.mb-n4,
-.my-n4 {
-  margin-bottom: -1.5rem !important; }
-
-.ml-n4,
-.mx-n4 {
-  margin-left: -1.5rem !important; }
-
-.m-n5 {
-  margin: -3rem !important; }
-
-.mt-n5,
-.my-n5 {
-  margin-top: -3rem !important; }
-
-.mr-n5,
-.mx-n5 {
-  margin-right: -3rem !important; }
-
-.mb-n5,
-.my-n5 {
-  margin-bottom: -3rem !important; }
-
-.ml-n5,
-.mx-n5 {
-  margin-left: -3rem !important; }
-
-.m-auto {
-  margin: auto !important; }
-
-.mt-auto,
-.my-auto {
-  margin-top: auto !important; }
-
-.mr-auto,
-.mx-auto {
-  margin-right: auto !important; }
-
-.mb-auto,
-.my-auto {
-  margin-bottom: auto !important; }
-
-.ml-auto,
-.mx-auto {
-  margin-left: auto !important; }
-
-@media (min-width: 576px) {
-  .m-sm-0 {
-    margin: 0 !important; }
-  .mt-sm-0,
-  .my-sm-0 {
-    margin-top: 0 !important; }
-  .mr-sm-0,
-  .mx-sm-0 {
-    margin-right: 0 !important; }
-  .mb-sm-0,
-  .my-sm-0 {
-    margin-bottom: 0 !important; }
-  .ml-sm-0,
-  .mx-sm-0 {
-    margin-left: 0 !important; }
-  .m-sm-1 {
-    margin: 0.25rem !important; }
-  .mt-sm-1,
-  .my-sm-1 {
-    margin-top: 0.25rem !important; }
-  .mr-sm-1,
-  .mx-sm-1 {
-    margin-right: 0.25rem !important; }
-  .mb-sm-1,
-  .my-sm-1 {
-    margin-bottom: 0.25rem !important; }
-  .ml-sm-1,
-  .mx-sm-1 {
-    margin-left: 0.25rem !important; }
-  .m-sm-2 {
-    margin: 0.5rem !important; }
-  .mt-sm-2,
-  .my-sm-2 {
-    margin-top: 0.5rem !important; }
-  .mr-sm-2,
-  .mx-sm-2 {
-    margin-right: 0.5rem !important; }
-  .mb-sm-2,
-  .my-sm-2 {
-    margin-bottom: 0.5rem !important; }
-  .ml-sm-2,
-  .mx-sm-2 {
-    margin-left: 0.5rem !important; }
-  .m-sm-3 {
-    margin: 1rem !important; }
-  .mt-sm-3,
-  .my-sm-3 {
-    margin-top: 1rem !important; }
-  .mr-sm-3,
-  .mx-sm-3 {
-    margin-right: 1rem !important; }
-  .mb-sm-3,
-  .my-sm-3 {
-    margin-bottom: 1rem !important; }
-  .ml-sm-3,
-  .mx-sm-3 {
-    margin-left: 1rem !important; }
-  .m-sm-4 {
-    margin: 1.5rem !important; }
-  .mt-sm-4,
-  .my-sm-4 {
-    margin-top: 1.5rem !important; }
-  .mr-sm-4,
-  .mx-sm-4 {
-    margin-right: 1.5rem !important; }
-  .mb-sm-4,
-  .my-sm-4 {
-    margin-bottom: 1.5rem !important; }
-  .ml-sm-4,
-  .mx-sm-4 {
-    margin-left: 1.5rem !important; }
-  .m-sm-5 {
-    margin: 3rem !important; }
-  .mt-sm-5,
-  .my-sm-5 {
-    margin-top: 3rem !important; }
-  .mr-sm-5,
-  .mx-sm-5 {
-    margin-right: 3rem !important; }
-  .mb-sm-5,
-  .my-sm-5 {
-    margin-bottom: 3rem !important; }
-  .ml-sm-5,
-  .mx-sm-5 {
-    margin-left: 3rem !important; }
-  .p-sm-0 {
-    padding: 0 !important; }
-  .pt-sm-0,
-  .py-sm-0 {
-    padding-top: 0 !important; }
-  .pr-sm-0,
-  .px-sm-0 {
-    padding-right: 0 !important; }
-  .pb-sm-0,
-  .py-sm-0 {
-    padding-bottom: 0 !important; }
-  .pl-sm-0,
-  .px-sm-0 {
-    padding-left: 0 !important; }
-  .p-sm-1 {
-    padding: 0.25rem !important; }
-  .pt-sm-1,
-  .py-sm-1 {
-    padding-top: 0.25rem !important; }
-  .pr-sm-1,
-  .px-sm-1 {
-    padding-right: 0.25rem !important; }
-  .pb-sm-1,
-  .py-sm-1 {
-    padding-bottom: 0.25rem !important; }
-  .pl-sm-1,
-  .px-sm-1 {
-    padding-left: 0.25rem !important; }
-  .p-sm-2 {
-    padding: 0.5rem !important; }
-  .pt-sm-2,
-  .py-sm-2 {
-    padding-top: 0.5rem !important; }
-  .pr-sm-2,
-  .px-sm-2 {
-    padding-right: 0.5rem !important; }
-  .pb-sm-2,
-  .py-sm-2 {
-    padding-bottom: 0.5rem !important; }
-  .pl-sm-2,
-  .px-sm-2 {
-    padding-left: 0.5rem !important; }
-  .p-sm-3 {
-    padding: 1rem !important; }
-  .pt-sm-3,
-  .py-sm-3 {
-    padding-top: 1rem !important; }
-  .pr-sm-3,
-  .px-sm-3 {
-    padding-right: 1rem !important; }
-  .pb-sm-3,
-  .py-sm-3 {
-    padding-bottom: 1rem !important; }
-  .pl-sm-3,
-  .px-sm-3 {
-    padding-left: 1rem !important; }
-  .p-sm-4 {
-    padding: 1.5rem !important; }
-  .pt-sm-4,
-  .py-sm-4 {
-    padding-top: 1.5rem !important; }
-  .pr-sm-4,
-  .px-sm-4 {
-    padding-right: 1.5rem !important; }
-  .pb-sm-4,
-  .py-sm-4 {
-    padding-bottom: 1.5rem !important; }
-  .pl-sm-4,
-  .px-sm-4 {
-    padding-left: 1.5rem !important; }
-  .p-sm-5 {
-    padding: 3rem !important; }
-  .pt-sm-5,
-  .py-sm-5 {
-    padding-top: 3rem !important; }
-  .pr-sm-5,
-  .px-sm-5 {
-    padding-right: 3rem !important; }
-  .pb-sm-5,
-  .py-sm-5 {
-    padding-bottom: 3rem !important; }
-  .pl-sm-5,
-  .px-sm-5 {
-    padding-left: 3rem !important; }
-  .m-sm-n1 {
-    margin: -0.25rem !important; }
-  .mt-sm-n1,
-  .my-sm-n1 {
-    margin-top: -0.25rem !important; }
-  .mr-sm-n1,
-  .mx-sm-n1 {
-    margin-right: -0.25rem !important; }
-  .mb-sm-n1,
-  .my-sm-n1 {
-    margin-bottom: -0.25rem !important; }
-  .ml-sm-n1,
-  .mx-sm-n1 {
-    margin-left: -0.25rem !important; }
-  .m-sm-n2 {
-    margin: -0.5rem !important; }
-  .mt-sm-n2,
-  .my-sm-n2 {
-    margin-top: -0.5rem !important; }
-  .mr-sm-n2,
-  .mx-sm-n2 {
-    margin-right: -0.5rem !important; }
-  .mb-sm-n2,
-  .my-sm-n2 {
-    margin-bottom: -0.5rem !important; }
-  .ml-sm-n2,
-  .mx-sm-n2 {
-    margin-left: -0.5rem !important; }
-  .m-sm-n3 {
-    margin: -1rem !important; }
-  .mt-sm-n3,
-  .my-sm-n3 {
-    margin-top: -1rem !important; }
-  .mr-sm-n3,
-  .mx-sm-n3 {
-    margin-right: -1rem !important; }
-  .mb-sm-n3,
-  .my-sm-n3 {
-    margin-bottom: -1rem !important; }
-  .ml-sm-n3,
-  .mx-sm-n3 {
-    margin-left: -1rem !important; }
-  .m-sm-n4 {
-    margin: -1.5rem !important; }
-  .mt-sm-n4,
-  .my-sm-n4 {
-    margin-top: -1.5rem !important; }
-  .mr-sm-n4,
-  .mx-sm-n4 {
-    margin-right: -1.5rem !important; }
-  .mb-sm-n4,
-  .my-sm-n4 {
-    margin-bottom: -1.5rem !important; }
-  .ml-sm-n4,
-  .mx-sm-n4 {
-    margin-left: -1.5rem !important; }
-  .m-sm-n5 {
-    margin: -3rem !important; }
-  .mt-sm-n5,
-  .my-sm-n5 {
-    margin-top: -3rem !important; }
-  .mr-sm-n5,
-  .mx-sm-n5 {
-    margin-right: -3rem !important; }
-  .mb-sm-n5,
-  .my-sm-n5 {
-    margin-bottom: -3rem !important; }
-  .ml-sm-n5,
-  .mx-sm-n5 {
-    margin-left: -3rem !important; }
-  .m-sm-auto {
-    margin: auto !important; }
-  .mt-sm-auto,
-  .my-sm-auto {
-    margin-top: auto !important; }
-  .mr-sm-auto,
-  .mx-sm-auto {
-    margin-right: auto !important; }
-  .mb-sm-auto,
-  .my-sm-auto {
-    margin-bottom: auto !important; }
-  .ml-sm-auto,
-  .mx-sm-auto {
-    margin-left: auto !important; } }
-
-@media (min-width: 768px) {
-  .m-md-0 {
-    margin: 0 !important; }
-  .mt-md-0,
-  .my-md-0 {
-    margin-top: 0 !important; }
-  .mr-md-0,
-  .mx-md-0 {
-    margin-right: 0 !important; }
-  .mb-md-0,
-  .my-md-0 {
-    margin-bottom: 0 !important; }
-  .ml-md-0,
-  .mx-md-0 {
-    margin-left: 0 !important; }
-  .m-md-1 {
-    margin: 0.25rem !important; }
-  .mt-md-1,
-  .my-md-1 {
-    margin-top: 0.25rem !important; }
-  .mr-md-1,
-  .mx-md-1 {
-    margin-right: 0.25rem !important; }
-  .mb-md-1,
-  .my-md-1 {
-    margin-bottom: 0.25rem !important; }
-  .ml-md-1,
-  .mx-md-1 {
-    margin-left: 0.25rem !important; }
-  .m-md-2 {
-    margin: 0.5rem !important; }
-  .mt-md-2,
-  .my-md-2 {
-    margin-top: 0.5rem !important; }
-  .mr-md-2,
-  .mx-md-2 {
-    margin-right: 0.5rem !important; }
-  .mb-md-2,
-  .my-md-2 {
-    margin-bottom: 0.5rem !important; }
-  .ml-md-2,
-  .mx-md-2 {
-    margin-left: 0.5rem !important; }
-  .m-md-3 {
-    margin: 1rem !important; }
-  .mt-md-3,
-  .my-md-3 {
-    margin-top: 1rem !important; }
-  .mr-md-3,
-  .mx-md-3 {
-    margin-right: 1rem !important; }
-  .mb-md-3,
-  .my-md-3 {
-    margin-bottom: 1rem !important; }
-  .ml-md-3,
-  .mx-md-3 {
-    margin-left: 1rem !important; }
-  .m-md-4 {
-    margin: 1.5rem !important; }
-  .mt-md-4,
-  .my-md-4 {
-    margin-top: 1.5rem !important; }
-  .mr-md-4,
-  .mx-md-4 {
-    margin-right: 1.5rem !important; }
-  .mb-md-4,
-  .my-md-4 {
-    margin-bottom: 1.5rem !important; }
-  .ml-md-4,
-  .mx-md-4 {
-    margin-left: 1.5rem !important; }
-  .m-md-5 {
-    margin: 3rem !important; }
-  .mt-md-5,
-  .my-md-5 {
-    margin-top: 3rem !important; }
-  .mr-md-5,
-  .mx-md-5 {
-    margin-right: 3rem !important; }
-  .mb-md-5,
-  .my-md-5 {
-    margin-bottom: 3rem !important; }
-  .ml-md-5,
-  .mx-md-5 {
-    margin-left: 3rem !important; }
-  .p-md-0 {
-    padding: 0 !important; }
-  .pt-md-0,
-  .py-md-0 {
-    padding-top: 0 !important; }
-  .pr-md-0,
-  .px-md-0 {
-    padding-right: 0 !important; }
-  .pb-md-0,
-  .py-md-0 {
-    padding-bottom: 0 !important; }
-  .pl-md-0,
-  .px-md-0 {
-    padding-left: 0 !important; }
-  .p-md-1 {
-    padding: 0.25rem !important; }
-  .pt-md-1,
-  .py-md-1 {
-    padding-top: 0.25rem !important; }
-  .pr-md-1,
-  .px-md-1 {
-    padding-right: 0.25rem !important; }
-  .pb-md-1,
-  .py-md-1 {
-    padding-bottom: 0.25rem !important; }
-  .pl-md-1,
-  .px-md-1 {
-    padding-left: 0.25rem !important; }
-  .p-md-2 {
-    padding: 0.5rem !important; }
-  .pt-md-2,
-  .py-md-2 {
-    padding-top: 0.5rem !important; }
-  .pr-md-2,
-  .px-md-2 {
-    padding-right: 0.5rem !important; }
-  .pb-md-2,
-  .py-md-2 {
-    padding-bottom: 0.5rem !important; }
-  .pl-md-2,
-  .px-md-2 {
-    padding-left: 0.5rem !important; }
-  .p-md-3 {
-    padding: 1rem !important; }
-  .pt-md-3,
-  .py-md-3 {
-    padding-top: 1rem !important; }
-  .pr-md-3,
-  .px-md-3 {
-    padding-right: 1rem !important; }
-  .pb-md-3,
-  .py-md-3 {
-    padding-bottom: 1rem !important; }
-  .pl-md-3,
-  .px-md-3 {
-    padding-left: 1rem !important; }
-  .p-md-4 {
-    padding: 1.5rem !important; }
-  .pt-md-4,
-  .py-md-4 {
-    padding-top: 1.5rem !important; }
-  .pr-md-4,
-  .px-md-4 {
-    padding-right: 1.5rem !important; }
-  .pb-md-4,
-  .py-md-4 {
-    padding-bottom: 1.5rem !important; }
-  .pl-md-4,
-  .px-md-4 {
-    padding-left: 1.5rem !important; }
-  .p-md-5 {
-    padding: 3rem !important; }
-  .pt-md-5,
-  .py-md-5 {
-    padding-top: 3rem !important; }
-  .pr-md-5,
-  .px-md-5 {
-    padding-right: 3rem !important; }
-  .pb-md-5,
-  .py-md-5 {
-    padding-bottom: 3rem !important; }
-  .pl-md-5,
-  .px-md-5 {
-    padding-left: 3rem !important; }
-  .m-md-n1 {
-    margin: -0.25rem !important; }
-  .mt-md-n1,
-  .my-md-n1 {
-    margin-top: -0.25rem !important; }
-  .mr-md-n1,
-  .mx-md-n1 {
-    margin-right: -0.25rem !important; }
-  .mb-md-n1,
-  .my-md-n1 {
-    margin-bottom: -0.25rem !important; }
-  .ml-md-n1,
-  .mx-md-n1 {
-    margin-left: -0.25rem !important; }
-  .m-md-n2 {
-    margin: -0.5rem !important; }
-  .mt-md-n2,
-  .my-md-n2 {
-    margin-top: -0.5rem !important; }
-  .mr-md-n2,
-  .mx-md-n2 {
-    margin-right: -0.5rem !important; }
-  .mb-md-n2,
-  .my-md-n2 {
-    margin-bottom: -0.5rem !important; }
-  .ml-md-n2,
-  .mx-md-n2 {
-    margin-left: -0.5rem !important; }
-  .m-md-n3 {
-    margin: -1rem !important; }
-  .mt-md-n3,
-  .my-md-n3 {
-    margin-top: -1rem !important; }
-  .mr-md-n3,
-  .mx-md-n3 {
-    margin-right: -1rem !important; }
-  .mb-md-n3,
-  .my-md-n3 {
-    margin-bottom: -1rem !important; }
-  .ml-md-n3,
-  .mx-md-n3 {
-    margin-left: -1rem !important; }
-  .m-md-n4 {
-    margin: -1.5rem !important; }
-  .mt-md-n4,
-  .my-md-n4 {
-    margin-top: -1.5rem !important; }
-  .mr-md-n4,
-  .mx-md-n4 {
-    margin-right: -1.5rem !important; }
-  .mb-md-n4,
-  .my-md-n4 {
-    margin-bottom: -1.5rem !important; }
-  .ml-md-n4,
-  .mx-md-n4 {
-    margin-left: -1.5rem !important; }
-  .m-md-n5 {
-    margin: -3rem !important; }
-  .mt-md-n5,
-  .my-md-n5 {
-    margin-top: -3rem !important; }
-  .mr-md-n5,
-  .mx-md-n5 {
-    margin-right: -3rem !important; }
-  .mb-md-n5,
-  .my-md-n5 {
-    margin-bottom: -3rem !important; }
-  .ml-md-n5,
-  .mx-md-n5 {
-    margin-left: -3rem !important; }
-  .m-md-auto {
-    margin: auto !important; }
-  .mt-md-auto,
-  .my-md-auto {
-    margin-top: auto !important; }
-  .mr-md-auto,
-  .mx-md-auto {
-    margin-right: auto !important; }
-  .mb-md-auto,
-  .my-md-auto {
-    margin-bottom: auto !important; }
-  .ml-md-auto,
-  .mx-md-auto {
-    margin-left: auto !important; } }
-
-@media (min-width: 992px) {
-  .m-lg-0 {
-    margin: 0 !important; }
-  .mt-lg-0,
-  .my-lg-0 {
-    margin-top: 0 !important; }
-  .mr-lg-0,
-  .mx-lg-0 {
-    margin-right: 0 !important; }
-  .mb-lg-0,
-  .my-lg-0 {
-    margin-bottom: 0 !important; }
-  .ml-lg-0,
-  .mx-lg-0 {
-    margin-left: 0 !important; }
-  .m-lg-1 {
-    margin: 0.25rem !important; }
-  .mt-lg-1,
-  .my-lg-1 {
-    margin-top: 0.25rem !important; }
-  .mr-lg-1,
-  .mx-lg-1 {
-    margin-right: 0.25rem !important; }
-  .mb-lg-1,
-  .my-lg-1 {
-    margin-bottom: 0.25rem !important; }
-  .ml-lg-1,
-  .mx-lg-1 {
-    margin-left: 0.25rem !important; }
-  .m-lg-2 {
-    margin: 0.5rem !important; }
-  .mt-lg-2,
-  .my-lg-2 {
-    margin-top: 0.5rem !important; }
-  .mr-lg-2,
-  .mx-lg-2 {
-    margin-right: 0.5rem !important; }
-  .mb-lg-2,
-  .my-lg-2 {
-    margin-bottom: 0.5rem !important; }
-  .ml-lg-2,
-  .mx-lg-2 {
-    margin-left: 0.5rem !important; }
-  .m-lg-3 {
-    margin: 1rem !important; }
-  .mt-lg-3,
-  .my-lg-3 {
-    margin-top: 1rem !important; }
-  .mr-lg-3,
-  .mx-lg-3 {
-    margin-right: 1rem !important; }
-  .mb-lg-3,
-  .my-lg-3 {
-    margin-bottom: 1rem !important; }
-  .ml-lg-3,
-  .mx-lg-3 {
-    margin-left: 1rem !important; }
-  .m-lg-4 {
-    margin: 1.5rem !important; }
-  .mt-lg-4,
-  .my-lg-4 {
-    margin-top: 1.5rem !important; }
-  .mr-lg-4,
-  .mx-lg-4 {
-    margin-right: 1.5rem !important; }
-  .mb-lg-4,
-  .my-lg-4 {
-    margin-bottom: 1.5rem !important; }
-  .ml-lg-4,
-  .mx-lg-4 {
-    margin-left: 1.5rem !important; }
-  .m-lg-5 {
-    margin: 3rem !important; }
-  .mt-lg-5,
-  .my-lg-5 {
-    margin-top: 3rem !important; }
-  .mr-lg-5,
-  .mx-lg-5 {
-    margin-right: 3rem !important; }
-  .mb-lg-5,
-  .my-lg-5 {
-    margin-bottom: 3rem !important; }
-  .ml-lg-5,
-  .mx-lg-5 {
-    margin-left: 3rem !important; }
-  .p-lg-0 {
-    padding: 0 !important; }
-  .pt-lg-0,
-  .py-lg-0 {
-    padding-top: 0 !important; }
-  .pr-lg-0,
-  .px-lg-0 {
-    padding-right: 0 !important; }
-  .pb-lg-0,
-  .py-lg-0 {
-    padding-bottom: 0 !important; }
-  .pl-lg-0,
-  .px-lg-0 {
-    padding-left: 0 !important; }
-  .p-lg-1 {
-    padding: 0.25rem !important; }
-  .pt-lg-1,
-  .py-lg-1 {
-    padding-top: 0.25rem !important; }
-  .pr-lg-1,
-  .px-lg-1 {
-    padding-right: 0.25rem !important; }
-  .pb-lg-1,
-  .py-lg-1 {
-    padding-bottom: 0.25rem !important; }
-  .pl-lg-1,
-  .px-lg-1 {
-    padding-left: 0.25rem !important; }
-  .p-lg-2 {
-    padding: 0.5rem !important; }
-  .pt-lg-2,
-  .py-lg-2 {
-    padding-top: 0.5rem !important; }
-  .pr-lg-2,
-  .px-lg-2 {
-    padding-right: 0.5rem !important; }
-  .pb-lg-2,
-  .py-lg-2 {
-    padding-bottom: 0.5rem !important; }
-  .pl-lg-2,
-  .px-lg-2 {
-    padding-left: 0.5rem !important; }
-  .p-lg-3 {
-    padding: 1rem !important; }
-  .pt-lg-3,
-  .py-lg-3 {
-    padding-top: 1rem !important; }
-  .pr-lg-3,
-  .px-lg-3 {
-    padding-right: 1rem !important; }
-  .pb-lg-3,
-  .py-lg-3 {
-    padding-bottom: 1rem !important; }
-  .pl-lg-3,
-  .px-lg-3 {
-    padding-left: 1rem !important; }
-  .p-lg-4 {
-    padding: 1.5rem !important; }
-  .pt-lg-4,
-  .py-lg-4 {
-    padding-top: 1.5rem !important; }
-  .pr-lg-4,
-  .px-lg-4 {
-    padding-right: 1.5rem !important; }
-  .pb-lg-4,
-  .py-lg-4 {
-    padding-bottom: 1.5rem !important; }
-  .pl-lg-4,
-  .px-lg-4 {
-    padding-left: 1.5rem !important; }
-  .p-lg-5 {
-    padding: 3rem !important; }
-  .pt-lg-5,
-  .py-lg-5 {
-    padding-top: 3rem !important; }
-  .pr-lg-5,
-  .px-lg-5 {
-    padding-right: 3rem !important; }
-  .pb-lg-5,
-  .py-lg-5 {
-    padding-bottom: 3rem !important; }
-  .pl-lg-5,
-  .px-lg-5 {
-    padding-left: 3rem !important; }
-  .m-lg-n1 {
-    margin: -0.25rem !important; }
-  .mt-lg-n1,
-  .my-lg-n1 {
-    margin-top: -0.25rem !important; }
-  .mr-lg-n1,
-  .mx-lg-n1 {
-    margin-right: -0.25rem !important; }
-  .mb-lg-n1,
-  .my-lg-n1 {
-    margin-bottom: -0.25rem !important; }
-  .ml-lg-n1,
-  .mx-lg-n1 {
-    margin-left: -0.25rem !important; }
-  .m-lg-n2 {
-    margin: -0.5rem !important; }
-  .mt-lg-n2,
-  .my-lg-n2 {
-    margin-top: -0.5rem !important; }
-  .mr-lg-n2,
-  .mx-lg-n2 {
-    margin-right: -0.5rem !important; }
-  .mb-lg-n2,
-  .my-lg-n2 {
-    margin-bottom: -0.5rem !important; }
-  .ml-lg-n2,
-  .mx-lg-n2 {
-    margin-left: -0.5rem !important; }
-  .m-lg-n3 {
-    margin: -1rem !important; }
-  .mt-lg-n3,
-  .my-lg-n3 {
-    margin-top: -1rem !important; }
-  .mr-lg-n3,
-  .mx-lg-n3 {
-    margin-right: -1rem !important; }
-  .mb-lg-n3,
-  .my-lg-n3 {
-    margin-bottom: -1rem !important; }
-  .ml-lg-n3,
-  .mx-lg-n3 {
-    margin-left: -1rem !important; }
-  .m-lg-n4 {
-    margin: -1.5rem !important; }
-  .mt-lg-n4,
-  .my-lg-n4 {
-    margin-top: -1.5rem !important; }
-  .mr-lg-n4,
-  .mx-lg-n4 {
-    margin-right: -1.5rem !important; }
-  .mb-lg-n4,
-  .my-lg-n4 {
-    margin-bottom: -1.5rem !important; }
-  .ml-lg-n4,
-  .mx-lg-n4 {
-    margin-left: -1.5rem !important; }
-  .m-lg-n5 {
-    margin: -3rem !important; }
-  .mt-lg-n5,
-  .my-lg-n5 {
-    margin-top: -3rem !important; }
-  .mr-lg-n5,
-  .mx-lg-n5 {
-    margin-right: -3rem !important; }
-  .mb-lg-n5,
-  .my-lg-n5 {
-    margin-bottom: -3rem !important; }
-  .ml-lg-n5,
-  .mx-lg-n5 {
-    margin-left: -3rem !important; }
-  .m-lg-auto {
-    margin: auto !important; }
-  .mt-lg-auto,
-  .my-lg-auto {
-    margin-top: auto !important; }
-  .mr-lg-auto,
-  .mx-lg-auto {
-    margin-right: auto !important; }
-  .mb-lg-auto,
-  .my-lg-auto {
-    margin-bottom: auto !important; }
-  .ml-lg-auto,
-  .mx-lg-auto {
-    margin-left: auto !important; } }
-
-@media (min-width: 1200px) {
-  .m-xl-0 {
-    margin: 0 !important; }
-  .mt-xl-0,
-  .my-xl-0 {
-    margin-top: 0 !important; }
-  .mr-xl-0,
-  .mx-xl-0 {
-    margin-right: 0 !important; }
-  .mb-xl-0,
-  .my-xl-0 {
-    margin-bottom: 0 !important; }
-  .ml-xl-0,
-  .mx-xl-0 {
-    margin-left: 0 !important; }
-  .m-xl-1 {
-    margin: 0.25rem !important; }
-  .mt-xl-1,
-  .my-xl-1 {
-    margin-top: 0.25rem !important; }
-  .mr-xl-1,
-  .mx-xl-1 {
-    margin-right: 0.25rem !important; }
-  .mb-xl-1,
-  .my-xl-1 {
-    margin-bottom: 0.25rem !important; }
-  .ml-xl-1,
-  .mx-xl-1 {
-    margin-left: 0.25rem !important; }
-  .m-xl-2 {
-    margin: 0.5rem !important; }
-  .mt-xl-2,
-  .my-xl-2 {
-    margin-top: 0.5rem !important; }
-  .mr-xl-2,
-  .mx-xl-2 {
-    margin-right: 0.5rem !important; }
-  .mb-xl-2,
-  .my-xl-2 {
-    margin-bottom: 0.5rem !important; }
-  .ml-xl-2,
-  .mx-xl-2 {
-    margin-left: 0.5rem !important; }
-  .m-xl-3 {
-    margin: 1rem !important; }
-  .mt-xl-3,
-  .my-xl-3 {
-    margin-top: 1rem !important; }
-  .mr-xl-3,
-  .mx-xl-3 {
-    margin-right: 1rem !important; }
-  .mb-xl-3,
-  .my-xl-3 {
-    margin-bottom: 1rem !important; }
-  .ml-xl-3,
-  .mx-xl-3 {
-    margin-left: 1rem !important; }
-  .m-xl-4 {
-    margin: 1.5rem !important; }
-  .mt-xl-4,
-  .my-xl-4 {
-    margin-top: 1.5rem !important; }
-  .mr-xl-4,
-  .mx-xl-4 {
-    margin-right: 1.5rem !important; }
-  .mb-xl-4,
-  .my-xl-4 {
-    margin-bottom: 1.5rem !important; }
-  .ml-xl-4,
-  .mx-xl-4 {
-    margin-left: 1.5rem !important; }
-  .m-xl-5 {
-    margin: 3rem !important; }
-  .mt-xl-5,
-  .my-xl-5 {
-    margin-top: 3rem !important; }
-  .mr-xl-5,
-  .mx-xl-5 {
-    margin-right: 3rem !important; }
-  .mb-xl-5,
-  .my-xl-5 {
-    margin-bottom: 3rem !important; }
-  .ml-xl-5,
-  .mx-xl-5 {
-    margin-left: 3rem !important; }
-  .p-xl-0 {
-    padding: 0 !important; }
-  .pt-xl-0,
-  .py-xl-0 {
-    padding-top: 0 !important; }
-  .pr-xl-0,
-  .px-xl-0 {
-    padding-right: 0 !important; }
-  .pb-xl-0,
-  .py-xl-0 {
-    padding-bottom: 0 !important; }
-  .pl-xl-0,
-  .px-xl-0 {
-    padding-left: 0 !important; }
-  .p-xl-1 {
-    padding: 0.25rem !important; }
-  .pt-xl-1,
-  .py-xl-1 {
-    padding-top: 0.25rem !important; }
-  .pr-xl-1,
-  .px-xl-1 {
-    padding-right: 0.25rem !important; }
-  .pb-xl-1,
-  .py-xl-1 {
-    padding-bottom: 0.25rem !important; }
-  .pl-xl-1,
-  .px-xl-1 {
-    padding-left: 0.25rem !important; }
-  .p-xl-2 {
-    padding: 0.5rem !important; }
-  .pt-xl-2,
-  .py-xl-2 {
-    padding-top: 0.5rem !important; }
-  .pr-xl-2,
-  .px-xl-2 {
-    padding-right: 0.5rem !important; }
-  .pb-xl-2,
-  .py-xl-2 {
-    padding-bottom: 0.5rem !important; }
-  .pl-xl-2,
-  .px-xl-2 {
-    padding-left: 0.5rem !important; }
-  .p-xl-3 {
-    padding: 1rem !important; }
-  .pt-xl-3,
-  .py-xl-3 {
-    padding-top: 1rem !important; }
-  .pr-xl-3,
-  .px-xl-3 {
-    padding-right: 1rem !important; }
-  .pb-xl-3,
-  .py-xl-3 {
-    padding-bottom: 1rem !important; }
-  .pl-xl-3,
-  .px-xl-3 {
-    padding-left: 1rem !important; }
-  .p-xl-4 {
-    padding: 1.5rem !important; }
-  .pt-xl-4,
-  .py-xl-4 {
-    padding-top: 1.5rem !important; }
-  .pr-xl-4,
-  .px-xl-4 {
-    padding-right: 1.5rem !important; }
-  .pb-xl-4,
-  .py-xl-4 {
-    padding-bottom: 1.5rem !important; }
-  .pl-xl-4,
-  .px-xl-4 {
-    padding-left: 1.5rem !important; }
-  .p-xl-5 {
-    padding: 3rem !important; }
-  .pt-xl-5,
-  .py-xl-5 {
-    padding-top: 3rem !important; }
-  .pr-xl-5,
-  .px-xl-5 {
-    padding-right: 3rem !important; }
-  .pb-xl-5,
-  .py-xl-5 {
-    padding-bottom: 3rem !important; }
-  .pl-xl-5,
-  .px-xl-5 {
-    padding-left: 3rem !important; }
-  .m-xl-n1 {
-    margin: -0.25rem !important; }
-  .mt-xl-n1,
-  .my-xl-n1 {
-    margin-top: -0.25rem !important; }
-  .mr-xl-n1,
-  .mx-xl-n1 {
-    margin-right: -0.25rem !important; }
-  .mb-xl-n1,
-  .my-xl-n1 {
-    margin-bottom: -0.25rem !important; }
-  .ml-xl-n1,
-  .mx-xl-n1 {
-    margin-left: -0.25rem !important; }
-  .m-xl-n2 {
-    margin: -0.5rem !important; }
-  .mt-xl-n2,
-  .my-xl-n2 {
-    margin-top: -0.5rem !important; }
-  .mr-xl-n2,
-  .mx-xl-n2 {
-    margin-right: -0.5rem !important; }
-  .mb-xl-n2,
-  .my-xl-n2 {
-    margin-bottom: -0.5rem !important; }
-  .ml-xl-n2,
-  .mx-xl-n2 {
-    margin-left: -0.5rem !important; }
-  .m-xl-n3 {
-    margin: -1rem !important; }
-  .mt-xl-n3,
-  .my-xl-n3 {
-    margin-top: -1rem !important; }
-  .mr-xl-n3,
-  .mx-xl-n3 {
-    margin-right: -1rem !important; }
-  .mb-xl-n3,
-  .my-xl-n3 {
-    margin-bottom: -1rem !important; }
-  .ml-xl-n3,
-  .mx-xl-n3 {
-    margin-left: -1rem !important; }
-  .m-xl-n4 {
-    margin: -1.5rem !important; }
-  .mt-xl-n4,
-  .my-xl-n4 {
-    margin-top: -1.5rem !important; }
-  .mr-xl-n4,
-  .mx-xl-n4 {
-    margin-right: -1.5rem !important; }
-  .mb-xl-n4,
-  .my-xl-n4 {
-    margin-bottom: -1.5rem !important; }
-  .ml-xl-n4,
-  .mx-xl-n4 {
-    margin-left: -1.5rem !important; }
-  .m-xl-n5 {
-    margin: -3rem !important; }
-  .mt-xl-n5,
-  .my-xl-n5 {
-    margin-top: -3rem !important; }
-  .mr-xl-n5,
-  .mx-xl-n5 {
-    margin-right: -3rem !important; }
-  .mb-xl-n5,
-  .my-xl-n5 {
-    margin-bottom: -3rem !important; }
-  .ml-xl-n5,
-  .mx-xl-n5 {
-    margin-left: -3rem !important; }
-  .m-xl-auto {
-    margin: auto !important; }
-  .mt-xl-auto,
-  .my-xl-auto {
-    margin-top: auto !important; }
-  .mr-xl-auto,
-  .mx-xl-auto {
-    margin-right: auto !important; }
-  .mb-xl-auto,
-  .my-xl-auto {
-    margin-bottom: auto !important; }
-  .ml-xl-auto,
-  .mx-xl-auto {
-    margin-left: auto !important; } }
-
-.stretched-link::after {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 1;
-  pointer-events: auto;
-  content: "";
-  background-color: rgba(0, 0, 0, 0); }
-
-.text-monospace {
-  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important; }
-
-.text-justify {
-  text-align: justify !important; }
-
-.text-wrap {
-  white-space: normal !important; }
-
-.text-nowrap {
-  white-space: nowrap !important; }
-
-.text-truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap; }
-
-.text-left {
-  text-align: left !important; }
-
-.text-right {
-  text-align: right !important; }
-
-.text-center {
-  text-align: center !important; }
-
-@media (min-width: 576px) {
-  .text-sm-left {
-    text-align: left !important; }
-  .text-sm-right {
-    text-align: right !important; }
-  .text-sm-center {
-    text-align: center !important; } }
-
-@media (min-width: 768px) {
-  .text-md-left {
-    text-align: left !important; }
-  .text-md-right {
-    text-align: right !important; }
-  .text-md-center {
-    text-align: center !important; } }
-
-@media (min-width: 992px) {
-  .text-lg-left {
-    text-align: left !important; }
-  .text-lg-right {
-    text-align: right !important; }
-  .text-lg-center {
-    text-align: center !important; } }
-
-@media (min-width: 1200px) {
-  .text-xl-left {
-    text-align: left !important; }
-  .text-xl-right {
-    text-align: right !important; }
-  .text-xl-center {
-    text-align: center !important; } }
-
-.text-lowercase {
-  text-transform: lowercase !important; }
-
-.text-uppercase {
-  text-transform: uppercase !important; }
-
-.text-capitalize {
-  text-transform: capitalize !important; }
-
-.font-weight-light {
-  font-weight: 300 !important; }
-
-.font-weight-lighter {
-  font-weight: lighter !important; }
-
-.font-weight-normal {
-  font-weight: 400 !important; }
-
-.font-weight-bold {
-  font-weight: 700 !important; }
-
-.font-weight-bolder {
-  font-weight: bolder !important; }
-
-.font-italic {
-  font-style: italic !important; }
-
-.text-white {
-  color: #fff !important; }
-
-.text-primary {
-  color: #007bff !important; }
-
-a.text-primary:hover, a.text-primary:focus {
-  color: #0056b3 !important; }
-
-.text-secondary {
-  color: #6c757d !important; }
-
-a.text-secondary:hover, a.text-secondary:focus {
-  color: #494f54 !important; }
-
-.text-success {
-  color: #28a745 !important; }
-
-a.text-success:hover, a.text-success:focus {
-  color: #19692c !important; }
-
-.text-info {
-  color: #17a2b8 !important; }
-
-a.text-info:hover, a.text-info:focus {
-  color: #0f6674 !important; }
-
-.text-warning {
-  color: #ffc107 !important; }
-
-a.text-warning:hover, a.text-warning:focus {
-  color: #ba8b00 !important; }
-
-.text-danger {
-  color: #dc3545 !important; }
-
-a.text-danger:hover, a.text-danger:focus {
-  color: #a71d2a !important; }
-
-.text-light {
-  color: #f8f9fa !important; }
-
-a.text-light:hover, a.text-light:focus {
-  color: #cbd3da !important; }
-
-.text-dark {
-  color: #343a40 !important; }
-
-a.text-dark:hover, a.text-dark:focus {
-  color: #121416 !important; }
-
-.text-body {
-  color: #212529 !important; }
-
-.text-muted {
-  color: #6c757d !important; }
-
-.text-black-50 {
-  color: rgba(0, 0, 0, 0.5) !important; }
-
-.text-white-50 {
-  color: rgba(255, 255, 255, 0.5) !important; }
-
-.text-hide {
-  font: 0/0 a;
-  color: transparent;
-  text-shadow: none;
-  background-color: transparent;
-  border: 0; }
-
-.text-decoration-none {
-  text-decoration: none !important; }
-
-.text-break {
-  word-break: break-word !important;
-  word-wrap: break-word !important; }
-
-.text-reset {
-  color: inherit !important; }
-
-.visible {
-  visibility: visible !important; }
-
-.invisible {
-  visibility: hidden !important; }
-
-@media print {
-  *,
-  *::before,
-  *::after {
-    text-shadow: none !important;
-    box-shadow: none !important; }
-  a:not(.btn) {
-    text-decoration: underline; }
-  abbr[title]::after {
-    content: " (" attr(title) ")"; }
-  pre {
-    white-space: pre-wrap !important; }
-  pre,
-  blockquote {
-    border: 1px solid #adb5bd;
-    page-break-inside: avoid; }
-  thead {
-    display: table-header-group; }
-  tr,
-  img {
-    page-break-inside: avoid; }
-  p,
-  h2,
-  h3 {
-    orphans: 3;
-    widows: 3; }
-  h2,
-  h3 {
-    page-break-after: avoid; }
-  @page {
-    size: a3; }
-  body {
-    min-width: 992px !important; }
-  .container {
-    min-width: 992px !important; }
-  .navbar {
-    display: none; }
-  .badge {
-    border: 1px solid #000; }
-  .table {
-    border-collapse: collapse !important; }
-  .table td,
-  .table th {
-    background-color: #fff !important; }
-  .table-bordered th,
-  .table-bordered td {
-    border: 1px solid #dee2e6 !important; }
-  .table-dark {
-    color: inherit; }
-  .table-dark th,
-  .table-dark td,
-  .table-dark thead th,
-  .table-dark tbody + tbody {
-    border-color: #dee2e6; }
-  .table .thead-dark th {
-    color: inherit;
-    border-color: #dee2e6; } }
-
-/* HTML5 display definitions
-   ========================================================================= */
+  border: 0;
+}
+
+/*.sr-only-focusable:active, .sr-only-focusable:focus {*/
+/*  position: static;*/
+/*  width: auto;*/
+/*  height: auto;*/
+/*  overflow: visible;*/
+/*  clip: auto;*/
+/*  white-space: normal;*/
+/*}*/
+
+/*.shadow-sm {*/
+/*  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.075) !important;*/
+/*}*/
+
+/*.shadow {*/
+/*  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15) !important;*/
+/*}*/
+
+/*.shadow-lg {*/
+/*  box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.175) !important;*/
+/*}*/
+
+/*.shadow-none {*/
+/*  box-shadow: none !important;*/
+/*}*/
+
+/*.w-25 {*/
+/*  width: 25% !important;*/
+/*}*/
+
+/*.w-50 {*/
+/*  width: 50% !important;*/
+/*}*/
+
+/*.w-75 {*/
+/*  width: 75% !important;*/
+/*}*/
+
+/*.w-100 {*/
+/*  width: 100% !important;*/
+/*}*/
+
+/*.w-auto {*/
+/*  width: auto !important;*/
+/*}*/
+
+/*.h-25 {*/
+/*  height: 25% !important;*/
+/*}*/
+
+/*.h-50 {*/
+/*  height: 50% !important;*/
+/*}*/
+
+/*.h-75 {*/
+/*  height: 75% !important;*/
+/*}*/
+
+/*.h-100 {*/
+/*  height: 100% !important;*/
+/*}*/
+
+/*.h-auto {*/
+/*  height: auto !important;*/
+/*}*/
+
+/*.mw-100 {*/
+/*  max-width: 100% !important;*/
+/*}*/
+
+/*.mh-100 {*/
+/*  max-height: 100% !important;*/
+/*}*/
+
+/*.min-vw-100 {*/
+/*  min-width: 100vw !important;*/
+/*}*/
+
+/*.min-vh-100 {*/
+/*  min-height: 100vh !important;*/
+/*}*/
+
+/*.vw-100 {*/
+/*  width: 100vw !important;*/
+/*}*/
+
+/*.vh-100 {*/
+/*  height: 100vh !important;*/
+/*}*/
+
+/*.m-0 {*/
+/*  margin: 0 !important;*/
+/*}*/
+
+/*.mt-0, .my-0 {*/
+/*  margin-top: 0 !important;*/
+/*}*/
+
+/*.mr-0, .mx-0 {*/
+/*  margin-right: 0 !important;*/
+/*}*/
+
+.mb-0, .my-0 {
+  margin-bottom: 0 !important;
+}
+
+/*.ml-0, .mx-0 {*/
+/*  margin-left: 0 !important;*/
+/*}*/
+
+/*.m-1 {*/
+/*  margin: 0.25rem !important;*/
+/*}*/
+
+/*.mt-1, .my-1 {*/
+/*  margin-top: 0.25rem !important;*/
+/*}*/
+
+/*.mr-1, .mx-1 {*/
+/*  margin-right: 0.25rem !important;*/
+/*}*/
+
+/*.mb-1, .my-1 {*/
+/*  margin-bottom: 0.25rem !important;*/
+/*}*/
+
+/*.ml-1, .mx-1 {*/
+/*  margin-left: 0.25rem !important;*/
+/*}*/
+
+/*.m-2 {*/
+/*  margin: 0.5rem !important;*/
+/*}*/
+
+/*.mt-2, .my-2 {*/
+/*  margin-top: 0.5rem !important;*/
+/*}*/
+
+/*.mr-2, .mx-2 {*/
+/*  margin-right: 0.5rem !important;*/
+/*}*/
+
+/*.mb-2, .my-2 {*/
+/*  margin-bottom: 0.5rem !important;*/
+/*}*/
+
+/*.ml-2, .mx-2 {*/
+/*  margin-left: 0.5rem !important;*/
+/*}*/
+
+/*.m-3 {*/
+/*  margin: 1rem !important;*/
+/*}*/
+
+/*.mt-3, .my-3 {*/
+/*  margin-top: 1rem !important;*/
+/*}*/
+
+/*.mr-3, .mx-3 {*/
+/*  margin-right: 1rem !important;*/
+/*}*/
+
+.mb-3, .my-3 {
+  margin-bottom: 1rem !important;
+}
+
+/*.ml-3, .mx-3 {*/
+/*  margin-left: 1rem !important;*/
+/*}*/
+
+/*.m-4 {*/
+/*  margin: 1.5rem !important;*/
+/*}*/
+
+/*.mt-4, .my-4 {*/
+/*  margin-top: 1.5rem !important;*/
+/*}*/
+
+/*.mr-4, .mx-4 {*/
+/*  margin-right: 1.5rem !important;*/
+/*}*/
+
+/*.mb-4, .my-4 {*/
+/*  margin-bottom: 1.5rem !important;*/
+/*}*/
+
+/*.ml-4, .mx-4 {*/
+/*  margin-left: 1.5rem !important;*/
+/*}*/
+
+/*.m-5 {*/
+/*  margin: 3rem !important;*/
+/*}*/
+
+/*.mt-5, .my-5 {*/
+/*  margin-top: 3rem !important;*/
+/*}*/
+
+/*.mr-5, .mx-5 {*/
+/*  margin-right: 3rem !important;*/
+/*}*/
+
+/*.mb-5, .my-5 {*/
+/*  margin-bottom: 3rem !important;*/
+/*}*/
+
+/*.ml-5, .mx-5 {*/
+/*  margin-left: 3rem !important;*/
+/*}*/
+
+/*.p-0 {*/
+/*  padding: 0 !important;*/
+/*}*/
+
+/*.pt-0, .py-0 {*/
+/*  padding-top: 0 !important;*/
+/*}*/
+
+/*.pr-0, .px-0 {*/
+/*  padding-right: 0 !important;*/
+/*}*/
+
+/*.pb-0, .py-0 {*/
+/*  padding-bottom: 0 !important;*/
+/*}*/
+
+/*.pl-0, .px-0 {*/
+/*  padding-left: 0 !important;*/
+/*}*/
+
+/*.p-1 {*/
+/*  padding: 0.25rem !important;*/
+/*}*/
+
+/*.pt-1, .py-1 {*/
+/*  padding-top: 0.25rem !important;*/
+/*}*/
+
+/*.pr-1, .px-1 {*/
+/*  padding-right: 0.25rem !important;*/
+/*}*/
+
+/*.pb-1, .py-1 {*/
+/*  padding-bottom: 0.25rem !important;*/
+/*}*/
+
+/*.pl-1, .px-1 {*/
+/*  padding-left: 0.25rem !important;*/
+/*}*/
+
+/*.p-2 {*/
+/*  padding: 0.5rem !important;*/
+/*}*/
+
+/*.pt-2, .py-2 {*/
+/*  padding-top: 0.5rem !important;*/
+/*}*/
+
+/*.pr-2, .px-2 {*/
+/*  padding-right: 0.5rem !important;*/
+/*}*/
+
+/*.pb-2, .py-2 {*/
+/*  padding-bottom: 0.5rem !important;*/
+/*}*/
+
+/*.pl-2, .px-2 {*/
+/*  padding-left: 0.5rem !important;*/
+/*}*/
+
+/*.p-3 {*/
+/*  padding: 1rem !important;*/
+/*}*/
+
+/*.pt-3, .py-3 {*/
+/*  padding-top: 1rem !important;*/
+/*}*/
+
+/*.pr-3, .px-3 {*/
+/*  padding-right: 1rem !important;*/
+/*}*/
+
+/*.pb-3, .py-3 {*/
+/*  padding-bottom: 1rem !important;*/
+/*}*/
+
+/*.pl-3, .px-3 {*/
+/*  padding-left: 1rem !important;*/
+/*}*/
+
+/*.p-4 {*/
+/*  padding: 1.5rem !important;*/
+/*}*/
+
+/*.pt-4, .py-4 {*/
+/*  padding-top: 1.5rem !important;*/
+/*}*/
+
+/*.pr-4, .px-4 {*/
+/*  padding-right: 1.5rem !important;*/
+/*}*/
+
+/*.pb-4, .py-4 {*/
+/*  padding-bottom: 1.5rem !important;*/
+/*}*/
+
+/*.pl-4, .px-4 {*/
+/*  padding-left: 1.5rem !important;*/
+/*}*/
+
+/*.p-5 {*/
+/*  padding: 3rem !important;*/
+/*}*/
+
+/*.pt-5, .py-5 {*/
+/*  padding-top: 3rem !important;*/
+/*}*/
+
+/*.pr-5, .px-5 {*/
+/*  padding-right: 3rem !important;*/
+/*}*/
+
+/*.pb-5, .py-5 {*/
+/*  padding-bottom: 3rem !important;*/
+/*}*/
+
+/*.pl-5, .px-5 {*/
+/*  padding-left: 3rem !important;*/
+/*}*/
+
+/*.m-n1 {*/
+/*  margin: -0.25rem !important;*/
+/*}*/
+
+/*.mt-n1, .my-n1 {*/
+/*  margin-top: -0.25rem !important;*/
+/*}*/
+
+/*.mr-n1, .mx-n1 {*/
+/*  margin-right: -0.25rem !important;*/
+/*}*/
+
+/*.mb-n1, .my-n1 {*/
+/*  margin-bottom: -0.25rem !important;*/
+/*}*/
+
+/*.ml-n1, .mx-n1 {*/
+/*  margin-left: -0.25rem !important;*/
+/*}*/
+
+/*.m-n2 {*/
+/*  margin: -0.5rem !important;*/
+/*}*/
+
+/*.mt-n2, .my-n2 {*/
+/*  margin-top: -0.5rem !important;*/
+/*}*/
+
+/*.mr-n2, .mx-n2 {*/
+/*  margin-right: -0.5rem !important;*/
+/*}*/
+
+/*.mb-n2, .my-n2 {*/
+/*  margin-bottom: -0.5rem !important;*/
+/*}*/
+
+/*.ml-n2, .mx-n2 {*/
+/*  margin-left: -0.5rem !important;*/
+/*}*/
+
+/*.m-n3 {*/
+/*  margin: -1rem !important;*/
+/*}*/
+
+/*.mt-n3, .my-n3 {*/
+/*  margin-top: -1rem !important;*/
+/*}*/
+
+/*.mr-n3, .mx-n3 {*/
+/*  margin-right: -1rem !important;*/
+/*}*/
+
+/*.mb-n3, .my-n3 {*/
+/*  margin-bottom: -1rem !important;*/
+/*}*/
+
+/*.ml-n3, .mx-n3 {*/
+/*  margin-left: -1rem !important;*/
+/*}*/
+
+/*.m-n4 {*/
+/*  margin: -1.5rem !important;*/
+/*}*/
+
+/*.mt-n4, .my-n4 {*/
+/*  margin-top: -1.5rem !important;*/
+/*}*/
+
+/*.mr-n4, .mx-n4 {*/
+/*  margin-right: -1.5rem !important;*/
+/*}*/
+
+/*.mb-n4, .my-n4 {*/
+/*  margin-bottom: -1.5rem !important;*/
+/*}*/
+
+/*.ml-n4, .mx-n4 {*/
+/*  margin-left: -1.5rem !important;*/
+/*}*/
+
+/*.m-n5 {*/
+/*  margin: -3rem !important;*/
+/*}*/
+
+/*.mt-n5, .my-n5 {*/
+/*  margin-top: -3rem !important;*/
+/*}*/
+
+/*.mr-n5, .mx-n5 {*/
+/*  margin-right: -3rem !important;*/
+/*}*/
+
+/*.mb-n5, .my-n5 {*/
+/*  margin-bottom: -3rem !important;*/
+/*}*/
+
+/*.ml-n5, .mx-n5 {*/
+/*  margin-left: -3rem !important;*/
+/*}*/
+
+/*.m-auto {*/
+/*  margin: auto !important;*/
+/*}*/
+
+/*.mt-auto, .my-auto {*/
+/*  margin-top: auto !important;*/
+/*}*/
+
+/*.mr-auto, .mx-auto {*/
+/*  margin-right: auto !important;*/
+/*}*/
+
+/*.mb-auto, .my-auto {*/
+/*  margin-bottom: auto !important;*/
+/*}*/
+
+/*.ml-auto, .mx-auto {*/
+/*  margin-left: auto !important;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .m-sm-0 {*/
+/*    margin: 0 !important;*/
+/*  }*/
+
+/*  .mt-sm-0, .my-sm-0 {*/
+/*    margin-top: 0 !important;*/
+/*  }*/
+
+/*  .mr-sm-0, .mx-sm-0 {*/
+/*    margin-right: 0 !important;*/
+/*  }*/
+
+/*  .mb-sm-0, .my-sm-0 {*/
+/*    margin-bottom: 0 !important;*/
+/*  }*/
+
+/*  .ml-sm-0, .mx-sm-0 {*/
+/*    margin-left: 0 !important;*/
+/*  }*/
+
+/*  .m-sm-1 {*/
+/*    margin: 0.25rem !important;*/
+/*  }*/
+
+/*  .mt-sm-1, .my-sm-1 {*/
+/*    margin-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .mr-sm-1, .mx-sm-1 {*/
+/*    margin-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .mb-sm-1, .my-sm-1 {*/
+/*    margin-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .ml-sm-1, .mx-sm-1 {*/
+/*    margin-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .m-sm-2 {*/
+/*    margin: 0.5rem !important;*/
+/*  }*/
+
+/*  .mt-sm-2, .my-sm-2 {*/
+/*    margin-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .mr-sm-2, .mx-sm-2 {*/
+/*    margin-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .mb-sm-2, .my-sm-2 {*/
+/*    margin-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .ml-sm-2, .mx-sm-2 {*/
+/*    margin-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .m-sm-3 {*/
+/*    margin: 1rem !important;*/
+/*  }*/
+
+/*  .mt-sm-3, .my-sm-3 {*/
+/*    margin-top: 1rem !important;*/
+/*  }*/
+
+/*  .mr-sm-3, .mx-sm-3 {*/
+/*    margin-right: 1rem !important;*/
+/*  }*/
+
+/*  .mb-sm-3, .my-sm-3 {*/
+/*    margin-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .ml-sm-3, .mx-sm-3 {*/
+/*    margin-left: 1rem !important;*/
+/*  }*/
+
+/*  .m-sm-4 {*/
+/*    margin: 1.5rem !important;*/
+/*  }*/
+
+/*  .mt-sm-4, .my-sm-4 {*/
+/*    margin-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .mr-sm-4, .mx-sm-4 {*/
+/*    margin-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .mb-sm-4, .my-sm-4 {*/
+/*    margin-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .ml-sm-4, .mx-sm-4 {*/
+/*    margin-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .m-sm-5 {*/
+/*    margin: 3rem !important;*/
+/*  }*/
+
+/*  .mt-sm-5, .my-sm-5 {*/
+/*    margin-top: 3rem !important;*/
+/*  }*/
+
+/*  .mr-sm-5, .mx-sm-5 {*/
+/*    margin-right: 3rem !important;*/
+/*  }*/
+
+/*  .mb-sm-5, .my-sm-5 {*/
+/*    margin-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .ml-sm-5, .mx-sm-5 {*/
+/*    margin-left: 3rem !important;*/
+/*  }*/
+
+/*  .p-sm-0 {*/
+/*    padding: 0 !important;*/
+/*  }*/
+
+/*  .pt-sm-0, .py-sm-0 {*/
+/*    padding-top: 0 !important;*/
+/*  }*/
+
+/*  .pr-sm-0, .px-sm-0 {*/
+/*    padding-right: 0 !important;*/
+/*  }*/
+
+/*  .pb-sm-0, .py-sm-0 {*/
+/*    padding-bottom: 0 !important;*/
+/*  }*/
+
+/*  .pl-sm-0, .px-sm-0 {*/
+/*    padding-left: 0 !important;*/
+/*  }*/
+
+/*  .p-sm-1 {*/
+/*    padding: 0.25rem !important;*/
+/*  }*/
+
+/*  .pt-sm-1, .py-sm-1 {*/
+/*    padding-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .pr-sm-1, .px-sm-1 {*/
+/*    padding-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .pb-sm-1, .py-sm-1 {*/
+/*    padding-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .pl-sm-1, .px-sm-1 {*/
+/*    padding-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .p-sm-2 {*/
+/*    padding: 0.5rem !important;*/
+/*  }*/
+
+/*  .pt-sm-2, .py-sm-2 {*/
+/*    padding-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .pr-sm-2, .px-sm-2 {*/
+/*    padding-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .pb-sm-2, .py-sm-2 {*/
+/*    padding-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .pl-sm-2, .px-sm-2 {*/
+/*    padding-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .p-sm-3 {*/
+/*    padding: 1rem !important;*/
+/*  }*/
+
+/*  .pt-sm-3, .py-sm-3 {*/
+/*    padding-top: 1rem !important;*/
+/*  }*/
+
+/*  .pr-sm-3, .px-sm-3 {*/
+/*    padding-right: 1rem !important;*/
+/*  }*/
+
+/*  .pb-sm-3, .py-sm-3 {*/
+/*    padding-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .pl-sm-3, .px-sm-3 {*/
+/*    padding-left: 1rem !important;*/
+/*  }*/
+
+/*  .p-sm-4 {*/
+/*    padding: 1.5rem !important;*/
+/*  }*/
+
+/*  .pt-sm-4, .py-sm-4 {*/
+/*    padding-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .pr-sm-4, .px-sm-4 {*/
+/*    padding-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .pb-sm-4, .py-sm-4 {*/
+/*    padding-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .pl-sm-4, .px-sm-4 {*/
+/*    padding-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .p-sm-5 {*/
+/*    padding: 3rem !important;*/
+/*  }*/
+
+/*  .pt-sm-5, .py-sm-5 {*/
+/*    padding-top: 3rem !important;*/
+/*  }*/
+
+/*  .pr-sm-5, .px-sm-5 {*/
+/*    padding-right: 3rem !important;*/
+/*  }*/
+
+/*  .pb-sm-5, .py-sm-5 {*/
+/*    padding-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .pl-sm-5, .px-sm-5 {*/
+/*    padding-left: 3rem !important;*/
+/*  }*/
+
+/*  .m-sm-n1 {*/
+/*    margin: -0.25rem !important;*/
+/*  }*/
+
+/*  .mt-sm-n1, .my-sm-n1 {*/
+/*    margin-top: -0.25rem !important;*/
+/*  }*/
+
+/*  .mr-sm-n1, .mx-sm-n1 {*/
+/*    margin-right: -0.25rem !important;*/
+/*  }*/
+
+/*  .mb-sm-n1, .my-sm-n1 {*/
+/*    margin-bottom: -0.25rem !important;*/
+/*  }*/
+
+/*  .ml-sm-n1, .mx-sm-n1 {*/
+/*    margin-left: -0.25rem !important;*/
+/*  }*/
+
+/*  .m-sm-n2 {*/
+/*    margin: -0.5rem !important;*/
+/*  }*/
+
+/*  .mt-sm-n2, .my-sm-n2 {*/
+/*    margin-top: -0.5rem !important;*/
+/*  }*/
+
+/*  .mr-sm-n2, .mx-sm-n2 {*/
+/*    margin-right: -0.5rem !important;*/
+/*  }*/
+
+/*  .mb-sm-n2, .my-sm-n2 {*/
+/*    margin-bottom: -0.5rem !important;*/
+/*  }*/
+
+/*  .ml-sm-n2, .mx-sm-n2 {*/
+/*    margin-left: -0.5rem !important;*/
+/*  }*/
+
+/*  .m-sm-n3 {*/
+/*    margin: -1rem !important;*/
+/*  }*/
+
+/*  .mt-sm-n3, .my-sm-n3 {*/
+/*    margin-top: -1rem !important;*/
+/*  }*/
+
+/*  .mr-sm-n3, .mx-sm-n3 {*/
+/*    margin-right: -1rem !important;*/
+/*  }*/
+
+/*  .mb-sm-n3, .my-sm-n3 {*/
+/*    margin-bottom: -1rem !important;*/
+/*  }*/
+
+/*  .ml-sm-n3, .mx-sm-n3 {*/
+/*    margin-left: -1rem !important;*/
+/*  }*/
+
+/*  .m-sm-n4 {*/
+/*    margin: -1.5rem !important;*/
+/*  }*/
+
+/*  .mt-sm-n4, .my-sm-n4 {*/
+/*    margin-top: -1.5rem !important;*/
+/*  }*/
+
+/*  .mr-sm-n4, .mx-sm-n4 {*/
+/*    margin-right: -1.5rem !important;*/
+/*  }*/
+
+/*  .mb-sm-n4, .my-sm-n4 {*/
+/*    margin-bottom: -1.5rem !important;*/
+/*  }*/
+
+/*  .ml-sm-n4, .mx-sm-n4 {*/
+/*    margin-left: -1.5rem !important;*/
+/*  }*/
+
+/*  .m-sm-n5 {*/
+/*    margin: -3rem !important;*/
+/*  }*/
+
+/*  .mt-sm-n5, .my-sm-n5 {*/
+/*    margin-top: -3rem !important;*/
+/*  }*/
+
+/*  .mr-sm-n5, .mx-sm-n5 {*/
+/*    margin-right: -3rem !important;*/
+/*  }*/
+
+/*  .mb-sm-n5, .my-sm-n5 {*/
+/*    margin-bottom: -3rem !important;*/
+/*  }*/
+
+/*  .ml-sm-n5, .mx-sm-n5 {*/
+/*    margin-left: -3rem !important;*/
+/*  }*/
+
+/*  .m-sm-auto {*/
+/*    margin: auto !important;*/
+/*  }*/
+
+/*  .mt-sm-auto, .my-sm-auto {*/
+/*    margin-top: auto !important;*/
+/*  }*/
+
+/*  .mr-sm-auto, .mx-sm-auto {*/
+/*    margin-right: auto !important;*/
+/*  }*/
+
+/*  .mb-sm-auto, .my-sm-auto {*/
+/*    margin-bottom: auto !important;*/
+/*  }*/
+
+/*  .ml-sm-auto, .mx-sm-auto {*/
+/*    margin-left: auto !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 768px) {*/
+/*  .m-md-0 {*/
+/*    margin: 0 !important;*/
+/*  }*/
+
+/*  .mt-md-0, .my-md-0 {*/
+/*    margin-top: 0 !important;*/
+/*  }*/
+
+/*  .mr-md-0, .mx-md-0 {*/
+/*    margin-right: 0 !important;*/
+/*  }*/
+
+/*  .mb-md-0, .my-md-0 {*/
+/*    margin-bottom: 0 !important;*/
+/*  }*/
+
+/*  .ml-md-0, .mx-md-0 {*/
+/*    margin-left: 0 !important;*/
+/*  }*/
+
+/*  .m-md-1 {*/
+/*    margin: 0.25rem !important;*/
+/*  }*/
+
+/*  .mt-md-1, .my-md-1 {*/
+/*    margin-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .mr-md-1, .mx-md-1 {*/
+/*    margin-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .mb-md-1, .my-md-1 {*/
+/*    margin-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .ml-md-1, .mx-md-1 {*/
+/*    margin-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .m-md-2 {*/
+/*    margin: 0.5rem !important;*/
+/*  }*/
+
+/*  .mt-md-2, .my-md-2 {*/
+/*    margin-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .mr-md-2, .mx-md-2 {*/
+/*    margin-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .mb-md-2, .my-md-2 {*/
+/*    margin-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .ml-md-2, .mx-md-2 {*/
+/*    margin-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .m-md-3 {*/
+/*    margin: 1rem !important;*/
+/*  }*/
+
+/*  .mt-md-3, .my-md-3 {*/
+/*    margin-top: 1rem !important;*/
+/*  }*/
+
+/*  .mr-md-3, .mx-md-3 {*/
+/*    margin-right: 1rem !important;*/
+/*  }*/
+
+/*  .mb-md-3, .my-md-3 {*/
+/*    margin-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .ml-md-3, .mx-md-3 {*/
+/*    margin-left: 1rem !important;*/
+/*  }*/
+
+/*  .m-md-4 {*/
+/*    margin: 1.5rem !important;*/
+/*  }*/
+
+/*  .mt-md-4, .my-md-4 {*/
+/*    margin-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .mr-md-4, .mx-md-4 {*/
+/*    margin-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .mb-md-4, .my-md-4 {*/
+/*    margin-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .ml-md-4, .mx-md-4 {*/
+/*    margin-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .m-md-5 {*/
+/*    margin: 3rem !important;*/
+/*  }*/
+
+/*  .mt-md-5, .my-md-5 {*/
+/*    margin-top: 3rem !important;*/
+/*  }*/
+
+/*  .mr-md-5, .mx-md-5 {*/
+/*    margin-right: 3rem !important;*/
+/*  }*/
+
+/*  .mb-md-5, .my-md-5 {*/
+/*    margin-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .ml-md-5, .mx-md-5 {*/
+/*    margin-left: 3rem !important;*/
+/*  }*/
+
+/*  .p-md-0 {*/
+/*    padding: 0 !important;*/
+/*  }*/
+
+/*  .pt-md-0, .py-md-0 {*/
+/*    padding-top: 0 !important;*/
+/*  }*/
+
+/*  .pr-md-0, .px-md-0 {*/
+/*    padding-right: 0 !important;*/
+/*  }*/
+
+/*  .pb-md-0, .py-md-0 {*/
+/*    padding-bottom: 0 !important;*/
+/*  }*/
+
+/*  .pl-md-0, .px-md-0 {*/
+/*    padding-left: 0 !important;*/
+/*  }*/
+
+/*  .p-md-1 {*/
+/*    padding: 0.25rem !important;*/
+/*  }*/
+
+/*  .pt-md-1, .py-md-1 {*/
+/*    padding-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .pr-md-1, .px-md-1 {*/
+/*    padding-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .pb-md-1, .py-md-1 {*/
+/*    padding-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .pl-md-1, .px-md-1 {*/
+/*    padding-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .p-md-2 {*/
+/*    padding: 0.5rem !important;*/
+/*  }*/
+
+/*  .pt-md-2, .py-md-2 {*/
+/*    padding-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .pr-md-2, .px-md-2 {*/
+/*    padding-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .pb-md-2, .py-md-2 {*/
+/*    padding-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .pl-md-2, .px-md-2 {*/
+/*    padding-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .p-md-3 {*/
+/*    padding: 1rem !important;*/
+/*  }*/
+
+/*  .pt-md-3, .py-md-3 {*/
+/*    padding-top: 1rem !important;*/
+/*  }*/
+
+/*  .pr-md-3, .px-md-3 {*/
+/*    padding-right: 1rem !important;*/
+/*  }*/
+
+/*  .pb-md-3, .py-md-3 {*/
+/*    padding-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .pl-md-3, .px-md-3 {*/
+/*    padding-left: 1rem !important;*/
+/*  }*/
+
+/*  .p-md-4 {*/
+/*    padding: 1.5rem !important;*/
+/*  }*/
+
+/*  .pt-md-4, .py-md-4 {*/
+/*    padding-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .pr-md-4, .px-md-4 {*/
+/*    padding-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .pb-md-4, .py-md-4 {*/
+/*    padding-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .pl-md-4, .px-md-4 {*/
+/*    padding-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .p-md-5 {*/
+/*    padding: 3rem !important;*/
+/*  }*/
+
+/*  .pt-md-5, .py-md-5 {*/
+/*    padding-top: 3rem !important;*/
+/*  }*/
+
+/*  .pr-md-5, .px-md-5 {*/
+/*    padding-right: 3rem !important;*/
+/*  }*/
+
+/*  .pb-md-5, .py-md-5 {*/
+/*    padding-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .pl-md-5, .px-md-5 {*/
+/*    padding-left: 3rem !important;*/
+/*  }*/
+
+/*  .m-md-n1 {*/
+/*    margin: -0.25rem !important;*/
+/*  }*/
+
+/*  .mt-md-n1, .my-md-n1 {*/
+/*    margin-top: -0.25rem !important;*/
+/*  }*/
+
+/*  .mr-md-n1, .mx-md-n1 {*/
+/*    margin-right: -0.25rem !important;*/
+/*  }*/
+
+/*  .mb-md-n1, .my-md-n1 {*/
+/*    margin-bottom: -0.25rem !important;*/
+/*  }*/
+
+/*  .ml-md-n1, .mx-md-n1 {*/
+/*    margin-left: -0.25rem !important;*/
+/*  }*/
+
+/*  .m-md-n2 {*/
+/*    margin: -0.5rem !important;*/
+/*  }*/
+
+/*  .mt-md-n2, .my-md-n2 {*/
+/*    margin-top: -0.5rem !important;*/
+/*  }*/
+
+/*  .mr-md-n2, .mx-md-n2 {*/
+/*    margin-right: -0.5rem !important;*/
+/*  }*/
+
+/*  .mb-md-n2, .my-md-n2 {*/
+/*    margin-bottom: -0.5rem !important;*/
+/*  }*/
+
+/*  .ml-md-n2, .mx-md-n2 {*/
+/*    margin-left: -0.5rem !important;*/
+/*  }*/
+
+/*  .m-md-n3 {*/
+/*    margin: -1rem !important;*/
+/*  }*/
+
+/*  .mt-md-n3, .my-md-n3 {*/
+/*    margin-top: -1rem !important;*/
+/*  }*/
+
+/*  .mr-md-n3, .mx-md-n3 {*/
+/*    margin-right: -1rem !important;*/
+/*  }*/
+
+/*  .mb-md-n3, .my-md-n3 {*/
+/*    margin-bottom: -1rem !important;*/
+/*  }*/
+
+/*  .ml-md-n3, .mx-md-n3 {*/
+/*    margin-left: -1rem !important;*/
+/*  }*/
+
+/*  .m-md-n4 {*/
+/*    margin: -1.5rem !important;*/
+/*  }*/
+
+/*  .mt-md-n4, .my-md-n4 {*/
+/*    margin-top: -1.5rem !important;*/
+/*  }*/
+
+/*  .mr-md-n4, .mx-md-n4 {*/
+/*    margin-right: -1.5rem !important;*/
+/*  }*/
+
+/*  .mb-md-n4, .my-md-n4 {*/
+/*    margin-bottom: -1.5rem !important;*/
+/*  }*/
+
+/*  .ml-md-n4, .mx-md-n4 {*/
+/*    margin-left: -1.5rem !important;*/
+/*  }*/
+
+/*  .m-md-n5 {*/
+/*    margin: -3rem !important;*/
+/*  }*/
+
+/*  .mt-md-n5, .my-md-n5 {*/
+/*    margin-top: -3rem !important;*/
+/*  }*/
+
+/*  .mr-md-n5, .mx-md-n5 {*/
+/*    margin-right: -3rem !important;*/
+/*  }*/
+
+/*  .mb-md-n5, .my-md-n5 {*/
+/*    margin-bottom: -3rem !important;*/
+/*  }*/
+
+/*  .ml-md-n5, .mx-md-n5 {*/
+/*    margin-left: -3rem !important;*/
+/*  }*/
+
+/*  .m-md-auto {*/
+/*    margin: auto !important;*/
+/*  }*/
+
+/*  .mt-md-auto, .my-md-auto {*/
+/*    margin-top: auto !important;*/
+/*  }*/
+
+/*  .mr-md-auto, .mx-md-auto {*/
+/*    margin-right: auto !important;*/
+/*  }*/
+
+/*  .mb-md-auto, .my-md-auto {*/
+/*    margin-bottom: auto !important;*/
+/*  }*/
+
+/*  .ml-md-auto, .mx-md-auto {*/
+/*    margin-left: auto !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 992px) {*/
+/*  .m-lg-0 {*/
+/*    margin: 0 !important;*/
+/*  }*/
+
+/*  .mt-lg-0, .my-lg-0 {*/
+/*    margin-top: 0 !important;*/
+/*  }*/
+
+/*  .mr-lg-0, .mx-lg-0 {*/
+/*    margin-right: 0 !important;*/
+/*  }*/
+
+/*  .mb-lg-0, .my-lg-0 {*/
+/*    margin-bottom: 0 !important;*/
+/*  }*/
+
+/*  .ml-lg-0, .mx-lg-0 {*/
+/*    margin-left: 0 !important;*/
+/*  }*/
+
+/*  .m-lg-1 {*/
+/*    margin: 0.25rem !important;*/
+/*  }*/
+
+/*  .mt-lg-1, .my-lg-1 {*/
+/*    margin-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .mr-lg-1, .mx-lg-1 {*/
+/*    margin-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .mb-lg-1, .my-lg-1 {*/
+/*    margin-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .ml-lg-1, .mx-lg-1 {*/
+/*    margin-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .m-lg-2 {*/
+/*    margin: 0.5rem !important;*/
+/*  }*/
+
+/*  .mt-lg-2, .my-lg-2 {*/
+/*    margin-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .mr-lg-2, .mx-lg-2 {*/
+/*    margin-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .mb-lg-2, .my-lg-2 {*/
+/*    margin-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .ml-lg-2, .mx-lg-2 {*/
+/*    margin-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .m-lg-3 {*/
+/*    margin: 1rem !important;*/
+/*  }*/
+
+/*  .mt-lg-3, .my-lg-3 {*/
+/*    margin-top: 1rem !important;*/
+/*  }*/
+
+/*  .mr-lg-3, .mx-lg-3 {*/
+/*    margin-right: 1rem !important;*/
+/*  }*/
+
+/*  .mb-lg-3, .my-lg-3 {*/
+/*    margin-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .ml-lg-3, .mx-lg-3 {*/
+/*    margin-left: 1rem !important;*/
+/*  }*/
+
+/*  .m-lg-4 {*/
+/*    margin: 1.5rem !important;*/
+/*  }*/
+
+/*  .mt-lg-4, .my-lg-4 {*/
+/*    margin-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .mr-lg-4, .mx-lg-4 {*/
+/*    margin-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .mb-lg-4, .my-lg-4 {*/
+/*    margin-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .ml-lg-4, .mx-lg-4 {*/
+/*    margin-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .m-lg-5 {*/
+/*    margin: 3rem !important;*/
+/*  }*/
+
+/*  .mt-lg-5, .my-lg-5 {*/
+/*    margin-top: 3rem !important;*/
+/*  }*/
+
+/*  .mr-lg-5, .mx-lg-5 {*/
+/*    margin-right: 3rem !important;*/
+/*  }*/
+
+/*  .mb-lg-5, .my-lg-5 {*/
+/*    margin-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .ml-lg-5, .mx-lg-5 {*/
+/*    margin-left: 3rem !important;*/
+/*  }*/
+
+/*  .p-lg-0 {*/
+/*    padding: 0 !important;*/
+/*  }*/
+
+/*  .pt-lg-0, .py-lg-0 {*/
+/*    padding-top: 0 !important;*/
+/*  }*/
+
+/*  .pr-lg-0, .px-lg-0 {*/
+/*    padding-right: 0 !important;*/
+/*  }*/
+
+/*  .pb-lg-0, .py-lg-0 {*/
+/*    padding-bottom: 0 !important;*/
+/*  }*/
+
+/*  .pl-lg-0, .px-lg-0 {*/
+/*    padding-left: 0 !important;*/
+/*  }*/
+
+/*  .p-lg-1 {*/
+/*    padding: 0.25rem !important;*/
+/*  }*/
+
+/*  .pt-lg-1, .py-lg-1 {*/
+/*    padding-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .pr-lg-1, .px-lg-1 {*/
+/*    padding-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .pb-lg-1, .py-lg-1 {*/
+/*    padding-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .pl-lg-1, .px-lg-1 {*/
+/*    padding-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .p-lg-2 {*/
+/*    padding: 0.5rem !important;*/
+/*  }*/
+
+/*  .pt-lg-2, .py-lg-2 {*/
+/*    padding-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .pr-lg-2, .px-lg-2 {*/
+/*    padding-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .pb-lg-2, .py-lg-2 {*/
+/*    padding-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .pl-lg-2, .px-lg-2 {*/
+/*    padding-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .p-lg-3 {*/
+/*    padding: 1rem !important;*/
+/*  }*/
+
+/*  .pt-lg-3, .py-lg-3 {*/
+/*    padding-top: 1rem !important;*/
+/*  }*/
+
+/*  .pr-lg-3, .px-lg-3 {*/
+/*    padding-right: 1rem !important;*/
+/*  }*/
+
+/*  .pb-lg-3, .py-lg-3 {*/
+/*    padding-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .pl-lg-3, .px-lg-3 {*/
+/*    padding-left: 1rem !important;*/
+/*  }*/
+
+/*  .p-lg-4 {*/
+/*    padding: 1.5rem !important;*/
+/*  }*/
+
+/*  .pt-lg-4, .py-lg-4 {*/
+/*    padding-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .pr-lg-4, .px-lg-4 {*/
+/*    padding-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .pb-lg-4, .py-lg-4 {*/
+/*    padding-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .pl-lg-4, .px-lg-4 {*/
+/*    padding-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .p-lg-5 {*/
+/*    padding: 3rem !important;*/
+/*  }*/
+
+/*  .pt-lg-5, .py-lg-5 {*/
+/*    padding-top: 3rem !important;*/
+/*  }*/
+
+/*  .pr-lg-5, .px-lg-5 {*/
+/*    padding-right: 3rem !important;*/
+/*  }*/
+
+/*  .pb-lg-5, .py-lg-5 {*/
+/*    padding-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .pl-lg-5, .px-lg-5 {*/
+/*    padding-left: 3rem !important;*/
+/*  }*/
+
+/*  .m-lg-n1 {*/
+/*    margin: -0.25rem !important;*/
+/*  }*/
+
+/*  .mt-lg-n1, .my-lg-n1 {*/
+/*    margin-top: -0.25rem !important;*/
+/*  }*/
+
+/*  .mr-lg-n1, .mx-lg-n1 {*/
+/*    margin-right: -0.25rem !important;*/
+/*  }*/
+
+/*  .mb-lg-n1, .my-lg-n1 {*/
+/*    margin-bottom: -0.25rem !important;*/
+/*  }*/
+
+/*  .ml-lg-n1, .mx-lg-n1 {*/
+/*    margin-left: -0.25rem !important;*/
+/*  }*/
+
+/*  .m-lg-n2 {*/
+/*    margin: -0.5rem !important;*/
+/*  }*/
+
+/*  .mt-lg-n2, .my-lg-n2 {*/
+/*    margin-top: -0.5rem !important;*/
+/*  }*/
+
+/*  .mr-lg-n2, .mx-lg-n2 {*/
+/*    margin-right: -0.5rem !important;*/
+/*  }*/
+
+/*  .mb-lg-n2, .my-lg-n2 {*/
+/*    margin-bottom: -0.5rem !important;*/
+/*  }*/
+
+/*  .ml-lg-n2, .mx-lg-n2 {*/
+/*    margin-left: -0.5rem !important;*/
+/*  }*/
+
+/*  .m-lg-n3 {*/
+/*    margin: -1rem !important;*/
+/*  }*/
+
+/*  .mt-lg-n3, .my-lg-n3 {*/
+/*    margin-top: -1rem !important;*/
+/*  }*/
+
+/*  .mr-lg-n3, .mx-lg-n3 {*/
+/*    margin-right: -1rem !important;*/
+/*  }*/
+
+/*  .mb-lg-n3, .my-lg-n3 {*/
+/*    margin-bottom: -1rem !important;*/
+/*  }*/
+
+/*  .ml-lg-n3, .mx-lg-n3 {*/
+/*    margin-left: -1rem !important;*/
+/*  }*/
+
+/*  .m-lg-n4 {*/
+/*    margin: -1.5rem !important;*/
+/*  }*/
+
+/*  .mt-lg-n4, .my-lg-n4 {*/
+/*    margin-top: -1.5rem !important;*/
+/*  }*/
+
+/*  .mr-lg-n4, .mx-lg-n4 {*/
+/*    margin-right: -1.5rem !important;*/
+/*  }*/
+
+/*  .mb-lg-n4, .my-lg-n4 {*/
+/*    margin-bottom: -1.5rem !important;*/
+/*  }*/
+
+/*  .ml-lg-n4, .mx-lg-n4 {*/
+/*    margin-left: -1.5rem !important;*/
+/*  }*/
+
+/*  .m-lg-n5 {*/
+/*    margin: -3rem !important;*/
+/*  }*/
+
+/*  .mt-lg-n5, .my-lg-n5 {*/
+/*    margin-top: -3rem !important;*/
+/*  }*/
+
+/*  .mr-lg-n5, .mx-lg-n5 {*/
+/*    margin-right: -3rem !important;*/
+/*  }*/
+
+/*  .mb-lg-n5, .my-lg-n5 {*/
+/*    margin-bottom: -3rem !important;*/
+/*  }*/
+
+/*  .ml-lg-n5, .mx-lg-n5 {*/
+/*    margin-left: -3rem !important;*/
+/*  }*/
+
+/*  .m-lg-auto {*/
+/*    margin: auto !important;*/
+/*  }*/
+
+/*  .mt-lg-auto, .my-lg-auto {*/
+/*    margin-top: auto !important;*/
+/*  }*/
+
+/*  .mr-lg-auto, .mx-lg-auto {*/
+/*    margin-right: auto !important;*/
+/*  }*/
+
+/*  .mb-lg-auto, .my-lg-auto {*/
+/*    margin-bottom: auto !important;*/
+/*  }*/
+
+/*  .ml-lg-auto, .mx-lg-auto {*/
+/*    margin-left: auto !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 1200px) {*/
+/*  .m-xl-0 {*/
+/*    margin: 0 !important;*/
+/*  }*/
+
+/*  .mt-xl-0, .my-xl-0 {*/
+/*    margin-top: 0 !important;*/
+/*  }*/
+
+/*  .mr-xl-0, .mx-xl-0 {*/
+/*    margin-right: 0 !important;*/
+/*  }*/
+
+/*  .mb-xl-0, .my-xl-0 {*/
+/*    margin-bottom: 0 !important;*/
+/*  }*/
+
+/*  .ml-xl-0, .mx-xl-0 {*/
+/*    margin-left: 0 !important;*/
+/*  }*/
+
+/*  .m-xl-1 {*/
+/*    margin: 0.25rem !important;*/
+/*  }*/
+
+/*  .mt-xl-1, .my-xl-1 {*/
+/*    margin-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .mr-xl-1, .mx-xl-1 {*/
+/*    margin-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .mb-xl-1, .my-xl-1 {*/
+/*    margin-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .ml-xl-1, .mx-xl-1 {*/
+/*    margin-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .m-xl-2 {*/
+/*    margin: 0.5rem !important;*/
+/*  }*/
+
+/*  .mt-xl-2, .my-xl-2 {*/
+/*    margin-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .mr-xl-2, .mx-xl-2 {*/
+/*    margin-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .mb-xl-2, .my-xl-2 {*/
+/*    margin-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .ml-xl-2, .mx-xl-2 {*/
+/*    margin-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .m-xl-3 {*/
+/*    margin: 1rem !important;*/
+/*  }*/
+
+/*  .mt-xl-3, .my-xl-3 {*/
+/*    margin-top: 1rem !important;*/
+/*  }*/
+
+/*  .mr-xl-3, .mx-xl-3 {*/
+/*    margin-right: 1rem !important;*/
+/*  }*/
+
+/*  .mb-xl-3, .my-xl-3 {*/
+/*    margin-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .ml-xl-3, .mx-xl-3 {*/
+/*    margin-left: 1rem !important;*/
+/*  }*/
+
+/*  .m-xl-4 {*/
+/*    margin: 1.5rem !important;*/
+/*  }*/
+
+/*  .mt-xl-4, .my-xl-4 {*/
+/*    margin-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .mr-xl-4, .mx-xl-4 {*/
+/*    margin-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .mb-xl-4, .my-xl-4 {*/
+/*    margin-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .ml-xl-4, .mx-xl-4 {*/
+/*    margin-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .m-xl-5 {*/
+/*    margin: 3rem !important;*/
+/*  }*/
+
+/*  .mt-xl-5, .my-xl-5 {*/
+/*    margin-top: 3rem !important;*/
+/*  }*/
+
+/*  .mr-xl-5, .mx-xl-5 {*/
+/*    margin-right: 3rem !important;*/
+/*  }*/
+
+/*  .mb-xl-5, .my-xl-5 {*/
+/*    margin-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .ml-xl-5, .mx-xl-5 {*/
+/*    margin-left: 3rem !important;*/
+/*  }*/
+
+/*  .p-xl-0 {*/
+/*    padding: 0 !important;*/
+/*  }*/
+
+/*  .pt-xl-0, .py-xl-0 {*/
+/*    padding-top: 0 !important;*/
+/*  }*/
+
+/*  .pr-xl-0, .px-xl-0 {*/
+/*    padding-right: 0 !important;*/
+/*  }*/
+
+/*  .pb-xl-0, .py-xl-0 {*/
+/*    padding-bottom: 0 !important;*/
+/*  }*/
+
+/*  .pl-xl-0, .px-xl-0 {*/
+/*    padding-left: 0 !important;*/
+/*  }*/
+
+/*  .p-xl-1 {*/
+/*    padding: 0.25rem !important;*/
+/*  }*/
+
+/*  .pt-xl-1, .py-xl-1 {*/
+/*    padding-top: 0.25rem !important;*/
+/*  }*/
+
+/*  .pr-xl-1, .px-xl-1 {*/
+/*    padding-right: 0.25rem !important;*/
+/*  }*/
+
+/*  .pb-xl-1, .py-xl-1 {*/
+/*    padding-bottom: 0.25rem !important;*/
+/*  }*/
+
+/*  .pl-xl-1, .px-xl-1 {*/
+/*    padding-left: 0.25rem !important;*/
+/*  }*/
+
+/*  .p-xl-2 {*/
+/*    padding: 0.5rem !important;*/
+/*  }*/
+
+/*  .pt-xl-2, .py-xl-2 {*/
+/*    padding-top: 0.5rem !important;*/
+/*  }*/
+
+/*  .pr-xl-2, .px-xl-2 {*/
+/*    padding-right: 0.5rem !important;*/
+/*  }*/
+
+/*  .pb-xl-2, .py-xl-2 {*/
+/*    padding-bottom: 0.5rem !important;*/
+/*  }*/
+
+/*  .pl-xl-2, .px-xl-2 {*/
+/*    padding-left: 0.5rem !important;*/
+/*  }*/
+
+/*  .p-xl-3 {*/
+/*    padding: 1rem !important;*/
+/*  }*/
+
+/*  .pt-xl-3, .py-xl-3 {*/
+/*    padding-top: 1rem !important;*/
+/*  }*/
+
+/*  .pr-xl-3, .px-xl-3 {*/
+/*    padding-right: 1rem !important;*/
+/*  }*/
+
+/*  .pb-xl-3, .py-xl-3 {*/
+/*    padding-bottom: 1rem !important;*/
+/*  }*/
+
+/*  .pl-xl-3, .px-xl-3 {*/
+/*    padding-left: 1rem !important;*/
+/*  }*/
+
+/*  .p-xl-4 {*/
+/*    padding: 1.5rem !important;*/
+/*  }*/
+
+/*  .pt-xl-4, .py-xl-4 {*/
+/*    padding-top: 1.5rem !important;*/
+/*  }*/
+
+/*  .pr-xl-4, .px-xl-4 {*/
+/*    padding-right: 1.5rem !important;*/
+/*  }*/
+
+/*  .pb-xl-4, .py-xl-4 {*/
+/*    padding-bottom: 1.5rem !important;*/
+/*  }*/
+
+/*  .pl-xl-4, .px-xl-4 {*/
+/*    padding-left: 1.5rem !important;*/
+/*  }*/
+
+/*  .p-xl-5 {*/
+/*    padding: 3rem !important;*/
+/*  }*/
+
+/*  .pt-xl-5, .py-xl-5 {*/
+/*    padding-top: 3rem !important;*/
+/*  }*/
+
+/*  .pr-xl-5, .px-xl-5 {*/
+/*    padding-right: 3rem !important;*/
+/*  }*/
+
+/*  .pb-xl-5, .py-xl-5 {*/
+/*    padding-bottom: 3rem !important;*/
+/*  }*/
+
+/*  .pl-xl-5, .px-xl-5 {*/
+/*    padding-left: 3rem !important;*/
+/*  }*/
+
+/*  .m-xl-n1 {*/
+/*    margin: -0.25rem !important;*/
+/*  }*/
+
+/*  .mt-xl-n1, .my-xl-n1 {*/
+/*    margin-top: -0.25rem !important;*/
+/*  }*/
+
+/*  .mr-xl-n1, .mx-xl-n1 {*/
+/*    margin-right: -0.25rem !important;*/
+/*  }*/
+
+/*  .mb-xl-n1, .my-xl-n1 {*/
+/*    margin-bottom: -0.25rem !important;*/
+/*  }*/
+
+/*  .ml-xl-n1, .mx-xl-n1 {*/
+/*    margin-left: -0.25rem !important;*/
+/*  }*/
+
+/*  .m-xl-n2 {*/
+/*    margin: -0.5rem !important;*/
+/*  }*/
+
+/*  .mt-xl-n2, .my-xl-n2 {*/
+/*    margin-top: -0.5rem !important;*/
+/*  }*/
+
+/*  .mr-xl-n2, .mx-xl-n2 {*/
+/*    margin-right: -0.5rem !important;*/
+/*  }*/
+
+/*  .mb-xl-n2, .my-xl-n2 {*/
+/*    margin-bottom: -0.5rem !important;*/
+/*  }*/
+
+/*  .ml-xl-n2, .mx-xl-n2 {*/
+/*    margin-left: -0.5rem !important;*/
+/*  }*/
+
+/*  .m-xl-n3 {*/
+/*    margin: -1rem !important;*/
+/*  }*/
+
+/*  .mt-xl-n3, .my-xl-n3 {*/
+/*    margin-top: -1rem !important;*/
+/*  }*/
+
+/*  .mr-xl-n3, .mx-xl-n3 {*/
+/*    margin-right: -1rem !important;*/
+/*  }*/
+
+/*  .mb-xl-n3, .my-xl-n3 {*/
+/*    margin-bottom: -1rem !important;*/
+/*  }*/
+
+/*  .ml-xl-n3, .mx-xl-n3 {*/
+/*    margin-left: -1rem !important;*/
+/*  }*/
+
+/*  .m-xl-n4 {*/
+/*    margin: -1.5rem !important;*/
+/*  }*/
+
+/*  .mt-xl-n4, .my-xl-n4 {*/
+/*    margin-top: -1.5rem !important;*/
+/*  }*/
+
+/*  .mr-xl-n4, .mx-xl-n4 {*/
+/*    margin-right: -1.5rem !important;*/
+/*  }*/
+
+/*  .mb-xl-n4, .my-xl-n4 {*/
+/*    margin-bottom: -1.5rem !important;*/
+/*  }*/
+
+/*  .ml-xl-n4, .mx-xl-n4 {*/
+/*    margin-left: -1.5rem !important;*/
+/*  }*/
+
+/*  .m-xl-n5 {*/
+/*    margin: -3rem !important;*/
+/*  }*/
+
+/*  .mt-xl-n5, .my-xl-n5 {*/
+/*    margin-top: -3rem !important;*/
+/*  }*/
+
+/*  .mr-xl-n5, .mx-xl-n5 {*/
+/*    margin-right: -3rem !important;*/
+/*  }*/
+
+/*  .mb-xl-n5, .my-xl-n5 {*/
+/*    margin-bottom: -3rem !important;*/
+/*  }*/
+
+/*  .ml-xl-n5, .mx-xl-n5 {*/
+/*    margin-left: -3rem !important;*/
+/*  }*/
+
+/*  .m-xl-auto {*/
+/*    margin: auto !important;*/
+/*  }*/
+
+/*  .mt-xl-auto, .my-xl-auto {*/
+/*    margin-top: auto !important;*/
+/*  }*/
+
+/*  .mr-xl-auto, .mx-xl-auto {*/
+/*    margin-right: auto !important;*/
+/*  }*/
+
+/*  .mb-xl-auto, .my-xl-auto {*/
+/*    margin-bottom: auto !important;*/
+/*  }*/
+
+/*  .ml-xl-auto, .mx-xl-auto {*/
+/*    margin-left: auto !important;*/
+/*  }*/
+/*}*/
+
+/*.stretched-link::after {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  bottom: 0;*/
+/*  left: 0;*/
+/*  z-index: 1;*/
+/*  pointer-events: auto;*/
+/*  content: "";*/
+/*  background-color: rgba(0, 0, 0, 0);*/
+/*}*/
+
+/*.text-monospace {*/
+/*  font-family: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace !important;*/
+/*}*/
+
+/*.text-justify {*/
+/*  text-align: justify !important;*/
+/*}*/
+
+/*.text-wrap {*/
+/*  white-space: normal !important;*/
+/*}*/
+
+/*.text-nowrap {*/
+/*  white-space: nowrap !important;*/
+/*}*/
+
+/*.text-truncate {*/
+/*  overflow: hidden;*/
+/*  text-overflow: ellipsis;*/
+/*  white-space: nowrap;*/
+/*}*/
+
+/*.text-left {*/
+/*  text-align: left !important;*/
+/*}*/
+
+/*.text-right {*/
+/*  text-align: right !important;*/
+/*}*/
+
+/*.text-center {*/
+/*  text-align: center !important;*/
+/*}*/
+
+/*@media (min-width: 576px) {*/
+/*  .text-sm-left {*/
+/*    text-align: left !important;*/
+/*  }*/
+
+/*  .text-sm-right {*/
+/*    text-align: right !important;*/
+/*  }*/
+
+/*  .text-sm-center {*/
+/*    text-align: center !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 768px) {*/
+/*  .text-md-left {*/
+/*    text-align: left !important;*/
+/*  }*/
+
+/*  .text-md-right {*/
+/*    text-align: right !important;*/
+/*  }*/
+
+/*  .text-md-center {*/
+/*    text-align: center !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 992px) {*/
+/*  .text-lg-left {*/
+/*    text-align: left !important;*/
+/*  }*/
+
+/*  .text-lg-right {*/
+/*    text-align: right !important;*/
+/*  }*/
+
+/*  .text-lg-center {*/
+/*    text-align: center !important;*/
+/*  }*/
+/*}*/
+
+/*@media (min-width: 1200px) {*/
+/*  .text-xl-left {*/
+/*    text-align: left !important;*/
+/*  }*/
+
+/*  .text-xl-right {*/
+/*    text-align: right !important;*/
+/*  }*/
+
+/*  .text-xl-center {*/
+/*    text-align: center !important;*/
+/*  }*/
+/*}*/
+
+/*.text-lowercase {*/
+/*  text-transform: lowercase !important;*/
+/*}*/
+
+/*.text-uppercase {*/
+/*  text-transform: uppercase !important;*/
+/*}*/
+
+/*.text-capitalize {*/
+/*  text-transform: capitalize !important;*/
+/*}*/
+
+/*.font-weight-light {*/
+/*  font-weight: 300 !important;*/
+/*}*/
+
+/*.font-weight-lighter {*/
+/*  font-weight: lighter !important;*/
+/*}*/
+
+/*.font-weight-normal {*/
+/*  font-weight: 400 !important;*/
+/*}*/
+
+/*.font-weight-bold {*/
+/*  font-weight: 700 !important;*/
+/*}*/
+
+/*.font-weight-bolder {*/
+/*  font-weight: bolder !important;*/
+/*}*/
+
+/*.font-italic {*/
+/*  font-style: italic !important;*/
+/*}*/
+
+/*.text-white {*/
+/*  color: #fff !important;*/
+/*}*/
+
+/*.text-primary {*/
+/*  color: #007bff !important;*/
+/*}*/
+
+/*a.text-primary:hover, a.text-primary:focus {*/
+/*  color: #0056b3 !important;*/
+/*}*/
+
+/*.text-secondary {*/
+/*  color: #6c757d !important;*/
+/*}*/
+
+/*a.text-secondary:hover, a.text-secondary:focus {*/
+/*  color: #494f54 !important;*/
+/*}*/
+
+/*.text-success {*/
+/*  color: #28a745 !important;*/
+/*}*/
+
+/*a.text-success:hover, a.text-success:focus {*/
+/*  color: #19692c !important;*/
+/*}*/
+
+/*.text-info {*/
+/*  color: #17a2b8 !important;*/
+/*}*/
+
+/*a.text-info:hover, a.text-info:focus {*/
+/*  color: #0f6674 !important;*/
+/*}*/
+
+/*.text-warning {*/
+/*  color: #ffc107 !important;*/
+/*}*/
+
+/*a.text-warning:hover, a.text-warning:focus {*/
+/*  color: #ba8b00 !important;*/
+/*}*/
+
+/*.text-danger {*/
+/*  color: #dc3545 !important;*/
+/*}*/
+
+/*a.text-danger:hover, a.text-danger:focus {*/
+/*  color: #a71d2a !important;*/
+/*}*/
+
+/*.text-light {*/
+/*  color: #f8f9fa !important;*/
+/*}*/
+
+/*a.text-light:hover, a.text-light:focus {*/
+/*  color: #cbd3da !important;*/
+/*}*/
+
+/*.text-dark {*/
+/*  color: #343a40 !important;*/
+/*}*/
+
+/*a.text-dark:hover, a.text-dark:focus {*/
+/*  color: #121416 !important;*/
+/*}*/
+
+/*.text-body {*/
+/*  color: #212529 !important;*/
+/*}*/
+
+/*.text-muted {*/
+/*  color: #6c757d !important;*/
+/*}*/
+
+/*.text-black-50 {*/
+/*  color: rgba(0, 0, 0, 0.5) !important;*/
+/*}*/
+
+/*.text-white-50 {*/
+/*  color: rgba(255, 255, 255, 0.5) !important;*/
+/*}*/
+
+/*.text-hide {*/
+/*  font: 0/0 a;*/
+/*  color: transparent;*/
+/*  text-shadow: none;*/
+/*  background-color: transparent;*/
+/*  border: 0;*/
+/*}*/
+
+/*.text-decoration-none {*/
+/*  text-decoration: none !important;*/
+/*}*/
+
+/*.text-break {*/
+/*  word-break: break-word !important;*/
+/*  word-wrap: break-word !important;*/
+/*}*/
+
+/*.text-reset {*/
+/*  color: inherit !important;*/
+/*}*/
+
+/*.visible {*/
+/*  visibility: visible !important;*/
+/*}*/
+
+/*.invisible {*/
+/*  visibility: hidden !important;*/
+/*}*/
+
+/*@media print {*/
+/*  *, *::before, *::after {*/
+/*    text-shadow: none !important;*/
+/*    box-shadow: none !important;*/
+/*  }*/
+
+/*  a:not(.btn) {*/
+/*    text-decoration: underline;*/
+/*  }*/
+
+/*  abbr[title]::after {*/
+/*    content: " (" attr(title) ")";*/
+/*  }*/
+
+/*  pre {*/
+/*    white-space: pre-wrap !important;*/
+/*  }*/
+
+/*  pre, blockquote {*/
+/*    border: 1px solid #adb5bd;*/
+/*    page-break-inside: avoid;*/
+/*  }*/
+
+/*  thead {*/
+/*    display: table-header-group;*/
+/*  }*/
+
+/*  tr, img {*/
+/*    page-break-inside: avoid;*/
+/*  }*/
+
+/*  p, h2, h3 {*/
+/*    orphans: 3;*/
+/*    widows: 3;*/
+/*  }*/
+
+/*  h2, h3 {*/
+/*    page-break-after: avoid;*/
+/*  }*/
+
+/*  @page {*/
+/*    size: a3;*/
+/*  }*/
+
+/*  body {*/
+/*    min-width: 992px !important;*/
+/*  }*/
+
+/*  .container {*/
+/*    min-width: 992px !important;*/
+/*  }*/
+
+/*  .navbar {*/
+/*    display: none;*/
+/*  }*/
+
+/*  .badge {*/
+/*    border: 1px solid #000;*/
+/*  }*/
+
+/*  .table {*/
+/*    border-collapse: collapse !important;*/
+/*  }*/
+
+/*  .table td, .table th {*/
+/*    background-color: #fff !important;*/
+/*  }*/
+
+/*  .table-bordered th, .table-bordered td {*/
+/*    border: 1px solid #dee2e6 !important;*/
+/*  }*/
+
+/*  .table-dark {*/
+/*    color: inherit;*/
+/*  }*/
+
+/*  .table-dark th, .table-dark td, .table-dark thead th, .table-dark tbody + tbody {*/
+/*    border-color: #dee2e6;*/
+/*  }*/
+
+/*  .table .thead-dark th {*/
+/*    color: inherit;*/
+/*    border-color: #dee2e6;*/
+/*  }*/
+/*}*/
+
+/*!* HTML5 display definitions*/
+/*   ========================================================================= *!*/
 /**
  * Correct `block` display not defined for any HTML5 element in IE 8/9.
  * Correct `block` display not defined for `details` or `summary` in IE 10/11
  * and Firefox.
  * Correct `block` display not defined for `main` in IE 11.
  */
-article,
-aside,
-details,
-figcaption,
-figure,
-footer,
-header,
-hgroup,
-main,
-menu,
-nav,
-section,
-summary {
-  display: block; }
+article, aside, details, figcaption, figure, footer, header, hgroup, main, menu, nav, section, summary {
+  display: block;
+}
 
-/**
- * 1. Correct `inline-block` display not defined in IE 8/9.
- * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.
- */
-audio,
-canvas,
-progress,
-video {
-  display: inline-block;
-  /* 1 */
-  vertical-align: baseline;
-  /* 2 */ }
+/*!***/
+/* * 1. Correct `inline-block` display not defined in IE 8/9.*/
+/* * 2. Normalize vertical alignment of `progress` in Chrome, Firefox, and Opera.*/
+/* *!*/
+/*audio, canvas, progress, video {*/
+/*  display: inline-block;*/
+/*  !* 1 *!*/
+/*  vertical-align: baseline;*/
+/*  !* 2 *!*/
+/*}*/
 
-/**
- * Prevent modern browsers from displaying `audio` without controls.
- * Remove excess height in iOS 5 devices.
- */
-audio:not([controls]) {
-  display: none;
-  height: 0; }
+/*!***/
+/* * Prevent modern browsers from displaying `audio` without controls.*/
+/* * Remove excess height in iOS 5 devices.*/
+/* *!*/
+/*audio:not([controls]) {*/
+/*  display: none;*/
+/*  height: 0;*/
+/*}*/
 
 /**
  * Address `[hidden]` styling not present in IE 8/9/10.
  * Hide the `template` element in IE 8/9/10/11, Safari, and Firefox < 22.
  */
-[hidden],
-template {
-  display: none; }
+[hidden], template {
+  display: none;
+}
 
 /* Links
    ========================================================================== */
@@ -8240,36 +10492,39 @@ template {
  * Remove the gray background color from active links in IE 10.
  */
 a {
-  background-color: transparent; }
+  background-color: transparent;
+}
 
 /**
  * Improve readability of focused elements when they are also in an
  * active/hover state.
  */
-a:active,
-a:hover {
-  outline: 0; }
+a:active, a:hover {
+  outline: 0;
+}
 
 /* Text-level semantics
    ========================================================================== */
 /**
  * Address styling not present in IE 8/9/10/11, Safari, and Chrome.
  */
-abbr[title] {
-  border-bottom: 1px dotted; }
+/*abbr[title] {*/
+/*  border-bottom: 1px dotted;*/
+/*}*/
 
 /**
  * Address style set to `bolder` in Firefox 4+, Safari, and Chrome.
  */
-b,
-strong {
-  font-weight: bold; }
+b, strong {
+  font-weight: bold;
+}
 
-/**
- * Address styling not present in Safari and Chrome.
- */
-dfn {
-  font-style: italic; }
+/*!***/
+/* * Address styling not present in Safari and Chrome.*/
+/* *!*/
+/*dfn {*/
+/*  font-style: italic;*/
+/*}*/
 
 /**
  * Address variable `h1` font-size and margin within `section` and `article`
@@ -8277,36 +10532,41 @@ dfn {
  */
 h1 {
   font-size: 2em;
-  margin: .67em 0; }
+  margin: .67em 0;
+}
 
-/**
- * Address styling not present in IE 8/9.
- */
-mark {
-  background: #ff0;
-  color: #000; }
+/*!***/
+/* * Address styling not present in IE 8/9.*/
+/* *!*/
+/*mark {*/
+/*  background: #ff0;*/
+/*  color: #000;*/
+/*}*/
 
 /**
  * Address inconsistent and variable font size in all browsers.
  */
 small {
-  font-size: 80%; }
+  font-size: 80%;
+}
 
-/**
- * Prevent `sub` and `sup` affecting `line-height` in all browsers.
- */
-sub,
-sup {
-  font-size: 75%;
-  line-height: 0;
-  position: relative;
-  vertical-align: baseline; }
+/*!***/
+/* * Prevent `sub` and `sup` affecting `line-height` in all browsers.*/
+/* *!*/
+/*sub, sup {*/
+/*  font-size: 75%;*/
+/*  line-height: 0;*/
+/*  position: relative;*/
+/*  vertical-align: baseline;*/
+/*}*/
 
-sup {
-  top: -.5em; }
+/*sup {*/
+/*  top: -.5em;*/
+/*}*/
 
-sub {
-  bottom: -.25em; }
+/*sub {*/
+/*  bottom: -.25em;*/
+/*}*/
 
 /* Embedded content
    ========================================================================== */
@@ -8314,13 +10574,15 @@ sub {
  * Remove border when inside `a` element in IE 8/9/10.
  */
 img {
-  border: 0; }
+  border: 0;
+}
 
 /**
  * Correct overflow not hidden in IE 9/10/11.
  */
 svg:not(:root) {
-  overflow: hidden; }
+  overflow: hidden;
+}
 
 /* Grouping content
    ========================================================================== */
@@ -8328,30 +10590,31 @@ svg:not(:root) {
  * Address margin not present in IE 8/9 and Safari.
  */
 figure {
-  margin: 1em 40px; }
+  margin: 1em 40px;
+}
 
 /**
  * Address differences between Firefox and other browsers.
  */
 hr {
   box-sizing: content-box;
-  height: 0; }
+  height: 0;
+}
 
-/**
- * Contain overflow in all browsers.
- */
-pre {
-  overflow: auto; }
+/*!***/
+/* * Contain overflow in all browsers.*/
+/* *!*/
+/*pre {*/
+/*  overflow: auto;*/
+/*}*/
 
-/**
- * Address odd `em`-unit font size rendering in all browsers.
- */
-code,
-kbd,
-pre,
-samp {
-  font-family: monospace;
-  font-size: 1em; }
+/*!***/
+/* * Address odd `em`-unit font size rendering in all browsers.*/
+/* *!*/
+/*code, kbd, pre, samp {*/
+/*  font-family: monospace;*/
+/*  font-size: 1em;*/
+/*}*/
 
 /* Forms
    ========================================================================== */
@@ -8365,23 +10628,21 @@ samp {
  * 2. Correct font properties not being inherited.
  * 3. Address margins set differently in Firefox 4+, Safari, and Chrome.
  */
-button,
-input,
-optgroup,
-select,
-textarea {
+button, input, optgroup, select, textarea {
   color: inherit;
   /* 1 */
   font: inherit;
   /* 2 */
   margin: 0;
-  /* 3 */ }
+  /* 3 */
+}
 
 /**
  * Address `overflow` set to `hidden` in IE 8/9/10/11.
  */
 button {
-  overflow: visible; }
+  overflow: visible;
+}
 
 /**
  * Address inconsistent `text-transform` inheritance for `button` and `select`.
@@ -8389,9 +10650,9 @@ button {
  * Correct `button` style inheritance in Firefox, IE 8/9/10/11, and Opera.
  * Correct `select` style inheritance in Firefox.
  */
-button,
-select {
-  text-transform: none; }
+button, select {
+  text-transform: none;
+}
 
 /**
  * 1. Avoid the WebKit bug in Android 4.0.* where (2) destroys native `audio`
@@ -8400,36 +10661,35 @@ select {
  * 3. Improve usability and consistency of cursor style between image-type
  *    `input` and others.
  */
-button,
-html input[type="button"],
-input[type="reset"],
-input[type="submit"] {
+button, html input[type="button"], input[type="reset"], input[type="submit"] {
   -webkit-appearance: button;
   /* 2 */
   cursor: pointer;
-  /* 3 */ }
+  /* 3 */
+}
 
 /**
  * Re-set default cursor for disabled elements.
  */
-button[disabled],
-html input[disabled] {
-  cursor: default; }
+button[disabled], html input[disabled] {
+  cursor: default;
+}
 
 /**
  * Remove inner padding and border in Firefox 4+.
  */
-button::-moz-focus-inner,
-input::-moz-focus-inner {
+button::-moz-focus-inner, input::-moz-focus-inner {
   border: 0;
-  padding: 0; }
+  padding: 0;
+}
 
 /**
  * Address Firefox 4+ setting `line-height` on `input` using `!important` in
  * the UA stylesheet.
  */
 input {
-  line-height: normal; }
+  line-height: normal;
+}
 
 /**
  * It's recommended that you don't attempt to style these elements.
@@ -8438,40 +10698,41 @@ input {
  * 1. Address box sizing set to `content-box` in IE 8/9/10.
  * 2. Remove excess padding in IE 8/9/10.
  */
-input[type="checkbox"],
-input[type="radio"] {
+input[type="checkbox"], input[type="radio"] {
   box-sizing: border-box;
   /* 1 */
   padding: 0;
-  /* 2 */ }
+  /* 2 */
+}
 
 /**
  * Fix the cursor style for Chrome's increment/decrement buttons. For certain
  * `font-size` values of the `input`, it causes the cursor style of the
  * decrement button to change from `default` to `text`.
  */
-input[type="number"]::-webkit-inner-spin-button,
-input[type="number"]::-webkit-outer-spin-button {
-  height: auto; }
+input[type="number"]::-webkit-inner-spin-button, input[type="number"]::-webkit-outer-spin-button {
+  height: auto;
+}
 
 /**
  * 1. Address `appearance` set to `searchfield` in Safari and Chrome.
  * 2. Address `box-sizing` set to `border-box` in Safari and Chrome.
  */
-input[type="search"] {
-  -webkit-appearance: textfield;
-  /* 1 */
-  box-sizing: content-box;
-  /* 2 */ }
+/*input[type="search"] {*/
+/*  -webkit-appearance: textfield;*/
+/*  !* 1 *!*/
+/*  box-sizing: content-box;*/
+/*  !* 2 *!*/
+/*}*/
 
-/**
- * Remove inner padding and search cancel button in Safari and Chrome on OS X.
- * Safari (but not Chrome) clips the cancel button when the search input has
- * padding (and `textfield` appearance).
- */
-input[type="search"]::-webkit-search-cancel-button,
-input[type="search"]::-webkit-search-decoration {
-  -webkit-appearance: none; }
+/*!***/
+/* * Remove inner padding and search cancel button in Safari and Chrome on OS X.*/
+/* * Safari (but not Chrome) clips the cancel button when the search input has*/
+/* * padding (and `textfield` appearance).*/
+/* *!*/
+/*input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration {*/
+/*  -webkit-appearance: none;*/
+/*}*/
 
 /**
  * Define consistent border, margin, and padding.
@@ -8479,7 +10740,8 @@ input[type="search"]::-webkit-search-decoration {
 fieldset {
   border: 1px solid #c0c0c0;
   margin: 0 2px;
-  padding: .35em .625em .75em; }
+  padding: .35em .625em .75em;
+}
 
 /**
  * 1. Correct `color` not being inherited in IE 8/9/10/11.
@@ -8489,20 +10751,23 @@ legend {
   border: 0;
   /* 1 */
   padding: 0;
-  /* 2 */ }
+  /* 2 */
+}
 
 /**
  * Remove default vertical scrollbar in IE 8/9/10/11.
  */
 textarea {
-  overflow: auto; }
+  overflow: auto;
+}
 
 /**
  * Don't inherit the `font-weight` (applied by a rule above).
  * NOTE: the default cannot safely be changed in Chrome and Safari on OS X.
  */
 optgroup {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 /* Tables
    ========================================================================== */
@@ -8511,1667 +10776,2333 @@ optgroup {
  */
 table {
   border-collapse: collapse;
-  border-spacing: 0; }
+  border-spacing: 0;
+}
 
-td,
-th {
-  padding: 0; }
+td, th {
+  padding: 0;
+}
 
-#comments-wrapper {
-  scroll-behavior: smooth; }
+/*#comments-wrapper {*/
+/*  scroll-behavior: smooth;*/
+/*}*/
 
-#comments-wrapper::-webkit-scrollbar {
-  width: 0; }
+/*#comments-wrapper::-webkit-scrollbar {*/
+/*  width: 0;*/
+/*}*/
 
-#comments-wrapper::-webkit-scrollbar-track {
-  background: transparent; }
+/*#comments-wrapper::-webkit-scrollbar-track {*/
+/*  background: transparent;*/
+/*}*/
 
-#comments-wrapper::-webkit-scrollbar-thumb {
-  background-color: transparent;
-  z-index: 9999;
-  border-radius: 50px; }
+/*#comments-wrapper::-webkit-scrollbar-thumb {*/
+/*  background-color: transparent;*/
+/*  z-index: 9999;*/
+/*  border-radius: 50px;*/
+/*}*/
 
-svg.map-svg,
-path.map-svg {
-  fill: #2e3c5d70; }
-  svg.map-svg text,
-  path.map-svg text {
-    pointer-events: none;
-    fill: white !important; }
+svg.map-svg, path.map-svg {
+  fill: #2e3c5d70;
+}
+
+svg.map-svg text, path.map-svg text {
+  pointer-events: none;
+  fill: white !important;
+}
 
 svg {
-  width: 100%; }
+  width: 100%;
+}
 
-.us-state-map path:hover {
-  fill: #2e3c5d !important;
-  cursor: pointer; }
+/*.us-state-map path:hover {*/
+/*  fill: #2e3c5d !important;*/
+/*  cursor: pointer;*/
+/*}*/
 
-.app-wrapper {
-  height: 100%;
-  min-height: 100%;
-  position: relative; }
-  @media all and (min-width: 960px) {
-    .app-wrapper {
-      margin: 0 auto; } }
-  .app-wrapper__cordova {
-    position: relative;
-    height: unset;
-    min-height: unset; }
+/*.app-wrapper {*/
+/*  height: 100%;*/
+/*  min-height: 100%;*/
+/*  position: relative;*/
+/*}*/
 
-.app-toast-cordova__iphone {
-  margin-top: 24px !important; }
+/*@media all and (min-width: 960px) {*/
+/*  .app-wrapper {*/
+/*    margin: 0 auto;*/
+/*  }*/
+/*}*/
 
-.app-toast-cordova__iphone-notch {
-  margin-top: 40px !important; }
+/*.app-wrapper__cordova {*/
+/*  position: relative;*/
+/*  height: unset;*/
+/*  min-height: unset;*/
+/*}*/
 
-.container-main {
-  padding-top: 16px;
-  padding-bottom: 64px; }
+/*.app-toast-cordova__iphone {*/
+/*  margin-top: 24px !important;*/
+/*}*/
 
-.container-settings {
-  padding-top: 0;
-  padding-bottom: 64px; }
+/*.app-toast-cordova__iphone-notch {*/
+/*  margin-top: 40px !important;*/
+/*}*/
 
-.cordova-base {
-  -webkit-user-select: none;
-  -html-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none; }
+/*.container-main {*/
+/*  padding-top: 16px;*/
+/*  padding-bottom: 64px;*/
+/*}*/
 
-*,
-*::before,
-*::after {
-  box-sizing: inherit; }
+/*.container-settings {*/
+/*  padding-top: 0;*/
+/*  padding-bottom: 64px;*/
+/*}*/
+
+/*.cordova-base {*/
+/*  -webkit-user-select: none;*/
+/*  -html-user-select: none;*/
+/*  -moz-user-select: none;*/
+/*  -ms-user-select: none;*/
+/*  user-select: none;*/
+/*}*/
+
+*, *::before, *::after {
+  box-sizing: inherit;
+}
 
 a {
-  cursor: pointer; }
+  cursor: pointer;
+}
 
 img {
-  max-width: 100%; }
+  max-width: 100%;
+}
 
 button:focus {
-  outline: 0 !important; }
+  outline: 0 !important;
+}
 
-@font-face {
-  font-family: 'app-fonts';
-  src: url("~sass/base/fonts/app-fonts.eot");
-  src: url("~sass/base/fonts/app-fonts.eot?#iefix") format("embedded-opentype"), url("~sass/base/fonts/app-fonts.woff") format("woff"), url("~sass/base/fonts/app-fonts.ttf") format("truetype"), url("~sass/base/fonts/app-fonts.svg#app-fonts") format("svg");
-  font-weight: normal;
-  font-style: normal; }
+/*@font-face {*/
+/*  font-family: 'app-fonts';*/
+/*  src: url("~sass/base/fonts/app-fonts.eot");*/
+/*  src: url("~sass/base/fonts/app-fonts.eot?#iefix") format("embedded-opentype"), url("~sass/base/fonts/app-fonts.woff") format("woff"), url("~sass/base/fonts/app-fonts.ttf") format("truetype"), url("~sass/base/fonts/app-fonts.svg#app-fonts") format("svg");*/
+/*  font-weight: normal;*/
+/*  font-style: normal;*/
+/*}*/
 
-[data-icon]::before {
-  font-family: 'app-fonts' !important;
-  content: attr(data-icon);
-  font-style: normal !important;
-  font-weight: normal !important;
-  font-variant: normal !important;
-  text-transform: none !important;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+/*[data-icon]::before {*/
+/*  font-family: 'app-fonts' !important;*/
+/*  content: attr(data-icon);*/
+/*  font-style: normal !important;*/
+/*  font-weight: normal !important;*/
+/*  font-variant: normal !important;*/
+/*  text-transform: none !important;*/
+/*  line-height: 1;*/
+/*  -webkit-font-smoothing: antialiased;*/
+/*  -moz-osx-font-smoothing: grayscale;*/
+/*}*/
 
-[class^='icon-']::before,
-[class*=' icon-']::before {
-  font-family: 'app-fonts' !important;
-  font-style: normal !important;
-  font-weight: normal !important;
-  font-variant: normal !important;
-  text-transform: none !important;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+/*[class^='icon-']::before, [class*=' icon-']::before {*/
+/*  font-family: 'app-fonts' !important;*/
+/*  font-style: normal !important;*/
+/*  font-weight: normal !important;*/
+/*  font-variant: normal !important;*/
+/*  text-transform: none !important;*/
+/*  line-height: 1;*/
+/*  -webkit-font-smoothing: antialiased;*/
+/*  -moz-osx-font-smoothing: grayscale;*/
+/*}*/
 
-.icon-icon-vote-3-4::before {
-  content: 'a'; }
+/*.icon-icon-vote-3-4::before {*/
+/*  content: 'a';*/
+/*}*/
 
-.icon-icon-person-placeholder-6-1::before {
-  content: 'b';
-  vertical-align: middle;
-  position: relative;
-  bottom: .5rem; }
+/*.icon-icon-person-placeholder-6-1::before {*/
+/*  content: 'b';*/
+/*  vertical-align: middle;*/
+/*  position: relative;*/
+/*  bottom: .5rem;*/
+/*}*/
 
-.icon-candidate-small.icon-main.icon-icon-person-placeholder-6-1 {
-  vertical-align: middle; }
+/*.icon-candidate-small.icon-main.icon-icon-person-placeholder-6-1 {*/
+/*  vertical-align: middle;*/
+/*}*/
 
-.icon-icon-org-placeholder-6-2::before {
-  content: 'c';
-  vertical-align: middle;
-  font-size: 1.6em; }
+/*.icon-icon-org-placeholder-6-2::before {*/
+/*  content: 'c';*/
+/*  vertical-align: middle;*/
+/*  font-size: 1.6em;*/
+/*}*/
 
-.icon-icon-more-opinions-2-2::before {
-  content: 'd'; }
+/*.icon-icon-more-opinions-2-2::before {*/
+/*  content: 'd';*/
+/*}*/
 
-.icon-icon-connect-1-3::before {
-  content: 'e';
-  font-size: 1.25em; }
+/*.icon-icon-connect-1-3::before {*/
+/*  content: 'e';*/
+/*  font-size: 1.25em;*/
+/*}*/
 
-.icon-icon-add-friends-2-1::before {
-  content: 'f'; }
+/*.icon-icon-add-friends-2-1::before {*/
+/*  content: 'f';*/
+/*}*/
 
-.icon-icon-activity-1-4::before {
-  content: 'g';
-  font-size: 1.25em;
-  line-height: .5; }
+/*.icon-icon-activity-1-4::before {*/
+/*  content: 'g';*/
+/*  font-size: 1.25em;*/
+/*  line-height: .5;*/
+/*}*/
 
-.icon-icon-connect1-3::before {
-  content: 'h'; }
+/*.icon-icon-connect1-3::before {*/
+/*  content: 'h';*/
+/*}*/
 
-.icon-xl {
-  font-size: 10em; }
+/*.icon-xl {*/
+/*  font-size: 10em;*/
+/*}*/
 
 .icon-office-child {
-  font-size: 24px; }
-  @media all and (min-width: 480px) {
-    .icon-office-child {
-      font-size: 48px; } }
+  font-size: 24px;
+}
 
-.icon-candidate-large {
-  font-size: 80px; }
+@media all and (min-width: 480px) {
+  .icon-office-child {
+    font-size: 48px;
+  }
+}
 
-.icon-candidate-medium {
-  font-size: 50px; }
+/*.icon-candidate-large {*/
+/*  font-size: 80px;*/
+/*}*/
+
+/*.icon-candidate-medium {*/
+/*  font-size: 50px;*/
+/*}*/
 
 .icon-candidate-small {
-  font-size: 40px; }
-  @media all and (min-width: 480px) {
-    .icon-candidate-small {
-      font-size: 40px; } }
+  font-size: 40px;
+}
+
+@media all and (min-width: 480px) {
+  .icon-candidate-small {
+    font-size: 40px;
+  }
+}
 
 .icon-lg {
-  font-size: 5rem; }
-  @media all and (max-width: 479px) {
-    .icon-lg {
-      font-size: 2rem; } }
+  font-size: 5rem;
+}
 
-.icon-medium {
-  font-size: 2em; }
+@media all and (max-width: 479px) {
+  .icon-lg {
+    font-size: 2rem;
+  }
+}
 
-.icon-small {
-  font-size: 15px; }
+/*.icon-medium {*/
+/*  font-size: 2em;*/
+/*}*/
+
+/*.icon-small {*/
+/*  font-size: 15px;*/
+/*}*/
 
 .icon-main {
-  color: #999; }
+  color: #999;
+}
 
-.icon-org-resting-color {
-  color: #999; }
+/*.icon-org-resting-color {*/
+/*  color: #999;*/
+/*}*/
 
-.icon-org-lg {
-  font-size: 3.2rem; }
+/*.icon-org-lg {*/
+/*  font-size: 3.2rem;*/
+/*}*/
 
-.icon-org-medium {
-  font-size: 2em; }
+/*.icon-org-medium {*/
+/*  font-size: 2em;*/
+/*}*/
 
-.icon-org-small {
-  font-size: 15px; }
+/*.icon-org-small {*/
+/*  font-size: 15px;*/
+/*}*/
 
 .ion-input-icon {
   font-size: 24px;
-  color: #999; }
+  color: #999;
+}
 
-.icon-45 {
-  font-size: 1.9em !important; }
-  .icon-45::before {
-    font-size: 1.9em !important; }
+/*.icon-45 {*/
+/*  font-size: 1.9em !important;*/
+/*}*/
+
+/*.icon-45::before {*/
+/*  font-size: 1.9em !important;*/
+/*}*/
 
 h1, h2, h3, h4, h5, h6 {
-  font-size: 16px; }
+  font-size: 16px;
+}
 
 .image-lg {
-  width: 50px; }
+  width: 50px;
+}
 
 .image-12x12 {
   height: 12px;
-  width: 12px; }
+  width: 12px;
+}
 
 .image-16x16 {
   border-radius: 3px;
   height: 16px;
-  width: 16px; }
+  width: 16px;
+}
 
 .image-24x24 {
   border-radius: 4px;
   height: 24px;
-  width: 24px; }
+  width: 24px;
+}
 
 .image-border-gray-border {
   border: 2px solid #999;
-  border-radius: 4px; }
+  border-radius: 4px;
+}
 
 .image-border-support {
   border: 2px solid #1fc06f;
-  border-radius: 4px; }
+  border-radius: 4px;
+}
 
 .image-border-oppose {
   border: 2px solid #ff4922;
-  border-radius: 4px; }
+  border-radius: 4px;
+}
 
-.image-issue-photo-placeholder {
-  background-color: #999;
-  min-height: 80px;
-  min-width: 80px; }
+/*.image-issue-photo-placeholder {*/
+/*  background-color: #999;*/
+/*  min-height: 80px;*/
+/*  min-width: 80px;*/
+/*}*/
 
-.image-issue-placeholder {
-  vertical-align: middle; }
+/*.image-issue-placeholder {*/
+/*  vertical-align: middle;*/
+/*}*/
 
 .image-organization-placeholder {
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 .image-person-placeholder {
-  vertical-align: middle; }
+  vertical-align: middle;
+}
 
 .u-cursor--pointer:hover {
-  cursor: pointer; }
+  cursor: pointer;
+}
 
 .u-min-50 {
-  min-width: 50%; }
+  min-width: 50%;
+}
 
-.u-gray-border-bottom {
-  border-bottom: 1px solid #ddd; }
+/*.u-gray-border-bottom {*/
+/*  border-bottom: 1px solid #ddd;*/
+/*}*/
 
 .u-no-scroll {
-  overflow: hidden !important; }
+  overflow: hidden !important;
+}
 
 .u-position-relative {
-  position: relative !important; }
+  position: relative !important;
+}
 
 .u-overflow-hidden {
-  overflow: hidden !important; }
+  overflow: hidden !important;
+}
 
 .no-decoration {
-  text-decoration: none !important; }
+  text-decoration: none !important;
+}
 
 .full-width {
-  width: 100%; }
+  width: 100%;
+}
 
-.u-bg-gray-pale {
-  background-color: #f8f8f8; }
+/*.u-bg-gray-pale {*/
+/*  background-color: #f8f8f8;*/
+/*}*/
 
-.u-bg-gray-lighter {
-  background-color: #eee; }
+/*.u-bg-gray-lighter {*/
+/*  background-color: #eee;*/
+/*}*/
 
-.u-bg-gray-light {
-  background-color: #ccc; }
+/*.u-bg-gray-light {*/
+/*  background-color: #ccc;*/
+/*}*/
 
-.u-bg-gray-mid {
-  background-color: #999; }
+/*.u-bg-gray-mid {*/
+/*  background-color: #999;*/
+/*}*/
 
-.u-bg-gray-dark {
-  background-color: #555; }
+/*.u-bg-gray-dark {*/
+/*  background-color: #555;*/
+/*}*/
 
-.u-bg-gray-darker {
-  background-color: #333; }
+/*.u-bg-gray-darker {*/
+/*  background-color: #333;*/
+/*}*/
 
-.u-bg-gray-border {
-  background-color: #ddd; }
+/*.u-bg-gray-border {*/
+/*  background-color: #ddd;*/
+/*}*/
 
-.u-bg-white {
-  background-color: #fff; }
+/*.u-bg-white {*/
+/*  background-color: #fff;*/
+/*}*/
 
 .u-flex {
-  display: flex; }
+  display: flex;
+}
 
-.u-inline-flex {
-  display: inline-flex; }
+/*.u-inline-flex {*/
+/*  display: inline-flex;*/
+/*}*/
 
-.u-flex-auto {
-  min-width: 0;
-  min-height: 0;
-  flex: 1 1 auto; }
+/*.u-flex-auto {*/
+/*  min-width: 0;*/
+/*  min-height: 0;*/
+/*  flex: 1 1 auto;*/
+/*}*/
 
 .u-flex-none {
-  flex: none; }
+  flex: none;
+}
 
-.u-flex-column {
-  flex-direction: column; }
+/*.u-flex-column {*/
+/*  flex-direction: column;*/
+/*}*/
 
-.u-flex-row {
-  flex-direction: row; }
+/*.u-flex-row {*/
+/*  flex-direction: row;*/
+/*}*/
 
-.u-flex-wrap {
-  flex-wrap: wrap; }
+/*.u-flex-wrap {*/
+/*  flex-wrap: wrap;*/
+/*}*/
 
-.u-flex-single-column {
-  flex: 1; }
+/*.u-flex-single-column {*/
+/*  flex: 1;*/
+/*}*/
 
-.u-items-start {
-  align-items: flex-start; }
+/*.u-items-start {*/
+/*  align-items: flex-start;*/
+/*}*/
 
-.u-items-end {
-  align-items: flex-end; }
+/*.u-items-end {*/
+/*  align-items: flex-end;*/
+/*}*/
 
-.u-items-center {
-  align-items: center; }
+/*.u-items-center {*/
+/*  align-items: center;*/
+/*}*/
 
-.u-items-baseline {
-  align-items: baseline; }
+/*.u-items-baseline {*/
+/*  align-items: baseline;*/
+/*}*/
 
-.u-items-stretch {
-  align-items: stretch; }
+/*.u-items-stretch {*/
+/*  align-items: stretch;*/
+/*}*/
 
-.u-self-start {
-  align-self: flex-start; }
+/*.u-self-start {*/
+/*  align-self: flex-start;*/
+/*}*/
 
-.u-self-end {
-  align-self: flex-end; }
+/*.u-self-end {*/
+/*  align-self: flex-end;*/
+/*}*/
 
-.u-self-center {
-  align-self: center; }
+/*.u-self-center {*/
+/*  align-self: center;*/
+/*}*/
 
-.u-self-baseline {
-  align-self: baseline; }
+/*.u-self-baseline {*/
+/*  align-self: baseline;*/
+/*}*/
 
-.u-self-stretch {
-  align-self: stretch; }
+/*.u-self-stretch {*/
+/*  align-self: stretch;*/
+/*}*/
 
-.u-justify-start {
-  justify-content: flex-start; }
+/*.u-justify-start {*/
+/*  justify-content: flex-start;*/
+/*}*/
 
-.u-justify-end {
-  justify-content: flex-end; }
+/*.u-justify-end {*/
+/*  justify-content: flex-end;*/
+/*}*/
 
-.u-justify-center {
-  justify-content: center; }
+/*.u-justify-center {*/
+/*  justify-content: center;*/
+/*}*/
 
-.u-justify-between {
-  justify-content: space-between; }
+/*.u-justify-between {*/
+/*  justify-content: space-between;*/
+/*}*/
 
-.u-justify-around {
-  justify-content: space-around; }
+/*.u-justify-around {*/
+/*  justify-content: space-around;*/
+/*}*/
 
-.u-content-start {
-  align-content: flex-start; }
+/*.u-content-start {*/
+/*  align-content: flex-start;*/
+/*}*/
 
-.u-content-end {
-  align-content: flex-end; }
+/*.u-content-end {*/
+/*  align-content: flex-end;*/
+/*}*/
 
-.u-content-center {
-  align-content: center; }
+/*.u-content-center {*/
+/*  align-content: center;*/
+/*}*/
 
-.u-content-between {
-  align-content: space-between; }
+/*.u-content-between {*/
+/*  align-content: space-between;*/
+/*}*/
 
-.u-content-around {
-  align-content: space-around; }
+/*.u-content-around {*/
+/*  align-content: space-around;*/
+/*}*/
 
-.u-content-stretch {
-  align-content: stretch; }
+/*.u-content-stretch {*/
+/*  align-content: stretch;*/
+/*}*/
 
-.u-order-0 {
-  order: 0; }
+/*.u-order-0 {*/
+/*  order: 0;*/
+/*}*/
 
-.u-order-1 {
-  order: 1; }
+/*.u-order-1 {*/
+/*  order: 1;*/
+/*}*/
 
-.u-order-2 {
-  order: 2; }
+/*.u-order-2 {*/
+/*  order: 2;*/
+/*}*/
 
-.u-order-3 {
-  order: 3; }
+/*.u-order-3 {*/
+/*  order: 3;*/
+/*}*/
 
-.u-order-4 {
-  order: 4; }
+/*.u-order-4 {*/
+/*  order: 4;*/
+/*}*/
 
-.u-order-5 {
-  order: 5; }
+/*.u-order-5 {*/
+/*  order: 5;*/
+/*}*/
 
-.u-order-6 {
-  order: 6; }
+/*.u-order-6 {*/
+/*  order: 6;*/
+/*}*/
 
-.u-order-7 {
-  order: 7; }
+/*.u-order-7 {*/
+/*  order: 7;*/
+/*}*/
 
-.u-order-8 {
-  order: 8; }
+/*.u-order-8 {*/
+/*  order: 8;*/
+/*}*/
 
-.u-order-last {
-  order: 99999; }
+/*.u-order-last {*/
+/*  order: 99999;*/
+/*}*/
 
-.emphasize {
-  font-style: italic !important; }
-  .emphasize * {
-    font-style: italic !important; }
+/*.emphasize {*/
+/*  font-style: italic !important;*/
+/*}*/
 
-.u-f1,
-.u-f2,
-.u-f3,
-.u-f4,
-.u-f5,
-.u-f6 {
-  line-height: 1.25; }
+/*.emphasize * {*/
+/*  font-style: italic !important;*/
+/*}*/
 
-.u-f1,
-.h1 {
-  font-size: 2rem; }
+.u-f1, .u-f2, .u-f3, .u-f4, .u-f5, .u-f6 {
+  line-height: 1.25;
+}
 
-.u-f2,
-.h2 {
-  font-size: 1.5rem; }
+.u-f1, .h1 {
+  font-size: 2rem;
+}
 
-.u-f3,
-.h3 {
-  font-size: 1.25rem; }
+.u-f2, .h2 {
+  font-size: 1.5rem;
+}
 
-.u-f4,
-.h4 {
-  font-size: 1.125rem; }
+.u-f3, .h3 {
+  font-size: 1.25rem;
+}
 
-.u-f5,
-.h5 {
-  font-size: 1.1rem; }
+.u-f4, .h4 {
+  font-size: 1.125rem;
+}
 
-.u-font-size6 {
-  font-size: 1rem; }
+.u-f5, .h5 {
+  font-size: 1.1rem;
+}
 
-.u-f6,
-.h6 {
-  font-size: 1rem; }
+/*.u-font-size6 {*/
+/*  font-size: 1rem;*/
+/*}*/
 
-.u-font-size7 {
-  font-size: .875rem; }
+/*.u-f6, .h6 {*/
+/*  font-size: 1rem;*/
+/*}*/
 
-.u-f7 {
-  font-size: .875rem; }
+/*.u-font-size7 {*/
+/*  font-size: .875rem;*/
+/*}*/
 
-.u-f8,
-.u-f--small {
-  font-size: .75rem; }
+/*.u-f7 {*/
+/*  font-size: .875rem;*/
+/*}*/
 
-.u-gray-pale {
-  color: #f8f8f8; }
+/*.u-f8, .u-f--small {*/
+/*  font-size: .75rem;*/
+/*}*/
 
-.u-gray-lighter {
-  color: #eee; }
+/*.u-gray-pale {*/
+/*  color: #f8f8f8;*/
+/*}*/
 
-.u-gray-light {
-  color: #ccc; }
+/*.u-gray-lighter {*/
+/*  color: #eee;*/
+/*}*/
+
+/*.u-gray-light {*/
+/*  color: #ccc;*/
+/*}*/
 
 .u-gray-mid {
-  color: #999; }
+  color: #999;
+}
 
-.u-gray-dark {
-  color: #555; }
+/*.u-gray-dark {*/
+/*  color: #555;*/
+/*}*/
 
 .u-gray-darker {
-  color: #333; }
+  color: #333;
+}
 
 .u-gray-border {
-  color: #ddd; }
+  color: #ddd;
+}
 
 .u-link-color {
-  color: #4371cc; }
+  color: #4371cc;
+}
 
-.u-link-color-light {
-  color: #969dff; }
+/*.u-link-color-light {*/
+/*  color: #969dff;*/
+/*}*/
 
-.u-measure {
-  max-width: 30em; }
+/*.u-measure {*/
+/*  max-width: 30em;*/
+/*}*/
 
-.u-measure--narrow {
-  max-width: 20em; }
+/*.u-measure--narrow {*/
+/*  max-width: 20em;*/
+/*}*/
 
-.u-measure--wide {
-  max-width: 34em; }
+/*.u-measure--wide {*/
+/*  max-width: 34em;*/
+/*}*/
 
 .u-bold {
-  font-weight: bold; }
+  font-weight: bold;
+}
 
-.u-italic {
-  font-style: italic; }
+/*.u-italic {*/
+/*  font-style: italic;*/
+/*}*/
 
 .u-underline {
-  text-decoration: underline; }
+  text-decoration: underline;
+}
 
 .u-no-underline {
-  text-decoration: none; }
+  text-decoration: none;
+}
 
-:hover.u-no-underline,
-:focus.u-no-underline,
-:active.u-no-underline {
-  text-decoration: none; }
+:hover.u-no-underline, :focus.u-no-underline, :active.u-no-underline {
+  text-decoration: none;
+}
 
-.u-uppercase {
-  text-transform: uppercase; }
+/*.u-uppercase {*/
+/*  text-transform: uppercase;*/
+/*}*/
 
-.u-capitalize {
-  text-transform: capitalize; }
+/*.u-capitalize {*/
+/*  text-transform: capitalize;*/
+/*}*/
 
-.u-mobile-x {
-  font-size: 1.3rem; }
+/*.u-mobile-x {*/
+/*  font-size: 1.3rem;*/
+/*}*/
 
-.u-inline {
-  display: inline-block;
-  width: auto; }
+/*.u-inline {*/
+/*  display: inline-block;*/
+/*  width: auto;*/
+/*}*/
 
 .u-break-word {
   overflow-wrap: break-word;
   word-wrap: break-word;
-  -ms-word-break: break-all;
+  /*-ms-word-break: break-all;*/
   word-break: break-word;
-  -ms-hyphens: auto;
+  /*-ms-hyphens: auto;*/
   -moz-hyphens: auto;
   -webkit-hyphens: auto;
-  hyphens: auto; }
+  hyphens: auto;
+}
 
-.u-tr {
-  text-align: right; }
+/*.u-tr {*/
+/*  text-align: right;*/
+/*}*/
 
-.u-tc {
-  text-align: center; }
+/*.u-tc {*/
+/*  text-align: center;*/
+/*}*/
 
 .u-tl {
-  text-align: left; }
+  text-align: left;
+}
 
 @media all and (min-width: 576px) {
   .u-show-mobile {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (max-width: 320px) {
   .u-show-mobile-bigger-than-iphone5 {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (min-width: 576px) {
   .u-show-mobile-bigger-than-iphone5 {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (min-width: 321px) {
   .u-show-mobile-iphone5-or-smaller {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (max-width: 575px) {
   .u-show-desktop-tablet {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (max-width: 575px) {
   .u-show-tablet {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (min-width: 992px) {
   .u-show-tablet {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (min-width: 992px) {
   .u-show-mobile-tablet {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 @media all and (max-width: 991px) {
   .u-show-desktop {
-    display: none !important; } }
+    display: none !important;
+  }
+}
 
 .u-push--xxs {
-  margin-right: 2px; }
+  margin-right: 2px;
+}
 
 .u-push--xs {
-  margin-right: 4px; }
+  margin-right: 4px;
+}
 
 .u-push--sm {
-  margin-right: 8px; }
+  margin-right: 8px;
+}
 
 .u-push--md {
-  margin-right: 16px; }
+  margin-right: 16px;
+}
 
 .u-push--lg {
-  margin-right: 32px; }
+  margin-right: 32px;
+}
 
 .u-margin-left--xxs {
-  margin-left: 2px; }
+  margin-left: 2px;
+}
 
 .u-margin-left--xs {
-  margin-left: 4px; }
+  margin-left: 4px;
+}
 
 .u-margin-left--sm {
-  margin-left: 8px; }
+  margin-left: 8px;
+}
 
 .u-margin-left--md {
-  margin-left: 16px; }
+  margin-left: 16px;
+}
 
 .u-margin-left--lg {
-  margin-left: 32px; }
+  margin-left: 32px;
+}
 
 .u-margin-left-right--xxs {
   margin-left: 2px;
-  margin-right: 2px; }
+  margin-right: 2px;
+}
 
 .u-margin-left-right--xs {
   margin-left: 4px;
-  margin-right: 4px; }
+  margin-right: 4px;
+}
 
 .u-margin-left-right--sm {
   margin-left: 8px;
-  margin-right: 8px; }
+  margin-right: 8px;
+}
 
 .u-margin-left-right--md {
   margin-left: 16px;
-  margin-right: 16px; }
+  margin-right: 16px;
+}
 
 .u-margin-left-right--lg {
   margin-left: 32px;
-  margin-right: 32px; }
+  margin-right: 32px;
+}
 
 .u_margin-center {
-  margin: 0 auto; }
+  margin: 0 auto;
+}
 
 .u-margin-none {
-  margin: 0 !important; }
+  margin: 0 !important;
+}
 
 .u-margin-top--xxs {
-  margin-top: 2px; }
+  margin-top: 2px;
+}
 
 .u-margin-top--xs {
-  margin-top: 4px; }
+  margin-top: 4px;
+}
 
 .u-margin-top--sm {
-  margin-top: 8px; }
+  margin-top: 8px;
+}
 
 .u-margin-top--md {
-  margin-top: 16px; }
+  margin-top: 16px;
+}
 
 .u-margin-top--lg {
-  margin-top: 32px; }
+  margin-top: 32px;
+}
 
 .u-stack--xs {
-  margin-bottom: 4px; }
+  margin-bottom: 4px;
+}
 
 .u-stack--sm {
-  margin-bottom: 8px; }
+  margin-bottom: 8px;
+}
 
 .u-stack--md {
-  margin-bottom: 16px; }
+  margin-bottom: 16px;
+}
 
 .u-stack--lg {
-  margin-bottom: 32px; }
+  margin-bottom: 32px;
+}
 
 .u-stack--xl {
-  margin-bottom: 64px; }
+  margin-bottom: 64px;
+}
 
 .u-padding-top--none {
-  padding-top: 0; }
+  padding-top: 0;
+}
 
 .u-padding-top--xxs {
-  padding-top: 2px; }
+  padding-top: 2px;
+}
 
 .u-padding-top--xs {
-  padding-top: 4px; }
+  padding-top: 4px;
+}
 
 .u-padding-top--sm {
-  padding-top: 8px; }
+  padding-top: 8px;
+}
 
 .u-padding-top--md {
-  padding-top: 16px; }
+  padding-top: 16px;
+}
 
 .u-padding-top--lg {
-  padding-top: 32px; }
+  padding-top: 32px;
+}
 
 .u-padding-bottom--xxs {
-  padding-bottom: 2px; }
+  padding-bottom: 2px;
+}
 
 .u-padding-bottom--xs {
-  padding-bottom: 4px; }
+  padding-bottom: 4px;
+}
 
 .u-padding-bottom--sm {
-  padding-bottom: 8px; }
+  padding-bottom: 8px;
+}
 
 .u-padding-bottom--md {
-  padding-bottom: 16px; }
+  padding-bottom: 16px;
+}
 
 .u-padding-bottom--lg {
-  padding-bottom: 32px; }
+  padding-bottom: 32px;
+}
 
 .u-inset--xs {
-  padding: 4px; }
+  padding: 4px;
+}
 
 .u-inset--sm {
-  padding: 8px; }
+  padding: 8px;
+}
 
 .u-inset--md {
-  padding: 16px; }
+  padding: 16px;
+}
 
 .u-inset--lg {
-  padding: 32px; }
+  padding: 32px;
+}
 
 .u-inset--xl {
-  padding: 64px; }
+  padding: 64px;
+}
 
 .u-inset__squish--sm {
-  padding: 4px 8px; }
+  padding: 4px 8px;
+}
 
 .u-inset__squish--md {
-  padding: 8px 16px; }
+  padding: 8px 16px;
+}
 
 .u-inset__squish--lg {
-  padding: 16px 32px; }
+  padding: 16px 32px;
+}
 
 .u-inset__stretch--sm {
-  padding: 8px 4px; }
+  padding: 8px 4px;
+}
 
 .u-inset__stretch--md {
-  padding: 16px 8px; }
+  padding: 16px 8px;
+}
 
 .u-inset__stretch--lg {
-  padding: 32px 16px; }
+  padding: 32px 16px;
+}
 
 .u-inset__v--xs {
   padding-top: 4px;
-  padding-bottom: 4px; }
+  padding-bottom: 4px;
+}
 
 .u-inset__v--sm {
   padding-top: 8px;
-  padding-bottom: 8px; }
+  padding-bottom: 8px;
+}
 
 .u-inset__v--md {
   padding-top: 16px;
-  padding-bottom: 16px; }
+  padding-bottom: 16px;
+}
 
 .u-inset__v--lg {
   padding-top: 32px;
-  padding-bottom: 32px; }
+  padding-bottom: 32px;
+}
 
 .u-inset__v--xl {
   padding-top: 64px;
-  padding-bottom: 64px; }
+  padding-bottom: 64px;
+}
 
 .u-inset__h--xs {
   padding-left: 4px;
-  padding-right: 4px; }
+  padding-right: 4px;
+}
 
 .u-inset__h--sm {
   padding-left: 8px;
-  padding-right: 8px; }
+  padding-right: 8px;
+}
 
 .u-inset__h--md {
   padding-left: 16px;
-  padding-right: 16px; }
+  padding-right: 16px;
+}
 
 .u-inset__h--lg {
   padding-left: 32px;
-  padding-right: 32px; }
+  padding-right: 32px;
+}
 
 .u-inset__h--xl {
   padding-left: 64px;
-  padding-right: 64px; }
+  padding-right: 64px;
+}
 
 .u-float-right {
-  float: right; }
+  float: right;
+}
 
 .u-hidden {
-  display: none; }
+  display: none;
+}
 
 .u-no-break {
-  white-space: nowrap; }
+  white-space: nowrap;
+}
 
 .u-wrap-links {
   overflow-wrap: break-word;
   word-wrap: break-word;
-  -ms-word-break: break-all;
-  word-break: break-word; }
+  /*-ms-word-break: break-all;*/
+  word-break: break-word;
+}
 
 .u-full-height {
-  height: 100%; }
+  height: 100%;
+}
 
 .u-full-width {
-  width: 100%; }
+  width: 100%;
+}
 
 .u-z-index-1000 {
-  z-index: 1000 !important; }
+  z-index: 1000 !important;
+}
 
 .u-z-index-5000 {
-  z-index: 5000 !important; }
+  z-index: 5000 !important;
+}
 
 .u-z-index-5010 {
-  z-index: 5010 !important; }
+  z-index: 5010 !important;
+}
 
 .u-z-index-5020 {
-  z-index: 5020 !important; }
+  z-index: 5020 !important;
+}
 
 .u-z-index-5030 {
-  z-index: 5030 !important; }
+  z-index: 5030 !important;
+}
 
 .u-z-index-9000 {
-  z-index: 9000 !important; }
+  z-index: 9000 !important;
+}
 
 .u-z-index-9010 {
-  z-index: 9010 !important; }
+  z-index: 9010 !important;
+}
 
-.o-media-object, .o-media-object--center, .o-media-object--end {
-  display: flex;
-  position: relative;
-  flex: auto; }
+/*.o-media-object, .o-media-object--center, .o-media-object--end {*/
+/*  display: flex;*/
+/*  position: relative;*/
+/*  flex: auto;*/
+/*}*/
 
-.o-media-object {
-  align-items: flex-start; }
-  .o-media-object--center {
-    align-items: center; }
-  .o-media-object--end {
-    align-items: flex-end; }
-  .o-media-object__anchor {
-    display: flex; }
-  .o-media-object__body {
-    flex: 1; }
+/*.o-media-object {*/
+/*  align-items: flex-start;*/
+/*}*/
 
-.btn--email {
-  color: #fff;
-  background-color: #f0ad4e;
-  border-color: #df8a13; }
-  .btn--email:hover {
-    background-color: #ec971f;
-    color: #fff; }
-  .btn--email__icon {
-    height: 20px; }
+/*.o-media-object--center {*/
+/*  align-items: center;*/
+/*}*/
 
-.btn--medium {
-  border-color: #ddd; }
+/*.o-media-object--end {*/
+/*  align-items: flex-end;*/
+/*}*/
+
+/*.o-media-object__anchor {*/
+/*  display: flex;*/
+/*}*/
+
+/*.o-media-object__body {*/
+/*  flex: 1;*/
+/*}*/
+
+/*.btn--email {*/
+/*  color: #fff;*/
+/*  background-color: #f0ad4e;*/
+/*  border-color: #df8a13;*/
+/*}*/
+
+/*.btn--email:hover {*/
+/*  background-color: #ec971f;*/
+/*  color: #fff;*/
+/*}*/
+
+/*.btn--email__icon {*/
+/*  height: 20px;*/
+/*}*/
+
+/*.btn--medium {*/
+/*  border-color: #ddd;*/
+/*}*/
 
 .btn__icon {
   margin-right: 4px;
   display: inline-block;
   vertical-align: middle;
-  line-height: 1; }
+  line-height: 1;
+}
 
 .btn_donate {
   margin-bottom: 8px;
-  margin-right: 8px; }
+  margin-right: 8px;
+}
 
 .btn_ballot_filter {
   width: 120px;
   margin-bottom: 8px !important;
   outline: none !important;
-  padding: 0 12px !important; }
-  @media all and (max-width: 575px) {
-    .btn_ballot_filter {
-      font-size: 10px !important;
-      padding: 0 0 0 12px !important;
-      width: fit-content !important;
-      line-height: 1.2rem; } }
+  padding: 0 12px !important;
+}
+
+@media all and (max-width: 575px) {
+  .btn_ballot_filter {
+    font-size: 10px !important;
+    padding: 0 0 0 12px !important;
+    width: fit-content !important;
+    line-height: 1.2rem;
+  }
+}
 
 .btn-default {
   background-color: #fff;
   border-color: #fff;
-  color: #333; }
-  .btn-default:active {
-    border-color: #ccc; }
-  .btn-default:hover {
-    border-color: #ccc; }
-  .btn-default:link {
-    border-color: #ccc; }
+  color: #333;
+}
 
-.btn-outline-primary {
-  background-color: #fff;
-  border-color: #3464c1;
-  color: #4371cc; }
-  .btn-outline-primary:active {
-    background-color: #76d00b;
-    color: #fff; }
-  .btn-outline-primary:hover {
-    background-color: #76d00b;
-    color: #fff; }
-  .btn-outline-primary:link {
-    background-color: #76d00b;
-    color: #fff; }
+/*.btn-default:active {*/
+/*  border-color: #ccc;*/
+/*}*/
+
+/*.btn-default:hover {*/
+/*  border-color: #ccc;*/
+/*}*/
+
+/*.btn-default:link {*/
+/*  border-color: #ccc;*/
+/*}*/
+
+/*.btn-outline-primary {*/
+/*  background-color: #fff;*/
+/*  border-color: #3464c1;*/
+/*  color: #4371cc;*/
+/*}*/
+
+/*.btn-outline-primary:active {*/
+/*  background-color: #76d00b;*/
+/*  color: #fff;*/
+/*}*/
+
+/*.btn-outline-primary:hover {*/
+/*  background-color: #76d00b;*/
+/*  color: #fff;*/
+/*}*/
+
+/*.btn-outline-primary:link {*/
+/*  background-color: #76d00b;*/
+/*  color: #fff;*/
+/*}*/
 
 .no-outline {
-  outline: none !important; }
+  outline: none !important;
+}
 
 .button-icon {
-  margin-right: 0.5rem; }
+  margin-right: 0.5rem;
+}
 
-.u-loading-spinner {
-  margin: 0 auto 1.6rem auto;
-  position: relative;
-  text-indent: -9999em;
-  transform: translateZ(0);
-  animation-delay: -120ms;
-  overflow: visible;
-  font-size: 1.6rem; }
-  .u-loading-spinner, .u-loading-spinner::before, .u-loading-spinner::after {
-    border-radius: 100rem;
-    width: 0.8rem;
-    height: 0.8rem;
-    animation-name: bouncedelay;
-    animation-duration: 1.4s;
-    animation-timing-function: ease-in-out;
-    animation-timing-function: cubic-bezier(0.5, 0, 0.5, 1);
-    animation-iteration-count: infinite;
-    animation-fill-mode: both;
-    color: rgba(85, 85, 85, 0.7); }
-  .u-loading-spinner--light, .u-loading-spinner--light::before, .u-loading-spinner--light::after {
-    color: rgba(255, 255, 255, 0.7); }
-  .u-loading-spinner::before {
-    left: -1.2rem;
-    animation-delay: -240ms; }
-  .u-loading-spinner::after {
-    left: 1.2rem; }
-  .u-loading-spinner::before, .u-loading-spinner::after {
-    content: '';
-    position: absolute;
-    top: 0; }
-  .u-loading-spinner__wrapper {
-    margin: 16px auto 32px auto; }
-    .u-loading-spinner__wrapper::before, .u-loading-spinner__wrapper::after {
-      content: ' ';
-      display: table; }
-    .u-loading-spinner__wrapper::after {
-      clear: both; }
+/*.u-loading-spinner {*/
+/*  margin: 0 auto 1.6rem auto;*/
+/*  position: relative;*/
+/*  text-indent: -9999em;*/
+/*  transform: translateZ(0);*/
+/*  animation-delay: -120ms;*/
+/*  overflow: visible;*/
+/*  font-size: 1.6rem;*/
+/*}*/
 
-@keyframes bouncedelay {
-  0%,
-  20%,
-  100% {
-    box-shadow: 0 0.8rem 0 -0.8rem; }
-  60% {
-    box-shadow: 0 0.8rem 0 0; } }
+/*.u-loading-spinner, .u-loading-spinner::before, .u-loading-spinner::after {*/
+/*  border-radius: 100rem;*/
+/*  width: 0.8rem;*/
+/*  height: 0.8rem;*/
+/*  animation-name: bouncedelay;*/
+/*  animation-duration: 1.4s;*/
+/*  animation-timing-function: ease-in-out;*/
+/*  animation-timing-function: cubic-bezier(0.5, 0, 0.5, 1);*/
+/*  animation-iteration-count: infinite;*/
+/*  animation-fill-mode: both;*/
+/*  color: rgba(85, 85, 85, 0.7);*/
+/*}*/
 
-.NPSInput {
-  position: fixed;
-  bottom: 0px;
-  left: 0px;
-  right: 0px;
-  border-top: 1px solid #e5e5e5;
-  background: #fff;
-  box-shadow: 0px -10px 10px rgba(200, 200, 200, 0.08); }
-  .NPSInput.animated {
-    animation-duration: 0.7s;
-    animation-name: NPSInput-slidein; }
-  .NPSInput .NPSInput-Close {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    background: transparent;
-    outline: none;
-    display: inline-block;
-    zoom: 1;
-    line-height: normal;
-    white-space: nowrap;
-    vertical-align: baseline;
-    text-align: center;
-    cursor: pointer;
-    user-select: none;
-    font-family: inherit;
-    padding: 0.5em 1em;
-    text-decoration: none;
-    border: 0;
-    opacity: 0.4;
-    font-size: 16px; }
-    .NPSInput .NPSInput-Close:hover {
-      opacity: 1; }
-  .NPSInput .NPSInput-Inner {
-    width: 100%;
-    max-width: 1000px;
-    margin: 20px auto;
-    text-align: center; }
-  .NPSInput .NPSScale {
-    width: 418px;
-    margin: 0px auto; }
-    .NPSInput .NPSScale .NPSScale-Values .NPSScale-Value {
-      padding: 0px 3px;
-      display: inline-block; }
-      .NPSInput .NPSScale .NPSScale-Values .NPSScale-Value div {
-        background: #f2f5fd;
-        width: 32px;
-        height: 32px;
-        line-height: 32px;
-        border-radius: 32px;
-        cursor: pointer;
-        transition: 0.15s ease all;
-        color: #999; }
-      .NPSInput .NPSScale .NPSScale-Values .NPSScale-Value.selected div {
-        background: #3884ff;
-        color: #fff; }
-      .NPSInput .NPSScale .NPSScale-Values .NPSScale-Value:hover div {
-        transform: scale(1.25); }
-    .NPSInput .NPSScale .NPSScale-Legend {
-      display: flex;
-      margin-top: 12px; }
-      .NPSInput .NPSScale .NPSScale-Legend .NPSScale-Label {
-        flex: 1;
-        color: #999;
-        font-size: 12px; }
-        .NPSInput .NPSScale .NPSScale-Legend .NPSScale-Label.left {
-          text-align: left; }
-        .NPSInput .NPSScale .NPSScale-Legend .NPSScale-Label.right {
-          text-align: right; }
-  .NPSInput .NPSInput-Message {
-    margin: 0px;
-    margin-bottom: 15px;
-    font-size: 16px; }
+/*.u-loading-spinner--light, .u-loading-spinner--light::before, .u-loading-spinner--light::after {*/
+/*  color: rgba(255, 255, 255, 0.7);*/
+/*}*/
 
-@keyframes NPSInput-slidein {
-  from {
-    bottom: -100%; }
-  to {
-    bottom: 0px; } }
+/*.u-loading-spinner::before {*/
+/*  left: -1.2rem;*/
+/*  animation-delay: -240ms;*/
+/*}*/
 
-.twitter-followers__badge {
-  color: #999;
-  display: inline-block;
-  line-height: 1.25rem;
-  padding: 4px 0;
-  white-space: nowrap; }
+/*.u-loading-spinner::after {*/
+/*  left: 1.2rem;*/
+/*}*/
+
+/*.u-loading-spinner::before, .u-loading-spinner::after {*/
+/*  content: '';*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*}*/
+
+/*.u-loading-spinner__wrapper {*/
+/*  margin: 16px auto 32px auto;*/
+/*}*/
+
+/*.u-loading-spinner__wrapper::before, .u-loading-spinner__wrapper::after {*/
+/*  content: ' ';*/
+/*  display: table;*/
+/*}*/
+
+/*.u-loading-spinner__wrapper::after {*/
+/*  clear: both;*/
+/*}*/
+
+/*@keyframes bouncedelay {*/
+/*  0%, 20%, 100% {*/
+/*    box-shadow: 0 0.8rem 0 -0.8rem;*/
+/*  }*/
+
+/*  60% {*/
+/*    box-shadow: 0 0.8rem 0 0;*/
+/*  }*/
+/*}*/
+
+/*.NPSInput {*/
+/*  position: fixed;*/
+/*  bottom: 0px;*/
+/*  left: 0px;*/
+/*  right: 0px;*/
+/*  border-top: 1px solid #e5e5e5;*/
+/*  background: #fff;*/
+/*  box-shadow: 0px -10px 10px rgba(200, 200, 200, 0.08);*/
+/*}*/
+
+/*.NPSInput.animated {*/
+/*  animation-duration: 0.7s;*/
+/*  animation-name: NPSInput-slidein;*/
+/*}*/
+
+/*.NPSInput .NPSInput-Close {*/
+/*  position: absolute;*/
+/*  top: 10px;*/
+/*  right: 10px;*/
+/*  background: transparent;*/
+/*  outline: none;*/
+/*  display: inline-block;*/
+/*  zoom: 1; line-height: normal;*/
+/*  white-space: nowrap;*/
+/*  vertical-align: baseline;*/
+/*  text-align: center;*/
+/*  cursor: pointer;*/
+/*  user-select: none;*/
+/*  font-family: inherit;*/
+/*  padding: 0.5em 1em;*/
+/*  text-decoration: none;*/
+/*  border: 0;*/
+/*  opacity: 0.4;*/
+/*  font-size: 16px;*/
+/*}*/
+
+/*.NPSInput .NPSInput-Close:hover {*/
+/*  opacity: 1;*/
+/*}*/
+
+/*.NPSInput .NPSInput-Inner {*/
+/*  width: 100%;*/
+/*  max-width: 1000px;*/
+/*  margin: 20px auto;*/
+/*  text-align: center;*/
+/*}*/
+
+/*.NPSInput .NPSScale {*/
+/*  width: 418px;*/
+/*  margin: 0px auto;*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Values .NPSScale-Value {*/
+/*  padding: 0px 3px;*/
+/*  display: inline-block;*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Values .NPSScale-Value div {*/
+/*  background: #f2f5fd;*/
+/*  width: 32px;*/
+/*  height: 32px;*/
+/*  line-height: 32px;*/
+/*  border-radius: 32px;*/
+/*  cursor: pointer;*/
+/*  transition: 0.15s ease all;*/
+/*  color: #999;*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Values .NPSScale-Value.selected div {*/
+/*  background: #3884ff;*/
+/*  color: #fff;*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Values .NPSScale-Value:hover div {*/
+/*  transform: scale(1.25);*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Legend {*/
+/*  display: flex;*/
+/*  margin-top: 12px;*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Legend .NPSScale-Label {*/
+/*  flex: 1;*/
+/*  color: #999;*/
+/*  font-size: 12px;*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Legend .NPSScale-Label.left {*/
+/*  text-align: left;*/
+/*}*/
+
+/*.NPSInput .NPSScale .NPSScale-Legend .NPSScale-Label.right {*/
+/*  text-align: right;*/
+/*}*/
+
+/*.NPSInput .NPSInput-Message {*/
+/*  margin: 0px;*/
+/*  margin-bottom: 15px;*/
+/*  font-size: 16px;*/
+/*}*/
+
+/*@keyframes NPSInput-slidein {*/
+/*  from {*/
+/*    bottom: -100%;*/
+/*  }*/
+
+/*  to {*/
+/*    bottom: 0px;*/
+/*  }*/
+/*}*/
+
+/*.twitter-followers__badge {*/
+/*  color: #999;*/
+/*  display: inline-block;*/
+/*  line-height: 1.25rem;*/
+/*  padding: 4px 0;*/
+/*  white-space: nowrap;*/
+/*}*/
 
 .twitter-followers__icon {
   font-size: 1.25rem;
   color: #ccc;
   margin-right: 4px;
-  vertical-align: bottom; }
+  vertical-align: bottom;
+}
 
 .card-main__media-object {
   display: flex;
   align-items: flex-start;
-  position: relative; }
+  position: relative;
+}
 
 .card-main__media-object-anchor {
-  margin-right: 10px; }
+  margin-right: 10px;
+}
 
 .card-main__media-object-content {
-  flex: 1; }
+  flex: 1;
+}
 
 .card {
   background-color: #fff;
   border-radius: 4px;
   box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12);
   margin-bottom: 16px;
-  border: none; }
-  .card::before, .card::after {
-    content: ' ';
-    display: table; }
-  .card::after {
-    clear: both; }
-  @media all and (max-width: 479px) {
-    .card {
-      margin-bottom: 8px;
-      /*margin-right: -15px;*/
-      /*margin-left: -15px;*/
-      border-radius: 0; }
-      [class^='col'] .card {
-        margin-right: -15px;
-        margin-left: -15px;
-      }
+  border: none;
+}
+
+.card::before, .card::after {
+  content: ' ';
+  display: table;
+}
+
+.card::after {
+  clear: both;
+}
+
+@media all and (max-width: 479px) {
+  .card {
+    margin-bottom: 8px;
+    /*margin-right: -15px;*/
+    /*margin-left: -15px;*/
+    border-radius: 0;
   }
-  .card__body {
-    padding: 16px; }
+
+  [class^='col'] .card {
+    margin-right: -15px;
+    margin-left: -15px;
+  }
+}
+
+.card__body {
+  padding: 16px;
+}
+
+.card-main {
+  padding: 16px 16px 8px;
+  font-size: 14px;
+}
+
+@media print {
   .card-main {
-    padding: 16px 16px 8px;
-    font-size: 14px; }
-    @media print {
-      .card-main {
-        padding: 0; } }
-    .card-main__location-guess {
-      position: relative;
-      display: flex;
-      margin-bottom: 16px;
-      font-size: 14px;
-      background-color: #fff;
-      background-clip: border-box;
-      border: 2px solid #999; }
-    .card-main--outline {
-      border: 1px solid #4371cc;
-      border-radius: 3px;
-      text-decoration: none !important; }
-    .card-main__no-underline *,
-    .card-main--outline a {
-      text-decoration: none !important; }
-    .card-main__content {
-      position: relative; }
-      @media print {
-        .card-main__content {
-          border-top: 1px solid #999;
-          padding-top: 16px; } }
-    @media all and (min-width: 480px) {
-      .card-main__media-object {
-        min-width: 260px; } }
-    .card-main__media-object-anchor {
-      display: flex;
-      flex-direction: column; }
-    @media all and (min-width: 480px) {
-      .card-main__media-object-content {
-        padding: 4px 32px;
-        margin-bottom: 32px;
-        font-size: 16px; } }
-    .card-main__avatar {
-      border-radius: 2px;
-      width: 48px; }
-      .card-main__avatar__testimonial {
-        border-radius: 100rem;
-        border-style: solid;
-        border-width: 1px;
-        border-color: #ddd;
-        height: 40px;
-        display: block;
-        margin-left: auto;
-        margin-right: auto;
-        margin-top: 16px; }
-      .card-main .card-main__avatar {
-        border-radius: 100rem; }
-        @media all and (min-width: 480px) {
-          .card-main .card-main__avatar {
-            width: 48px; } }
-      @media print {
-        .card-main__avatar {
-          width: 48px; } }
-    .card-main__avatar-border {
-      border-style: solid;
-      border-width: 1px;
-      border-color: #ddd; }
-    .card-main__avatar-compressed {
-      border-radius: 2px;
-      width: 40px;
-      height: 40px; }
-      .card-main .card-main__avatar-compressed {
-        border-radius: 100rem; }
-        @media all and (min-width: 480px) {
-          .card-main .card-main__avatar-compressed {
-            width: 40px; } }
-      @media print {
-        .card-main__avatar-compressed {
-          width: 40px; } }
-    .card-main__avatar-compressed-cordova {
-      border-radius: 2px;
-      width: 40px;
-      height: 40px; }
-      .card-main .card-main__avatar-compressed-cordova {
-        border-radius: 100rem; }
-        @media all and (min-width: 480px) {
-          .card-main .card-main__avatar-compressed-cordova {
-            width: 40px; } }
-      @media print {
-        .card-main__avatar-compressed-cordova {
-          width: 40px; } }
-    .card-main__org-avatar {
-      max-width: 50px; }
-      @media all and (min-width: 480px) {
-        .card-main__org-avatar {
-          max-width: 80px; } }
-    .card-main .icon-lg {
-      font-size: 50px; }
-      @media all and (min-width: 480px) {
-        .card-main .icon-lg {
-          font-size: 80px; } }
-    .card-main__flex {
-      display: flex;
-      align-content: center;
-      justify-content: flex-start; }
-    .card-main__position-icon {
-      display: inline-block;
-      margin-right: 4px;
-      vertical-align: text-bottom; }
-    .card-main__candidate-name {
-      font-weight: 400; }
-    .card-main__candidate-name-link {
-      color: #4371cc; }
-    .card-main__candidate-party-description {
-      font-size: .7rem;
-      color: #555; }
-    .card-main__candidate-description {
-      font-size: .875rem;
-      color: #999; }
-    .card-main__display-name {
-      display: inline-block;
-      font-size: 18px;
-      font-weight: 700;
-      margin-right: 8px;
-      margin-bottom: 8px;
-      vertical-align: middle; }
-      @media all and (min-width: 480px) {
-        .card-main__display-name {
-          font-size: 18px; } }
-      @media print {
-        .card-main__display-name {
-          font-size: 22px; } }
-      .card-main__display-name--inline {
-        margin: 0;
-        padding: 4px 8px; }
-    .card-main__description {
-      color: #555;
-      font-size: 14px; }
-    .card-main__rating-description {
-      font-size: .875em; }
-      .card-main__rating-description__header {
-        color: #549bb6; }
-    .card-main__description-container--truncated {
-      overflow: hidden;
-      position: relative;
-      height: 50px; }
-      .card-main__description-container--truncated::before {
-        content: '';
-        float: left;
-        width: 4px;
-        height: 50px; }
-      .card-main__description-container--truncated > *:first-child {
-        float: right;
-        width: 100%;
-        margin-left: -4px; }
-      .card-main__description-container--truncated::after {
-        box-sizing: content-box;
-        float: right;
-        position: relative;
-        top: -25px;
-        left: 100%;
-        width: 7em;
-        margin-left: -7em;
-        padding-right: 4px;
-        text-align: right;
-        background-size: 100% 100%;
-        background: linear-gradient(to right, rgba(255, 255, 255, 0), white 15%, white);
-        font-style: normal;
-        color: #4371cc; }
-    .card-main__candidate-read-more-link {
-      margin-left: 8px;
-      top: 0;
-      font-size: 14px;
-      font-weight: 100 !important;
-      color: #4371cc;
-      width: 100%;
-      height: 100%;
-      overflow: hidden; }
-    .card-main__measure-read-more-link {
-      margin-left: 8px;
-      font-size: 14px;
-      font-weight: 100 !important;
-      color: #4371cc;
-      width: 100%;
-      height: 100%;
-      overflow: hidden; }
-    .card-main__ballot-name-group {
-      display: block; }
-    .card-main__ballot-name-item {
-      float: left; }
-    .card-main__ballot-name-link {
-      color: #4371cc; }
-    .card-main__ballot-name {
-      font-weight: 600; }
-    .card-main__ballot-read-more-link {
-      margin-left: 8px;
-      font-size: 14px;
-      font-weight: 100 !important;
-      width: 100%;
-      height: 100%;
-      overflow: hidden; }
-    .card-main__read-more-link {
-      position: absolute;
-      left: 0;
-      top: 0;
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      text-indent: -9999px;
-      z-index: 5; }
-    .card-main__button-linked {
-      pointer-events: none !important; }
-    .card-main__office-item {
-      max-width: 960px;
-      width: 100%; }
-  .card .card-child {
-    display: flex;
-    align-items: flex-start;
-    position: relative; }
-  .card .card-child__media-object-anchor {
-    margin-right: 10px; }
-  .card .card-child__media-object-content {
-    flex: 1; }
-  .card .card-child {
-    padding: 16px;
-    background-color: #f8f8f8;
-    border: 1px solid #e7e7e7;
-    margin: -1px 0 12px 0; }
-    @media all and (max-width: 479px) {
-      .card .card-child {
-        margin-left: -16px;
-        margin-right: -16px; } }
-    .card .card-child__list-group {
-      padding: 0;
-      margin: 0; }
-      @media all and (max-width: 479px) {
-        .card .card-child__list-group {
-          padding: 0 16px; } }
-      @media all and (max-width: 479px) {
-        .card .card-child__list-group .card__additional-heading {
-          margin-right: 0;
-          margin-left: 0; } }
-    .card .card-child__avatar {
-      max-width: 50px; }
-      @media all and (max-width: 479px) {
-        .card .card-child__avatar {
-          max-width: 32px; } }
-      .card .card-child__avatar--round {
-        border-radius: 100rem;
-        max-width: 50px; }
-        @media all and (max-width: 479px) {
-          .card .card-child__avatar--round {
-            max-width: 32px; } }
-        @media print {
-          .card .card-child__avatar--round {
-            max-width: 50px; } }
-    .card .card-child .icon-lg {
-      font-size: 50px; }
-      @media print {
-        .card .card-child .icon-lg {
-          max-width: 50px; } }
-    .card .card-child__media-object-content {
-      display: flex;
-      flex-direction: column;
-      justify-content: space-between; }
-      @media all and (min-width: 768px) {
-        .card .card-child__media-object-content {
-          flex-direction: row; } }
-    .card .card-child__content {
-      flex: auto; }
-    .card .card-child__content-text {
-      flex: auto;
-      margin: 16px; }
-      @media all and (max-width: 479px) {
-        .card .card-child__content-text {
-          margin-right: 0;
-          margin-left: 0; } }
-    .card .card-child__display-name {
-      margin-bottom: 4px;
-      flex: auto; }
-    .card .card-child__organization-description {
-      color: #999; }
-    .card .card-child__fine_print {
-      font-size: .75em;
-      color: #555;
-      margin-top: 16px; }
-    .card .card-child__follow-buttons {
-      display: flex;
-      align-items: flex-end; }
-      .card .card-child__follow-buttons .btn {
-        margin: 0 4px 0 0; }
-      .card .card-child__follow-buttons .twitter-followers__badge {
-        margin: 4px 0; }
-      @media all and (min-width: 768px) {
-        .card .card-child__follow-buttons {
-          flex-direction: column; }
-          .card .card-child__follow-buttons .btn {
-            margin: 0 0 4px; }
-          .card .card-child__follow-buttons .twitter-followers__badge {
-            margin: 0; } }
-    .card .card-child__additional {
-      display: flex;
-      margin-top: 8px; }
-      @media all and (min-width: 768px) {
-        .card .card-child__additional {
-          flex-direction: column;
-          padding-left: 16px;
-          margin-top: inherit;
-          text-align: right; } }
-    .card .card-child--not-followed .card .card-child__additional {
-      margin-top: 16px; }
-    .card .card-child .bookmark-action {
-      order: 4;
-      position: relative; }
-    .card .card-child .public-friends-indicator {
-      color: #999;
-      display: inline-block;
-      top: 16px;
-      height: 18px; }
-  .card__blue,
-  .card__blue * {
-    color: #4371cc !important; }
-  .card__additional {
-    border-top: 5px solid #eee; }
-    .card__additional::before, .card__additional::after {
-      content: ' ';
-      display: table; }
-    .card__additional::after {
-      clear: both; }
-  .card__additional-heading {
+    padding: 0;
+  }
+}
+
+/*.card-main__location-guess {*/
+/*  position: relative;*/
+/*  display: flex;*/
+/*  margin-bottom: 16px;*/
+/*  font-size: 14px;*/
+/*  background-color: #fff;*/
+/*  background-clip: border-box;*/
+/*  border: 2px solid #999;*/
+/*}*/
+
+.card-main--outline {
+  border: 1px solid #4371cc;
+  border-radius: 3px;
+  text-decoration: none !important;
+}
+
+.card-main__no-underline *, .card-main--outline a {
+  text-decoration: none !important;
+}
+
+.card-main__content {
+  position: relative;
+}
+
+@media print {
+  .card-main__content {
+    border-top: 1px solid #999;
+    padding-top: 16px;
+  }
+}
+
+@media all and (min-width: 480px) {
+  .card-main__media-object {
+    min-width: 260px;
+  }
+}
+
+.card-main__media-object-anchor {
+  display: flex;
+  flex-direction: column;
+}
+
+@media all and (min-width: 480px) {
+  .card-main__media-object-content {
+    padding: 4px 32px;
+    margin-bottom: 32px;
+    font-size: 16px;
+  }
+}
+
+.card-main__avatar {
+  border-radius: 2px;
+  width: 48px;
+}
+
+.card-main__avatar__testimonial {
+  border-radius: 100rem;
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ddd;
+  height: 40px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 16px;
+}
+
+.card-main .card-main__avatar {
+  border-radius: 100rem;
+}
+
+@media all and (min-width: 480px) {
+  .card-main .card-main__avatar {
+    width: 48px;
+  }
+}
+
+@media print {
+  .card-main__avatar {
+    width: 48px;
+  }
+}
+
+.card-main__avatar-border {
+  border-style: solid;
+  border-width: 1px;
+  border-color: #ddd;
+}
+
+.card-main__avatar-compressed {
+  border-radius: 2px;
+  width: 40px;
+  height: 40px;
+}
+
+.card-main .card-main__avatar-compressed {
+  border-radius: 100rem;
+}
+
+@media all and (min-width: 480px) {
+  .card-main .card-main__avatar-compressed {
+    width: 40px;
+  }
+}
+
+/*@media print {*/
+/*  .card-main__avatar-compressed {*/
+/*    width: 40px;*/
+/*  }*/
+/*}*/
+
+/*.card-main__avatar-compressed-cordova {*/
+/*  border-radius: 2px;*/
+/*  width: 40px;*/
+/*  height: 40px;*/
+/*}*/
+
+/*.card-main .card-main__avatar-compressed-cordova {*/
+/*  border-radius: 100rem;*/
+/*}*/
+
+/*@media all and (min-width: 480px) {*/
+/*  .card-main .card-main__avatar-compressed-cordova {*/
+/*    width: 40px;*/
+/*  }*/
+/*}*/
+
+/*@media print {*/
+/*  .card-main__avatar-compressed-cordova {*/
+/*    width: 40px;*/
+/*  }*/
+/*}*/
+
+.card-main__org-avatar {
+  max-width: 50px;
+}
+
+@media all and (min-width: 480px) {
+  .card-main__org-avatar {
+    max-width: 80px;
+  }
+}
+
+.card-main .icon-lg {
+  font-size: 50px;
+}
+
+@media all and (min-width: 480px) {
+  .card-main .icon-lg {
+    font-size: 80px;
+  }
+}
+
+/*.card-main__flex {*/
+/*  display: flex;*/
+/*  align-content: center;*/
+/*  justify-content: flex-start;*/
+/*}*/
+
+/*.card-main__position-icon {*/
+/*  display: inline-block;*/
+/*  margin-right: 4px;*/
+/*  vertical-align: text-bottom;*/
+/*}*/
+
+.card-main__candidate-name {
+  font-weight: 400;
+}
+
+.card-main__candidate-name-link {
+  color: #4371cc;
+}
+
+.card-main__candidate-party-description {
+  font-size: .7rem;
+  color: #555;
+}
+
+.card-main__candidate-description {
+  font-size: .875rem;
+  color: #999;
+}
+
+.card-main__display-name {
+  display: inline-block;
+  font-size: 18px;
+  font-weight: 700;
+  margin-right: 8px;
+  margin-bottom: 8px;
+  vertical-align: middle;
+}
+
+@media all and (min-width: 480px) {
+  .card-main__display-name {
     font-size: 18px;
-    margin: 16px 16px; }
-  .card__additional-text {
-    margin: 16px 16px; }
-  .card__no-additional {
-    margin: 16px 16px; }
+  }
+}
 
-.card-popover {
-  padding-top: 0;
-  padding-left: 0;
-  padding-right: 0;
-  background-color: #fff;
-  max-width: 350px; }
-  @media all and (max-width: 479px) {
-    .card-popover {
-      max-width: 290px; } }
-  .card-popover__width--minimum {
-    max-width: 290px;
-    width: 90vw; }
+@media print {
+  .card-main__display-name {
+    font-size: 22px;
+  }
+}
 
-.card-popover-body {
-  max-width: 290px;
-  padding: 4px; }
+.card-main__display-name--inline {
+  margin: 0;
+  padding: 4px 8px;
+}
 
-.card-popover-header {
-  background-color: #2e3c5d;
-  color: #fff; }
+.card-main__description {
+  color: #555;
+  font-size: 14px;
+}
 
-.network-positions {
+.card-main__rating-description {
+  font-size: .875em;
+}
+
+.card-main__rating-description__header {
+  color: #549bb6;
+}
+
+.card-main__description-container--truncated {
+  overflow: hidden;
   position: relative;
-  display: flex;
-  align-items: center;
-  flex: 5 0 130px;
-  min-width: 130px; }
-  .network-positions__bar-well {
-    display: block;
-    position: relative;
-    margin-right: 8px;
-    margin-left: 8px;
-    flex: 5 0 48px;
-    height: 10px;
-    border-radius: 100rem;
-    background-color: #ccc;
-    overflow: hidden; }
-  .network-positions__bar-label {
-    position: absolute;
-    margin-top: 20px;
-    width: 100%;
-    text-align: center;
-    color: #999; }
-    @media all and (max-width: 299px) {
-      .network-positions__bar-label {
-        display: none; } }
-  .network-positions__bar {
-    position: absolute;
-    display: block;
-    height: 10px;
-    width: 0;
-    transition: width .2s ease-out;
-    box-sizing: content-box; }
-  .network-positions__support, .network-positions__oppose {
-    display: flex;
-    align-items: center;
-    flex: none; }
-  .network-positions__count {
-    text-align: center;
-    color: #555; }
-  .network-positions__bar--support {
-    left: 0;
-    background-color: #76d00b;
-    background: linear-gradient(to bottom, #76d00b, #68b80a);
-    border-right: 2px solid #fff; }
-  .network-positions__bar--oppose {
-    right: 0;
-    background-color: #ff4921;
-    background: linear-gradient(to bottom, #ff4921, #ff3408);
-    border-left: 2px solid #fff; }
-  .network-positions__support-score {
-    font-size: 2rem;
-    font-weight: 500;
-    justify-content: center;
-    align-items: center; }
-  .network-positions__show-support-underline {
-    border-bottom: solid;
-    border-bottom-color: #76d00b; }
-  .network-positions__show-oppose-underline {
-    border-bottom: solid;
-    border-bottom-color: #ff4921; }
-  .network-positions__to-follow-fade {
-    opacity: .4;
-    filter: alpha(opacity=40);
-    /* For IE8 and earlier */ }
-  .network-positions__to-follow-fade:hover {
-    opacity: .6;
-    filter: alpha(opacity=60);
-    /* For IE8 and earlier */ }
+  height: 50px;
+}
 
-.network-positions-stacked {
-  position: relative;
+.card-main__description-container--truncated::before {
+  content: '';
+  float: left;
+  width: 4px;
+  height: 50px;
+}
+
+.card-main__description-container--truncated > *:first-child {
+  float: right;
   width: 100%;
-  align-items: center; }
-  .network-positions-stacked__bar {
-    position: absolute;
-    display: block;
-    height: 10px;
-    width: 0;
-    transition: width .2s ease-out;
-    box-sizing: content-box; }
-  .network-positions-stacked__info-icon-for-popover {
-    color: #999; }
-  .network-positions-stacked__support, .network-positions-stacked__oppose {
-    display: flex;
-    align-items: center;
-    flex: none; }
-  .network-positions-stacked__more-opinions {
-    color: #999; }
-  .network-positions-stacked__support-score {
-    color: #555;
-    font-size: 2rem;
-    font-weight: 500;
-    display: flex;
-    justify-content: center;
-    align-items: center; }
-  .network-positions-stacked__support-score-label, .network-positions-stacked__support-label {
-    color: #555;
-    font-size: .875rem;
-    font-weight: 200;
-    line-height: 1.2;
-    vertical-align: middle;
-    display: inline-flex;
+  margin-left: -4px;
+}
+
+/*.card-main__description-container--truncated::after {*/
+/*  box-sizing: content-box;*/
+/*  float: right;*/
+/*  position: relative;*/
+/*  top: -25px;*/
+/*  left: 100%;*/
+/*  width: 7em;*/
+/*  margin-left: -7em;*/
+/*  padding-right: 4px;*/
+/*  text-align: right;*/
+/*  background-size: 100% 100%;*/
+/*  background: linear-gradient(to right, rgba(255, 255, 255, 0), white 15%, white);*/
+/*  font-style: normal;*/
+/*  color: #4371cc;*/
+/*}*/
+
+/*.card-main__candidate-read-more-link {*/
+/*  margin-left: 8px;*/
+/*  top: 0;*/
+/*  font-size: 14px;*/
+/*  font-weight: 100 !important;*/
+/*  color: #4371cc;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.card-main__measure-read-more-link {*/
+/*  margin-left: 8px;*/
+/*  font-size: 14px;*/
+/*  font-weight: 100 !important;*/
+/*  color: #4371cc;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.card-main__ballot-name-group {*/
+/*  display: block;*/
+/*}*/
+
+/*.card-main__ballot-name-item {*/
+/*  float: left;*/
+/*}*/
+
+/*.card-main__ballot-name-link {*/
+/*  color: #4371cc;*/
+/*}*/
+
+/*.card-main__ballot-name {*/
+/*  font-weight: 600;*/
+/*}*/
+
+/*.card-main__ballot-read-more-link {*/
+/*  margin-left: 8px;*/
+/*  font-size: 14px;*/
+/*  font-weight: 100 !important;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.card-main__read-more-link {*/
+/*  position: absolute;*/
+/*  left: 0;*/
+/*  top: 0;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  overflow: hidden;*/
+/*  text-indent: -9999px;*/
+/*  z-index: 5;*/
+/*}*/
+
+/*.card-main__button-linked {*/
+/*  pointer-events: none !important;*/
+/*}*/
+
+/*.card-main__office-item {*/
+/*  max-width: 960px;*/
+/*  width: 100%;*/
+/*}*/
+
+.card .card-child {
+  display: flex;
+  align-items: flex-start;
+  position: relative;
+}
+
+.card .card-child__media-object-anchor {
+  margin-right: 10px;
+}
+
+.card .card-child__media-object-content {
+  flex: 1;
+}
+
+.card .card-child {
+  padding: 16px;
+  background-color: #f8f8f8;
+  border: 1px solid #e7e7e7;
+  margin: -1px 0 12px 0;
+}
+
+@media all and (max-width: 479px) {
+  .card .card-child {
+    margin-left: -16px;
+    margin-right: -16px;
+  }
+}
+
+.card .card-child__list-group {
+  padding: 0;
+  margin: 0;
+}
+
+@media all and (max-width: 479px) {
+  .card .card-child__list-group {
+    padding: 0 16px;
+  }
+}
+
+@media all and (max-width: 479px) {
+  .card .card-child__list-group .card__additional-heading {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+
+.card .card-child__avatar {
+  max-width: 50px;
+}
+
+@media all and (max-width: 479px) {
+  .card .card-child__avatar {
+    max-width: 32px;
+  }
+}
+
+.card .card-child__avatar--round {
+  border-radius: 100rem;
+  max-width: 50px;
+}
+
+@media all and (max-width: 479px) {
+  .card .card-child__avatar--round {
+    max-width: 32px;
+  }
+}
+
+@media print {
+  .card .card-child__avatar--round {
+    max-width: 50px;
+  }
+}
+
+.card .card-child .icon-lg {
+  font-size: 50px;
+}
+
+@media print {
+  .card .card-child .icon-lg {
+    max-width: 50px;
+  }
+}
+
+.card .card-child__media-object-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+@media all and (min-width: 768px) {
+  .card .card-child__media-object-content {
     flex-direction: row;
-    align-items: center; }
-    @media all and (min-width: 320px) and (max-width: 479px) {
-      .network-positions-stacked__support-score-label, .network-positions-stacked__support-label {
-        font-size: .875rem; } }
-  .network-positions-stacked__support-list {
-    margin-left: -36px;
-    margin-right: -16px; }
-    .network-positions-stacked__support-list__container-wrap {
-      box-sizing: content-box;
-      overflow: hidden;
-      height: 55px;
-      flex-grow: 1; }
-    .network-positions-stacked__support-list__container {
-      white-space: nowrap;
-      height: 76px; }
-    .network-positions-stacked__support-list__items {
-      padding: 0;
-      margin-bottom: 16px;
-      list-style: none; }
-    .network-positions-stacked__support-list__item {
-      position: relative;
-      display: inline-block;
-      float: none; }
-    .network-positions-stacked__support-list__scroll-icon {
-      color: #999;
-      margin: 0 8px;
-      margin-top: 4px; }
-      @media all and (min-width: 768px) {
-        .network-positions-stacked__support-list__scroll-icon {
-          margin-top: 16px; } }
-      @media all and (max-width: 767px) {
-        .network-positions-stacked__support-list__scroll-icon--small {
-          margin-top: -8px; } }
-      .network-positions-stacked__support-list__scroll-icon--disabled {
-        color: transparent;
-        margin: 0 8px; }
-      .network-positions-stacked__support-list__scroll-icon--disabled-small {
-        color: transparent;
-        margin: 0 13px; }
+  }
+}
 
-.red-bar {
-  background-color: #ff4921; }
+.card .card-child__content {
+  flex: auto;
+}
 
-.green-bar {
-  background-color: #76d00b; }
+.card .card-child__content-text {
+  flex: auto;
+  margin: 16px;
+}
 
-.explicit-position {
+@media all and (max-width: 479px) {
+  .card .card-child__content-text {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
+
+.card .card-child__display-name {
+  margin-bottom: 4px;
+  flex: auto;
+}
+
+.card .card-child__organization-description {
+  color: #999;
+}
+
+.card .card-child__fine_print {
+  font-size: .75em;
+  color: #555;
+  margin-top: 16px;
+}
+
+.card .card-child__follow-buttons {
   display: flex;
-  align-items: flex-start;
-  position: relative; }
+  align-items: flex-end;
+}
 
-.explicit-position__icon {
-  margin-right: 5px; }
+.card .card-child__follow-buttons .btn {
+  margin: 0 4px 0 0;
+}
 
-.explicit-position__text {
-  flex: 1; }
+.card .card-child__follow-buttons .twitter-followers__badge {
+  margin: 4px 0;
+}
 
-.explicit-position__icon {
-  margin-top: 2px; }
+@media all and (min-width: 768px) {
+  .card .card-child__follow-buttons {
+    flex-direction: column;
+  }
 
-.explicit-position__text {
-  padding-top: 4px;
-  color: #555; }
+  .card .card-child__follow-buttons .btn {
+    margin: 0 0 4px;
+  }
 
-.explicit-position__position-label {
-  font-weight: bold; }
+  .card .card-child__follow-buttons .twitter-followers__badge {
+    margin: 0;
+  }
+}
 
-.explicit-position__source {
-  color: #999; }
-
-.explicit-position__media-player {
-  max-width: 300px;
-  max-height: 231px; }
-
-.explicit-position__voter-guide-increase {
-  font-size: 1.15rem; }
-
-.position-rating {
+.card .card-child__additional {
   display: flex;
-  align-items: flex-start;
-  position: relative; }
+  margin-top: 8px;
+}
 
-.position-rating__icon {
-  margin-right: 5px; }
+@media all and (min-width: 768px) {
+  .card .card-child__additional {
+    flex-direction: column;
+    padding-left: 16px;
+    margin-top: inherit;
+    text-align: right;
+  }
+}
 
-.position-rating__text {
-  flex: 1; }
+/*.card .card-child--not-followed .card .card-child__additional {*/
+/*  margin-top: 16px;*/
+/*}*/
 
-.position-rating {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: flex-end !important; }
-  .position-rating__icon {
-    margin: 4px; }
-  .position-rating__rating {
-    color: #549bb6; }
-  .position-rating__percentage {
-    font-size: 18px; }
-  .position-rating__source {
-    color: #999; }
-  .position-rating__candidate-name {
-    font-size: 18px; }
+/*.card .card-child .bookmark-action {*/
+/*  order: 4;*/
+/*  position: relative;*/
+/*}*/
 
-.with-popover {
-  color: #549bb6; }
-  .with-popover:hover {
-    cursor: pointer; }
+/*.card .card-child .public-friends-indicator {*/
+/*  color: #999;*/
+/*  display: inline-block;*/
+/*  top: 16px;*/
+/*  height: 18px;*/
+/*}*/
 
-.organization-position-item-toggle {
-  position: absolute;
-  right: 40px;
-  top: 17px; }
+.card__blue, .card__blue * {
+  color: #4371cc !important;
+}
 
-.edit-position-action:hover {
-  cursor: pointer; }
+/*.card__additional {*/
+/*  border-top: 5px solid #eee;*/
+/*}*/
 
-.toggle-override .react-toggle-track-x {
-  margin-top: 3px;
-  right: 13px; }
+/*.card__additional::before, .card__additional::after {*/
+/*  content: ' ';*/
+/*  display: table;*/
+/*}*/
 
-.toggle-override .react-toggle-track-check {
-  margin-top: 3px;
-  left: 6px; }
+/*.card__additional::after {*/
+/*  clear: both;*/
+/*}*/
 
-.position-item {
-  border-left: 4px solid #999; }
+/*.card__additional-heading {*/
+/*  font-size: 18px;*/
+/*  margin: 16px 16px;*/
+/*}*/
+
+/*.card__additional-text {*/
+/*  margin: 16px 16px;*/
+/*}*/
+
+/*.card__no-additional {*/
+/*  margin: 16px 16px;*/
+/*}*/
+
+/*.card-popover {*/
+/*  padding-top: 0;*/
+/*  padding-left: 0;*/
+/*  padding-right: 0;*/
+/*  background-color: #fff;*/
+/*  max-width: 350px;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .card-popover {*/
+/*    max-width: 290px;*/
+/*  }*/
+/*}*/
+
+.card-popover__width--minimum {
+  max-width: 290px;
+  width: 90vw;
+}
+
+/*.card-popover-body {*/
+/*  max-width: 290px;*/
+/*  padding: 4px;*/
+/*}*/
+
+/*.card-popover-header {*/
+/*  background-color: #2e3c5d;*/
+/*  color: #fff;*/
+/*}*/
+
+/*.network-positions {*/
+/*  position: relative;*/
+/*  display: flex;*/
+/*  align-items: center;*/
+/*  flex: 5 0 130px;*/
+/*  min-width: 130px;*/
+/*}*/
+
+/*.network-positions__bar-well {*/
+/*  display: block;*/
+/*  position: relative;*/
+/*  margin-right: 8px;*/
+/*  margin-left: 8px;*/
+/*  flex: 5 0 48px;*/
+/*  height: 10px;*/
+/*  border-radius: 100rem;*/
+/*  background-color: #ccc;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.network-positions__bar-label {*/
+/*  position: absolute;*/
+/*  margin-top: 20px;*/
+/*  width: 100%;*/
+/*  text-align: center;*/
+/*  color: #999;*/
+/*}*/
+
+/*@media all and (max-width: 299px) {*/
+/*  .network-positions__bar-label {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*.network-positions__bar {*/
+/*  position: absolute;*/
+/*  display: block;*/
+/*  height: 10px;*/
+/*  width: 0;*/
+/*  transition: width .2s ease-out;*/
+/*  box-sizing: content-box;*/
+/*}*/
+
+/*.network-positions__support, .network-positions__oppose {*/
+/*  display: flex;*/
+/*  align-items: center;*/
+/*  flex: none;*/
+/*}*/
+
+/*.network-positions__count {*/
+/*  text-align: center;*/
+/*  color: #555;*/
+/*}*/
+
+/*.network-positions__bar--support {*/
+/*  left: 0;*/
+/*  background-color: #76d00b;*/
+/*  background: linear-gradient(to bottom, #76d00b, #68b80a);*/
+/*  border-right: 2px solid #fff;*/
+/*}*/
+
+/*.network-positions__bar--oppose {*/
+/*  right: 0;*/
+/*  background-color: #ff4921;*/
+/*  background: linear-gradient(to bottom, #ff4921, #ff3408);*/
+/*  border-left: 2px solid #fff;*/
+/*}*/
+
+/*.network-positions__support-score {*/
+/*  font-size: 2rem;*/
+/*  font-weight: 500;*/
+/*  justify-content: center;*/
+/*  align-items: center;*/
+/*}*/
+
+/*.network-positions__show-support-underline {*/
+/*  border-bottom: solid;*/
+/*  border-bottom-color: #76d00b;*/
+/*}*/
+
+/*.network-positions__show-oppose-underline {*/
+/*  border-bottom: solid;*/
+/*  border-bottom-color: #ff4921;*/
+/*}*/
+
+/*.network-positions__to-follow-fade {*/
+/*  opacity: .4;*/
+/*  filter: alpha(opacity=40);*/
+/*  !* For IE8 and earlier *!*/
+/*}*/
+
+/*.network-positions__to-follow-fade:hover {*/
+/*  opacity: .6;*/
+/*  filter: alpha(opacity=60);*/
+/*  !* For IE8 and earlier *!*/
+/*}*/
+
+/*.network-positions-stacked {*/
+/*  position: relative;*/
+/*  width: 100%;*/
+/*  align-items: center;*/
+/*}*/
+
+/*.network-positions-stacked__bar {*/
+/*  position: absolute;*/
+/*  display: block;*/
+/*  height: 10px;*/
+/*  width: 0;*/
+/*  transition: width .2s ease-out;*/
+/*  box-sizing: content-box;*/
+/*}*/
+
+/*.network-positions-stacked__info-icon-for-popover {*/
+/*  color: #999;*/
+/*}*/
+
+/*.network-positions-stacked__support, .network-positions-stacked__oppose {*/
+/*  display: flex;*/
+/*  align-items: center;*/
+/*  flex: none;*/
+/*}*/
+
+/*.network-positions-stacked__more-opinions {*/
+/*  color: #999;*/
+/*}*/
+
+/*.network-positions-stacked__support-score {*/
+/*  color: #555;*/
+/*  font-size: 2rem;*/
+/*  font-weight: 500;*/
+/*  display: flex;*/
+/*  justify-content: center;*/
+/*  align-items: center;*/
+/*}*/
+
+/*.network-positions-stacked__support-score-label, .network-positions-stacked__support-label {*/
+/*  color: #555;*/
+/*  font-size: .875rem;*/
+/*  font-weight: 200;*/
+/*  line-height: 1.2;*/
+/*  vertical-align: middle;*/
+/*  display: inline-flex;*/
+/*  flex-direction: row;*/
+/*  align-items: center;*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 479px) {*/
+/*  .network-positions-stacked__support-score-label, .network-positions-stacked__support-label {*/
+/*    font-size: .875rem;*/
+/*  }*/
+/*}*/
+
+/*.network-positions-stacked__support-list {*/
+/*  margin-left: -36px;*/
+/*  margin-right: -16px;*/
+/*}*/
+
+/*.network-positions-stacked__support-list__container-wrap {*/
+/*  box-sizing: content-box;*/
+/*  overflow: hidden;*/
+/*  height: 55px;*/
+/*  flex-grow: 1;*/
+/*}*/
+
+/*.network-positions-stacked__support-list__container {*/
+/*  white-space: nowrap;*/
+/*  height: 76px;*/
+/*}*/
+
+/*.network-positions-stacked__support-list__items {*/
+/*  padding: 0;*/
+/*  margin-bottom: 16px;*/
+/*  list-style: none;*/
+/*}*/
+
+/*.network-positions-stacked__support-list__item {*/
+/*  position: relative;*/
+/*  display: inline-block;*/
+/*  float: none;*/
+/*}*/
+
+/*.network-positions-stacked__support-list__scroll-icon {*/
+/*  color: #999;*/
+/*  margin: 0 8px;*/
+/*  margin-top: 4px;*/
+/*}*/
+
+/*@media all and (min-width: 768px) {*/
+/*  .network-positions-stacked__support-list__scroll-icon {*/
+/*    margin-top: 16px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .network-positions-stacked__support-list__scroll-icon--small {*/
+/*    margin-top: -8px;*/
+/*  }*/
+/*}*/
+
+/*.network-positions-stacked__support-list__scroll-icon--disabled {*/
+/*  color: transparent;*/
+/*  margin: 0 8px;*/
+/*}*/
+
+/*.network-positions-stacked__support-list__scroll-icon--disabled-small {*/
+/*  color: transparent;*/
+/*  margin: 0 13px;*/
+/*}*/
+
+/*.red-bar {*/
+/*  background-color: #ff4921;*/
+/*}*/
+
+/*.green-bar {*/
+/*  background-color: #76d00b;*/
+/*}*/
+
+/*.explicit-position {*/
+/*  display: flex;*/
+/*  align-items: flex-start;*/
+/*  position: relative;*/
+/*}*/
+
+/*.explicit-position__icon {*/
+/*  margin-right: 5px;*/
+/*}*/
+
+/*.explicit-position__text {*/
+/*  flex: 1;*/
+/*}*/
+
+/*.explicit-position__icon {*/
+/*  margin-top: 2px;*/
+/*}*/
+
+/*.explicit-position__text {*/
+/*  padding-top: 4px;*/
+/*  color: #555;*/
+/*}*/
+
+/*.explicit-position__position-label {*/
+/*  font-weight: bold;*/
+/*}*/
+
+/*.explicit-position__source {*/
+/*  color: #999;*/
+/*}*/
+
+/*.explicit-position__media-player {*/
+/*  max-width: 300px;*/
+/*  max-height: 231px;*/
+/*}*/
+
+/*.explicit-position__voter-guide-increase {*/
+/*  font-size: 1.15rem;*/
+/*}*/
+
+/*.position-rating {*/
+/*  display: flex;*/
+/*  align-items: flex-start;*/
+/*  position: relative;*/
+/*}*/
+
+/*.position-rating__icon {*/
+/*  margin-right: 5px;*/
+/*}*/
+
+/*.position-rating__text {*/
+/*  flex: 1;*/
+/*}*/
+
+/*.position-rating {*/
+/*  display: flex;*/
+/*  flex-direction: row;*/
+/*  justify-content: flex-start;*/
+/*  align-items: flex-end !important;*/
+/*}*/
+
+/*.position-rating__icon {*/
+/*  margin: 4px;*/
+/*}*/
+
+/*.position-rating__rating {*/
+/*  color: #549bb6;*/
+/*}*/
+
+/*.position-rating__percentage {*/
+/*  font-size: 18px;*/
+/*}*/
+
+/*.position-rating__source {*/
+/*  color: #999;*/
+/*}*/
+
+/*.position-rating__candidate-name {*/
+/*  font-size: 18px;*/
+/*}*/
+
+/*.with-popover {*/
+/*  color: #549bb6;*/
+/*}*/
+
+/*.with-popover:hover {*/
+/*  cursor: pointer;*/
+/*}*/
+
+/*.organization-position-item-toggle {*/
+/*  position: absolute;*/
+/*  right: 40px;*/
+/*  top: 17px;*/
+/*}*/
+
+/*.edit-position-action:hover {*/
+/*  cursor: pointer;*/
+/*}*/
+
+/*.toggle-override .react-toggle-track-x {*/
+/*  margin-top: 3px;*/
+/*  right: 13px;*/
+/*}*/
+
+/*.toggle-override .react-toggle-track-check {*/
+/*  margin-top: 3px;*/
+/*  left: 6px;*/
+/*}*/
+
+/*.position-item {*/
+/*  border-left: 4px solid #999;*/
+/*}*/
 
 .tabs__tabs-container-wrap {
   border-bottom: 1px solid #aaa;
@@ -10181,100 +13112,140 @@ h1, h2, h3, h4, h5, h6 {
   box-sizing: content-box;
   padding: 8px 16px 0 16px;
   overflow: hidden;
-  height: 30px; }
-  @media all and (min-width: 320px) and (max-width: 479px) {
-    .tabs__tabs-container-wrap {
-      margin-right: -16px;
-      margin-left: -16px; } }
+  height: 30px;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
+  .tabs__tabs-container-wrap {
+    margin-right: -16px;
+    margin-left: -16px;
+  }
+}
 
 .tabs__tabs-container {
   white-space: nowrap;
   overflow-x: scroll;
   overflow-y: hidden;
-  height: 50px; }
+  height: 50px;
+}
 
 .tabs__tabs .tab-item {
   display: inline-block;
-  float: none; }
+  float: none;
+}
 
 .tabs__tabs .tab {
   font-size: 1rem;
   padding: 0 0 4px;
-  margin-right: 24px; }
-  @media all and (min-width: 320px) and (max-width: 479px) {
-    .tabs__tabs .tab {
-      margin-right: 16px; } }
+  margin-right: 24px;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
+  .tabs__tabs .tab {
+    margin-right: 16px;
+  }
+}
 
 .tabs__tabs .tab-active {
   border-bottom: 4px solid #000;
-  color: #000; }
+  color: #000;
+}
 
 .tabs__tabs .tab-default {
-  color: #999; }
+  color: #999;
+}
 
-.tabs__tabs a:focus,
-.tabs__tabs a:hover {
-  background-color: transparent !important; }
+.tabs__tabs a:focus, .tabs__tabs a:hover {
+  background-color: transparent !important;
+}
 
-.tabs__tabs a.tab-default:focus,
-.tabs__tabs a.tab-default:hover {
-  border-bottom: 6px solid #999; }
+.tabs__tabs a.tab-default:focus, .tabs__tabs a.tab-default:hover {
+  border-bottom: 6px solid #999;
+}
 
 .team-member {
-  margin-bottom: 16px; }
+  margin-bottom: 16px;
+}
+
+.team-member__photo {
+  border-radius: 4px;
+  margin-bottom: 8px;
+}
+
+@media all and (max-width: 767px) {
   .team-member__photo {
-    border-radius: 4px;
-    margin-bottom: 8px; }
-    @media all and (max-width: 767px) {
-      .team-member__photo {
-        border-radius: 50%;
-        width: 100%; } }
-  .team-member__name {
-    line-height: 1.2;
-    margin-top: 4px; }
-  .team-member__title {
-    font-size: .8rem; }
+    border-radius: 50%;
+    width: 100%;
+  }
+}
+
+.team-member__name {
+  line-height: 1.2;
+  margin-top: 4px;
+}
+
+.team-member__title {
+  font-size: .8rem;
+}
 
 .team-members-list {
   padding-right: 4px;
-  padding-left: 4px; }
-  .team-members-list .team-member {
-    padding-right: 4px;
-    padding-left: 4px; }
+  padding-left: 4px;
+}
+
+.team-members-list .team-member {
+  padding-right: 4px;
+  padding-left: 4px;
+}
 
 .open-web-site {
   color: #4371cc;
   padding-right: 2px;
-  padding-left: 2px; }
-  .open-web-site__no-right-padding {
-    padding-right: 0; }
-  .open-web-site__no-left-padding {
-    padding-left: 0; }
-  .open-web-site__no-padding {
-    padding-left: 0;
-    padding-right: 0; }
+  padding-left: 2px;
+}
+
+.open-web-site__no-right-padding {
+  padding-right: 0;
+}
+
+.open-web-site__no-left-padding {
+  padding-left: 0;
+}
+
+.open-web-site__no-padding {
+  padding-left: 0;
+  padding-right: 0;
+}
 
 .donate-frequency {
   display: flex;
-  flex-flow: row; }
-  .donate-frequency__radio-button-div {
-    margin-left: 28px;
-    margin-bottom: 8px;
-    width: 80px; }
+  flex-flow: row;
+}
+
+.donate-frequency__radio-button-div {
+  margin-left: 28px;
+  margin-bottom: 8px;
+  width: 80px;
+}
 
 .signin-button > div > div > svg {
   height: 39px;
-  width: 100%; }
+  width: 100%;
+}
 
 .signin-button > div {
-  max-width: unset !important; }
+  max-width: unset !important;
+}
 
 .ballot__filter {
   white-space: nowrap;
   overflow-x: hidden;
-  overflow-y: hidden; }
-  .ballot__filter__container {
-    overflow: hidden; }
+  overflow-y: hidden;
+}
+
+.ballot__filter__container {
+  overflow: hidden;
+}
 
 /*.ballot__heading {*/
 /*  width: 100%;*/
@@ -10296,7 +13267,6 @@ h1, h2, h3, h4, h5, h6 {
 /*    z-index: 9000 !important;*/
 /*    transform: translate3d(0, -58px, 0);*/
 /*    transition: all 100ms ease-in-out 0s; }*/
-
 .ballot__heading-vote-section {
   width: 100%;
   background-color: #fff;
@@ -10308,713 +13278,949 @@ h1, h2, h3, h4, h5, h6 {
   padding-top: 54px;
   transform: translate3d(0, -53px, 0);
   transition: all 100ms ease-in-out 0s;
-  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12); }
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
+}
 
 .ballot__heading-webapp {
   padding-top: 41%;
-  margin-top: -15vh; }
+  margin-top: -15vh;
+}
 
 .ballot__header__title {
   display: inline-block;
   margin-bottom: 0;
   margin-top: 8px;
-  font-size: 14px; }
-  @media all and (min-width: 768px) {
-    .ballot__header__title {
-      font-size: 20px; } }
-  .ballot__header__title__cordova {
-    font-size: 1.5rem;
-    margin: 0 !important; }
-  .ballot__header__title__cordova-text {
-    font-size: 14px; }
+  font-size: 14px;
+}
+
+@media all and (min-width: 768px) {
+  .ballot__header__title {
+    font-size: 20px;
+  }
+}
+
+.ballot__header__title__cordova {
+  font-size: 1.5rem;
+  margin: 0 !important;
+}
+
+.ballot__header__title__cordova-text {
+  font-size: 14px;
+}
 
 .ballot__header__title-voter-guide {
   display: inline-block;
   margin-top: 4px;
-  font-size: 1.1rem; }
-  @media print {
-    .ballot__header__title-voter-guide {
-      font-size: 2rem; } }
+  font-size: 1.1rem;
+}
+
+@media print {
+  .ballot__header__title-voter-guide {
+    font-size: 2rem;
+  }
+}
 
 .ballot__header__address {
-  margin: 26px 26px 0 0; }
-  .ballot__header__address--xs {
-    margin: -4px 0 8px 0; }
+  margin: 26px 26px 0 0;
+}
+
+.ballot__header__address--xs {
+  margin: -4px 0 8px 0;
+}
 
 .ballot__header__group {
   display: block;
-  border-bottom: 0 solid #000; }
+  border-bottom: 0 solid #000;
+}
 
 .ballot__header__top-cordova {
-  margin-top: 16px; }
+  margin-top: 16px;
+}
 
 .ballot__header__cordova {
-  padding-bottom: 50px; }
+  padding-bottom: 50px;
+}
 
 .ballot__tabs .tab {
   padding: 0 0 4px;
-  margin-right: 24px; }
-  .ballot__tabs .tab__item {
-    display: inline-block;
-    float: none; }
-  .ballot__tabs .tab--active {
-    border-bottom: 6px solid #000;
-    color: #000; }
-  .ballot__tabs .tab--default {
-    color: #999; }
-  @media all and (min-width: 320px) and (max-width: 479px) {
-    .ballot__tabs .tab {
-      margin-right: 16px; } }
+  margin-right: 24px;
+}
 
-.ballot__tabs a:focus,
-.ballot__tabs a:hover {
-  background-color: transparent !important; }
+.ballot__tabs .tab__item {
+  display: inline-block;
+  float: none;
+}
 
-.ballot__tabs a.tab--default:focus,
-.ballot__tabs a.tab--default:hover {
-  border-bottom: 6px solid #999; }
+.ballot__tabs .tab--active {
+  border-bottom: 6px solid #000;
+  color: #000;
+}
+
+.ballot__tabs .tab--default {
+  color: #999;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
+  .ballot__tabs .tab {
+    margin-right: 16px;
+  }
+}
+
+.ballot__tabs a:focus, .ballot__tabs a:hover {
+  background-color: transparent !important;
+}
+
+.ballot__tabs a.tab--default:focus, .ballot__tabs a.tab--default:hover {
+  border-bottom: 6px solid #999;
+}
 
 .ballot__filter-row {
   display: flex;
-  flex-flow: row; }
+  flex-flow: row;
+}
 
 .ballot__body {
   margin-top: 16px;
-  padding-top: 128px; }
-  @media all and (min-width: 320px) and (max-width: 575px) {
-    .ballot__body {
-      padding-top: 128px; } }
+  padding-top: 128px;
+}
+
+@media all and (min-width: 320px) and (max-width: 575px) {
+  .ballot__body {
+    padding-top: 128px;
+  }
+}
+
+.ballot__body__no-decision-tabs {
+  margin-top: 16px;
+  padding-top: 90px;
+}
+
+@media all and (min-width: 375px) and (max-width: 575px) {
   .ballot__body__no-decision-tabs {
-    margin-top: 16px;
-    padding-top: 90px; }
-    @media all and (min-width: 375px) and (max-width: 575px) {
-      .ballot__body__no-decision-tabs {
-        padding-top: 85px; } }
-    @media all and (min-width: 320px) and (max-width: 374px) {
-      .ballot__body__no-decision-tabs {
-        padding-top: 84px; } }
+    padding-top: 85px;
+  }
+}
+
+@media all and (min-width: 320px) and (max-width: 374px) {
+  .ballot__body__no-decision-tabs {
+    padding-top: 84px;
+  }
+}
+
+.ballot__body__ready-to-vote {
+  margin-top: 16px;
+  padding-top: 92px;
+}
+
+@media all and (min-width: 320px) and (max-width: 575px) {
   .ballot__body__ready-to-vote {
-    margin-top: 16px;
-    padding-top: 92px; }
-    @media all and (min-width: 320px) and (max-width: 575px) {
-      .ballot__body__ready-to-vote {
-        padding-top: 92px; } }
-    .ballot__body__ready-to-vote--empty {
-      padding-top: 64px; }
-      @media all and (min-width: 320px) and (max-width: 575px) {
-        .ballot__body__ready-to-vote--empty {
-          padding-top: 44px; } }
+    padding-top: 92px;
+  }
+}
+
+.ballot__body__ready-to-vote--empty {
+  padding-top: 64px;
+}
+
+@media all and (min-width: 320px) and (max-width: 575px) {
+  .ballot__body__ready-to-vote--empty {
+    padding-top: 44px;
+  }
+}
 
 .ballot__body-vg {
-  padding-top: 0; }
+  padding-top: 0;
+}
 
 .ballot__item-filter-tabs {
   display: flex;
   overflow-y: hidden;
   overflow-x: auto;
   justify-content: flex-start;
-  margin-top: 8px; }
-  @media all and (min-width: 960px) {
-    .ballot__item-filter-tabs {
-      overflow-x: hidden; } }
+  margin-top: 8px;
+}
+
+@media all and (min-width: 960px) {
+  .ballot__item-filter-tabs {
+    overflow-x: hidden;
+  }
+}
 
 .ballot__edit-address-preview {
   font-size: 1.2rem;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .ballot__edit-address-preview-link {
   color: #4371cc;
   font-size: 1.2rem;
-  font-weight: bold; }
+  font-weight: bold;
+}
 
 .ballot__voter-guide-body {
   margin-top: 16px;
   margin-left: -32px;
-  margin-right: -32px; }
+  margin-right: -32px;
+}
 
 .ballot__cordova-shim {
-  margin-top: 58px; }
+  margin-top: 58px;
+}
 
 .ballot__change-address {
   margin-bottom: 8px;
-  margin-top: 16px; }
+  margin-top: 16px;
+}
 
 .ballot__no-race-cats {
-  margin-top: -10px; }
+  margin-top: -10px;
+}
 
 .ballot_filter_btns {
-  margin-right: 4px; }
-  @media all and (min-width: 768px) {
-    .ballot_filter_btns {
-      margin-right: 16px; } }
+  margin-right: 4px;
+}
+
+@media all and (min-width: 768px) {
+  .ballot_filter_btns {
+    margin-right: 16px;
+  }
+}
 
 .ballot-header-divider {
   margin: 0;
   width: 200%;
   left: -300px;
-  position: absolute; }
+  position: absolute;
+}
 
 @media print {
   .BallotList {
-    column-count: 1; } }
+    column-count: 1;
+  }
+}
 
 .BallotItem {
   position: relative;
-  margin-bottom: 16px; }
-  .BallotItem__display-name {
-    font-size: 24px;
-    color: #555; }
-    @media all and (max-width: 479px) {
-      .BallotItem__display-name {
-        font-size: 18px;
-        max-width: 100%;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis; } }
-  .BallotItem__learn-more {
-    font-size: .8rem;
-    font-weight: 200;
-    position: relative;
-    z-index: 99999; }
-  .BallotItem__view-more {
-    font-size: .9rem;
-    font-weight: 200;
-    color: #000;
-    text-align: center;
-    border-top: 1px solid;
-    border-color: #ccc;
-    padding-top: 5px; }
-    .BallotItem__view-more .material-icons.arrow-forward {
-      font-size: .9rem;
-      margin-bottom: 1.5px; }
-  .BallotItem__view-more:hover {
-    color: #4371cc; }
-  .BallotItem__view-more-plus {
-    font-size: .8rem;
-    font-weight: 100; }
-  .BallotItem__summary__wrapper {
-    box-shadow: none !important; }
-  .BallotItem__summary__title {
-    width: 100% !important;
-    border-bottom: 1px solid #333 !important;
-    background: white !important; }
-  .BallotItem__summary__body {
-    padding-left: 8px !important; }
-  .BallotItem__summary__list {
-    list-style: none !important;
-    margin: 0 !important;
-    padding: 0 !important; }
-  .BallotItem__top-comment {
-    color: #555;
-    font-size: 14px;
-    font-weight: 600; }
-    .BallotItem__top-comment__endorser-name {
-      color: #999;
-      font-weight: 900; }
+  margin-bottom: 16px;
+}
 
-.organization__image--tiny {
+/*.BallotItem__display-name {*/
+/*  font-size: 24px;*/
+/*  color: #555;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .BallotItem__display-name {*/
+/*    font-size: 18px;*/
+/*    max-width: 100%;*/
+/*    white-space: nowrap;*/
+/*    overflow: hidden;*/
+/*    text-overflow: ellipsis;*/
+/*  }*/
+/*}*/
+
+/*.BallotItem__learn-more {*/
+/*  font-size: .8rem;*/
+/*  font-weight: 200;*/
+/*  position: relative;*/
+/*  z-index: 99999;*/
+/*}*/
+
+/*.BallotItem__view-more {*/
+/*  font-size: .9rem;*/
+/*  font-weight: 200;*/
+/*  color: #000;*/
+/*  text-align: center;*/
+/*  border-top: 1px solid;*/
+/*  border-color: #ccc;*/
+/*  padding-top: 5px;*/
+/*}*/
+
+/*.BallotItem__view-more .material-icons.arrow-forward {*/
+/*  font-size: .9rem;*/
+/*  margin-bottom: 1.5px;*/
+/*}*/
+
+/*.BallotItem__view-more:hover {*/
+/*  color: #4371cc;*/
+/*}*/
+
+/*.BallotItem__view-more-plus {*/
+/*  font-size: .8rem;*/
+/*  font-weight: 100;*/
+/*}*/
+
+/*.BallotItem__summary__wrapper {*/
+/*  box-shadow: none !important;*/
+/*}*/
+
+/*.BallotItem__summary__title {*/
+/*  width: 100% !important;*/
+/*  border-bottom: 1px solid #333 !important;*/
+/*  background: white !important;*/
+/*}*/
+
+/*.BallotItem__summary__body {*/
+/*  padding-left: 8px !important;*/
+/*}*/
+
+/*.BallotItem__summary__list {*/
+/*  list-style: none !important;*/
+/*  margin: 0 !important;*/
+/*  padding: 0 !important;*/
+/*}*/
+
+/*.BallotItem__top-comment {*/
+/*  color: #555;*/
+/*  font-size: 14px;*/
+/*  font-weight: 600;*/
+/*}*/
+
+/*.BallotItem__top-comment__endorser-name {*/
+/*  color: #999;*/
+/*  font-weight: 900;*/
+/*}*/
+
+/*.organization__image--tiny {*/
+/*  margin-left: 2px;*/
+/*  margin-right: 2px;*/
+/*  width: 32px;*/
+/*  border-radius: 2px;*/
+/*}*/
+
+/*.issue__image {*/
+/*  display: inline;*/
+/*}*/
+
+.issue__image--small {
   margin-left: 2px;
   margin-right: 2px;
   width: 32px;
-  border-radius: 2px; }
+  border-radius: 2px;
+}
 
-.issue__image {
-  display: inline; }
-  .issue__image--small {
-    margin-left: 2px;
-    margin-right: 2px;
-    width: 32px;
-    border-radius: 2px; }
-  .issue__image--medium {
-    margin-left: 2px;
-    margin-right: 2px;
-    width: 48px;
-    border-radius: 2px; }
-  .issue__image--large {
-    margin-left: 2px;
-    margin-right: 2px;
-    width: 125px;
-    border-radius: 2px; }
+.issue__image--medium {
+  margin-left: 2px;
+  margin-right: 2px;
+  width: 48px;
+  border-radius: 2px;
+}
+
+.issue__image--large {
+  margin-left: 2px;
+  margin-right: 2px;
+  width: 125px;
+  border-radius: 2px;
+}
 
 .issue__image-modal {
-  display: inline; }
+  display: inline;
+}
 
 .issue__image-modal img {
-  display: inline; }
+  display: inline;
+}
 
-.BallotItemsSummary {
-  padding-top: 16px;
-  margin-bottom: -16px;
-  text-align: center;
-  text-decoration: underline;
-  font-weight: bold; }
+/*.BallotItemsSummary {*/
+/*  padding-top: 16px;*/
+/*  margin-bottom: -16px;*/
+/*  text-align: center;*/
+/*  text-decoration: underline;*/
+/*  font-weight: bold;*/
+/*}*/
 
-.invite-inputs {
-  position: relative;
-  margin-bottom: 0; }
+/*.invite-inputs {*/
+/*  position: relative;*/
+/*  margin-bottom: 0;*/
+/*}*/
 
-.invite-inputs .input-group {
-  width: 100%; }
+/*.invite-inputs .input-group {*/
+/*  width: 100%;*/
+/*}*/
 
-.close-on-right {
-  position: absolute;
-  top: 2rem;
-  right: -5px; }
+/*.close-on-right {*/
+/*  position: absolute;*/
+/*  top: 2rem;*/
+/*  right: -5px;*/
+/*}*/
 
-.display-in-column-with-vertical-scroll {
-  border-radius: 4px;
-  -webkit-column-count: 1;
-  -moz-column-count: 1;
-  column-count: 1;
-  -webkit-column-gap: 0;
-  -moz-column-gap: 0;
-  column-gap: 0; }
+/*.display-in-column-with-vertical-scroll {*/
+/*  border-radius: 4px;*/
+/*  -webkit-column-count: 1;*/
+/*  -moz-column-count: 1;*/
+/*  column-count: 1;*/
+/*  -webkit-column-gap: 0;*/
+/*  -moz-column-gap: 0;*/
+/*  column-gap: 0;*/
+/*}*/
 
-.display-in-column-with-vertical-scroll-contain {
-  height: calc(100vh - 384px);
-  max-height: 990px;
-  overflow-y: auto; }
+/*.display-in-column-with-vertical-scroll-contain {*/
+/*  height: calc(100vh - 384px);*/
+/*  max-height: 990px;*/
+/*  overflow-y: auto;*/
+/*}*/
 
-.friends-list__grid {
-  padding: 0 16px; }
+/*.friends-list__grid {*/
+/*  padding: 0 16px;*/
+/*}*/
 
-.friends-list__welcome {
-  padding: 0 16px;
-  align-items: center; }
+/*.friends-list__welcome {*/
+/*  padding: 0 16px;*/
+/*  align-items: center;*/
+/*}*/
 
-.friends-list__welcome-image {
-  position: relative;
-  padding: 4px; }
+/*.friends-list__welcome-image {*/
+/*  position: relative;*/
+/*  padding: 4px;*/
+/*}*/
 
-.friends-list__square {
-  position: relative;
-  text-align: left;
-  padding: 4px; }
+/*.friends-list__square {*/
+/*  position: relative;*/
+/*  text-align: left;*/
+/*  padding: 4px;*/
+/*}*/
 
-.friends-list__square-image {
-  height: 100%;
-  width: 100%;
-  border: 1px solid #ddd;
-  border-radius: 8px;
-  filter: brightness(90%) contrast(90%); }
+/*.friends-list__square-image {*/
+/*  height: 100%;*/
+/*  width: 100%;*/
+/*  border: 1px solid #ddd;*/
+/*  border-radius: 8px;*/
+/*  filter: brightness(90%) contrast(90%);*/
+/*}*/
 
-.friends-list__square-following {
-  filter: brightness(60%); }
+/*.friends-list__square-following {*/
+/*  filter: brightness(60%);*/
+/*}*/
 
-.friends-list__square-check-mark {
-  position: absolute;
-  top: 0;
-  left: 0;
-  transform: scale(0.5); }
+/*.friends-list__square-check-mark {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  left: 0;*/
+/*  transform: scale(0.5);*/
+/*}*/
 
-.friends-list__square-name {
-  position: absolute;
-  right: 12px;
-  bottom: 12px;
-  left: 12px;
-  font-size: .875rem;
-  color: #fff;
-  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6); }
-  @media all and (min-width: 576px) and (max-width: 767px) {
-    .friends-list__square-name {
-      right: 10px;
-      bottom: 10px;
-      left: 10px;
-      font-size: .65rem; } }
-  @media all and (min-width: 375px) and (max-width: 479px) {
-    .friends-list__square-name {
-      right: 10px;
-      bottom: 10px;
-      left: 10px;
-      font-size: .65rem;
-      -webkit-hyphens: auto;
-      -moz-hyphens: auto;
-      -ms-hyphens: auto;
-      hyphens: auto; } }
-  @media all and (max-width: 374px) {
-    .friends-list__square-name {
-      right: 8px;
-      bottom: 8px;
-      left: 8px;
-      font-size: .6rem;
-      -webkit-hyphens: auto;
-      -moz-hyphens: auto;
-      -ms-hyphens: auto;
-      hyphens: auto; } }
+/*.friends-list__square-name {*/
+/*  position: absolute;*/
+/*  right: 12px;*/
+/*  bottom: 12px;*/
+/*  left: 12px;*/
+/*  font-size: .875rem;*/
+/*  color: #fff;*/
+/*  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6);*/
+/*}*/
 
-.friends-list__default-text {
-  width: 100%;
-  padding: 16px;
-  text-align: center; }
+/*@media all and (min-width: 576px) and (max-width: 767px) {*/
+/*  .friends-list__square-name {*/
+/*    right: 10px;*/
+/*    bottom: 10px;*/
+/*    left: 10px;*/
+/*    font-size: .65rem;*/
+/*  }*/
+/*}*/
+
+/*@media all and (min-width: 375px) and (max-width: 479px) {*/
+/*  .friends-list__square-name {*/
+/*    right: 10px;*/
+/*    bottom: 10px;*/
+/*    left: 10px;*/
+/*    font-size: .65rem;*/
+/*    -webkit-hyphens: auto;*/
+/*    -moz-hyphens: auto;*/
+/*    -ms-hyphens: auto;*/
+/*    hyphens: auto;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 374px) {*/
+/*  .friends-list__square-name {*/
+/*    right: 8px;*/
+/*    bottom: 8px;*/
+/*    left: 8px;*/
+/*    font-size: .6rem;*/
+/*    -webkit-hyphens: auto;*/
+/*    -moz-hyphens: auto;*/
+/*    -ms-hyphens: auto;*/
+/*    hyphens: auto;*/
+/*  }*/
+/*}*/
+
+/*.friends-list__default-text {*/
+/*  width: 100%;*/
+/*  padding: 16px;*/
+/*  text-align: center;*/
+/*}*/
 
 .item-actionbar__position-bar {
   display: flex;
-  align-items: center; }
-  @media all and (max-width: 767px) {
-    .item-actionbar__position-bar--mobile {
-      display: flex !important; } }
+  align-items: center;
+}
+
+@media all and (max-width: 767px) {
+  .item-actionbar__position-bar--mobile {
+    display: flex !important;
+  }
+}
 
 .item-actionbar__position-btn-label {
   color: #000;
   font-weight: bold;
-  text-transform: uppercase; }
-  .item-actionbar__position-btn-label--at-state {
-    color: #fff;
-    font-weight: bold;
-    text-transform: uppercase; }
+  text-transform: uppercase;
+}
+
+.item-actionbar__position-btn-label--at-state {
+  color: #fff;
+  font-weight: bold;
+  text-transform: uppercase;
+}
 
 .item-actionbar__position-choose-btn-label {
   color: #000;
   font-weight: bold;
-  text-transform: uppercase; }
-  .item-actionbar__position-choose-btn-label--at-state {
-    font-weight: bold;
-    text-transform: uppercase; }
+  text-transform: uppercase;
+}
+
+.item-actionbar__position-choose-btn-label--at-state {
+  font-weight: bold;
+  text-transform: uppercase;
+}
 
 .item-actionbar__following-text {
-  margin-left: 8px; }
+  margin-left: 8px;
+}
 
 .item-actionbar .support-at-state {
   color: #fff;
   font-weight: bold;
-  background-color: #76d00b; }
+  background-color: #76d00b;
+}
 
 .item-actionbar .oppose-at-state {
-  background-color: #ff4921; }
+  background-color: #ff4921;
+}
 
 .item-actionbar--inline__position-btn-label {
   color: #000;
   font-weight: bold;
-  text-transform: uppercase; }
-  .item-actionbar--inline__position-btn-label--at-state {
-    color: #fff;
-    text-transform: uppercase; }
+  text-transform: uppercase;
+}
+
+.item-actionbar--inline__position-btn-label--at-state {
+  color: #fff;
+  text-transform: uppercase;
+}
 
 .item-actionbar--inline__position-choose-btn-label {
   color: #000;
   font-weight: bold;
-  text-transform: uppercase; }
-  .item-actionbar--inline__position-choose-btn-label--at-state {
-    font-weight: bold;
-    text-transform: uppercase; }
+  text-transform: uppercase;
+}
 
-.item-actionbar--inline .btn-group {
-  display: flex;
-  flex-wrap: nowrap; }
+.item-actionbar--inline__position-choose-btn-label--at-state {
+  font-weight: bold;
+  text-transform: uppercase;
+}
 
-.item-actionbar--inline .support-at-state {
-  color: #fff;
-  background-color: #76d00b;
-  border-color: #76d00b; }
+/*.item-actionbar--inline .btn-group {*/
+/*  display: flex;*/
+/*  flex-wrap: nowrap;*/
+/*}*/
 
-.item-actionbar--inline .oppose-at-state {
-  background-color: #ff4921; }
+/*.item-actionbar--inline .support-at-state {*/
+/*  color: #fff;*/
+/*  background-color: #76d00b;*/
+/*  border-color: #76d00b;*/
+/*}*/
 
-.position-statement {
-  display: flex;
-  align-items: flex-start;
-  position: relative; }
+/*.item-actionbar--inline .oppose-at-state {*/
+/*  background-color: #ff4921;*/
+/*}*/
 
-.position-statement__avatar {
-  margin-right: 10px; }
+/*.position-statement {*/
+/*  display: flex;*/
+/*  align-items: flex-start;*/
+/*  position: relative;*/
+/*}*/
 
-.position-statement__input-group {
-  flex: 1; }
+/*.position-statement__avatar {*/
+/*  margin-right: 10px;*/
+/*}*/
 
-.position-statement {
-  display: flex;
-  flex: 1 1 100%;
-  width: 100%; }
-  .position-statement__avatar {
-    overflow: hidden;
-    border-radius: 4px;
-    background-color: #fff;
-    display: inline-block;
-    flex-shrink: 0; }
-  .position-statement__description {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    word-break: break-word;
-    -webkit-hyphens: auto;
-    -moz-hyphens: auto;
-    -ms-hyphens: auto;
-    hyphens: auto; }
-  .position-statement__post-button {
-    margin: 6px 0 0 0;
-    padding: 3px 7px; }
-  .position-statement--truncated {
-    overflow: hidden;
-    position: relative;
-    height: 75px;
-    line-height: 25px; }
-    .position-statement--truncated::before {
-      content: '';
-      float: left;
-      width: 5px;
-      height: 75px; }
-    .position-statement--truncated > *:first-child {
-      float: right;
-      width: 100%;
-      margin-left: -4px; }
-    .position-statement--truncated::after {
-      content: '\00A0 Edit';
-      box-sizing: content-box;
-      float: right;
-      position: relative;
-      top: -25px;
-      left: 100%;
-      width: 7em;
-      margin-left: -7em;
-      padding-right: 4px;
-      text-align: right;
-      background-size: 100% 100%;
-      background: linear-gradient(to right, rgba(255, 255, 255, 0), #fff 15%, #fff);
-      font-style: normal;
-      color: #4371cc;
-      cursor: pointer; }
+/*.position-statement__input-group {*/
+/*  flex: 1;*/
+/*}*/
 
-.position-statement__edit-position-link {
-  color: #4371cc;
-  cursor: pointer; }
-  .position-statement__edit-position-link--area {
-    text-indent: -10000em;
-    overflow: hidden;
-    white-space: nowrap;
-    position: absolute;
-    left: 0;
-    top: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 5; }
+/*.position-statement {*/
+/*  display: flex;*/
+/*  flex: 1 1 100%;*/
+/*  width: 100%;*/
+/*}*/
+
+/*.position-statement__avatar {*/
+/*  overflow: hidden;*/
+/*  border-radius: 4px;*/
+/*  background-color: #fff;*/
+/*  display: inline-block;*/
+/*  flex-shrink: 0;*/
+/*}*/
+
+/*.position-statement__description {*/
+/*  word-wrap: break-word;*/
+/*  overflow-wrap: break-word;*/
+/*  word-break: break-word;*/
+/*  -webkit-hyphens: auto;*/
+/*  -moz-hyphens: auto;*/
+/*  -ms-hyphens: auto;*/
+/*  hyphens: auto;*/
+/*}*/
+
+/*.position-statement__post-button {*/
+/*  margin: 6px 0 0 0;*/
+/*  padding: 3px 7px;*/
+/*}*/
+
+/*.position-statement--truncated {*/
+/*  overflow: hidden;*/
+/*  position: relative;*/
+/*  height: 75px;*/
+/*  line-height: 25px;*/
+/*}*/
+
+/*.position-statement--truncated::before {*/
+/*  content: '';*/
+/*  float: left;*/
+/*  width: 5px;*/
+/*  height: 75px;*/
+/*}*/
+
+/*.position-statement--truncated > *:first-child {*/
+/*  float: right;*/
+/*  width: 100%;*/
+/*  margin-left: -4px;*/
+/*}*/
+
+/*.position-statement--truncated::after {*/
+/*  content: '\00A0 Edit';*/
+/*  box-sizing: content-box;*/
+/*  float: right;*/
+/*  position: relative;*/
+/*  top: -25px;*/
+/*  left: 100%;*/
+/*  width: 7em;*/
+/*  margin-left: -7em;*/
+/*  padding-right: 4px;*/
+/*  text-align: right;*/
+/*  background-size: 100% 100%;*/
+/*  background: linear-gradient(to right, rgba(255, 255, 255, 0), #fff 15%, #fff);*/
+/*  font-style: normal;*/
+/*  color: #4371cc;*/
+/*  cursor: pointer;*/
+/*}*/
+
+/*.position-statement__edit-position-link {*/
+/*  color: #4371cc;*/
+/*  cursor: pointer;*/
+/*}*/
+
+/*.position-statement__edit-position-link--area {*/
+/*  text-indent: -10000em;*/
+/*  overflow: hidden;*/
+/*  white-space: nowrap;*/
+/*  position: absolute;*/
+/*  left: 0;*/
+/*  top: 0;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  z-index: 5;*/
+/*}*/
 
 .search-bar {
   width: 100%;
   height: 38px;
   overflow: hidden;
-  position: relative; }
-  .search-bar .search-bar-options {
-    position: absolute;
-    height: 32px;
-    right: 0;
-    top: 0;
-    margin-top: 1px;
-    margin-right: 1px;
-    border-radius: 0 4px 4px 0;
-    overflow: hidden; }
-    .search-bar .search-bar-options .search-clear-btn {
-      height: inherit;
-      border: none;
-      background-color: transparent;
-      line-height: 30px; }
-    .search-bar .search-bar-options .search-options-btn {
-      height: inherit;
-      border: none;
-      background-color: transparent;
-      line-height: 32px;
-      width: 32px; }
-      .search-bar .search-bar-options .search-options-btn:hover {
-        background-color: #eee; }
-    .search-bar .search-bar-options .hidden {
-      display: none; }
-
-.SettingsItem {
   position: relative;
-  margin-bottom: 16px; }
-  .SettingsItem__summary__organization-title {
-    font-size: 1.6rem;
-    color: #555;
-    padding-bottom: 0;
-    padding-top: 8px; }
-  .SettingsItem__summary__title {
-    font-size: 1.6rem;
-    color: #555;
-    padding-bottom: 0;
-    padding-top: 16px; }
-  .SettingsItem__summary__election-title {
-    font-size: 1.2rem;
-    color: #555;
-    padding-bottom: 0;
-    padding-top: 4px; }
-  .SettingsItem__summary__election-date {
-    font-size: 1rem;
-    color: #ccc;
-    padding-bottom: 16px;
-    padding-top: 4px; }
-  .SettingsItem__summary__item {
-    display: block;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    color: #999;
-    line-height: 1.5rem;
-    position: relative;
-    font-size: 1rem; }
-    .SettingsItem__summary__item__display-name {
-      color: #4371cc;
-      font-size: 1.2rem; }
-      .SettingsItem__summary__item__display-name--selected {
-        color: #000;
-        font-weight: bold;
-        margin-left: 14px; }
-    .SettingsItem__summary__item__subtitle {
-      color: #999;
-      font-size: .8rem; }
-      .SettingsItem__summary__item__subtitle--selected {
-        margin-left: 14px; }
-  .SettingsItem__summary__item-container {
-    align-items: center;
-    margin-bottom: 16px;
-    margin-top: 0;
-    overflow: hidden;
-    position: relative; }
-    .SettingsItem__summary__item-container--selected {
-      border-left: 2px solid #ff4921;
-      margin-left: -16px; }
+}
+
+.search-bar .search-bar-options {
+  position: absolute;
+  height: 32px;
+  right: 0;
+  top: 0;
+  margin-top: 1px;
+  margin-right: 1px;
+  border-radius: 0 4px 4px 0;
+  overflow: hidden;
+}
+
+.search-bar .search-bar-options .search-clear-btn {
+  height: inherit;
+  border: none;
+  background-color: transparent;
+  line-height: 30px;
+}
+
+.search-bar .search-bar-options .search-options-btn {
+  height: inherit;
+  border: none;
+  background-color: transparent;
+  line-height: 32px;
+  width: 32px;
+}
+
+/*.search-bar .search-bar-options .search-options-btn:hover {*/
+/*  background-color: #eee;*/
+/*}*/
+
+/*.search-bar .search-bar-options .hidden {*/
+/*  display: none;*/
+/*}*/
+
+/*.SettingsItem {*/
+/*  position: relative;*/
+/*  margin-bottom: 16px;*/
+/*}*/
+
+/*.SettingsItem__summary__organization-title {*/
+/*  font-size: 1.6rem;*/
+/*  color: #555;*/
+/*  padding-bottom: 0;*/
+/*  padding-top: 8px;*/
+/*}*/
+
+.SettingsItem__summary__title {
+  font-size: 1.6rem;
+  color: #555;
+  padding-bottom: 0;
+  padding-top: 16px;
+}
+
+/*.SettingsItem__summary__election-title {*/
+/*  font-size: 1.2rem;*/
+/*  color: #555;*/
+/*  padding-bottom: 0;*/
+/*  padding-top: 4px;*/
+/*}*/
+
+/*.SettingsItem__summary__election-date {*/
+/*  font-size: 1rem;*/
+/*  color: #ccc;*/
+/*  padding-bottom: 16px;*/
+/*  padding-top: 4px;*/
+/*}*/
+
+.SettingsItem__summary__item {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  color: #999;
+  line-height: 1.5rem;
+  position: relative;
+  font-size: 1rem;
+}
+
+.SettingsItem__summary__item__display-name {
+  color: #4371cc;
+  font-size: 1.2rem;
+}
+
+.SettingsItem__summary__item__display-name--selected {
+  color: #000;
+  font-weight: bold;
+  margin-left: 14px;
+}
+
+.SettingsItem__summary__item__subtitle {
+  color: #999;
+  font-size: .8rem;
+}
+
+.SettingsItem__summary__item__subtitle--selected {
+  margin-left: 14px;
+}
+
+.SettingsItem__summary__item-container {
+  align-items: center;
+  margin-bottom: 16px;
+  margin-top: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.SettingsItem__summary__item-container--selected {
+  border-left: 2px solid #ff4921;
+  margin-left: -16px;
+}
 
 .SettingsCardBottomCordova {
-  padding-bottom: 150px; }
+  padding-bottom: 150px;
+}
 
 .settingsIssues__image {
-  padding-left: 0; }
-  @media all and (max-width: 319px) {
-    .settingsIssues__image {
-      padding-right: 0; } }
+  padding-left: 0;
+}
+
+@media all and (max-width: 319px) {
+  .settingsIssues__image {
+    padding-right: 0;
+  }
+}
 
 .settingsIssues__description {
-  white-space: normal; }
+  white-space: normal;
+}
 
 .nav > li > a {
-  padding: 10px 15px; }
+  padding: 10px 15px;
+}
 
 .nav > li, .nav > li > a {
   position: relative;
-  display: block; }
+  display: block;
+}
 
 a {
-  cursor: pointer; }
+  cursor: pointer;
+}
 
 a {
-  background-color: transparent; }
+  background-color: transparent;
+}
 
 a {
   color: #000;
-  text-decoration: none; }
+  text-decoration: none;
+}
 
-.input-group {
-  position: relative;
-  display: table;
-  border-collapse: separate; }
-  .input-group[class*="col-"] {
-    float: none;
-    padding-left: 0;
-    padding-right: 0; }
-  .input-group .form-control {
-    position: relative;
-    z-index: 2;
-    float: left;
-    width: 100%;
-    margin-bottom: 0; }
-    .input-group .form-control:focus {
-      z-index: 3; }
+/*.input-group {*/
+/*  position: relative;*/
+/*  display: table;*/
+/*  border-collapse: separate;*/
+/*}*/
 
-.input-group-addon,
-.input-group-btn,
-.input-group .form-control {
-  display: table-cell; }
-  .input-group-addon:not(:first-child):not(:last-child),
-  .input-group-btn:not(:first-child):not(:last-child),
-  .input-group .form-control:not(:first-child):not(:last-child) {
-    border-radius: 0; }
+/*.input-group[class*="col-"] {*/
+/*  float: none;*/
+/*  padding-left: 0;*/
+/*  padding-right: 0;*/
+/*}*/
 
-.input-group-addon,
-.input-group-btn {
-  width: 1%;
-  white-space: nowrap;
-  vertical-align: middle; }
+/*.input-group .form-control {*/
+/*  position: relative;*/
+/*  z-index: 2;*/
+/*  float: left;*/
+/*  width: 100%;*/
+/*  margin-bottom: 0;*/
+/*}*/
 
-.input-group-addon {
-  padding: 6px 12px;
-  font-size: 1rem;
-  font-weight: normal;
-  line-height: 1;
-  color: #495057;
-  text-align: center;
-  background-color: #e9ecef;
-  border: 1px solid #ced4da;
-  border-radius: 0.25rem; }
-  .input-group-addon.input-sm {
-    padding: 5px 10px;
-    font-size: 1rem;
-    border-radius: 0.2rem; }
-  .input-group-addon.input-lg {
-    padding: 10px 16px;
-    font-size: 2rem;
-    border-radius: 0.3rem; }
-  .input-group-addon input[type="radio"],
-  .input-group-addon input[type="checkbox"] {
-    margin-top: 0; }
+/*.input-group .form-control:focus {*/
+/*  z-index: 3;*/
+/*}*/
 
-.input-group .form-control:first-child,
-.input-group-addon:first-child,
-.input-group-btn:first-child > .btn,
-.input-group-btn:first-child > .btn-group > .btn,
-.input-group-btn:first-child > .dropdown-toggle,
-.input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle),
-.input-group-btn:last-child > .btn-group:not(:last-child) > .btn {
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0; }
+/*.input-group-addon, .input-group-btn, .input-group .form-control {*/
+/*  display: table-cell;*/
+/*}*/
 
-.input-group-addon:first-child {
-  border-right: 0; }
+/*.input-group-addon:not(:first-child):not(:last-child), .input-group-btn:not(:first-child):not(:last-child), .input-group .form-control:not(:first-child):not(:last-child) {*/
+/*  border-radius: 0;*/
+/*}*/
 
-.input-group .form-control:last-child,
-.input-group-addon:last-child,
-.input-group-btn:last-child > .btn,
-.input-group-btn:last-child > .btn-group > .btn,
-.input-group-btn:last-child > .dropdown-toggle,
-.input-group-btn:first-child > .btn:not(:first-child),
-.input-group-btn:first-child > .btn-group:not(:first-child) > .btn {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0; }
+/*.input-group-addon, .input-group-btn {*/
+/*  width: 1%;*/
+/*  white-space: nowrap;*/
+/*  vertical-align: middle;*/
+/*}*/
 
-.input-group-addon:last-child {
-  border-left: 0; }
+/*.input-group-addon {*/
+/*  padding: 6px 12px;*/
+/*  font-size: 1rem;*/
+/*  font-weight: normal;*/
+/*  line-height: 1;*/
+/*  color: #495057;*/
+/*  text-align: center;*/
+/*  background-color: #e9ecef;*/
+/*  border: 1px solid #ced4da;*/
+/*  border-radius: 0.25rem;*/
+/*}*/
 
-.input-group-btn {
-  position: relative;
-  font-size: 0;
-  white-space: nowrap; }
-  .input-group-btn > .btn {
-    position: relative; }
-    .input-group-btn > .btn + .btn {
-      margin-left: -1px; }
-    .input-group-btn > .btn:hover, .input-group-btn > .btn:focus, .input-group-btn > .btn:active {
-      z-index: 2; }
-  .input-group-btn:first-child > .btn,
-  .input-group-btn:first-child > .btn-group {
-    margin-right: -1px; }
-  .input-group-btn:last-child > .btn,
-  .input-group-btn:last-child > .btn-group {
-    z-index: 2;
-    margin-left: -1px; }
+/*.input-group-addon.input-sm {*/
+/*  padding: 5px 10px;*/
+/*  font-size: 1rem;*/
+/*  border-radius: 0.2rem;*/
+/*}*/
 
-.site-search__button, .site-search__clear {
-  border: none;
-  height: 34px;
-  color: #333;
-  background-color: #fff;
-  border-color: #ccc; }
+/*.input-group-addon.input-lg {*/
+/*  padding: 10px 16px;*/
+/*  font-size: 2rem;*/
+/*  border-radius: 0.3rem;*/
+/*}*/
 
-.candidate-h2 {
-  margin-top: 10px; }
+/*.input-group-addon input[type="radio"], .input-group-addon input[type="checkbox"] {*/
+/*  margin-top: 0;*/
+/*}*/
 
-.center-block {
-  display: block;
-  margin-left: auto;
-  margin-right: auto; }
+/*.input-group .form-control:first-child, .input-group-addon:first-child, .input-group-btn:first-child > .btn, .input-group-btn:first-child > .btn-group > .btn, .input-group-btn:first-child > .dropdown-toggle, .input-group-btn:last-child > .btn:not(:last-child):not(.dropdown-toggle), .input-group-btn:last-child > .btn-group:not(:last-child) > .btn {*/
+/*  border-top-right-radius: 0;*/
+/*  border-bottom-right-radius: 0;*/
+/*}*/
 
-.listFilter,
-.groupedFilter {
+/*.input-group-addon:first-child {*/
+/*  border-right: 0;*/
+/*}*/
+
+/*.input-group .form-control:last-child, .input-group-addon:last-child, .input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-group > .btn, .input-group-btn:last-child > .dropdown-toggle, .input-group-btn:first-child > .btn:not(:first-child), .input-group-btn:first-child > .btn-group:not(:first-child) > .btn {*/
+/*  border-bottom-left-radius: 0;*/
+/*  border-top-left-radius: 0;*/
+/*}*/
+
+/*.input-group-addon:last-child {*/
+/*  border-left: 0;*/
+/*}*/
+
+/*.input-group-btn {*/
+/*  position: relative;*/
+/*  font-size: 0;*/
+/*  white-space: nowrap;*/
+/*}*/
+
+/*.input-group-btn > .btn {*/
+/*  position: relative;*/
+/*}*/
+
+/*.input-group-btn > .btn + .btn {*/
+/*  margin-left: -1px;*/
+/*}*/
+
+/*.input-group-btn > .btn:hover, .input-group-btn > .btn:focus, .input-group-btn > .btn:active {*/
+/*  z-index: 2;*/
+/*}*/
+
+/*.input-group-btn:first-child > .btn, .input-group-btn:first-child > .btn-group {*/
+/*  margin-right: -1px;*/
+/*}*/
+
+/*.input-group-btn:last-child > .btn, .input-group-btn:last-child > .btn-group {*/
+/*  z-index: 2;*/
+/*  margin-left: -1px;*/
+/*}*/
+
+/*.site-search__button, .site-search__clear {*/
+/*  border: none;*/
+/*  height: 34px;*/
+/*  color: #333;*/
+/*  background-color: #fff;*/
+/*  border-color: #ccc;*/
+/*}*/
+
+/*.candidate-h2 {*/
+/*  margin-top: 10px;*/
+/*}*/
+
+/*.center-block {*/
+/*  display: block;*/
+/*  margin-left: auto;*/
+/*  margin-right: auto;*/
+/*}*/
+
+.listFilter, .groupedFilter {
   border: 1px solid #ccc;
   border-radius: 4px;
   margin-right: 1rem;
@@ -11026,146 +14232,190 @@ a {
   height: 26px;
   white-space: nowrap;
   cursor: pointer;
-  transition: background .13s ease-in; }
-  @media all and (max-width: 767px) {
-    .listFilter,
-    .groupedFilter {
-      margin-right: 0.5rem;
-      margin-bottom: 8px;
-      padding: 0 4px; } }
-  .listFilter:active,
-  .groupedFilter:active {
-    background: #89ed9f; }
-  .listFilter__text,
-  .groupedFilter__text {
-    font-size: 1rem;
-    margin: auto 0; }
-    @media all and (max-width: 479px) {
-      .listFilter__text,
-      .groupedFilter__text {
-        font-size: 14px; } }
-    @media all and (min-width: 480px) and (max-width: 767px) {
-      .listFilter__text,
-      .groupedFilter__text {
-        font-size: 16px; } }
-  .listFilter svg,
-  .groupedFilter svg {
-    font-size: 18px;
-    margin: auto 0; }
-    @media all and (max-width: 479px) {
-      .listFilter svg,
-      .groupedFilter svg {
-        font-size: 12px; } }
-    @media all and (min-width: 480px) and (max-width: 767px) {
-      .listFilter svg,
-      .groupedFilter svg {
-        font-size: 16px; } }
+  transition: background .13s ease-in;
+}
+
+@media all and (max-width: 767px) {
+  .listFilter, .groupedFilter {
+    margin-right: 0.5rem;
+    margin-bottom: 8px;
+    padding: 0 4px;
+  }
+}
+
+.listFilter:active, .groupedFilter:active {
+  background: #89ed9f;
+}
+
+.listFilter__text, .groupedFilter__text {
+  font-size: 1rem;
+  margin: auto 0;
+}
+
+@media all and (max-width: 479px) {
+  .listFilter__text, .groupedFilter__text {
+    font-size: 14px;
+  }
+}
+
+@media all and (min-width: 480px) and (max-width: 767px) {
+  .listFilter__text, .groupedFilter__text {
+    font-size: 16px;
+  }
+}
+
+.listFilter svg, .groupedFilter svg {
+  font-size: 18px;
+  margin: auto 0;
+}
+
+@media all and (max-width: 479px) {
+  .listFilter svg, .groupedFilter svg {
+    font-size: 12px;
+  }
+}
+
+@media all and (min-width: 480px) and (max-width: 767px) {
+  .listFilter svg, .groupedFilter svg {
+    font-size: 16px;
+  }
+}
 
 .listFilterSelected {
   background: #1fc06f;
-  color: #fff; }
+  color: #fff;
+}
 
 .groupedFilter {
-  margin-right: 0; }
+  margin-right: 0;
+}
 
 .groupedFilterFirst {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
-  border-right: none; }
+  border-right: none;
+}
 
 .groupedFilterMiddle {
   border-radius: 0;
-  border-right: none; }
+  border-right: none;
+}
 
 .groupedFilterLast {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
-  margin-right: 1rem; }
-  @media all and (max-width: 767px) {
-    .groupedFilterLast {
-      margin-right: 0.5rem; } }
+  margin-right: 1rem;
+}
 
-.ballot-election-list,
-.select-address {
-  font-size: 12px;
-  text-align: inherit; }
-  @media all and (max-width: 959px) {
-    .ballot-election-list,
-    .select-address {
-      width: 100%; } }
-  .ballot-election-list .modal-header,
-  .select-address .modal-header {
-    border-bottom: 1px;
-    padding-bottom: 0; }
-  .ballot-election-list__modal,
-  .select-address__modal {
-    position: absolute;
-    top: 20%;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    overflow: auto;
-    z-index: 1050;
-    background: rgba(43, 43, 43, 0.164); }
-    @media all and (min-width: 320px) and (max-width: 479px) {
-      .ballot-election-list__modal--mobile,
-      .select-address__modal--mobile {
-        top: 0; } }
-    .ballot-election-list__modal--cordova,
-    .select-address__modal--cordova {
-      margin-top: 5vh; }
-  .ballot-election-list__h1,
-  .select-address__h1 {
-    font-size: 30px; }
-    @media all and (max-width: 959px) {
-      .ballot-election-list__h1,
-      .select-address__h1 {
-        font-size: 22px; } }
-    @media all and (min-width: 320px) and (max-width: 479px) {
-      .ballot-election-list__h1,
-      .select-address__h1 {
-        font-size: 20px; } }
-  .ballot-election-list__h2,
-  .select-address__h2 {
-    font-size: 12px; }
-  .ballot-election-list__button,
-  .select-address__button {
-    width: 100%; }
+@media all and (max-width: 767px) {
+  .groupedFilterLast {
+    margin-right: 0.5rem;
+  }
+}
 
-.ballot-election-list__modal {
-  top: 0; }
+/*.ballot-election-list, .select-address {*/
+/*  font-size: 12px;*/
+/*  text-align: inherit;*/
+/*}*/
 
-.ballot-election-list__toggle-link {
-  display: block;
-  font-size: 14px;
-  margin: -4px 0 8px 0; }
+/*@media all and (max-width: 959px) {*/
+/*  .ballot-election-list, .select-address {*/
+/*    width: 100%;*/
+/*  }*/
+/*}*/
 
-.ballot-election-list__prior {
-  margin-top: 50px !important; }
+/*.ballot-election-list .modal-header, .select-address .modal-header {*/
+/*  border-bottom: 1px;*/
+/*  padding-bottom: 0;*/
+/*}*/
 
-.ballot-election-list__show-all {
-  margin-top: 20px !important; }
+/*.ballot-election-list__modal, .select-address__modal {*/
+/*  position: absolute;*/
+/*  top: 20%;*/
+/*  right: 0;*/
+/*  bottom: 0;*/
+/*  left: 0;*/
+/*  overflow: auto;*/
+/*  z-index: 1050;*/
+/*  background: rgba(43, 43, 43, 0.164);*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 479px) {*/
+/*  .ballot-election-list__modal--mobile, .select-address__modal--mobile {*/
+/*    top: 0;*/
+/*  }*/
+/*}*/
+
+/*.ballot-election-list__modal--cordova, .select-address__modal--cordova {*/
+/*  margin-top: 5vh;*/
+/*}*/
+
+/*.ballot-election-list__h1, .select-address__h1 {*/
+/*  font-size: 30px;*/
+/*}*/
+
+/*@media all and (max-width: 959px) {*/
+/*  .ballot-election-list__h1, .select-address__h1 {*/
+/*    font-size: 22px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 479px) {*/
+/*  .ballot-election-list__h1, .select-address__h1 {*/
+/*    font-size: 20px;*/
+/*  }*/
+/*}*/
+
+/*.ballot-election-list__h2, .select-address__h2 {*/
+/*  font-size: 12px;*/
+/*}*/
+
+/*.ballot-election-list__button, .select-address__button {*/
+/*  width: 100%;*/
+/*}*/
+
+/*.ballot-election-list__modal {*/
+/*  top: 0;*/
+/*}*/
+
+/*.ballot-election-list__toggle-link {*/
+/*  display: block;*/
+/*  font-size: 14px;*/
+/*  margin: -4px 0 8px 0;*/
+/*}*/
+
+/*.ballot-election-list__prior {*/
+/*  margin-top: 50px !important;*/
+/*}*/
+
+/*.ballot-election-list__show-all {*/
+/*  margin-top: 20px !important;*/
+/*}*/
 
 .ballot-election-list__upcoming {
-  margin-top: 10px !important; }
+  margin-top: 10px !important;
+}
 
 .modal-backdrop {
-  z-index: 1000; }
+  z-index: 1000;
+}
 
 .header-slide-out-menu-text-left {
   color: #000;
-  font-size: 1.2rem; }
+  font-size: 1.2rem;
+}
 
 .we-vote-promise {
   color: #999;
   font-size: .9em;
-  font-weight: 400; }
+  font-weight: 400;
+}
 
-.terms-and-privacy,
-.terms-and-privacy a {
+.terms-and-privacy, .terms-and-privacy a {
   color: #999;
   font-size: .9em;
-  font-weight: 400; }
+  font-weight: 400;
+}
 
 .page-header {
   border: none;
@@ -11178,88 +14428,136 @@ a {
   justify-content: space-between;
   align-items: center;
   height: 48px;
-  max-width: 960px;}
-  .page-header__ballot {
-    box-shadow: none !important;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.1); }
-  .page-header__container {
-    background-color: #2e3c5d; }
-  /*.page-header__container_ipad {*/
-  /*  background-color: #2e3c5d;*/
-  /*  margin-top: 26px !important; }*/
-  .page-header__container_branding_off {
-    background-color: #333;
-    padding: 8px 0; }
-  .page-header__search {
-    margin: 4px;
-    position: relative;
-    width: 100%; }
-  .page-header__backToButton {
-    background-color: #2e3c5d;
-    color: #fff;
-    margin: 4px; }
-    @media all and (min-width: 320px) and (max-width: 575px) {
-      .page-header__backToButton {
-        font-size: 0.8rem !important; } }
-  .page-header__back-to-ballot {
-    height: 96px; }
-  .page-header__back-to-ballot-cordova {
-    height: 71px; }
-  .page-header__backToButtonIPhoneX {
-    margin-top: 4px; }
-  .page-header__cordova {
-    margin: 0 15px 0 15px;
-    padding-bottom: 4px;
-    padding-left: 0;
-    padding-right: 5px; }
-  .page-header__cordova-iphonex {
-    margin: 0;
-    padding-bottom: 4px;
-    padding-top: 0 !important; }
-  .page-header__voter-guide-creator {
-    height: 108px;}
+  max-width: 960px;
+}
+
+.page-header__ballot {
+  box-shadow: none !important;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+.page-header__container {
+  background-color: #2e3c5d;
+}
+
+/*!*.page-header__container_ipad {*!*/
+/*!*  background-color: #2e3c5d;*!*/
+/*!*  margin-top: 26px !important; }*!*/
+/*.page-header__container_branding_off {*/
+/*  background-color: #333;*/
+/*  padding: 8px 0;*/
+/*}*/
+
+/*.page-header__search {*/
+/*  margin: 4px;*/
+/*  position: relative;*/
+/*  width: 100%;*/
+/*}*/
+
+/*.page-header__backToButton {*/
+/*  background-color: #2e3c5d;*/
+/*  color: #fff;*/
+/*  margin: 4px;*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 575px) {*/
+/*  .page-header__backToButton {*/
+/*    font-size: 0.8rem !important;*/
+/*  }*/
+/*}*/
+
+/*.page-header__back-to-ballot {*/
+/*  height: 96px;*/
+/*}*/
+
+/*.page-header__back-to-ballot-cordova {*/
+/*  height: 71px;*/
+/*}*/
+
+/*.page-header__backToButtonIPhoneX {*/
+/*  margin-top: 4px;*/
+/*}*/
+
+/*.page-header__cordova {*/
+/*  margin: 0 15px 0 15px;*/
+/*  padding-bottom: 4px;*/
+/*  padding-left: 0;*/
+/*  padding-right: 5px;*/
+/*}*/
+
+/*.page-header__cordova-iphonex {*/
+/*  margin: 0;*/
+/*  padding-bottom: 4px;*/
+/*  padding-top: 0 !important;*/
+/*}*/
+
+.page-header__voter-guide-creator {
+  height: 108px;
+}
+
+.header-toolbar {
+  width: 100%;
+  max-width: 960px;
+}
+
+@media all and (min-width: 576px) {
   .header-toolbar {
-    width: 100%;
-    max-width: 960px;}
-  @media all and (min-width: 576px) {
-    .header-toolbar {
-      padding-left: 15px;
-      padding-right: 10px; } }
+    padding-left: 15px;
+    padding-right: 10px;
+  }
+}
 
 .header-backto-toolbar {
-  justify-content: space-between; }
+  justify-content: space-between;
+}
 
 .header-logo-img {
   max-width: 132px;
-  max-height: 42px; }
-  @media all and (min-width: 320px) and (max-width: 479px) {
-    .header-logo-img {
-      max-width: 110px;
-      max-height: 36px; } }
-  @media all and (max-width: 319px) {
-    .header-logo-img {
-      max-width: 100px;
-      max-height: 32px; } }
+  max-height: 42px;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
+  .header-logo-img {
+    max-width: 110px;
+    max-height: 36px;
+  }
+}
+
+@media all and (max-width: 319px) {
+  .header-logo-img {
+    max-width: 100px;
+    max-height: 32px;
+  }
+}
 
 .header-link {
   color: inherit;
-  text-decoration: none; }
-  .header-link:hover {
-    color: inherit;
-    text-decoration: none; }
+  text-decoration: none;
+}
+
+.header-link:hover {
+  color: inherit;
+  text-decoration: none;
+}
 
 .header-sign-in {
-  color: #2e3c5d; }
-  @media all and (min-width: 320px) and (max-width: 575px) {
-    .header-sign-in {
-      font-size: 0.8rem !important; } }
+  color: #2e3c5d;
+}
+
+@media all and (min-width: 320px) and (max-width: 575px) {
+  .header-sign-in {
+    font-size: 0.8rem !important;
+  }
+}
 
 .search-cordova {
-  width: 100%; }
+  width: 100%;
+}
 
 .search-cordova-iphonex {
   width: 100%;
-  padding-top: 35px; }
+  padding-top: 35px;
+}
 
 /*.ios-no-notch-spacer {*/
 /*  top: 0;*/
@@ -11269,7 +14567,6 @@ a {
 /*  width: 100%;*/
 /*  opacity: 1;*/
 /*  z-index: 3; }*/
-
 /*.ios-notched-spacer {*/
 /*  top: 0;*/
 /*  position: fixed;*/
@@ -11278,7 +14575,6 @@ a {
 /*  width: 100%;*/
 /*  opacity: 1;*/
 /*  z-index: 1300; }*/
-
 .page-secondary-nav-header {
   border: none;
   padding: 0;
@@ -11286,114 +14582,173 @@ a {
   position: relative;
   display: flex;
   align-items: center;
-  justify-content: center; }
-  .page-secondary-nav-header::before, .page-secondary-nav-header::after {
-    content: ' ';
-    display: table; }
-  .page-secondary-nav-header::after {
-    clear: both; }
-  @media all and (min-width: 768px) {
-    .page-secondary-nav-header {
-      padding-right: 15px;
-      padding-left: 15px; } }
+  justify-content: center;
+}
+
+.page-secondary-nav-header::before, .page-secondary-nav-header::after {
+  content: ' ';
+  display: table;
+}
+
+.page-secondary-nav-header::after {
+  clear: both;
+}
+
+@media all and (min-width: 768px) {
+  .page-secondary-nav-header {
+    padding-right: 15px;
+    padding-left: 15px;
+  }
+}
 
 .page-secondary-nav-header-background {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
-  background-color: #fff; }
+  background-color: #fff;
+}
 
 .page-logo {
-  width: 45px; }
-  @media all and (min-width: 576px) {
-    .page-logo {
-      width: 120px; } }
+  width: 45px;
+}
+
+@media all and (min-width: 576px) {
+  .page-logo {
+    width: 120px;
+  }
+}
 
 .page-logo > .beta-marker {
-  position: relative; }
+  position: relative;
+}
 
-.page-logo > .beta-marker > .beta-marker-inner {
-  position: absolute;
-  font-size: 10px;
-  color: #2e3c5d;
-  text-transform: capitalize; }
+/*.page-logo > .beta-marker > .beta-marker-inner {*/
+/*  position: absolute;*/
+/*  font-size: 10px;*/
+/*  color: #2e3c5d;*/
+/*  text-transform: capitalize;*/
+/*}*/
 
-.page-logo-full-size > .beta-marker > .beta-marker-inner {
-  right: 0;
-  top: 18px; }
+/*.page-logo-full-size > .beta-marker > .beta-marker-inner {*/
+/*  right: 0;*/
+/*  top: 18px;*/
+/*}*/
 
-.page-logo-short > .beta-marker > .beta-marker-inner {
-  right: -10px;
-  top: 24px; }
+/*.page-logo-short > .beta-marker > .beta-marker-inner {*/
+/*  right: -10px;*/
+/*  top: 24px;*/
+/*}*/
 
-.site-search {
-  padding: 0 16px; }
-  .site-search__input-field {
-    border: none; }
-  .site-search__button, .site-search__clear {
-    border: none;
-    height: 34px; }
-    .site-search__button__hidden, .site-search__clear__hidden {
-      display: none; }
-  .site-search__input-field::placeholder {
-    opacity: 0; }
-    @media all and (min-width: 480px) {
-      .site-search__input-field::placeholder {
-        opacity: 1; } }
+/*.site-search {*/
+/*  padding: 0 16px;*/
+/*}*/
 
-.search-container {
-  background-color: #fff;
-  box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.2);
-  margin: 0 16px;
-  position: absolute;
-  top: 36px;
-  right: 0;
+/*.site-search__input-field {*/
+/*  border: none;*/
+/*}*/
+
+/*.site-search__button, .site-search__clear {*/
+/*  border: none;*/
+/*  height: 34px;*/
+/*}*/
+
+/*.site-search__button__hidden, .site-search__clear__hidden {*/
+/*  display: none;*/
+/*}*/
+
+/*.site-search__input-field::placeholder {*/
+/*  opacity: 0;*/
+/*}*/
+
+/*@media all and (min-width: 480px) {*/
+/*  .site-search__input-field::placeholder {*/
+/*    opacity: 1;*/
+/*  }*/
+/*}*/
+
+/*.search-container {*/
+/*  background-color: #fff;*/
+/*  box-shadow: 5px 5px 10px rgba(0, 0, 0, 0.2);*/
+/*  margin: 0 16px;*/
+/*  position: absolute;*/
+/*  top: 36px;*/
+/*  right: 0;*/
+/*  left: 0;*/
+/*  min-width: 80%;*/
+/*  z-index: 1;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .search-container {*/
+/*    left: -86px;*/
+/*    width: 100vw;*/
+/*  }*/
+/*}*/
+
+/*.search-container__hidden {*/
+/*  display: none !important;*/
+/*}*/
+
+/*.search-container__results {*/
+/*  background-color: #fff;*/
+/*  padding: 16px;*/
+/*  display: flex;*/
+/*  font-size: 1rem;*/
+/*  align-items: center;*/
+/*}*/
+
+/*.search-container__results--highlighted {*/
+/*  background-color: #d9edf7;*/
+/*}*/
+
+/*.search-container__links {*/
+/*  display: block;*/
+/*  font-size: 1.25rem;*/
+/*}*/
+
+/*.search-container__links:hover {*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.search-container__election_results {*/
+/*  background-color: #fff;*/
+/*  padding: 16px;*/
+/*  font-size: 1rem;*/
+/*}*/
+
+/*.search-container__election_results--highlighted {*/
+/*  background-color: #d9edf7;*/
+/*}*/
+
+/*.search-container__election-details {*/
+/*  text-align: right;*/
+/*}*/
+
+/*.search-container__election-type {*/
+/*  font-size: 14px;*/
+/*  color: #999;*/
+/*}*/
+
+.search-container--cordova {
   left: 0;
-  min-width: 80%;
-  z-index: 1; }
-  @media all and (max-width: 479px) {
-    .search-container {
-      left: -86px;
-      width: 100vw; } }
-  .search-container__hidden {
-    display: none !important; }
-  .search-container__results {
-    background-color: #fff;
-    padding: 16px;
-    display: flex;
-    font-size: 1rem;
-    align-items: center; }
-    .search-container__results--highlighted {
-      background-color: #d9edf7; }
-  .search-container__links {
-    display: block;
-    font-size: 1.25rem; }
-    .search-container__links:hover {
-      text-decoration: none; }
-  .search-container__election_results {
-    background-color: #fff;
-    padding: 16px;
-    font-size: 1rem; }
-    .search-container__election_results--highlighted {
-      background-color: #d9edf7; }
-  .search-container__election-details {
-    text-align: right; }
-  .search-container__election-type {
-    font-size: 14px;
-    color: #999; }
-  .search-container--cordova {
-    left: 0;
-    width: auto; }
+  width: auto;
+}
 
 .search-image {
   display: inline-block;
   width: 30px;
   font-size: 30px;
   margin-right: 16px;
-  height: 30px; }
-  .search-image__filler {
-    padding: 0 16px; }
-  @media all and (max-width: 694px) {
-    .search-image {
-      display: none; } }
+  height: 30px;
+}
+
+.search-image__filler {
+  padding: 0 16px;
+}
+
+@media all and (max-width: 694px) {
+  .search-image {
+    display: none;
+  }
+}
 
 .headroom {
   position: fixed;
@@ -11412,7 +14767,8 @@ a {
 }
 
 .headroom--unpinned {
-  transform: translateY(-120%) !important; }
+  transform: translateY(-120%) !important;
+}
 
 .footer-container {
   background: #fff;
@@ -11421,434 +14777,657 @@ a {
   box-shadow: 0 -4px 4px -1px rgba(0, 0, 0, 0.2), 0 -4px 5px 0 rgba(0, 0, 0, 0.14), 0 -1px 10px 0 rgba(0, 0, 0, 0.12);
   padding-bottom: env(safe-area-inset-bottom);
   position: fixed;
-  width: 100%; }
-
-.footer-icon {
-  font-size: 24px; }
-
-.pageFooter {
-  background-color: #2e3c5d;
-  border-top: 1px solid #ccc;
-  color: #fff;
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  height: 54px;
-  width: 100%; }
-  .pageFooter__iosNotch {
-    height: 65px; }
-
-.footerNav {
-  display: flex;
-  align-items: flex-start;
-  position: relative;
-  flex-direction: row;
-  justify-content: space-between;
-  margin-right: 16px;
-  margin-left: 16px; }
-  .footerNav .badge-total {
-    position: absolute;
-    background-color: #db4437;
-    top: 0;
-    right: 0; }
-    .footerNav .badge-total--overLimit {
-      right: -.5em; }
-
-.keyboard-open .has-footer {
-  bottom: 0; }
-
-.intro-modal {
-  padding: 0;
-  height: 100%;
   width: 100%;
-  color: #fff;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  /* stylelint-disable selector-max-type */
-  /* stylelint-enable */ }
-  .intro-modal__h1 {
-    font-weight: 400;
-    font-size: 30px;
-    padding: 16px 0 8px; }
-    @media all and (min-width: 480px) and (max-width: 767px) {
-      .intro-modal__h1 {
-        font-size: 24px; } }
-    @media all and (max-width: 479px) {
-      .intro-modal__h1 {
-        font-size: 18px; } }
-  .intro-modal__h1--alt {
-    font-weight: 700;
-    font-size: 30px;
-    padding-top: 32px; }
-    @media all and (max-width: 767px) {
-      .intro-modal__h1--alt {
-        font-size: 16px; } }
-  .intro-modal__h2 {
-    font-size: 20px; }
-    @media all and (max-width: 767px) {
-      .intro-modal__h2 {
-        font-size: 16px; } }
-  .intro-modal__responsive-height, .intro-modal__description-text {
-    min-height: 100px; }
-    @media all and (min-width: 480px) and (max-width: 767px) {
-      .intro-modal__responsive-height, .intro-modal__description-text {
-        min-height: 120px; } }
-  .intro-modal__height-full {
-    height: 100%; }
-  .intro-modal__close {
-    position: relative;
-    width: 100%; }
-  .intro-modal__close-anchor {
-    position: absolute;
-    top: 0;
-    right: 0;
-    width: 48px;
-    z-index: 9999;
-    /* stylelint-disable selector-max-type */
-    /* stylelint-enable */ }
-    @media all and (max-width: 479px) {
-      .intro-modal__close-anchor {
-        width: 28px; } }
-    .intro-modal__close-anchor img {
-      padding: 0 0 16px 27.2px; }
-      @media all and (max-width: 479px) {
-        .intro-modal__close-anchor img {
-          padding: 0 0 8px 12px; } }
-  .intro-modal__close-anchor-iphonex {
-    top: 20px; }
-  .intro-modal__small {
-    font-size: 12px;
-    margin: 0; }
-  .intro-modal__p, .intro-modal__description-text {
-    font-size: 14px; }
-  .intro-modal__position-wrap {
-    min-height: 200px;
-    display: flex;
-    flex: 0 0 100%;
-    justify-content: flex-end;
-    align-items: center;
-    flex-direction: column; }
-  .intro-modal__position-img {
-    width: 85%;
-    max-width: 256px; }
-  .intro-modal__position-description-wrap {
-    justify-content: space-between;
-    display: flex;
-    padding-top: 16px; }
-    .intro-modal__position-description-wrap .intro-modal__p:first-child, .intro-modal__position-description-wrap .intro-modal__description-text:first-child {
-      flex: 0 1 45%; }
-    .intro-modal__position-description-wrap .intro-modal__p:last-child, .intro-modal__position-description-wrap .intro-modal__description-text:last-child {
-      flex: 0 1 35%; }
-  .intro-modal__button {
-    margin-bottom: 32px;
-    width: 80%; }
-  .intro-modal__button-wrap {
-    width: 100%;
-    margin-bottom: 32px; }
-  .intro-modal__span {
-    white-space: nowrap;
-    overflow: hidden; }
-    @media all and (max-width: 479px) {
-      .intro-modal__span {
-        text-align: start; } }
-  .intro-modal__top-description {
-    font-size: 20px;
-    padding-bottom: 16px; }
-    @media all and (min-width: 480px) and (max-width: 767px) {
-      .intro-modal__top-description {
-        font-size: 18px;
-        padding-bottom: 8px; } }
-    @media all and (max-width: 479px) {
-      .intro-modal__top-description {
-        font-size: 14px;
-        padding-bottom: 8px; } }
-  .intro-modal__margin-right {
-    margin-right: 8px; }
-  @media all and (max-width: 479px) {
-    .intro-modal__hide-sm {
-      display: none; } }
-  .intro-modal__white-space {
-    white-space: normal; }
-  .intro-modal__ellipsis {
-    text-overflow: ellipsis;
-    overflow: hidden; }
-  .intro-modal__padding {
-    padding: 16px; }
-    @media all and (max-width: 959px) {
-      .intro-modal__padding {
-        padding-top: 16px;
-        padding-bottom: 16px; } }
-  .intro-modal__padding-top, .intro-modal__description-text {
-    padding-top: 16px; }
-  .intro-modal__padding--btm {
-    padding-bottom: 32px; }
-  .intro-modal__padding-btn {
-    padding-top: 32px;
-    padding-bottom: 32px; }
-    @media all and (max-width: 959px) {
-      .intro-modal__padding-btn {
-        padding-top: 32px;
-        padding-bottom: 16px; } }
-  .intro-modal__btn-center {
-    text-align: center;
-    position: absolute;
-    top: 50%; }
-  .intro-modal__img-height {
-    height: 200px; }
-    @media all and (max-width: 479px) {
-      .intro-modal__img-height {
-        height: 165px; } }
-  .intro-modal__img-height--extra {
-    height: 225px; }
-    @media all and (max-width: 479px) {
-      .intro-modal__img-height--extra {
-        height: 175px; } }
-  .intro-modal__img-width {
-    width: 250px; }
-    @media all and (max-width: 479px) {
-      .intro-modal__img-width {
-        width: 200px; } }
-  @media all and (min-width: 320px) {
-    .intro-modal__background {
-      height: 100vh;
-      width: 100vw;
-      background-size: cover; } }
-  @media all and (min-width: 960px) {
-    .intro-modal__background {
-      height: 300px;
-      width: 100%;
-      float: left; } }
-  .intro-modal__menu-right {
-    font-size: 2.5em;
-    z-index: 3;
-    top: 45%;
-    right: 0;
-    position: absolute; }
-    @media all and (max-width: 479px) {
-      .intro-modal__menu-right {
-        display: none; } }
-  .intro-modal__menu-left {
-    font-size: 2.5em;
-    z-index: 3;
-    top: 45%;
-    left: 0;
-    position: absolute; }
-    @media all and (max-width: 479px) {
-      .intro-modal__menu-left {
-        display: none; } }
-  .intro-modal__footer {
-    position: absolute;
-    bottom: 20%;
-    width: 100%; }
-    @media all and (min-width: 480px) {
-      .intro-modal__footer {
-        bottom: 10%; } }
-  .intro-modal__text-dark {
-    color: #333; }
-  .intro-modal__gray-dots li button::before {
-    color: #999;
-    font-size: 12px;
-    content: "•";
-    opacity: .5; }
-  .intro-modal__gray-dots li.slick-active button::before {
-    color: #2e3c5d;
-    opacity: 1;
-    content: "•"; }
-  .intro-modal__default-text {
-    width: 100%;
-    color: #000;
-    padding: 16px;
-    text-align: center; }
-  .intro-modal__grid {
-    padding: 0 16px; }
-  .intro-modal__square {
-    position: relative;
-    padding: 2px; }
-    .intro-modal__square__sidebar {
-      padding: 0;
-      text-align: center; }
-  .intro-modal__square-image {
-    height: 100%;
-    width: 100%;
-    border-radius: 8px; }
-  .intro-modal__square-details {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    color: #ccc; }
-  .intro-modal__square-following {
-    filter: brightness(60%); }
-  .intro-modal__square-check-mark {
-    position: absolute;
-    top: 0;
-    left: 0;
-    transform: scale(0.5); }
-  .intro-modal__square-name {
-    display: flex;
-    flex-flow: column;
-    text-align: center;
-    position: absolute;
-    left: 2px;
-    bottom: -6px;
-    font-size: .9rem;
-    font-weight: 400;
-    word-wrap: break-word;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6);
-    background: rgba(0, 0, 0, 0.45);
-    padding: 4px;
-    width: 100%;
-    height: 100%;
-    border-radius: 8px;
-    border: 2px solid white;
-    justify-content: flex-end;
-    transition: all .2s ease-in; }
-    .intro-modal__square-name:hover {
-      border: 2px solid #2e3c5d;
-      background: rgba(0, 0, 0, 0.55); }
-    @media all and (min-width: 480px) and (max-width: 575px) {
-      .intro-modal__square-name {
-        padding: 8px; } }
-    @media all and (min-width: 375px) and (max-width: 479px) {
-      .intro-modal__square-name {
-        -webkit-hyphens: auto;
-        -moz-hyphens: auto;
-        -ms-hyphens: auto;
-        hyphens: auto; } }
-    @media all and (max-width: 374px) {
-      .intro-modal__square-name {
-        font-size: .85rem;
-        -webkit-hyphens: auto;
-        -moz-hyphens: auto;
-        -ms-hyphens: auto;
-        hyphens: auto; } }
-  .intro-modal__following {
-    background: transparent;
-    font-weight: bold;
-    color: #999;
-    text-shadow: -1px 0 #fff, 0 1px #fff, 1px 0 #fff, 0 -1px #fff; }
-    .intro-modal__following:hover {
-      border: 2px solid transparent;
-      background: rgba(0, 0, 0, 0.1); }
-  .intro-modal__details {
-    position: absolute;
-    top: 12px;
-    right: 12px; }
-    @media all and (min-width: 576px) and (max-width: 767px) {
-      .intro-modal__details {
-        top: 10px;
-        right: 10px; } }
-    @media all and (min-width: 375px) and (max-width: 479px) {
-      .intro-modal__details {
-        top: 10px;
-        right: 10px; } }
-    @media all and (max-width: 374px) {
-      .intro-modal__details {
-        top: 8px;
-        right: 8px; } }
-  .intro-modal__address-box {
-    align-self: center;
-    width: 80%; }
+}
 
-.intro-modal-shadow-wrap {
-  flex-basis: 0; }
+/*.footer-icon {*/
+/*  font-size: 24px;*/
+/*}*/
 
-.intro-modal-shadow {
-  position: relative;
-  top: -25px;
-  height: 25px;
-  width: 100%;
-  background: linear-gradient(to bottom, transparent 1%, #fff 100%); }
+/*.pageFooter {*/
+/*  background-color: #2e3c5d;*/
+/*  border-top: 1px solid #ccc;*/
+/*  color: #fff;*/
+/*  position: fixed;*/
+/*  left: 0;*/
+/*  bottom: 0;*/
+/*  height: 54px;*/
+/*  width: 100%;*/
+/*}*/
 
-.intro-modal-vertical-scroll {
-  border-radius: 4px 4px 4px 4px;
-  -webkit-column-count: 1;
-  -moz-column-count: 1;
-  column-count: 1;
-  -webkit-column-gap: 0;
-  -moz-column-gap: 0;
-  column-gap: 0; }
-  .intro-modal-vertical-scroll .card-main:hover {
-    cursor: pointer;
-    background: #29b6f6; }
-    .intro-modal-vertical-scroll .card-main:hover .card-main__candidate-name,
-    .intro-modal-vertical-scroll .card-main:hover .intro-modal__small {
-      color: #f8f8f8; }
+/*.pageFooter__iosNotch {*/
+/*  height: 65px;*/
+/*}*/
 
-.intro-modal-vertical-scroll.card {
-  margin-bottom: 0;
-  padding: 2px 2px 0 0; }
+/*.footerNav {*/
+/*  display: flex;*/
+/*  align-items: flex-start;*/
+/*  position: relative;*/
+/*  flex-direction: row;*/
+/*  justify-content: space-between;*/
+/*  margin-right: 16px;*/
+/*  margin-left: 16px;*/
+/*}*/
 
-.child-height-full > :first-child {
-  height: 100%; }
-  .child-height-full > :first-child > :first-child {
-    height: 100%; }
+/*.footerNav .badge-total {*/
+/*  position: absolute;*/
+/*  background-color: #db4437;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*}*/
 
-.intro-modal-vertical-scroll-contain_without_slider {
-  height: calc(100vh - 100px);
-  max-height: 540px;
-  overflow-y: auto;
-  -webkit-overflow-scrolling: auto;
-  overflow-x: hidden; }
+/*.footerNav .badge-total--overLimit {*/
+/*  right: -.5em;*/
+/*}*/
 
-.intro-modal-vertical-scroll-contain-wrap {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1; }
+/*.keyboard-open .has-footer {*/
+/*  bottom: 0;*/
+/*}*/
 
-.intro-modal-vertical-scroll-contain {
-  overflow-y: auto;
-  -webkit-overflow-scrolling: auto;
-  overflow-x: hidden; }
+/*.intro-modal {*/
+/*  padding: 0;*/
+/*  height: 100%;*/
+/*  width: 100%;*/
+/*  color: #fff;*/
+/*  text-align: center;*/
+/*  display: flex;*/
+/*  flex-direction: column;*/
+/*  justify-content: flex-start;*/
+/*  !* stylelint-disable selector-max-type *!*/
+/*  !* stylelint-enable *!*/
+/*}*/
 
-.x-close {
-  position: absolute;
-  height: 25px;
-  width: 25px;
-  top: 10px;
-  right: 10px;
-  z-index: 2;
-  color: #fff; }
-  .x-close__black {
-    -webkit-filter: invert(100%); }
-  .x-close__cordova {
-    top: 30px;
-    right: 14px; }
-  @media all and (min-width: 320px) and (max-width: 479px) {
-    .x-close {
-      height: 30px;
-      width: 30px;
-      padding: 4px; } }
+/*.intro-modal__h1 {*/
+/*  font-weight: 400;*/
+/*  font-size: 30px;*/
+/*  padding: 16px 0 8px;*/
+/*}*/
 
-.story-view .container-main {
-  margin: 0;
-  min-height: 100%;
-  padding: 0; }
+/*@media all and (min-width: 480px) and (max-width: 767px) {*/
+/*  .intro-modal__h1 {*/
+/*    font-size: 24px;*/
+/*  }*/
+/*}*/
 
-.story-view .well {
-  margin-bottom: 0;
-  border: none; }
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__h1 {*/
+/*    font-size: 18px;*/
+/*  }*/
+/*}*/
 
-.slick-dots {
-  top: 83vh;
-  content: "•";
-  height: 0; }
+/*.intro-modal__h1--alt {*/
+/*  font-weight: 700;*/
+/*  font-size: 30px;*/
+/*  padding-top: 32px;*/
+/*}*/
 
-.facebook-intro-connect,
-.twitter-intro-connect {
+/*@media all and (max-width: 767px) {*/
+/*  .intro-modal__h1--alt {*/
+/*    font-size: 16px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__h2 {*/
+/*  font-size: 20px;*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .intro-modal__h2 {*/
+/*    font-size: 16px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__responsive-height, .intro-modal__description-text {*/
+/*  min-height: 100px;*/
+/*}*/
+
+/*@media all and (min-width: 480px) and (max-width: 767px) {*/
+/*  .intro-modal__responsive-height, .intro-modal__description-text {*/
+/*    min-height: 120px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__height-full {*/
+/*  height: 100%;*/
+/*}*/
+
+/*.intro-modal__close {*/
+/*  position: relative;*/
+/*  width: 100%;*/
+/*}*/
+
+/*.intro-modal__close-anchor {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  width: 48px;*/
+/*  z-index: 9999;*/
+/*  !* stylelint-disable selector-max-type *!*/
+/*  !* stylelint-enable *!*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__close-anchor {*/
+/*    width: 28px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__close-anchor img {*/
+/*  padding: 0 0 16px 27.2px;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__close-anchor img {*/
+/*    padding: 0 0 8px 12px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__close-anchor-iphonex {*/
+/*  top: 20px;*/
+/*}*/
+
+/*.intro-modal__small {*/
+/*  font-size: 12px;*/
+/*  margin: 0;*/
+/*}*/
+
+/*.intro-modal__p, .intro-modal__description-text {*/
+/*  font-size: 14px;*/
+/*}*/
+
+/*.intro-modal__position-wrap {*/
+/*  min-height: 200px;*/
+/*  display: flex;*/
+/*  flex: 0 0 100%;*/
+/*  justify-content: flex-end;*/
+/*  align-items: center;*/
+/*  flex-direction: column;*/
+/*}*/
+
+/*.intro-modal__position-img {*/
+/*  width: 85%;*/
+/*  max-width: 256px;*/
+/*}*/
+
+/*.intro-modal__position-description-wrap {*/
+/*  justify-content: space-between;*/
+/*  display: flex;*/
+/*  padding-top: 16px;*/
+/*}*/
+
+/*.intro-modal__position-description-wrap .intro-modal__p:first-child, .intro-modal__position-description-wrap .intro-modal__description-text:first-child {*/
+/*  flex: 0 1 45%;*/
+/*}*/
+
+/*.intro-modal__position-description-wrap .intro-modal__p:last-child, .intro-modal__position-description-wrap .intro-modal__description-text:last-child {*/
+/*  flex: 0 1 35%;*/
+/*}*/
+
+/*.intro-modal__button {*/
+/*  margin-bottom: 32px;*/
+/*  width: 80%;*/
+/*}*/
+
+/*.intro-modal__button-wrap {*/
+/*  width: 100%;*/
+/*  margin-bottom: 32px;*/
+/*}*/
+
+/*.intro-modal__span {*/
+/*  white-space: nowrap;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__span {*/
+/*    text-align: start;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__top-description {*/
+/*  font-size: 20px;*/
+/*  padding-bottom: 16px;*/
+/*}*/
+
+/*@media all and (min-width: 480px) and (max-width: 767px) {*/
+/*  .intro-modal__top-description {*/
+/*    font-size: 18px;*/
+/*    padding-bottom: 8px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__top-description {*/
+/*    font-size: 14px;*/
+/*    padding-bottom: 8px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__margin-right {*/
+/*  margin-right: 8px;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__hide-sm {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__white-space {*/
+/*  white-space: normal;*/
+/*}*/
+
+/*.intro-modal__ellipsis {*/
+/*  text-overflow: ellipsis;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*.intro-modal__padding {*/
+/*  padding: 16px;*/
+/*}*/
+
+/*@media all and (max-width: 959px) {*/
+/*  .intro-modal__padding {*/
+/*    padding-top: 16px;*/
+/*    padding-bottom: 16px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__padding-top, .intro-modal__description-text {*/
+/*  padding-top: 16px;*/
+/*}*/
+
+/*.intro-modal__padding--btm {*/
+/*  padding-bottom: 32px;*/
+/*}*/
+
+/*.intro-modal__padding-btn {*/
+/*  padding-top: 32px;*/
+/*  padding-bottom: 32px;*/
+/*}*/
+
+/*@media all and (max-width: 959px) {*/
+/*  .intro-modal__padding-btn {*/
+/*    padding-top: 32px;*/
+/*    padding-bottom: 16px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__btn-center {*/
+/*  text-align: center;*/
+/*  position: absolute;*/
+/*  top: 50%;*/
+/*}*/
+
+/*.intro-modal__img-height {*/
+/*  height: 200px;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__img-height {*/
+/*    height: 165px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__img-height--extra {*/
+/*  height: 225px;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__img-height--extra {*/
+/*    height: 175px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__img-width {*/
+/*  width: 250px;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__img-width {*/
+/*    width: 200px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (min-width: 320px) {*/
+/*  .intro-modal__background {*/
+/*    height: 100vh;*/
+/*    width: 100vw;*/
+/*    background-size: cover;*/
+/*  }*/
+/*}*/
+
+/*@media all and (min-width: 960px) {*/
+/*  .intro-modal__background {*/
+/*    height: 300px;*/
+/*    width: 100%;*/
+/*    float: left;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__menu-right {*/
+/*  font-size: 2.5em;*/
+/*  z-index: 3;*/
+/*  top: 45%;*/
+/*  right: 0;*/
+/*  position: absolute;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__menu-right {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__menu-left {*/
+/*  font-size: 2.5em;*/
+/*  z-index: 3;*/
+/*  top: 45%;*/
+/*  left: 0;*/
+/*  position: absolute;*/
+/*}*/
+
+/*@media all and (max-width: 479px) {*/
+/*  .intro-modal__menu-left {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__footer {*/
+/*  position: absolute;*/
+/*  bottom: 20%;*/
+/*  width: 100%;*/
+/*}*/
+
+/*@media all and (min-width: 480px) {*/
+/*  .intro-modal__footer {*/
+/*    bottom: 10%;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__text-dark {*/
+/*  color: #333;*/
+/*}*/
+
+/*.intro-modal__gray-dots li button::before {*/
+/*  color: #999;*/
+/*  font-size: 12px;*/
+/*  content: "•";*/
+/*  opacity: .5;*/
+/*}*/
+
+/*.intro-modal__gray-dots li.slick-active button::before {*/
+/*  color: #2e3c5d;*/
+/*  opacity: 1;*/
+/*  content: "•";*/
+/*}*/
+
+/*.intro-modal__default-text {*/
+/*  width: 100%;*/
+/*  color: #000;*/
+/*  padding: 16px;*/
+/*  text-align: center;*/
+/*}*/
+
+/*.intro-modal__grid {*/
+/*  padding: 0 16px;*/
+/*}*/
+
+/*.intro-modal__square {*/
+/*  position: relative;*/
+/*  padding: 2px;*/
+/*}*/
+
+/*.intro-modal__square__sidebar {*/
+/*  padding: 0;*/
+/*  text-align: center;*/
+/*}*/
+
+/*.intro-modal__square-image {*/
+/*  height: 100%;*/
+/*  width: 100%;*/
+/*  border-radius: 8px;*/
+/*}*/
+
+/*.intro-modal__square-details {*/
+/*  position: absolute;*/
+/*  top: 10px;*/
+/*  right: 10px;*/
+/*  color: #ccc;*/
+/*}*/
+
+/*.intro-modal__square-following {*/
+/*  filter: brightness(60%);*/
+/*}*/
+
+/*.intro-modal__square-check-mark {*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  left: 0;*/
+/*  transform: scale(0.5);*/
+/*}*/
+
+/*.intro-modal__square-name {*/
+/*  display: flex;*/
+/*  flex-flow: column;*/
+/*  text-align: center;*/
+/*  position: absolute;*/
+/*  left: 2px;*/
+/*  bottom: -6px;*/
+/*  font-size: .9rem;*/
+/*  font-weight: 400;*/
+/*  word-wrap: break-word;*/
+/*  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6);*/
+/*  background: rgba(0, 0, 0, 0.45);*/
+/*  padding: 4px;*/
+/*  width: 100%;*/
+/*  height: 100%;*/
+/*  border-radius: 8px;*/
+/*  border: 2px solid white;*/
+/*  justify-content: flex-end;*/
+/*  transition: all .2s ease-in;*/
+/*}*/
+
+/*.intro-modal__square-name:hover {*/
+/*  border: 2px solid #2e3c5d;*/
+/*  background: rgba(0, 0, 0, 0.55);*/
+/*}*/
+
+/*@media all and (min-width: 480px) and (max-width: 575px) {*/
+/*  .intro-modal__square-name {*/
+/*    padding: 8px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (min-width: 375px) and (max-width: 479px) {*/
+/*  .intro-modal__square-name {*/
+/*    -webkit-hyphens: auto;*/
+/*    -moz-hyphens: auto;*/
+/*    -ms-hyphens: auto;*/
+/*    hyphens: auto;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 374px) {*/
+/*  .intro-modal__square-name {*/
+/*    font-size: .85rem;*/
+/*    -webkit-hyphens: auto;*/
+/*    -moz-hyphens: auto;*/
+/*    -ms-hyphens: auto;*/
+/*    hyphens: auto;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__following {*/
+/*  background: transparent;*/
+/*  font-weight: bold;*/
+/*  color: #999;*/
+/*  text-shadow: -1px 0 #fff, 0 1px #fff, 1px 0 #fff, 0 -1px #fff;*/
+/*}*/
+
+/*.intro-modal__following:hover {*/
+/*  border: 2px solid transparent;*/
+/*  background: rgba(0, 0, 0, 0.1);*/
+/*}*/
+
+/*.intro-modal__details {*/
+/*  position: absolute;*/
+/*  top: 12px;*/
+/*  right: 12px;*/
+/*}*/
+
+/*@media all and (min-width: 576px) and (max-width: 767px) {*/
+/*  .intro-modal__details {*/
+/*    top: 10px;*/
+/*    right: 10px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (min-width: 375px) and (max-width: 479px) {*/
+/*  .intro-modal__details {*/
+/*    top: 10px;*/
+/*    right: 10px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 374px) {*/
+/*  .intro-modal__details {*/
+/*    top: 8px;*/
+/*    right: 8px;*/
+/*  }*/
+/*}*/
+
+/*.intro-modal__address-box {*/
+/*  align-self: center;*/
+/*  width: 80%;*/
+/*}*/
+
+/*.intro-modal-shadow-wrap {*/
+/*  flex-basis: 0;*/
+/*}*/
+
+/*.intro-modal-shadow {*/
+/*  position: relative;*/
+/*  top: -25px;*/
+/*  height: 25px;*/
+/*  width: 100%;*/
+/*  background: linear-gradient(to bottom, transparent 1%, #fff 100%);*/
+/*}*/
+
+/*.intro-modal-vertical-scroll {*/
+/*  border-radius: 4px 4px 4px 4px;*/
+/*  -webkit-column-count: 1;*/
+/*  -moz-column-count: 1;*/
+/*  column-count: 1;*/
+/*  -webkit-column-gap: 0;*/
+/*  -moz-column-gap: 0;*/
+/*  column-gap: 0;*/
+/*}*/
+
+/*.intro-modal-vertical-scroll .card-main:hover {*/
+/*  cursor: pointer;*/
+/*  background: #29b6f6;*/
+/*}*/
+
+/*.intro-modal-vertical-scroll .card-main:hover .card-main__candidate-name, .intro-modal-vertical-scroll .card-main:hover .intro-modal__small {*/
+/*  color: #f8f8f8;*/
+/*}*/
+
+/*.intro-modal-vertical-scroll.card {*/
+/*  margin-bottom: 0;*/
+/*  padding: 2px 2px 0 0;*/
+/*}*/
+
+/*.child-height-full > :first-child {*/
+/*  height: 100%;*/
+/*}*/
+
+/*.child-height-full > :first-child > :first-child {*/
+/*  height: 100%;*/
+/*}*/
+
+/*.intro-modal-vertical-scroll-contain_without_slider {*/
+/*  height: calc(100vh - 100px);*/
+/*  max-height: 540px;*/
+/*  overflow-y: auto;*/
+/*  -webkit-overflow-scrolling: auto;*/
+/*  overflow-x: hidden;*/
+/*}*/
+
+/*.intro-modal-vertical-scroll-contain-wrap {*/
+/*  display: flex;*/
+/*  flex-direction: column;*/
+/*  flex-grow: 1;*/
+/*}*/
+
+/*.intro-modal-vertical-scroll-contain {*/
+/*  overflow-y: auto;*/
+/*  -webkit-overflow-scrolling: auto;*/
+/*  overflow-x: hidden;*/
+/*}*/
+
+/*.x-close {*/
+/*  position: absolute;*/
+/*  height: 25px;*/
+/*  width: 25px;*/
+/*  top: 10px;*/
+/*  right: 10px;*/
+/*  z-index: 2;*/
+/*  color: #fff;*/
+/*}*/
+
+/*.x-close__black {*/
+/*  -webkit-filter: invert(100%);*/
+/*}*/
+
+/*.x-close__cordova {*/
+/*  top: 30px;*/
+/*  right: 14px;*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 479px) {*/
+/*  .x-close {*/
+/*    height: 30px;*/
+/*    width: 30px;*/
+/*    padding: 4px;*/
+/*  }*/
+/*}*/
+
+/*.story-view .container-main {*/
+/*  margin: 0;*/
+/*  min-height: 100%;*/
+/*  padding: 0;*/
+/*}*/
+
+/*.story-view .well {*/
+/*  margin-bottom: 0;*/
+/*  border: none;*/
+/*}*/
+
+/*.slick-dots {*/
+/*  top: 83vh;*/
+/*  content: "•";*/
+/*  height: 0;*/
+/*}*/
+
+.facebook-intro-connect, .twitter-intro-connect {
   flex: initial;
-  max-width: initial; }
+  max-width: initial;
+}
 
 @media all and (max-width: 479px) {
   .calc-height {
     height: calc(100vh - 52px);
-    max-height: 548px; } }
+    max-height: 548px;
+  }
+}
 
 @media all and (min-width: 480px) {
   .calc-height {
     height: calc(100vh - 104px);
-    max-height: 496px; } }
+    max-height: 496px;
+  }
+}
 
 .modal-dialog {
   position: relative;
@@ -11857,121 +15436,191 @@ a {
   -webkit-transition: none !important;
   transition: none !important;
   -moz-transform: none !important;
-  -ms-transform: none !important;
+  /*-ms-transform: none !important;*/
   -o-transform: none !important;
   -webkit-transform: none !important;
-  transform: none !important; }
-  @media all and (min-width: 768px) and (max-width: 959px) {
-    .modal-dialog {
-      width: 750px; } }
-  @media all and (min-width: 960px) {
-    .modal-dialog {
-      width: 880px; } }
+  transform: none !important;
+}
+
+@media all and (min-width: 768px) and (max-width: 959px) {
+  .modal-dialog {
+    width: 750px;
+  }
+}
+
+@media all and (min-width: 960px) {
+  .modal-dialog {
+    width: 880px;
+  }
+}
 
 @media all and (min-width: 320px) {
   .modal-body {
-    height: inherit; }
-    .modal-body .calc-height {
-      height: calc(100vh - 100px);
-      max-height: 890px; }
-    .modal-body .intro-modal-vertical-scroll-contain_without_slider {
-      height: calc(100vh - 100px);
-      max-height: 540px; } }
+    height: inherit;
+  }
+
+  .modal-body .calc-height {
+    height: calc(100vh - 100px);
+    max-height: 890px;
+  }
+
+  .modal-body .intro-modal-vertical-scroll-contain_without_slider {
+    height: calc(100vh - 100px);
+    max-height: 540px;
+  }
+}
 
 .share-modal {
   padding: 0;
   width: 100%;
   color: #fff;
-  text-align: center; }
+  text-align: center;
+}
+
+.share-modal__input {
+  flex-basis: 80%;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
   .share-modal__input {
-    flex-basis: 80%; }
-    @media all and (min-width: 320px) and (max-width: 479px) {
-      .share-modal__input {
-        flex-basis: 70%; } }
-    @media all and (min-width: 480px) and (max-width: 767px) {
-      .share-modal__input {
-        flex-basis: 80%; } }
-    @media all and (min-width: 768px) and (max-width: 959px) {
-      .share-modal__input {
-        flex-basis: 75%; } }
+    flex-basis: 70%;
+  }
+}
+
+@media all and (min-width: 480px) and (max-width: 767px) {
+  .share-modal__input {
+    flex-basis: 80%;
+  }
+}
+
+@media all and (min-width: 768px) and (max-width: 959px) {
+  .share-modal__input {
+    flex-basis: 75%;
+  }
+}
+
+.share-modal__button {
+  flex-basis: 20%;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
   .share-modal__button {
-    flex-basis: 20%; }
-    @media all and (min-width: 320px) and (max-width: 479px) {
-      .share-modal__button {
-        flex-basis: 30%; } }
-    @media all and (min-width: 480px) and (max-width: 767px) {
-      .share-modal__button {
-        flex-basis: 20%; } }
-    @media all and (min-width: 768px) and (max-width: 959px) {
-      .share-modal__button {
-        flex-basis: 25%; } }
-  .share-modal__container {
-    width: 100%;
-    margin: 0 15px;
-    display: flex;
-    flex-flow: row wrap;
-    justify-content: space-between;
-    align-items: flex-start; }
-  .share-modal__default-text {
-    width: 100%;
-    color: #000;
-    text-align: center; }
-  .share-modal__span--right {
-    text-align: right; }
-  .share-modal__iphone-xr-xs {
-    margin-right: 0; }
+    flex-basis: 30%;
+  }
+}
+
+@media all and (min-width: 480px) and (max-width: 767px) {
+  .share-modal__button {
+    flex-basis: 20%;
+  }
+}
+
+@media all and (min-width: 768px) and (max-width: 959px) {
+  .share-modal__button {
+    flex-basis: 25%;
+  }
+}
+
+.share-modal__container {
+  width: 100%;
+  margin: 0 15px;
+  display: flex;
+  flex-flow: row wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.share-modal__default-text {
+  width: 100%;
+  color: #000;
+  text-align: center;
+}
+
+.share-modal__span--right {
+  text-align: right;
+}
+
+.share-modal__iphone-xr-xs {
+  margin-right: 0;
+}
+
+.share-modal-vertical-scroll-contain {
+  height: 300px;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: auto;
+  overflow-x: hidden;
+}
+
+@media all and (min-width: 320px) and (max-width: 767px) {
   .share-modal-vertical-scroll-contain {
-    height: 300px;
-    overflow-y: auto;
-    -webkit-overflow-scrolling: auto;
-    overflow-x: hidden; }
-    @media all and (min-width: 320px) and (max-width: 767px) {
-      .share-modal-vertical-scroll-contain {
-        height: calc(90vh - 100px); } }
+    height: calc(90vh - 100px);
+  }
+}
+
+.share-modal__calc-height {
+  height: 420px;
+}
+
+@media all and (min-width: 320px) and (max-width: 767px) {
   .share-modal__calc-height {
-    height: 420px; }
-    @media all and (min-width: 320px) and (max-width: 767px) {
-      .share-modal__calc-height {
-        height: calc(100vh - 50px); } }
+    height: calc(100vh - 50px);
+  }
+}
 
 .FriendInvitationTopHeader {
   font-size: 24px;
   font-weight: 600;
   padding-top: 6px;
-  padding-bottom: 0; }
-  @media all and (max-width: 479px) {
-    .FriendInvitationTopHeader {
-      font-size: 20px; } }
+  padding-bottom: 0;
+}
+
+@media all and (max-width: 479px) {
+  .FriendInvitationTopHeader {
+    font-size: 20px;
+  }
+}
 
 .FriendInvitationTopHeaderExplanation {
   color: #999;
   font-size: 16px;
   font-weight: 400;
   padding-bottom: 0;
-  padding-top: 0; }
-  @media all and (max-width: 479px) {
-    .FriendInvitationTopHeaderExplanation {
-      font-size: 14px; } }
+  padding-top: 0;
+}
+
+@media all and (max-width: 479px) {
+  .FriendInvitationTopHeaderExplanation {
+    font-size: 14px;
+  }
+}
 
 .FriendInvitationIntroHeader {
   color: #2e3c5d;
   font-size: 24px;
   font-weight: 600;
   padding-top: 32px;
-  padding-bottom: 0; }
-  @media all and (max-width: 479px) {
-    .FriendInvitationIntroHeader {
-      font-size: 22px; } }
+  padding-bottom: 0;
+}
+
+@media all and (max-width: 479px) {
+  .FriendInvitationIntroHeader {
+    font-size: 22px;
+  }
+}
 
 .FriendInvitationValuesHeader {
   color: #2e3c5d;
   font-size: 18px;
   font-weight: 600;
   padding-top: 0;
-  padding-bottom: 16px; }
-  @media all and (max-width: 479px) {
-    .FriendInvitationValuesHeader {
-      font-size: 16px; } }
+  padding-bottom: 16px;
+}
+
+@media all and (max-width: 479px) {
+  .FriendInvitationValuesHeader {
+    font-size: 16px;
+  }
+}
 
 .intro-story {
   background-color: #fff;
@@ -11980,131 +15629,207 @@ a {
   width: 100%;
   max-width: 750px;
   color: #000;
-  text-align: center; }
+  text-align: center;
+}
+
+.intro-story__h1 {
+  font-weight: 800;
+  font-size: 24px;
+  padding: 32px 0 0;
+}
+
+@media all and (min-width: 480px) {
   .intro-story__h1 {
-    font-weight: 800;
-    font-size: 24px;
-    padding: 32px 0 0; }
-    @media all and (min-width: 480px) {
-      .intro-story__h1 {
-        font-size: 28px; } }
-  .intro-story__h1--highlight {
-    color: #2e3c5d; }
+    font-size: 28px;
+  }
+}
+
+.intro-story__h1--highlight {
+  color: #2e3c5d;
+}
+
+.intro-story__h1--alt {
+  font-weight: 700;
+  font-size: 30px;
+  padding-top: 32px;
+}
+
+@media all and (max-width: 959px) {
   .intro-story__h1--alt {
-    font-weight: 700;
-    font-size: 30px;
-    padding-top: 32px; }
-    @media all and (max-width: 959px) {
-      .intro-story__h1--alt {
-        font-size: 22px; } }
+    font-size: 22px;
+  }
+}
+
+.intro-story__h2 {
+  padding-top: 32px;
+  padding-bottom: 16px;
+  font-size: 20px;
+  font-weight: 600;
+}
+
+@media all and (min-width: 480px) {
   .intro-story__h2 {
-    padding-top: 32px;
-    padding-bottom: 16px;
-    font-size: 20px;
-    font-weight: 600; }
-    @media all and (min-width: 480px) {
-      .intro-story__h2 {
-        font-size: 24px; } }
-  .intro-story__h2--highlight {
-    color: #2e3c5d; }
-  .intro-story__info {
-    color: #555; }
+    font-size: 24px;
+  }
+}
+
+.intro-story__h2--highlight {
+  color: #2e3c5d;
+}
+
+.intro-story__info {
+  color: #555;
+}
+
+.intro-story__padding {
+  padding: 16px;
+  height: 100vh;
+  position: relative;
+}
+
+@media all and (max-width: 959px) {
   .intro-story__padding {
-    padding: 16px;
+    padding-top: 16px;
+    padding-bottom: 16px;
     height: 100vh;
-    position: relative; }
-    @media all and (max-width: 959px) {
-      .intro-story__padding {
-        padding-top: 16px;
-        padding-bottom: 16px;
-        height: 100vh; } }
-  .intro-story__padding--top {
-    padding-top: 16px; }
-  .intro-story__padding--btm {
-    padding-bottom: 32px; }
+  }
+}
+
+.intro-story__padding--top {
+  padding-top: 16px;
+}
+
+.intro-story__padding--btm {
+  padding-bottom: 32px;
+}
+
+.intro-story__padding-btn {
+  padding-top: 32px;
+  padding-bottom: 32px;
+}
+
+@media all and (max-width: 959px) {
   .intro-story__padding-btn {
     padding-top: 32px;
-    padding-bottom: 32px; }
-    @media all and (max-width: 959px) {
-      .intro-story__padding-btn {
-        padding-top: 32px;
-        padding-bottom: 16px; } }
-  .intro-story__margin--auto {
-    margin: 0 auto;
-    max-width: 600px; }
-  .intro-story__img-height {
-    width: 100%;
-    max-width: 500px;
-    margin: 0 auto; }
+    padding-bottom: 16px;
+  }
+}
+
+.intro-story__margin--auto {
+  margin: 0 auto;
+  max-width: 600px;
+}
+
+.intro-story__img-height {
+  width: 100%;
+  max-width: 500px;
+  margin: 0 auto;
+}
+
+.intro-story__img-height--extra {
+  height: 225px;
+}
+
+@media all and (max-width: 479px) {
   .intro-story__img-height--extra {
-    height: 225px; }
-    @media all and (max-width: 479px) {
-      .intro-story__img-height--extra {
-        height: 175px; } }
-  .intro-story__separator {
-    height: 2px;
-    background: #eee;
-    border: none;
-    margin: 32px 0; }
-  @media all and (min-width: 320px) {
-    .intro-story__background {
-      height: 100vh;
-      width: 100vw;
-      background-size: cover; } }
-  @media all and (min-width: 960px) {
-    .intro-story__background {
-      height: 600px;
-      width: 100%;
-      float: left; } }
-  .intro-story__menu-right {
-    font-size: 2.5em;
-    z-index: 3;
-    top: 45%;
-    right: 0;
-    position: absolute; }
-    @media all and (max-width: 479px) {
-      .intro-story__menu-right {
-        display: none; } }
-  .intro-story__menu-left {
-    font-size: 2.5em;
-    z-index: 3;
-    top: 45%;
-    left: 0;
-    position: absolute; }
-    @media all and (max-width: 479px) {
-      .intro-story__menu-left {
-        display: none; } }
-  .intro-story__footer {
-    position: absolute;
-    bottom: 20%;
-    width: 100%; }
-    @media all and (min-width: 480px) {
-      .intro-story__footer {
-        bottom: 10%; } }
-  .intro-story__btn {
-    background: #2e3c5d;
-    color: #fff;
-    border: none;
-    border-radius: 0;
-    text-transform: uppercase;
-    font-size: 18px;
-    line-height: 2.2rem;
-    z-index: 999; }
-  .intro-story__btn--bottom {
-    position: absolute;
-    margin-left: 16px;
-    width: calc((100%) - 32px);
-    left: 0;
-    top: 90vh;
-    display: block; }
+    height: 175px;
+  }
+}
+
+.intro-story__separator {
+  height: 2px;
+  background: #eee;
+  border: none;
+  margin: 32px 0;
+}
 
 @media all and (min-width: 320px) {
-  .background--image3 {
-    background-image: url("/img/global/intro-story/slide3-historic-place-698x600.jpg"); } }
+  .intro-story__background {
+    height: 100vh;
+    width: 100vw;
+    background-size: cover;
+  }
+}
 
 @media all and (min-width: 960px) {
-  .background--image3 {
-    background-image: url("/img/global/intro-story/slide3-historic-place-1000x600.jpg"); } }
+  .intro-story__background {
+    height: 600px;
+    width: 100%;
+    float: left;
+  }
+}
+
+.intro-story__menu-right {
+  font-size: 2.5em;
+  z-index: 3;
+  top: 45%;
+  right: 0;
+  position: absolute;
+}
+
+@media all and (max-width: 479px) {
+  .intro-story__menu-right {
+    display: none;
+  }
+}
+
+.intro-story__menu-left {
+  font-size: 2.5em;
+  z-index: 3;
+  top: 45%;
+  left: 0;
+  position: absolute;
+}
+
+@media all and (max-width: 479px) {
+  .intro-story__menu-left {
+    display: none;
+  }
+}
+
+.intro-story__footer {
+  position: absolute;
+  bottom: 20%;
+  width: 100%;
+}
+
+@media all and (min-width: 480px) {
+  .intro-story__footer {
+    bottom: 10%;
+  }
+}
+
+.intro-story__btn {
+  background: #2e3c5d;
+  color: #fff;
+  border: none;
+  border-radius: 0;
+  text-transform: uppercase;
+  font-size: 18px;
+  line-height: 2.2rem;
+  z-index: 999;
+}
+
+.intro-story__btn--bottom {
+  position: absolute;
+  margin-left: 16px;
+  width: calc((100%) - 32px);
+  left: 0;
+  top: 90vh;
+  display: block;
+}
+
+/*@media all and (min-width: 320px) {*/
+/*  .background--image3 {*/
+/*    background-image: url("/img/global/intro-story/slide3-historic-place-698x600.jpg");*/
+/*  }*/
+/*}*/
+
+/*@media all and (min-width: 960px) {*/
+/*  .background--image3 {*/
+/*    background-image: url("/img/global/intro-story/slide3-historic-place-1000x600.jpg");*/
+/*  }*/
+/*}*/
 
 /*
 .sc-htpNat {
@@ -12118,11 +15843,13 @@ a {
   padding: 2px 4px;
   border-radius: 100rem;
   border: 1px solid #ccc;
-  margin-right: 4px; }
+  margin-right: 4px;
+}
 
 .issue-icon-list__endorsement-icon {
   padding: 0 2px;
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
 .issue-icon-list__endorsement-count {
   min-width: 1em;
@@ -12134,12 +15861,14 @@ a {
   background-color: #fff;
   border-radius: 100rem;
   display: flex;
-  align-content: center; }
+  align-content: center;
+}
 
 .issue-icon-list__issue-block {
   display: flex;
   flex: 1 0 auto;
-  align-items: start; }
+  align-items: start;
+}
 
 .issue-icon-list__issue-icon {
   color: #999;
@@ -12148,236 +15877,336 @@ a {
   width: calc(16px + 4px);
   flex: none;
   margin-right: 4px;
-  padding: 2px; }
+  padding: 2px;
+}
 
 .issue-icon-list__issue-label-name {
   color: #555;
   font-size: .7rem;
-  padding-top: 6px; }
+  padding-top: 6px;
+}
 
 .issues-list-stacked {
   position: relative;
   width: 100%;
-  align-items: center; }
-  .issues-list-stacked__bar {
-    position: absolute;
-    display: block;
-    height: 10px;
-    width: 0;
-    transition: width .2s ease-out;
-    box-sizing: content-box; }
-  .issues-list-stacked__info-icon-for-popover {
-    color: #999; }
-  .issues-list-stacked__support, .issues-list-stacked__oppose {
-    display: flex;
-    align-items: center;
-    flex: none; }
-  .issues-list-stacked__more-opinions {
-    color: #999; }
-  .issues-list-stacked__support-score {
-    color: #555;
-    font-size: 2rem;
-    font-weight: 500;
-    display: flex;
-    justify-content: center;
-    align-items: center; }
+  align-items: center;
+}
+
+.issues-list-stacked__bar {
+  position: absolute;
+  display: block;
+  height: 10px;
+  width: 0;
+  transition: width .2s ease-out;
+  box-sizing: content-box;
+}
+
+.issues-list-stacked__info-icon-for-popover {
+  color: #999;
+}
+
+.issues-list-stacked__support, .issues-list-stacked__oppose {
+  display: flex;
+  align-items: center;
+  flex: none;
+}
+
+.issues-list-stacked__more-opinions {
+  color: #999;
+}
+
+.issues-list-stacked__support-score {
+  color: #555;
+  font-size: 2rem;
+  font-weight: 500;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.issues-list-stacked__support-score-label, .issues-list-stacked__support-label {
+  color: #555;
+  font-size: .875rem;
+  font-weight: 200;
+  line-height: 1.2;
+  vertical-align: middle;
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  margin-right: 8px;
+  flex: none;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
   .issues-list-stacked__support-score-label, .issues-list-stacked__support-label {
-    color: #555;
     font-size: .875rem;
-    font-weight: 200;
-    line-height: 1.2;
-    vertical-align: middle;
-    display: inline-flex;
-    flex-direction: row;
-    align-items: center;
-    margin-right: 8px;
-    flex: none; }
-    @media all and (min-width: 320px) and (max-width: 479px) {
-      .issues-list-stacked__support-score-label, .issues-list-stacked__support-label {
-        font-size: .875rem; } }
-  .issues-list-stacked__support-list {
-    margin-left: 0;
-    margin-right: -16px; }
-    .issues-list-stacked__support-list__container-wrap {
-      flex-grow: 1; }
-    .issues-list-stacked__support-list__container {
-      height: 47px; }
-    .issues-list-stacked__support-list__items {
-      padding: 0;
-      margin-bottom: 16px;
-      list-style: none;
-      display: inline-flex; }
-    .issues-list-stacked__support-list__item {
-      position: relative;
-      display: inline-flex; }
-    .issues-list-stacked__support-list__scroll-icon {
-      color: #999;
-      margin: 0 8px;
-      margin-top: 4px; }
-      @media all and (min-width: 768px) {
-        .issues-list-stacked__support-list__scroll-icon {
-          margin-top: 16px; } }
-      @media all and (max-width: 767px) {
-        .issues-list-stacked__support-list__scroll-icon--small {
-          margin-top: -8px; } }
-      .issues-list-stacked__support-list__scroll-icon--disabled {
-        color: transparent;
-        margin: 0 8px; }
-      .issues-list-stacked__support-list__scroll-icon--disabled-small {
-        color: transparent;
-        margin: 0 13px; }
+  }
+}
+
+.issues-list-stacked__support-list {
+  margin-left: 0;
+  margin-right: -16px;
+}
+
+.issues-list-stacked__support-list__container-wrap {
+  flex-grow: 1;
+}
+
+.issues-list-stacked__support-list__container {
+  height: 47px;
+}
+
+.issues-list-stacked__support-list__items {
+  padding: 0;
+  margin-bottom: 16px;
+  list-style: none;
+  display: inline-flex;
+}
+
+.issues-list-stacked__support-list__item {
+  position: relative;
+  display: inline-flex;
+}
+
+.issues-list-stacked__support-list__scroll-icon {
+  color: #999;
+  margin: 0 8px;
+  margin-top: 4px;
+}
+
+@media all and (min-width: 768px) {
+  .issues-list-stacked__support-list__scroll-icon {
+    margin-top: 16px;
+  }
+}
+
+@media all and (max-width: 767px) {
+  .issues-list-stacked__support-list__scroll-icon--small {
+    margin-top: -8px;
+  }
+}
+
+.issues-list-stacked__support-list__scroll-icon--disabled {
+  color: transparent;
+  margin: 0 8px;
+}
+
+.issues-list-stacked__support-list__scroll-icon--disabled-small {
+  color: transparent;
+  margin: 0 13px;
+}
 
 .issues-follow-container {
   position: relative;
   display: flex;
   justify-content: center;
   width: 100%;
-  height: 32px !important; }
+  height: 32px !important;
+}
 
 .dropdown-toggle::after {
   position: absolute;
   font-size: 16px;
   top: calc(50% - 1px);
-  right: calc((35px / 2) - 6px); }
+  right: calc((35px / 2) - 6px);
+}
 
 .issues-follow-btn {
   height: 100% !important;
   min-width: 0 !important;
   padding-left: 0 !important;
   padding-right: 0 !important;
-  max-height: none !important; }
-  .issues-follow-btn--blue {
-    background: #2e3c5d !important;
-    color: #fff !important; }
-  .issues-follow-btn--white {
-    color: #0d546f !important;
-    background: white !important;
-    font-weight: 600 !important;
-    border: 1px solid #ccc !important; }
-  .issues-follow-btn__icon svg {
-    width: 18px !important;
-    height: 18px !important; }
-  .issues-follow-btn__main {
-    height: 32px !important;
-    border-radius: 3px !important;
-    border-top-right-radius: 0 !important;
-    border-bottom-right-radius: 0 !important;
-    border-right: none !important;
-    padding: 4px 8px !important;
-    flex: 1 0 0 !important;
-    text-align: center !important; }
-    .issues-follow-btn__main--radius {
-      border-radius: 3px !important;
-      border: 1px solid #ccc !important; }
-      .issues-follow-btn__main--radius .issues-follow-btn__dropdown {
-        display: none; }
-    .issues-follow-btn__main--radius.dropdown-toggle::after {
-      display: none !important;
-      font-size: 0 !important; }
-  .issues-follow-btn__separator {
-    display: inline-block;
-    height: 100%;
-    width: 1.5px;
-    background: rgba(204, 204, 204, 0.425);
-    z-index: 1;
-    position: absolute;
-    right: 34px; }
-  .issues-follow-btn__dropdown {
-    display: inline-block !important;
-    border-radius: 3px !important;
-    border-top-left-radius: 0 !important;
-    border-bottom-left-radius: 0 !important;
-    width: 35px !important;
-    min-width: 35px !important;
-    padding: 4px 8px !important;
-    height: 100% !important;
-    vertical-align: middle !important;
-    border-left: none !important; }
-  .issues-follow-btn__dropdown ::after {
-    font-size: 16px !important; }
-  .issues-follow-btn__menu {
-    font-size: 12.5px !important;
-    position: absolute !important;
-    width: 140px !important;
-    min-width: 0 !important;
-    max-width: 140px !important;
-    padding: 0 !important;
-    border: none !important;
-    box-shadow: 1px 1px 4px 0 #ddd; }
-  .issues-follow-btn__menu * {
-    width: 140px !important;
-    max-width: 140px !important; }
-  .issues-follow-btn__menu-item {
-    padding: 7px 0 !important;
-    border-radius: 0 !important; }
-  .issues-follow-btn[disabled] {
-    background: #fff; }
+  max-height: none !important;
+}
+
+.issues-follow-btn--blue {
+  background: #2e3c5d !important;
+  color: #fff !important;
+}
+
+.issues-follow-btn--white {
+  color: #0d546f !important;
+  background: white !important;
+  font-weight: 600 !important;
+  border: 1px solid #ccc !important;
+}
+
+.issues-follow-btn__icon svg {
+  width: 18px !important;
+  height: 18px !important;
+}
+
+.issues-follow-btn__main {
+  height: 32px !important;
+  border-radius: 3px !important;
+  border-top-right-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+  border-right: none !important;
+  padding: 4px 8px !important;
+  flex: 1 0 0 !important;
+  text-align: center !important;
+}
+
+.issues-follow-btn__main--radius {
+  border-radius: 3px !important;
+  border: 1px solid #ccc !important;
+}
+
+.issues-follow-btn__main--radius .issues-follow-btn__dropdown {
+  display: none;
+}
+
+.issues-follow-btn__main--radius.dropdown-toggle::after {
+  display: none !important;
+  font-size: 0 !important;
+}
+
+.issues-follow-btn__separator {
+  display: inline-block;
+  height: 100%;
+  width: 1.5px;
+  background: rgba(204, 204, 204, 0.425);
+  z-index: 1;
+  position: absolute;
+  right: 34px;
+}
+
+.issues-follow-btn__dropdown {
+  display: inline-block !important;
+  border-radius: 3px !important;
+  border-top-left-radius: 0 !important;
+  border-bottom-left-radius: 0 !important;
+  width: 35px !important;
+  min-width: 35px !important;
+  padding: 4px 8px !important;
+  height: 100% !important;
+  vertical-align: middle !important;
+  border-left: none !important;
+}
+
+.issues-follow-btn__dropdown ::after {
+  font-size: 16px !important;
+}
+
+.issues-follow-btn__menu {
+  font-size: 12.5px !important;
+  position: absolute !important;
+  width: 140px !important;
+  min-width: 0 !important;
+  max-width: 140px !important;
+  padding: 0 !important;
+  border: none !important;
+  box-shadow: 1px 1px 4px 0 #ddd;
+}
+
+.issues-follow-btn__menu * {
+  width: 140px !important;
+  max-width: 140px !important;
+}
+
+.issues-follow-btn__menu-item {
+  padding: 7px 0 !important;
+  border-radius: 0 !important;
+}
+
+.issues-follow-btn[disabled] {
+  background: #fff;
+}
 
 .follow-toggle__values {
-  margin-left: auto; }
-  @media all and (min-width: 768px) {
-    .follow-toggle__values {
-      position: absolute;
-      right: 0;
-      height: 46px; }
-      .follow-toggle__values .issues-follow-container {
-        height: 100% !important; }
-      .follow-toggle__values .issues-follow-btn {
-        height: 100% !important;
-        border-radius: 3px !important;
-        border-bottom-left-radius: 0 !important;
-        border-top-left-radius: 0 !important; } }
+  margin-left: auto;
+}
+
+@media all and (min-width: 768px) {
+  .follow-toggle__values {
+    position: absolute;
+    right: 0;
+    height: 46px;
+  }
+
+  .follow-toggle__values .issues-follow-container {
+    height: 100% !important;
+  }
+
+  .follow-toggle__values .issues-follow-btn {
+    height: 100% !important;
+    border-radius: 3px !important;
+    border-bottom-left-radius: 0 !important;
+    border-top-left-radius: 0 !important;
+  }
+}
 
 .card-main {
-  position: relative !important; }
+  position: relative !important;
+}
 
 .dropdown-divider {
   margin: 0 auto !important;
   width: 75% !important;
   border: none !important;
   height: 1px !important;
-  background: #ccc !important; }
+  background: #ccc !important;
+}
 
 .split-button {
   padding: 0 !important;
   box-shadow: none !important;
-  width: 100%; }
-  .split-button > span {
-    padding: 10px 0 !important;
-    height: 100%;
-    display: flex;
-    align-items: center; }
-  .split-button__left > span {
-    justify-content: flex-start; }
-  .split-button__separator {
-    display: inline-block;
-    height: 100%;
-    width: 1.5px !important;
-    flex: none;
-    background: rgba(204, 204, 204, 0.425);
-    z-index: 1;
-    position: absolute; }
-    .split-button__separator--left {
-      left: 44px; }
-    .split-button__separator--right {
-      right: 44px; }
-  .split-button__icon {
-    width: 44px;
-    flex: none;
-    display: flex;
-    align-items: center;
-    height: 100%;
-    padding: 0 12px; }
-    .split-button__icon * {
-      width: 100%;
-      font-size: 22px; }
-  .split-button__text {
-    padding: 0 8px 0;
-    font-size: 13px;
-    text-align: center;
-    flex: 1 1 0; }
-  .split-button * {
-    text-decoration: none !important; }
+  width: 100%;
+}
+
+.split-button > span {
+  padding: 10px 0 !important;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}
+
+.split-button__left > span {
+  justify-content: flex-start;
+}
+
+.split-button__separator {
+  display: inline-block;
+  height: 100%;
+  width: 1.5px !important;
+  flex: none;
+  background: rgba(204, 204, 204, 0.425);
+  z-index: 1;
+  position: absolute;
+}
+
+.split-button__separator--left {
+  left: 44px;
+}
+
+.split-button__separator--right {
+  right: 44px;
+}
+
+.split-button__icon {
+  width: 44px;
+  flex: none;
+  display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 12px;
+}
+
+.split-button__icon * {
+  width: 100%;
+  font-size: 22px;
+}
+
+.split-button__text {
+  padding: 0 8px 0;
+  font-size: 13px;
+  text-align: center;
+  flex: 1 1 0;
+}
+
+.split-button * {
+  text-decoration: none !important;
+}
 
 .background-brand-blue .modal-content {
   background: #2e3c5d;
@@ -12386,7 +16215,8 @@ a {
   background: -webkit-linear-gradient(-45deg, #2e3c5d 0%, #11758e 100%);
   /* Chrome10-25,Safari5.1-6 */
   background: linear-gradient(135deg, #2e3c5d 0%, #11758e 100%);
-  /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */ }
+  /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+}
 
 .code-copier {
   background-color: #fff;
@@ -12394,16 +16224,25 @@ a {
   margin-bottom: 32px;
   padding: 16px 16px 16px 16px;
   text-align: center;
-  min-height: 21rem; }
-  .code-copier__image {
-    width: 100%; }
-  .code-copier__link {
-    color: #999;
-    text-decoration: underline; }
-  .code-copier__status-success {
-    color: #76d00b; }
-  .code-copier__status-error {
-    color: #ff4921; }
+  min-height: 21rem;
+}
+
+.code-copier__image {
+  width: 100%;
+}
+
+.code-copier__link {
+  color: #999;
+  text-decoration: underline;
+}
+
+.code-copier__status-success {
+  color: #76d00b;
+}
+
+.code-copier__status-error {
+  color: #ff4921;
+}
 
 .textarea-clipboard {
   -webkit-appearance: none;
@@ -12425,18 +16264,17 @@ a {
   user-select: text;
   white-space: pre-wrap;
   width: 100%;
-  word-wrap: break-word; }
+  word-wrap: break-word;
+}
 
 @media all and (max-width: 479px) {
-  .about-us,
-  .Donate,
-  .gettingStarted {
+  .about-us, .Donate, .gettingStarted {
     margin-right: -15px !important;
-    margin-left: -15px !important; } }
+    margin-left: -15px !important;
+  }
+}
 
-.profile-menu,
-.profile-menu-welcome-mobile-page,
-.about-menu {
+.profile-menu, .profile-menu-welcome-mobile-page, .about-menu {
   max-width: 320px;
   position: absolute;
   top: 50px;
@@ -12446,7 +16284,8 @@ a {
   padding: 16px;
   transition: opacity .25s ease-in-out;
   z-index: 2;
-  pointer-events: none; }
+  pointer-events: none;
+}
 
 .profile-pop-up-menu-cordova {
   position: fixed;
@@ -12463,10 +16302,10 @@ a {
   padding-bottom: 10px;
   padding-left: 10px;
   pointer-events: none;
-  transition: 10s ease-in-out; }
+  transition: 10s ease-in-out;
+}
 
-.profile-menu::before,
-.about-menu::before {
+.profile-menu::before, .about-menu::before {
   content: '';
   display: block;
   width: 0;
@@ -12477,7 +16316,8 @@ a {
   border-right: 8px solid transparent;
   border-left: 8px solid transparent;
   right: 10px;
-  top: -16px; }
+  top: -16px;
+}
 
 .profile-menu-welcome-mobile-page::before {
   content: '';
@@ -12490,7 +16330,8 @@ a {
   border-right: 8px solid transparent;
   border-left: 8px solid transparent;
   right: 37px;
-  top: -16px; }
+  top: -16px;
+}
 
 .page-overlay {
   position: fixed;
@@ -12502,7 +16343,8 @@ a {
   z-index: 2;
   pointer-events: none;
   transition: opacity .4s ease-in-out;
-  opacity: 0; }
+  opacity: 0;
+}
 
 .page-overlay-slidein {
   position: fixed;
@@ -12512,43 +16354,48 @@ a {
   left: -10px;
   background-color: transparent;
   z-index: 2;
-  pointer-events: none; }
+  pointer-events: none;
+}
 
-.profile-menu--open .page-overlay,
-.profile-pop-up-menu-cordova--open .page-overlay,
-.about-menu--open .page-overlay {
+.profile-menu--open .page-overlay, .profile-pop-up-menu-cordova--open .page-overlay, .about-menu--open .page-overlay {
   opacity: 1;
-  pointer-events: all; }
+  pointer-events: all;
+}
 
-.profile-menu--open .profile-menu,
-.profile-menu-welcome-mobile-page--open .profile-menu-welcome-mobile-page,
-.profile-pop-up-menu-cordova--open .profile-pop-up-menu-cordova,
-.about-menu--open .about-menu {
+.profile-menu--open .profile-menu, .profile-menu-welcome-mobile-page--open .profile-menu-welcome-mobile-page, .profile-pop-up-menu-cordova--open .profile-pop-up-menu-cordova, .about-menu--open .about-menu {
   opacity: 1;
-  pointer-events: all; }
+  pointer-events: all;
+}
 
 .headroom-wrapper-webapp__ballot {
-  margin-top: 48px; }
+  margin-top: 48px;
+}
 
 .headroom-wrapper-webapp__office {
-  margin-top: 102px; }
+  margin-top: 102px;
+}
 
 /*.headroom-wrapper-webapp__default {*/
 /*  margin-top: 54px; }*/
-
 .headroom-wrapper-webapp__voter-guide {
-  margin-top: 56px; }
+  margin-top: 56px;
+}
 
 .headroom-wrapper-webapp__voter-guide-creator {
-  margin-top: 105px; }
+  margin-top: 105px;
+}
 
 .headroom-wrapper-webapp__cordova-ios {
-  margin-top: -1vh; }
+  margin-top: -1vh;
+}
 
 .footroom-wrapper {
-  padding-bottom: 54px; }
-  .footroom-wrapper__hide {
-    display: none; }
+  padding-bottom: 54px;
+}
+
+.footroom-wrapper__hide {
+  display: none;
+}
 
 .footroom-wrapper-cordova {
   padding-bottom: env(safe-area-inset-bottom);
@@ -12558,160 +16405,241 @@ a {
 }
 
 .headroom-secondary-nav__margin {
-  margin-top: 104px; }
-  @media print {
-    .headroom-secondary-nav__margin {
-      margin-top: 0; } }
+  margin-top: 104px;
+}
+
+@media print {
+  .headroom-secondary-nav__margin {
+    margin-top: 0;
+  }
+}
 
 .nav-secondary-nav__image, .nav-secondary-nav__image--fade {
-  height: 28px; }
-  .nav-secondary-nav__image--fade {
-    opacity: .3; }
+  height: 28px;
+}
+
+.nav-secondary-nav__image--fade {
+  opacity: .3;
+}
+
+.nav-secondary-nav__image--checked {
+  height: 16px;
+  top: 2px;
+  position: absolute;
+  z-index: 999;
+  right: 12px;
+  border-radius: 8px;
+  box-shadow: 2px 3px 4px 0 rgba(0, 0, 0, 0.4);
+}
+
+@media all and (max-width: 374px) {
   .nav-secondary-nav__image--checked {
-    height: 16px;
-    top: 2px;
-    position: absolute;
-    z-index: 999;
-    right: 12px;
-    border-radius: 8px;
-    box-shadow: 2px 3px 4px 0 rgba(0, 0, 0, 0.4); }
-    @media all and (max-width: 374px) {
-      .nav-secondary-nav__image--checked {
-        right: 0; } }
+    right: 0;
+  }
+}
 
 .header-nav {
   display: flex;
   /*width: 920px;*/
-  margin-left: 32px; }
-  @media all and (max-width: 374px) {
-    .header-nav {
-      margin-left: 16px; } }
-  @media all and (min-width: 320px) and (max-width: 575px) {
-    .header-nav {
-      justify-content: flex-end; } }
-  .header-nav__label {
-    display: block;
-    font-size: 10px; }
-  .header-nav__sign-in-label {
-    font-size: 14px; }
-  .header-nav__item {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    position: relative;
-    width: 60px;
-    height: 54px;
-    padding: 8px;
-    color: #fff;
-    opacity: .9;
-    text-align: center; }
-    .header-nav__item:active, .header-nav__item.active-icon, .header-nav__item:focus, .header-nav__item:hover {
-      color: #fff;
-      cursor: pointer;
-      opacity: 1;
-      text-decoration: none; }
-    .header-nav__item:active, .header-nav__item.active-icon {
-      background-color: #1d263b; }
-    .header-nav__item:hover {
-      background-color: #26314c; }
-    .header-nav__item.donate {
-      padding: 0; }
-      .header-nav__item.donate > .glyphicon {
-        max-width: 100%;
-        width: 29px; }
-  .header-nav .nav-icon {
-    font-size: 1rem;
-    height: 24px;
-    width: 24px;
-    display: flex;
-    justify-content: center;
-    align-items: center; }
-  .header-nav__icon {
-    height: 24px;
-    width: 24px; }
-    .header-nav__icon--about {
-      font-size: .8rem;
-      font-weight: 700;
-      height: 24px;
-      display: flex;
-      align-items: center;
-      justify-content: center; }
-    .header-nav__icon--ballot {
-      justify-content: center; }
-  .header-nav__avatar {
-    border-radius: 4px;
-    background: #fff;
-    overflow: hidden;
-    display: inline;
-    margin-top: 7px;
-    margin-bottom: 7px;
-    min-width: 24px;
-    max-width: 34px; }
-    @media all and (max-width: 479px) {
-      .header-nav__avatar {
-        margin-bottom: 4px; } }
-  .header-nav__avatar-container {
-    display: inline; }
-  .header-nav__avatar-cordova {
-    border-radius: 4px;
-    background: #fff;
-    display: inline;
-    overflow: hidden;
-    /* 10/1/21 commented out margin-right: 16px; */
+  margin-left: 32px;
+}
+
+@media all and (max-width: 374px) {
+  .header-nav {
+    margin-left: 16px;
   }
-  .header-nav__avatar-iphone-xr {
-    overflow: unset; }
-  .header-nav__avatar-wrapper {
-    z-index: 3; }
-  .header-nav__cordova {
-    background-color: unset;
-    /* stylelint-disable-line */ }
+}
+
+@media all and (min-width: 320px) and (max-width: 575px) {
+  .header-nav {
+    justify-content: flex-end;
+  }
+}
+
+.header-nav__label {
+  display: block;
+  font-size: 10px;
+}
+
+.header-nav__sign-in-label {
+  font-size: 14px;
+}
+
+.header-nav__item {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  position: relative;
+  width: 60px;
+  height: 54px;
+  padding: 8px;
+  color: #fff;
+  opacity: .9;
+  text-align: center;
+}
+
+.header-nav__item:active, .header-nav__item.active-icon, .header-nav__item:focus, .header-nav__item:hover {
+  color: #fff;
+  cursor: pointer;
+  opacity: 1;
+  text-decoration: none;
+}
+
+.header-nav__item:active, .header-nav__item.active-icon {
+  background-color: #1d263b;
+}
+
+.header-nav__item:hover {
+  background-color: #26314c;
+}
+
+.header-nav__item.donate {
+  padding: 0;
+}
+
+.header-nav__item.donate > .glyphicon {
+  max-width: 100%;
+  width: 29px;
+}
+
+.header-nav .nav-icon {
+  font-size: 1rem;
+  height: 24px;
+  width: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header-nav__icon {
+  height: 24px;
+  width: 24px;
+}
+
+.header-nav__icon--about {
+  font-size: .8rem;
+  font-weight: 700;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.header-nav__icon--ballot {
+  justify-content: center;
+}
+
+.header-nav__avatar {
+  border-radius: 4px;
+  background: #fff;
+  overflow: hidden;
+  display: inline;
+  margin-top: 7px;
+  margin-bottom: 7px;
+  min-width: 24px;
+  max-width: 34px;
+}
+
+@media all and (max-width: 479px) {
+  .header-nav__avatar {
+    margin-bottom: 4px;
+  }
+}
+
+.header-nav__avatar-container {
+  display: inline;
+}
+
+.header-nav__avatar-cordova {
+  border-radius: 4px;
+  background: #fff;
+  display: inline;
+  overflow: hidden;
+  /* 10/1/21 commented out margin-right: 16px; */
+}
+
+.header-nav__avatar-iphone-xr {
+  overflow: unset;
+}
+
+.header-nav__avatar-wrapper {
+  z-index: 3;
+}
+
+.header-nav__cordova {
+  background-color: unset;
+  /* stylelint-disable-line */
+}
 
 .header-secondary-nav {
   display: flex;
   align-items: center;
   width: 100%;
-  justify-content: center; }
-  .header-secondary-nav__label, .header-secondary-nav__label--fade {
-    display: block;
-    color: #555;
-    font-size: 10px; }
-    .header-secondary-nav__label--fade {
-      opacity: .5; }
+  justify-content: center;
+}
+
+.header-secondary-nav__label, .header-secondary-nav__label--fade {
+  display: block;
+  color: #555;
+  font-size: 10px;
+}
+
+.header-secondary-nav__label--fade {
+  opacity: .5;
+}
+
+.header-secondary-nav__item {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  position: relative;
+  width: 80px;
+  height: 48px;
+  padding: 0;
+  color: #2e3c5d;
+  opacity: .8;
+  text-align: center;
+}
+
+@media all and (min-width: 320px) and (max-width: 479px) {
   .header-secondary-nav__item {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    position: relative;
-    width: 80px;
-    height: 48px;
-    padding: 0;
-    color: #2e3c5d;
-    opacity: .8;
-    text-align: center; }
-    @media all and (min-width: 320px) and (max-width: 479px) {
-      .header-secondary-nav__item {
-        width: 65px; } }
-    .header-secondary-nav__item:active, .header-secondary-nav__item.active-icon, .header-secondary-nav__item:focus, .header-secondary-nav__item:hover {
-      color: #555;
-      opacity: 1;
-      text-decoration: none; }
-    .header-secondary-nav__item:active, .header-secondary-nav__item.active-icon {
-      background-color: #e6e6e6; }
-    .header-secondary-nav__item:hover {
-      background-color: #f2f2f2; }
-  .header-secondary-nav__item-image-wrapper {
-    height: 24px; }
-  .header-secondary-nav .fa {
-    font-size: 1.5rem; }
-  .header-secondary-nav .nav-icon {
-    font-size: 1rem;
-    height: 36px;
-    display: flex;
-    justify-content: center;
-    align-items: center; }
-  .header-secondary-nav__iphone-x-vertical-spacing {
-    margin-top: 18px; }
+    width: 65px;
+  }
+}
+
+.header-secondary-nav__item:active, .header-secondary-nav__item.active-icon, .header-secondary-nav__item:focus, .header-secondary-nav__item:hover {
+  color: #555;
+  opacity: 1;
+  text-decoration: none;
+}
+
+.header-secondary-nav__item:active, .header-secondary-nav__item.active-icon {
+  background-color: #e6e6e6;
+}
+
+.header-secondary-nav__item:hover {
+  background-color: #f2f2f2;
+}
+
+.header-secondary-nav__item-image-wrapper {
+  height: 24px;
+}
+
+.header-secondary-nav .fa {
+  font-size: 1.5rem;
+}
+
+.header-secondary-nav .nav-icon {
+  font-size: 1rem;
+  height: 36px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.header-secondary-nav__iphone-x-vertical-spacing {
+  margin-top: 18px;
+}
 
 .header-shadow {
   box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
@@ -12727,684 +16655,982 @@ a {
   height: 54px;
   color: #fff !important;
   opacity: .8;
-  margin-bottom: -.5em; }
-  .hamburger.active-icon {
-    color: #555;
-    opacity: .9;
-    text-decoration: none;
-    background-color: #1d263b !important; }
+  margin-bottom: -.5em;
+}
+
+.hamburger.active-icon {
+  color: #555;
+  opacity: .9;
+  text-decoration: none;
+  background-color: #1d263b !important;
+}
 
 .hamburger-menu {
-  background-color: #fff; }
-  .hamburger-menu__table {
-    border-top: 40px;
-    border-top-color: #fff;
-    margin-left: 1em;
-    width: 90%; }
-  .hamburger-menu__tr {
-    height: 50px;
-    border-bottom: 1px solid #e7e7e7; }
-  .hamburger-menu__tr-terms {
-    height: 40px; }
-  .hamburger-menu__td-0 {
-    padding-left: 16px !important;
-    vertical-align: middle !important; }
-  .hamburger-menu__td-1 {
-    font-size: 1.3rem;
-    vertical-align: middle !important; }
-  .hamburger-menu__td-2 {
-    font-size: 1.3rem;
-    vertical-align: middle !important; }
-  .hamburger-menu__td-3 {
-    vertical-align: middle !important;
-    font-size: 1.3rem; }
-  .hamburger-menu__td-4 {
-    vertical-align: middle !important;
-    width: 10%; }
+  background-color: #fff;
+}
+
+.hamburger-menu__table {
+  border-top: 40px;
+  border-top-color: #fff;
+  margin-left: 1em;
+  width: 90%;
+}
+
+.hamburger-menu__tr {
+  height: 50px;
+  border-bottom: 1px solid #e7e7e7;
+}
+
+.hamburger-menu__tr-terms {
+  height: 40px;
+}
+
+.hamburger-menu__td-0 {
+  padding-left: 16px !important;
+  vertical-align: middle !important;
+}
+
+.hamburger-menu__td-1 {
+  font-size: 1.3rem;
+  vertical-align: middle !important;
+}
+
+.hamburger-menu__td-2 {
+  font-size: 1.3rem;
+  vertical-align: middle !important;
+}
+
+.hamburger-menu__td-3 {
+  vertical-align: middle !important;
+  font-size: 1.3rem;
+}
+
+.hamburger-menu__td-4 {
+  vertical-align: middle !important;
+  width: 10%;
+}
 
 .hamburger-terms__tr {
-  height: 50px !important; }
+  height: 50px !important;
+}
 
 .hamburger-terms__td {
   border-top: 0 !important;
   padding-left: 16px !important;
   padding-bottom: 8px !important;
   padding-top: 12px !important;
-  margin-left: 1em; }
+  margin-left: 1em;
+}
 
 .hamburger-terms__text {
   font-weight: 300;
-  font-size: 13pt; }
+  font-size: 13pt;
+}
 
 .buttons-container {
   display: flex;
   flex-flow: row nowrap;
-  justify-content: space-around; }
+  justify-content: space-around;
+}
 
 .fa-info-circle {
   font-size: 18px;
   margin-right: 4px;
-  color: #999; }
+  color: #999;
+}
 
-.fa.fa-twitter,
-.fa.fa-facebook {
+.fa.fa-twitter, .fa.fa-facebook {
   font-size: inherit;
   bottom: 4px;
   display: flex;
   align-items: center;
-  justify-content: center; }
+  justify-content: center;
+}
 
 .value-btn {
   max-width: 100%;
-  width: 100%; }
-  @media all and (min-width: 320px) and (max-width: 767px) {
-    .value-btn {
-      font-size: 12px;
-      padding: 8px 8px 8px 52px !important; } }
-  @media all and (min-width: 960px) {
-    .value-btn {
-      font-size: 14px;
-      padding: 8px 16px 8px 64px; } }
+  width: 100%;
+}
+
+@media all and (min-width: 320px) and (max-width: 767px) {
+  .value-btn {
+    font-size: 12px;
+    padding: 8px 8px 8px 52px !important;
+  }
+}
+
+@media all and (min-width: 960px) {
+  .value-btn {
+    font-size: 14px;
+    padding: 8px 16px 8px 64px;
+  }
+}
 
 .network-btn {
-  display: inline-block; }
-  @media all and (min-width: 320px) and (max-width: 767px) {
-    .network-btn {
-      margin-left: 5px;
-      margin-right: 5px; } }
-  @media all and (min-width: 768px) {
-    .network-btn {
-      max-width: 100%;
-      margin-right: 0;
-      margin-left: 0; } }
+  display: inline-block;
+}
+
+@media all and (min-width: 320px) and (max-width: 767px) {
+  .network-btn {
+    margin-left: 5px;
+    margin-right: 5px;
+  }
+}
+
+@media all and (min-width: 768px) {
+  .network-btn {
+    max-width: 100%;
+    margin-right: 0;
+    margin-left: 0;
+  }
+}
 
 .endorsement-card {
   display: flex;
   bottom: 8px;
-  flex-direction: column; }
-  @media all and (min-width: 768px) {
-    .endorsement-card {
-      flex-direction: row;
-      align-items: center;
-      justify-content: space-between; } }
-  .endorsement-card__btn {
-    background: #2e3c5d !important;
-    color: #fff !important;
-    text-align: center;
-    width: 100%;
-    margin-top: 16px;
-    padding: 8px 16px 8px 52px !important; }
-    .endorsement-card__btn--icon {
-      width: 22.5px !important;
-      height: 22.5px !important; }
-    @media all and (min-width: 768px) {
-      .endorsement-card__btn {
-        width: auto;
-        margin-top: 0; } }
-  .endorsement-card__text {
-    padding: 16px 0;
-    font-size: 17px;
-    color: #555; }
-    @media all and (min-width: 768px) {
-      .endorsement-card__text {
-        padding: 0 16px;
-        justify-self: flex-end; } }
-
-.btn-social .fa.fa-twitter {
-  width: 46px !important;
-  line-height: 36px !important; }
+  flex-direction: column;
+}
 
 @media all and (min-width: 768px) {
-  .mobile-container {
-    display: none; } }
+  .endorsement-card {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
 
-@media all and (min-width: 320px) and (max-width: 767px) {
-  .mobile-container {
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: space-around; }
-    .mobile-container .btn-social {
-      width: 100%;
-      padding-left: 40px;
-      padding-right: 9px; } }
+.endorsement-card__btn {
+  background: #2e3c5d !important;
+  color: #fff !important;
+  text-align: center;
+  width: 100%;
+  margin-top: 16px;
+  padding: 8px 16px 8px 52px !important;
+}
 
-.social-btn-description {
-  margin-top: 10px;
-  word-wrap: break-word;
-  float: left;
-  text-align: left;
+.endorsement-card__btn--icon {
+  width: 22.5px !important;
+  height: 22.5px !important;
+}
+
+@media all and (min-width: 768px) {
+  .endorsement-card__btn {
+    width: auto;
+    margin-top: 0;
+  }
+}
+
+.endorsement-card__text {
+  padding: 16px 0;
+  font-size: 17px;
   color: #555;
-  font-size: 14px; }
+}
 
-.network-issues-list {
-  padding: 4px;
-  display: flex;
-  flex-flow: row wrap; }
-  .network-issues-list .intro-modal__square {
-    float: left;
-    color: #fff;
-    text-align: center; }
-  .network-issues-list .intro-modal__square-name {
-    position: absolute;
-    font-size: 1rem;
-    word-wrap: break-word;
-    color: #fff;
-    text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6);
-    background: rgba(0, 0, 0, 0.45);
-    padding: 10px;
-    width: 100%;
-    border-radius: 8px;
-    border: 2px solid #fff;
-    transition: all .2s ease-in; }
-    .network-issues-list .intro-modal__square-name:hover {
-      border: 2px solid #2e3c5d;
-      background: rgba(0, 0, 0, 0.55); }
-    @media all and (min-width: 576px) and (max-width: 991px) {
-      .network-issues-list .intro-modal__square-name {
-        font-size: .9rem; } }
-    @media all and (min-width: 375px) and (max-width: 479px) {
-      .network-issues-list .intro-modal__square-name {
-        font-size: .9rem;
-        -webkit-hyphens: auto;
-        -moz-hyphens: auto;
-        -ms-hyphens: auto;
-        hyphens: auto; } }
-    @media all and (max-width: 374px) {
-      .network-issues-list .intro-modal__square-name {
-        font-size: .85rem;
-        -webkit-hyphens: auto;
-        -moz-hyphens: auto;
-        -ms-hyphens: auto;
-        hyphens: auto; } }
+@media all and (min-width: 768px) {
+  .endorsement-card__text {
+    padding: 0 16px;
+    justify-self: flex-end;
+  }
+}
 
-@media all and (max-width: 479px) {
-  .network__card {
-    margin: -16px -16px 0 -16px; } }
+/*.btn-social .fa.fa-twitter {*/
+/*  width: 46px !important;*/
+/*  line-height: 36px !important;*/
+/*}*/
 
-.opinions-followed__missing-org-text {
-  font-size: 12px; }
+/*@media all and (min-width: 768px) {*/
+/*  .mobile-container {*/
+/*    display: none;*/
+/*  }*/
+/*}*/
 
-.opinions-followed__container-cordova {
-  padding-bottom: 64px; }
+/*@media all and (min-width: 320px) and (max-width: 767px) {*/
+/*  .mobile-container {*/
+/*    display: flex;*/
+/*    flex-flow: row nowrap;*/
+/*    justify-content: space-around;*/
+/*  }*/
 
-.scratch-pad {
-  padding-top: 8px; }
+/*  .mobile-container .btn-social {*/
+/*    width: 100%;*/
+/*    padding-left: 40px;*/
+/*    padding-right: 9px;*/
+/*  }*/
+/*}*/
 
-.organization-banner-image-non-twitter-users {
-  height: 0;
-  background-color: #999;
-  display: block; }
+/*.social-btn-description {*/
+/*  margin-top: 10px;*/
+/*  word-wrap: break-word;*/
+/*  float: left;*/
+/*  text-align: left;*/
+/*  color: #555;*/
+/*  font-size: 14px;*/
+/*}*/
 
-.organization-banner-image-div {
-  min-height: 200px;
-  max-height: 300px;
-  overflow: hidden; }
-  @media all and (min-width: 768px) and (max-width: 959px) {
-    .organization-banner-image-div {
-      min-height: 0; } }
-  @media all and (max-width: 767px) {
-    .organization-banner-image-div {
-      max-height: 200px;
-      min-height: 0; } }
+/*.network-issues-list {*/
+/*  padding: 4px;*/
+/*  display: flex;*/
+/*  flex-flow: row wrap;*/
+/*}*/
 
-.organization-banner-image-img {
-  width: 100%; }
+/*.network-issues-list .intro-modal__square {*/
+/*  float: left;*/
+/*  color: #fff;*/
+/*  text-align: center;*/
+/*}*/
 
-.voter-guide__pledge-to-support__current-supporters {
-  text-align: center;
-  font-size: .8rem; }
+/*.network-issues-list .intro-modal__square-name {*/
+/*  position: absolute;*/
+/*  font-size: 1rem;*/
+/*  word-wrap: break-word;*/
+/*  color: #fff;*/
+/*  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.6);*/
+/*  background: rgba(0, 0, 0, 0.45);*/
+/*  padding: 10px;*/
+/*  width: 100%;*/
+/*  border-radius: 8px;*/
+/*  border: 2px solid #fff;*/
+/*  transition: all .2s ease-in;*/
+/*}*/
 
-@media all and (min-width: 320px) and (max-width: 479px) {
-  .voter-guide__pledge-to-support__i-stand-with-button {
-    font-size: .9rem; } }
+/*.network-issues-list .intro-modal__square-name:hover {*/
+/*  border: 2px solid #2e3c5d;*/
+/*  background: rgba(0, 0, 0, 0.55);*/
+/*}*/
 
-.voter-guide__pledge-to-support__i-stand-with-button-description {
-  text-align: center;
-  font-size: .8rem; }
-  @media all and (min-width: 320px) and (max-width: 479px) {
-    .voter-guide__pledge-to-support__i-stand-with-button-description {
-      font-size: .9rem; } }
+/*@media all and (min-width: 576px) and (max-width: 991px) {*/
+/*  .network-issues-list .intro-modal__square-name {*/
+/*    font-size: .9rem;*/
+/*  }*/
+/*}*/
 
-.voter-guide__pledge-to-support__thank-you-for-supporting {
-  font-size: 1.2rem; }
+/*@media all and (min-width: 375px) and (max-width: 479px) {*/
+/*  .network-issues-list .intro-modal__square-name {*/
+/*    font-size: .9rem;*/
+/*    -webkit-hyphens: auto;*/
+/*    -moz-hyphens: auto;*/
+/*    -ms-hyphens: auto;*/
+/*    hyphens: auto;*/
+/*  }*/
+/*}*/
 
-.voter-guide-get-started__image {
-  width: 100%; }
+/*@media all and (max-width: 374px) {*/
+/*  .network-issues-list .intro-modal__square-name {*/
+/*    font-size: .85rem;*/
+/*    -webkit-hyphens: auto;*/
+/*    -moz-hyphens: auto;*/
+/*    -ms-hyphens: auto;*/
+/*    hyphens: auto;*/
+/*  }*/
+/*}*/
 
-.voter-guide-get-started__link {
-  color: #999;
-  text-decoration: underline; }
+/*@media all and (max-width: 479px) {*/
+/*  .network__card {*/
+/*    margin: -16px -16px 0 -16px;*/
+/*  }*/
+/*}*/
 
-.voter-guide-get-started__status-success {
-  color: #76d00b;
-  font-size: 1.4em; }
+/*.opinions-followed__missing-org-text {*/
+/*  font-size: 12px;*/
+/*}*/
 
-.voter-guide-get-started__status-error {
-  color: #ff4921;
-  font-size: 1.6em; }
+/*.opinions-followed__container-cordova {*/
+/*  padding-bottom: 64px;*/
+/*}*/
 
-.create-voter-guide {
-  background-color: #555;
-  padding: 0;
-  width: 100%; }
-  .create-voter-guide__h1 {
-    color: #fff;
-    font-weight: 700;
-    font-size: 30px;
-    padding: 32px 0 0;
-    text-align: center; }
-    @media all and (max-width: 959px) {
-      .create-voter-guide__h1 {
-        font-size: 22px; } }
-  .create-voter-guide__description {
-    color: #fff;
-    font-weight: 400;
-    font-size: 18px;
-    padding: 16px 16px 16px 16px;
-    text-align: center; }
-    @media all and (max-width: 959px) {
-      .create-voter-guide__description {
-        font-size: 16px; } }
-  .create-voter-guide__steps {
-    color: #fff;
-    font-weight: 300;
-    font-size: 16px;
-    padding: 4px 0 4px;
-    text-align: center; }
-    @media all and (max-width: 959px) {
-      .create-voter-guide__steps {
-        font-size: 14px; } }
-  .create-voter-guide__footer {
-    position: absolute;
-    bottom: 10%;
-    width: 100%; }
-    @media all and (min-width: 480px) {
-      .create-voter-guide__footer {
-        bottom: 10%; } }
-  .create-voter-guide__organization-container {
-    display: inline-block; }
-  .create-voter-guide__radio {
-    text-align: left; }
-  .create-voter-guide__radio-label {
-    padding-left: 10px; }
+/*.scratch-pad {*/
+/*  padding-top: 8px;*/
+/*}*/
 
-.welcome-page {
-  margin-top: -10px; }
-  .welcome-page .hero__section {
-    position: relative;
-    background-image: url("/img/welcome/header-image-desktop.png");
-    background-size: cover;
-    color: #fff;
-    margin: 0 auto;
-    max-width: 100%;
-    padding-top: 64px;
-    padding-bottom: 64px;
-    text-align: center; }
-    @media all and (min-width: 375px) and (max-width: 959px) {
-      .welcome-page .hero__section {
-        padding-top: 16px;
-        padding-bottom: 16px; } }
-    .welcome-page .hero__section__container {
-      background-color: #314965; }
-    .welcome-page .hero__section__row {
-      font-weight: normal;
-      letter-spacing: 1px; }
-    .welcome-page .hero__section::before {
-      content: '';
-      display: block;
-      position: absolute;
-      top: 0;
-      right: 0;
-      bottom: 0;
-      left: 0;
-      background-color: rgba(85, 85, 85, 0.5); }
-  @media all and (min-width: 320px) and (max-width: 479px) {
-    .welcome-page .share-your-vision__h1 {
-      margin-top: 8px; } }
-  .welcome-page .form-group {
-    padding: 0 8px; }
-  .welcome-page .form-control {
-    width: 100%; }
-  .welcome-page .form__section {
-    width: 100%;
-    padding-top: 0;
-    background-color: #2e3c5d; }
-  .welcome-page .form__email-verfication {
-    color: #fff; }
-  .welcome-page .form__container {
-    padding: 32px 0; }
-  .welcome-page .form__header {
-    margin-bottom: 16px;
-    color: #fff;
-    font-size: 20px;
-    font-weight: 500;
-    text-align: center; }
-  .welcome-page .form__button--disabled {
-    color: #333; }
-  .welcome-page .form__button--disabled:hover {
-    color: #fff; }
-  .welcome-page .quick-links__button {
-    display: -ms-flexbox;
-    display: flex;
-    -ms-flex-pack: center;
-    justify-content: center;
-    align-items: center;
-    -ms-flex-align: center;
-    color: #fff;
-    font-size: 18px;
-    text-align: center;
-    padding: 1em;
-    line-height: 1em;
-    transition: background .3s;
-    width: 60%;
-    border-radius: 16px; }
-    @media all and (max-width: 767px) {
-      .welcome-page .quick-links__button {
-        width: 80%;
-        margin-bottom: 32px; } }
-    .welcome-page .quick-links__button--left {
-      background: #fb2f2f; }
-    .welcome-page .quick-links__button--right {
-      background: #476480; }
-    .welcome-page .quick-links__button:hover {
-      background: #2e3c5d;
-      text-decoration: none; }
-  .welcome-page .quick-links__section--desktop {
-    padding: 16px 0 16px 0; }
-    .welcome-page .quick-links__section--desktop a {
-      margin: auto;
-      margin-top: 32px; }
-  .welcome-page .quick-links__section--mobile {
-    padding: 0 0 16px 0;
-    margin-top: 8px; }
-    .welcome-page .quick-links__section--mobile a {
-      margin: auto; }
-  .welcome-page .features__section {
-    background-color: #2e3c5d;
-    color: #fff;
-    padding-top: 20px;
-    padding-bottom: 64px; }
-  .welcome-page .features__block {
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    align-items: center;
-    text-align: center;
-    margin-bottom: 64px;
-    min-height: 120px; }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block {
-        width: 100%;
-        height: inherit; } }
-    .welcome-page .features__block a {
-      color: #fff;
-      text-decoration: none; }
-      @media all and (max-width: 767px) {
-        .welcome-page .features__block a {
-          width: 80%; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block__container {
-        height: 275px; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block__row1 {
-        height: 184px; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block__row1a {
-        height: 194px; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block__row2 {
-        height: 144px; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block__row2a {
-        height: 144px; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block__row3 {
-        height: 186px; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__block__row3a {
-        height: 236px; } }
-  .welcome-page .features__image {
-    margin-bottom: 16px;
-    height: auto; }
-  .welcome-page .features__h3 {
-    margin-bottom: 10px;
-    font-size: 24px;
-    line-height: 1.25;
-    font-weight: 600; }
-    .welcome-page .features__h3:hover {
-      text-decoration: underline; }
-    @media all and (max-width: 374px) {
-      .welcome-page .features__h3 {
-        font-size: 20px; } }
-  .welcome-page .features__p {
-    font-size: 14px;
-    padding: 0 32px;
-    height: 66px; }
-    @media all and (min-width: 768px) and (max-width: 991px) {
-      .welcome-page .features__p {
-        height: 110px; } }
-    @media all and (max-width: 767px) {
-      .welcome-page .features__p {
-        padding: 0; } }
-  .welcome-page .features__title {
-    margin-bottom: 0;
-    font-weight: bold;
-    font-size: 2rem; }
-    @media all and (min-width: 375px) and (max-width: 959px) {
-      .welcome-page .features__title {
-        font-size: 1.5rem; } }
-  .welcome-page .features-your-mission__block {
-    align-items: center;
-    text-align: center;
-    padding-bottom: 16px; }
-    @media all and (max-width: 767px) {
-      .welcome-page .features-your-mission__block {
-        margin-bottom: 64px; } }
-    .welcome-page .features-your-mission__block .h2 {
-      font-size: 24px;
-      font-weight: normal; }
-  .welcome-page .network__section {
-    padding-top: 32px;
-    padding-bottom: 32px;
-    text-align: center;
-    background-color: #fff; }
-  .welcome-page .partner__logos {
-    margin: 0;
-    text-align: center;
-    list-style: none;
-    padding-bottom: 0; }
-  .welcome-page .footer__section {
-    background-color: #2e3c5d;
-    padding-top: 64px;
-    padding-bottom: 64px;
-    text-align: center;
-    color: #fff; }
-    .welcome-page .footer__section a {
-      color: #fff;
-      text-decoration: none; }
-      .welcome-page .footer__section a:hover {
-        color: #fff;
-        text-decoration: underline; }
-    @media all and (max-width: 767px) {
-      .welcome-page .footer__section .btn-social {
-        width: 50%;
-        text-align: center;
-        margin-bottom: 8px; } }
+/*.organization-banner-image-non-twitter-users {*/
+/*  height: 0;*/
+/*  background-color: #999;*/
+/*  display: block;*/
+/*}*/
+
+/*.organization-banner-image-div {*/
+/*  min-height: 200px;*/
+/*  max-height: 300px;*/
+/*  overflow: hidden;*/
+/*}*/
+
+/*@media all and (min-width: 768px) and (max-width: 959px) {*/
+/*  .organization-banner-image-div {*/
+/*    min-height: 0;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .organization-banner-image-div {*/
+/*    max-height: 200px;*/
+/*    min-height: 0;*/
+/*  }*/
+/*}*/
+
+/*.organization-banner-image-img {*/
+/*  width: 100%;*/
+/*}*/
+
+/*.voter-guide__pledge-to-support__current-supporters {*/
+/*  text-align: center;*/
+/*  font-size: .8rem;*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 479px) {*/
+/*  .voter-guide__pledge-to-support__i-stand-with-button {*/
+/*    font-size: .9rem;*/
+/*  }*/
+/*}*/
+
+/*.voter-guide__pledge-to-support__i-stand-with-button-description {*/
+/*  text-align: center;*/
+/*  font-size: .8rem;*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 479px) {*/
+/*  .voter-guide__pledge-to-support__i-stand-with-button-description {*/
+/*    font-size: .9rem;*/
+/*  }*/
+/*}*/
+
+/*.voter-guide__pledge-to-support__thank-you-for-supporting {*/
+/*  font-size: 1.2rem;*/
+/*}*/
+
+/*.voter-guide-get-started__image {*/
+/*  width: 100%;*/
+/*}*/
+
+/*.voter-guide-get-started__link {*/
+/*  color: #999;*/
+/*  text-decoration: underline;*/
+/*}*/
+
+/*.voter-guide-get-started__status-success {*/
+/*  color: #76d00b;*/
+/*  font-size: 1.4em;*/
+/*}*/
+
+/*.voter-guide-get-started__status-error {*/
+/*  color: #ff4921;*/
+/*  font-size: 1.6em;*/
+/*}*/
+
+/*.create-voter-guide {*/
+/*  background-color: #555;*/
+/*  padding: 0;*/
+/*  width: 100%;*/
+/*}*/
+
+/*.create-voter-guide__h1 {*/
+/*  color: #fff;*/
+/*  font-weight: 700;*/
+/*  font-size: 30px;*/
+/*  padding: 32px 0 0;*/
+/*  text-align: center;*/
+/*}*/
+
+/*@media all and (max-width: 959px) {*/
+/*  .create-voter-guide__h1 {*/
+/*    font-size: 22px;*/
+/*  }*/
+/*}*/
+
+/*.create-voter-guide__description {*/
+/*  color: #fff;*/
+/*  font-weight: 400;*/
+/*  font-size: 18px;*/
+/*  padding: 16px 16px 16px 16px;*/
+/*  text-align: center;*/
+/*}*/
+
+/*@media all and (max-width: 959px) {*/
+/*  .create-voter-guide__description {*/
+/*    font-size: 16px;*/
+/*  }*/
+/*}*/
+
+/*.create-voter-guide__steps {*/
+/*  color: #fff;*/
+/*  font-weight: 300;*/
+/*  font-size: 16px;*/
+/*  padding: 4px 0 4px;*/
+/*  text-align: center;*/
+/*}*/
+
+/*@media all and (max-width: 959px) {*/
+/*  .create-voter-guide__steps {*/
+/*    font-size: 14px;*/
+/*  }*/
+/*}*/
+
+/*.create-voter-guide__footer {*/
+/*  position: absolute;*/
+/*  bottom: 10%;*/
+/*  width: 100%;*/
+/*}*/
+
+/*@media all and (min-width: 480px) {*/
+/*  .create-voter-guide__footer {*/
+/*    bottom: 10%;*/
+/*  }*/
+/*}*/
+
+/*.create-voter-guide__organization-container {*/
+/*  display: inline-block;*/
+/*}*/
+
+/*.create-voter-guide__radio {*/
+/*  text-align: left;*/
+/*}*/
+
+/*.create-voter-guide__radio-label {*/
+/*  padding-left: 10px;*/
+/*}*/
+
+/*.welcome-page {*/
+/*  margin-top: -10px;*/
+/*}*/
+
+/*.welcome-page .hero__section {*/
+/*  position: relative;*/
+/*  background-image: url("/img/welcome/header-image-desktop.png");*/
+/*  background-size: cover;*/
+/*  color: #fff;*/
+/*  margin: 0 auto;*/
+/*  max-width: 100%;*/
+/*  padding-top: 64px;*/
+/*  padding-bottom: 64px;*/
+/*  text-align: center;*/
+/*}*/
+
+/*@media all and (min-width: 375px) and (max-width: 959px) {*/
+/*  .welcome-page .hero__section {*/
+/*    padding-top: 16px;*/
+/*    padding-bottom: 16px;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .hero__section__container {*/
+/*  background-color: #314965;*/
+/*}*/
+
+/*.welcome-page .hero__section__row {*/
+/*  font-weight: normal;*/
+/*  letter-spacing: 1px;*/
+/*}*/
+
+/*.welcome-page .hero__section::before {*/
+/*  content: '';*/
+/*  display: block;*/
+/*  position: absolute;*/
+/*  top: 0;*/
+/*  right: 0;*/
+/*  bottom: 0;*/
+/*  left: 0;*/
+/*  background-color: rgba(85, 85, 85, 0.5);*/
+/*}*/
+
+/*@media all and (min-width: 320px) and (max-width: 479px) {*/
+/*  .welcome-page .share-your-vision__h1 {*/
+/*    margin-top: 8px;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .form-group {*/
+/*  padding: 0 8px;*/
+/*}*/
+
+/*.welcome-page .form-control {*/
+/*  width: 100%;*/
+/*}*/
+
+/*.welcome-page .form__section {*/
+/*  width: 100%;*/
+/*  padding-top: 0;*/
+/*  background-color: #2e3c5d;*/
+/*}*/
+
+/*.welcome-page .form__email-verfication {*/
+/*  color: #fff;*/
+/*}*/
+
+/*.welcome-page .form__container {*/
+/*  padding: 32px 0;*/
+/*}*/
+
+/*.welcome-page .form__header {*/
+/*  margin-bottom: 16px;*/
+/*  color: #fff;*/
+/*  font-size: 20px;*/
+/*  font-weight: 500;*/
+/*  text-align: center;*/
+/*}*/
+
+/*.welcome-page .form__button--disabled {*/
+/*  color: #333;*/
+/*}*/
+
+/*.welcome-page .form__button--disabled:hover {*/
+/*  color: #fff;*/
+/*}*/
+
+/*.welcome-page .quick-links__button {*/
+/*  display: -ms-flexbox;*/
+/*  display: flex;*/
+/*  -ms-flex-pack: center;*/
+/*  justify-content: center;*/
+/*  align-items: center;*/
+/*  -ms-flex-align: center;*/
+/*  color: #fff;*/
+/*  font-size: 18px;*/
+/*  text-align: center;*/
+/*  padding: 1em;*/
+/*  line-height: 1em;*/
+/*  transition: background .3s;*/
+/*  width: 60%;*/
+/*  border-radius: 16px;*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .quick-links__button {*/
+/*    width: 80%;*/
+/*    margin-bottom: 32px;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .quick-links__button--left {*/
+/*  background: #fb2f2f;*/
+/*}*/
+
+/*.welcome-page .quick-links__button--right {*/
+/*  background: #476480;*/
+/*}*/
+
+/*.welcome-page .quick-links__button:hover {*/
+/*  background: #2e3c5d;*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.welcome-page .quick-links__section--desktop {*/
+/*  padding: 16px 0 16px 0;*/
+/*}*/
+
+/*.welcome-page .quick-links__section--desktop a {*/
+/*  margin: auto;*/
+/*  margin-top: 32px;*/
+/*}*/
+
+/*.welcome-page .quick-links__section--mobile {*/
+/*  padding: 0 0 16px 0;*/
+/*  margin-top: 8px;*/
+/*}*/
+
+/*.welcome-page .quick-links__section--mobile a {*/
+/*  margin: auto;*/
+/*}*/
+
+/*.welcome-page .features__section {*/
+/*  background-color: #2e3c5d;*/
+/*  color: #fff;*/
+/*  padding-top: 20px;*/
+/*  padding-bottom: 64px;*/
+/*}*/
+
+/*.welcome-page .features__block {*/
+/*  display: flex;*/
+/*  flex-direction: column;*/
+/*  justify-content: flex-end;*/
+/*  align-items: center;*/
+/*  text-align: center;*/
+/*  margin-bottom: 64px;*/
+/*  min-height: 120px;*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block {*/
+/*    width: 100%;*/
+/*    height: inherit;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .features__block a {*/
+/*  color: #fff;*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block a {*/
+/*    width: 80%;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block__container {*/
+/*    height: 275px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block__row1 {*/
+/*    height: 184px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block__row1a {*/
+/*    height: 194px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block__row2 {*/
+/*    height: 144px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block__row2a {*/
+/*    height: 144px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block__row3 {*/
+/*    height: 186px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__block__row3a {*/
+/*    height: 236px;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .features__image {*/
+/*  margin-bottom: 16px;*/
+/*  height: auto;*/
+/*}*/
+
+/*.welcome-page .features__h3 {*/
+/*  margin-bottom: 10px;*/
+/*  font-size: 24px;*/
+/*  line-height: 1.25;*/
+/*  font-weight: 600;*/
+/*}*/
+
+/*.welcome-page .features__h3:hover {*/
+/*  text-decoration: underline;*/
+/*}*/
+
+/*@media all and (max-width: 374px) {*/
+/*  .welcome-page .features__h3 {*/
+/*    font-size: 20px;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .features__p {*/
+/*  font-size: 14px;*/
+/*  padding: 0 32px;*/
+/*  height: 66px;*/
+/*}*/
+
+/*@media all and (min-width: 768px) and (max-width: 991px) {*/
+/*  .welcome-page .features__p {*/
+/*    height: 110px;*/
+/*  }*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features__p {*/
+/*    padding: 0;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .features__title {*/
+/*  margin-bottom: 0;*/
+/*  font-weight: bold;*/
+/*  font-size: 2rem;*/
+/*}*/
+
+/*@media all and (min-width: 375px) and (max-width: 959px) {*/
+/*  .welcome-page .features__title {*/
+/*    font-size: 1.5rem;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .features-your-mission__block {*/
+/*  align-items: center;*/
+/*  text-align: center;*/
+/*  padding-bottom: 16px;*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .features-your-mission__block {*/
+/*    margin-bottom: 64px;*/
+/*  }*/
+/*}*/
+
+/*.welcome-page .features-your-mission__block .h2 {*/
+/*  font-size: 24px;*/
+/*  font-weight: normal;*/
+/*}*/
+
+/*.welcome-page .network__section {*/
+/*  padding-top: 32px;*/
+/*  padding-bottom: 32px;*/
+/*  text-align: center;*/
+/*  background-color: #fff;*/
+/*}*/
+
+/*.welcome-page .partner__logos {*/
+/*  margin: 0;*/
+/*  text-align: center;*/
+/*  list-style: none;*/
+/*  padding-bottom: 0;*/
+/*}*/
+
+/*.welcome-page .footer__section {*/
+/*  background-color: #2e3c5d;*/
+/*  padding-top: 64px;*/
+/*  padding-bottom: 64px;*/
+/*  text-align: center;*/
+/*  color: #fff;*/
+/*}*/
+
+/*.welcome-page .footer__section a {*/
+/*  color: #fff;*/
+/*  text-decoration: none;*/
+/*}*/
+
+/*.welcome-page .footer__section a:hover {*/
+/*  color: #fff;*/
+/*  text-decoration: underline;*/
+/*}*/
+
+/*@media all and (max-width: 767px) {*/
+/*  .welcome-page .footer__section .btn-social {*/
+/*    width: 50%;*/
+/*    text-align: center;*/
+/*    margin-bottom: 8px;*/
+/*  }*/
+/*}*/
 
 .h1 {
-  font-size: 22px; }
-  @media all and (min-width: 768px) {
-    .h1 {
-      font-size: 28px; } }
+  font-size: 22px;
+}
 
-.pac-container {
-  z-index: 1301 !important; }
+@media all and (min-width: 768px) {
+  .h1 {
+    font-size: 28px;
+  }
+}
 
-.pac-icon {
-  display: none !important; }
+/*.pac-container {*/
+/*  z-index: 1301 !important;*/
+/*}*/
 
-.modal-open {
-  overflow: hidden;
-  position: fixed;
-  width: 100%; }
+/*.pac-icon {*/
+/*  display: none !important;*/
+/*}*/
+
+/*.modal-open {*/
+/*  overflow: hidden;*/
+/*  position: fixed;*/
+/*  width: 100%;*/
+/*}*/
 
 .bs-popover-bottom > .arrow::after, .bs-popover-auto[x-placement^="bottom"] > .arrow::after {
   top: 1px;
   border-width: 0 .5rem .5rem .5rem;
-  border-bottom-color: #2e3c5d; }
+  border-bottom-color: #2e3c5d;
+}
 
-.glyphicon {
-  position: relative;
-  top: 1px;
-  display: inline-block;
-  font-family: 'Glyphicons Halflings';
-  font-style: normal;
-  font-weight: 400;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale; }
+/*.glyphicon {*/
+/*  position: relative;*/
+/*  top: 1px;*/
+/*  display: inline-block;*/
+/*  font-family: 'Glyphicons Halflings';*/
+/*  font-style: normal;*/
+/*  font-weight: 400;*/
+/*  line-height: 1;*/
+/*  -webkit-font-smoothing: antialiased;*/
+/*  -moz-osx-font-smoothing: grayscale;*/
+/*}*/
 
-@media print {
-  @page {
-    size: portrait; }
-  @-moz-document url-prefix('') {
-    body {
-      background-color: white !important; } }
-  body {
-    background-color: white !important;
-    color: #000; }
-  .sidebar-menu {
-    display: none; }
-  .container-main {
-    width: 100%; }
-  .container-settings {
-    width: 100%; }
-  a[href]::after {
-    content: "";
-    text-decoration: none; }
-  a, a:not(.btn) {
-    text-decoration: none; } }
+/*@media print {*/
+/*  @page {*/
+/*    size: portrait;*/
+/*  }*/
 
-/*!  Copied October 20, 2018 from https://raw.githubusercontent.com/instructure-react/react-toggle/master/style.css
-*/
-.react-toggle {
-  touch-action: pan-x;
-  display: inline-block;
-  position: relative;
-  cursor: pointer;
-  background-color: transparent;
-  border: 0;
-  padding: 0;
-  -webkit-touch-callout: none;
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  user-select: none;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-  -webkit-tap-highlight-color: transparent; }
+/*  @-moz-document url-prefix('') {*/
+/*    body {*/
+/*      background-color: white !important;*/
+/*    }*/
+/*  }*/
 
-.react-toggle-screenreader-only {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px; }
+/*  body {*/
+/*    background-color: white !important;*/
+/*    color: #000;*/
+/*  }*/
 
-.react-toggle--disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-  -webkit-transition: opacity 0.25s;
-  transition: opacity 0.25s; }
+/*  .sidebar-menu {*/
+/*    display: none;*/
+/*  }*/
 
-.react-toggle-track {
-  width: 50px;
-  height: 24px;
-  padding: 0;
-  border-radius: 30px;
-  background-color: #4D4D4D;
-  -webkit-transition: all 0.2s ease;
-  -moz-transition: all 0.2s ease;
-  transition: all 0.2s ease; }
+/*  .container-main {*/
+/*    width: 100%;*/
+/*  }*/
 
-.react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background-color: #000000; }
+/*  .container-settings {*/
+/*    width: 100%;*/
+/*  }*/
 
-.react-toggle--checked .react-toggle-track {
-  background-color: #19AB27; }
+/*  a[href]::after {*/
+/*    content: "";*/
+/*    text-decoration: none;*/
+/*  }*/
 
-.react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {
-  background-color: #128D15; }
+/*  a, a:not(.btn) {*/
+/*    text-decoration: none;*/
+/*  }*/
+/*}*/
 
-.react-toggle-track-check {
-  position: absolute;
-  width: 14px;
-  height: 10px;
-  top: 0px;
-  bottom: 0px;
-  margin-top: auto;
-  margin-bottom: auto;
-  line-height: 0;
-  left: 8px;
-  opacity: 0;
-  -webkit-transition: opacity 0.25s ease;
-  -moz-transition: opacity 0.25s ease;
-  transition: opacity 0.25s ease; }
+/*!*!  Copied October 20, 2018 from https://raw.githubusercontent.com/instructure-react/react-toggle/master/style.css*/
+/**!*/
+/*.react-toggle {*/
+/*  touch-action: pan-x;*/
+/*  display: inline-block;*/
+/*  position: relative;*/
+/*  cursor: pointer;*/
+/*  background-color: transparent;*/
+/*  border: 0;*/
+/*  padding: 0;*/
+/*  -webkit-touch-callout: none;*/
+/*  -webkit-user-select: none;*/
+/*  -khtml-user-select: none;*/
+/*  -moz-user-select: none;*/
+/*  -ms-user-select: none;*/
+/*  user-select: none;*/
+/*  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);*/
+/*  -webkit-tap-highlight-color: transparent;*/
+/*}*/
 
-.react-toggle--checked .react-toggle-track-check {
-  opacity: 1;
-  -webkit-transition: opacity 0.25s ease;
-  -moz-transition: opacity 0.25s ease;
-  transition: opacity 0.25s ease; }
+/*.react-toggle-screenreader-only {*/
+/*  border: 0;*/
+/*  clip: rect(0 0 0 0);*/
+/*  height: 1px;*/
+/*  margin: -1px;*/
+/*  overflow: hidden;*/
+/*  padding: 0;*/
+/*  position: absolute;*/
+/*  width: 1px;*/
+/*}*/
 
-.react-toggle-track-x {
-  position: absolute;
-  width: 10px;
-  height: 10px;
-  top: 0px;
-  bottom: 0px;
-  margin-top: auto;
-  margin-bottom: auto;
-  line-height: 0;
-  right: 10px;
-  opacity: 1;
-  -webkit-transition: opacity 0.25s ease;
-  -moz-transition: opacity 0.25s ease;
-  transition: opacity 0.25s ease; }
+/*.react-toggle--disabled {*/
+/*  cursor: not-allowed;*/
+/*  opacity: 0.5;*/
+/*  -webkit-transition: opacity 0.25s;*/
+/*  transition: opacity 0.25s;*/
+/*}*/
 
-.react-toggle--checked .react-toggle-track-x {
-  opacity: 0; }
+/*.react-toggle-track {*/
+/*  width: 50px;*/
+/*  height: 24px;*/
+/*  padding: 0;*/
+/*  border-radius: 30px;*/
+/*  background-color: #4D4D4D;*/
+/*  -webkit-transition: all 0.2s ease;*/
+/*  -moz-transition: all 0.2s ease;*/
+/*  transition: all 0.2s ease;*/
+/*}*/
 
-.react-toggle-thumb {
-  transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;
-  position: absolute;
-  top: 1px;
-  left: 1px;
-  width: 22px;
-  height: 22px;
-  border: 1px solid #4D4D4D;
-  border-radius: 50%;
-  background-color: #FAFAFA;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  -webkit-transition: all 0.25s ease;
-  -moz-transition: all 0.25s ease;
-  transition: all 0.25s ease; }
+/*.react-toggle:hover:not(.react-toggle--disabled) .react-toggle-track {*/
+/*  background-color: #000000;*/
+/*}*/
 
-.react-toggle--checked .react-toggle-thumb {
-  left: 27px;
-  border-color: #19AB27; }
+/*.react-toggle--checked .react-toggle-track {*/
+/*  background-color: #19AB27;*/
+/*}*/
 
-.react-toggle--focus .react-toggle-thumb {
-  -webkit-box-shadow: 0px 0px 3px 2px #0099E0;
-  -moz-box-shadow: 0px 0px 3px 2px #0099E0;
-  box-shadow: 0px 0px 2px 3px #0099E0; }
+/*.react-toggle--checked:hover:not(.react-toggle--disabled) .react-toggle-track {*/
+/*  background-color: #128D15;*/
+/*}*/
 
-.react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb {
-  -webkit-box-shadow: 0px 0px 5px 5px #0099E0;
-  -moz-box-shadow: 0px 0px 5px 5px #0099E0;
-  box-shadow: 0px 0px 5px 5px #0099E0; }
+/*.react-toggle-track-check {*/
+/*  position: absolute;*/
+/*  width: 14px;*/
+/*  height: 10px;*/
+/*  top: 0px;*/
+/*  bottom: 0px;*/
+/*  margin-top: auto;*/
+/*  margin-bottom: auto;*/
+/*  line-height: 0;*/
+/*  left: 8px;*/
+/*  opacity: 0;*/
+/*  -webkit-transition: opacity 0.25s ease;*/
+/*  -moz-transition: opacity 0.25s ease;*/
+/*  transition: opacity 0.25s ease;*/
+/*}*/
+
+/*.react-toggle--checked .react-toggle-track-check {*/
+/*  opacity: 1;*/
+/*  -webkit-transition: opacity 0.25s ease;*/
+/*  -moz-transition: opacity 0.25s ease;*/
+/*  transition: opacity 0.25s ease;*/
+/*}*/
+
+/*.react-toggle-track-x {*/
+/*  position: absolute;*/
+/*  width: 10px;*/
+/*  height: 10px;*/
+/*  top: 0px;*/
+/*  bottom: 0px;*/
+/*  margin-top: auto;*/
+/*  margin-bottom: auto;*/
+/*  line-height: 0;*/
+/*  right: 10px;*/
+/*  opacity: 1;*/
+/*  -webkit-transition: opacity 0.25s ease;*/
+/*  -moz-transition: opacity 0.25s ease;*/
+/*  transition: opacity 0.25s ease;*/
+/*}*/
+
+/*.react-toggle--checked .react-toggle-track-x {*/
+/*  opacity: 0;*/
+/*}*/
+
+/*.react-toggle-thumb {*/
+/*  transition: all 0.5s cubic-bezier(0.23, 1, 0.32, 1) 0ms;*/
+/*  position: absolute;*/
+/*  top: 1px;*/
+/*  left: 1px;*/
+/*  width: 22px;*/
+/*  height: 22px;*/
+/*  border: 1px solid #4D4D4D;*/
+/*  border-radius: 50%;*/
+/*  background-color: #FAFAFA;*/
+/*  -webkit-box-sizing: border-box;*/
+/*  -moz-box-sizing: border-box;*/
+/*  box-sizing: border-box;*/
+/*  -webkit-transition: all 0.25s ease;*/
+/*  -moz-transition: all 0.25s ease;*/
+/*  transition: all 0.25s ease;*/
+/*}*/
+
+/*.react-toggle--checked .react-toggle-thumb {*/
+/*  left: 27px;*/
+/*  border-color: #19AB27;*/
+/*}*/
+
+/*.react-toggle--focus .react-toggle-thumb {*/
+/*  -webkit-box-shadow: 0px 0px 3px 2px #0099E0;*/
+/*  -moz-box-shadow: 0px 0px 3px 2px #0099E0;*/
+/*  box-shadow: 0px 0px 2px 3px #0099E0;*/
+/*}*/
+
+/*.react-toggle:active:not(.react-toggle--disabled) .react-toggle-thumb {*/
+/*  -webkit-box-shadow: 0px 0px 5px 5px #0099E0;*/
+/*  -moz-box-shadow: 0px 0px 5px 5px #0099E0;*/
+/*  box-shadow: 0px 0px 5px 5px #0099E0;*/
+/*}*/

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,14 @@ function startReact () {
     document.getElementById('app'),
   );
 
-  module.hot.accept();
+  try {
+    const { hostname } = window.location;
+    if (hostname && hostname === 'localhost') {
+      module.hot.accept();   // For Webpack
+    }
+  } catch (e) {
+    console.log('Webpack\'s module.hot.accept() threw:', e);
+  }
 }
 
 // Begin inline code

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,14 @@ module.exports = (env, argv) => ({
       ] : []),
       new CssMinimizerPlugin({
         test: /\.css$/i,
+        minimizerOptions: {
+          preset: [
+            'default',
+            {
+              discardComments: { removeAll: true },
+            },
+          ],
+        },
       }),
     ],
   },
@@ -143,10 +151,7 @@ module.exports = (env, argv) => ({
           include: [
             './srcCordova',
           ],
-          log: true,
-          logWarning: true,
-          logError: true,
-          logDebug: true,
+          logWarning: false,
         },
       }),
     ] : []),


### PR DESCRIPTION
I used the coverage analyzer in DevTools to see what css was not being used, then commented out the unused css. I spent a few hours going over the app, in multiple screen sizes, and am fairly confident that I did not miss anything.  But if you find something that doesn't style, just un-comment the missing css.  This reduces main.css to about 58k minimized, an 88% reduction.  I also made the styling WC3 valid (bulk linted it), and removed the deprecated '-ms*' css extensions (which were needed for the deprecated Internet Explorer).  Removed the comments in the compiled main.css for production.
Cleared an error thrown by WebPack's "module.hot.accept();" when in production mode.
