### PR TITLE
Removed older SignInModal in favor of newer SignInModalSimple.jsx

### DIFF
--- a/src/js/components/Activity/ActivityPostPublicToggle.jsx
+++ b/src/js/components/Activity/ActivityPostPublicToggle.jsx
@@ -10,7 +10,7 @@ import ActivityStore from '../../stores/ActivityStore';
 import VoterStore from '../../stores/VoterStore';
 import { openSnackbar } from '../Widgets/SnackNotifier';
 
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 
 class ActivityPostPublicToggle extends Component {
@@ -190,7 +190,7 @@ class ActivityPostPublicToggle extends Component {
           ) : (
             <div>
               <Suspense fallback={<></>}>
-                <SettingsAccount
+                <SignInOptionsPanel
                   pleaseSignInTitle="Sign In to Make Your Posts Public"
                   pleaseSignInSubTitle=""
                   inModal

--- a/src/js/components/Ballot/PositionRowEmpty.jsx
+++ b/src/js/components/Ballot/PositionRowEmpty.jsx
@@ -13,7 +13,7 @@ import { renderLog } from '../../common/utils/logging';
 import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import SvgImage from '../../common/components/Widgets/SvgImage';
 
-const SignInModalSimple = React.lazy(() => import(/* webpackChunkName: 'SignInModalSimple' */ '../Settings/SignInModalSimple'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
 
 class PositionRowEmpty extends Component {
   constructor (props) {
@@ -148,11 +148,11 @@ class PositionRowEmpty extends Component {
       <OuterWrapper>
         { showSignInModal && (
           <Suspense fallback={<></>}>
-            <SignInModalSimple
-              settingsAccountIsSignedInSubTitle={<></>}
-              settingsAccountIsSignedInTitle={<></>}
-              settingsAccountSignInTitle="Sign in to ask your friends."
-              settingsAccountSignInSubTitle=""
+            <SignInModal
+              isSignedInSubTitle={<></>}
+              isSignedInTitle={<></>}
+              signInTitle="Sign in to ask your friends."
+              signInSubTitle=""
               signedInTitle={<></>}
               signedOutTitle={<></>}
               toggleOnClose={this.closeSignInModal}

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -16,7 +16,7 @@ import VoterStore from '../../stores/VoterStore';
 import { validatePhoneOrEmail } from '../../utils/regex-checks';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 
 class AddFriendsByEmail extends Component {
@@ -296,7 +296,7 @@ class AddFriendsByEmail extends Component {
                   </ul>
                 </Alert>
                 <Suspense fallback={<></>}>
-                  <SettingsAccount
+                  <SignInOptionsPanel
                     pleaseSignInTitle="Sign In to Send Your Friend Requests"
                     pleaseSignInSubTitle=""
                   />

--- a/src/js/components/Navigation/HeaderBackTo.jsx
+++ b/src/js/components/Navigation/HeaderBackTo.jsx
@@ -24,7 +24,7 @@ import SignInButton from '../Widgets/SignInButton';
 import HeaderBackToButton from './HeaderBackToButton';
 
 const HeaderNotificationMenu = React.lazy(() => import(/* webpackChunkName: 'HeaderNotificationMenu' */ './HeaderNotificationMenu'));
-const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../Widgets/SignInModal'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModalOriginal'));
 
 const appleSiliconDebug = false;
 
@@ -278,8 +278,10 @@ class HeaderBackTo extends Component {
         {showSignInModal && (
           <Suspense fallback={<></>}>
             <SignInModal
-              show={showSignInModal}
-              closeFunction={this.closeSignInModal}
+              isSignedInTitle={<div style={{ marginLeft: '10px' }}>Successfully signed in</div>}
+              signInTitle="Sign In Or Sign Up"
+              signInSubTitle="Don't worry, we won't post anything automatically."
+              toggleOnClose={this.closeSignInModal}
             />
           </Suspense>
         )}

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -31,7 +31,7 @@ import HeaderBackToButton from './HeaderBackToButton';
 
 const HeaderNotificationMenu = React.lazy(() => import(/* webpackChunkName: 'HeaderNotificationMenu' */ './HeaderNotificationMenu'));
 const ShareModal = React.lazy(() => import(/* webpackChunkName: 'ShareModal' */ '../Share/ShareModal'));
-const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../Widgets/SignInModal'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
 
 const appleSiliconDebug = false;
 
@@ -805,8 +805,10 @@ class HeaderBackToBallot extends Component {
           {showSignInModal && (
             <Suspense fallback={<></>}>
               <SignInModal
-                show={showSignInModal}
-                closeFunction={this.closeSignInModal}
+                isSignedInTitle={<div style={{ marginLeft: '10px' }}>Successfully signed in</div>}
+                signInTitle="Sign In Or Sign Up"
+                signInSubTitle="Don't worry, we won't post anything automatically."
+                toggleOnClose={this.closeSignInModal}
               />
             </Suspense>
           )}

--- a/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
+++ b/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
@@ -29,7 +29,7 @@ import SignInButton from '../Widgets/SignInButton';
 import EndorsementModeTabs from './EndorsementModeTabs';
 import HeaderBackToButton from './HeaderBackToButton';
 
-const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../Widgets/SignInModal'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
 
 
 class HeaderBackToVoterGuides extends Component {
@@ -363,8 +363,10 @@ class HeaderBackToVoterGuides extends Component {
         {showSignInModal && (
           <Suspense fallback={<></>}>
             <SignInModal
-              show={showSignInModal}
-              closeFunction={this.closeSignInModal}
+              isSignedInTitle={<div style={{ marginLeft: '10px' }}>Successfully signed in</div>}
+              signInTitle="Sign In Or Sign Up"
+              signInSubTitle="Don't worry, we won't post anything automatically."
+              toggleOnClose={this.closeSignInModal}
             />
           </Suspense>
         )}

--- a/src/js/components/Navigation/HeaderBarModals.jsx
+++ b/src/js/components/Navigation/HeaderBarModals.jsx
@@ -14,7 +14,7 @@ const ImageUploadModal = React.lazy(() => import(/* webpackChunkName: 'ImageUplo
 const PersonalizedScoreIntroModal = React.lazy(() => import(/* webpackChunkName: 'PersonalizedScoreIntroModal' */ '../CompleteYourProfile/PersonalizedScoreIntroModal'));
 const SelectBallotModal = React.lazy(() => import(/* webpackChunkName: 'SelectBallotModal' */ '../Ballot/SelectBallotModal'));
 const ShareModal = React.lazy(() => import(/* webpackChunkName: 'ShareModal' */ '../Share/ShareModal'));
-const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../Widgets/SignInModal'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
 const ValuesIntroModal = React.lazy(() => import(/* webpackChunkName: 'ValuesIntroModal' */ '../CompleteYourProfile/ValuesIntroModal'));
 
 // A function component, for all the various modals that come out of the HeaderBar
@@ -137,8 +137,10 @@ function HeaderBarModals (props) {
     return (
       <Suspense fallback={<></>}>
         <SignInModal
-          show={showSignInModal}
-          closeFunction={closeSignInModal}
+          isSignedInTitle={<div style={{ marginLeft: '10px' }}>Successfully signed in</div>}
+          signInTitle="Sign In Or Sign Up"
+          signInSubTitle="Don't worry, we won't post anything automatically."
+          toggleOnClose={closeSignInModal}
         />
       </Suspense>
     );

--- a/src/js/components/Navigation/WelcomeAppbar.jsx
+++ b/src/js/components/Navigation/WelcomeAppbar.jsx
@@ -21,7 +21,7 @@ import { Divider, LogoContainer, MobileNavDivider, MobileNavigationMenu, Navigat
 import HeaderBarLogo from './HeaderBarLogo';
 
 const HeaderBarProfilePopUp = React.lazy(() => import(/* webpackChunkName: 'HeaderBarProfilePopUp' */ './HeaderBarProfilePopUp'));
-const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../Widgets/SignInModal'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
 
 // TODO: Backport "@stripe/react-stripe-js" use from Campaigns
 // const PaidAccountUpgradeModal = React.lazy(() => import('../Settings/PaidAccountUpgradeModal'));
@@ -466,8 +466,10 @@ class WelcomeAppbar extends Component {
         {showSignInModal && (
           <Suspense fallback={<></>}>
             <SignInModal
-              show={showSignInModal}
-              closeFunction={this.closeSignInModal}
+              isSignedInTitle={<div style={{ marginLeft: '10px' }}>Successfully signed in</div>}
+              signInTitle="Sign In Or Sign Up"
+              signInSubTitle="Don't worry, we won't post anything automatically."
+              toggleOnClose={this.closeSignInModal}
             />
           </Suspense>
         )}

--- a/src/js/components/Settings/SeeTheseSettingsInAction.jsx
+++ b/src/js/components/Settings/SeeTheseSettingsInAction.jsx
@@ -7,7 +7,7 @@ import OrganizationStore from '../../stores/OrganizationStore';
 import VoterStore from '../../stores/VoterStore';
 
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 
 class SeeTheseSettingsInAction extends Component {
@@ -76,7 +76,7 @@ class SeeTheseSettingsInAction extends Component {
       // console.log('voterIsSignedIn is false');
       return (
         <Suspense fallback={<></>}>
-          <SettingsAccount />
+          <SignInOptionsPanel />
         </Suspense>
       );
     } else if (!voter || !organizationWeVoteId) {

--- a/src/js/components/Settings/SettingsAnalytics.jsx
+++ b/src/js/components/Settings/SettingsAnalytics.jsx
@@ -15,7 +15,7 @@ import CreateConfiguredVersion from './CreateConfiguredVersion';
 import SeeTheseSettingsInAction from './SeeTheseSettingsInAction';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 const SettingsAccountLevelChip = React.lazy(() => import(/* webpackChunkName: 'SettingsAccountLeveLChip' */ './SettingsAccountLevelChip'));
 
 
@@ -285,7 +285,7 @@ class SettingsAnalytics extends Component {
       return (
         <Suspense fallback={<></>}>
           <DelayedLoad waitBeforeShow={1000}>
-            <SettingsAccount />
+            <SignInOptionsPanel />
           </DelayedLoad>
         </Suspense>
       );

--- a/src/js/components/Settings/SettingsDomain.jsx
+++ b/src/js/components/Settings/SettingsDomain.jsx
@@ -17,7 +17,7 @@ import PremiumableButton from '../Widgets/PremiumableButton';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 const SettingsAccountLevelChip = React.lazy(() => import(/* webpackChunkName: 'SettingsAccountLeveLChip' */ './SettingsAccountLevelChip'));
 
 
@@ -360,7 +360,7 @@ class SettingsDomain extends Component {
       return (
         <Suspense fallback={<></>}>
           <DelayedLoad waitBeforeShow={1000}>
-            <SettingsAccount />
+            <SignInOptionsPanel />
           </DelayedLoad>
         </Suspense>
       );

--- a/src/js/components/Settings/SettingsIssueLinks.jsx
+++ b/src/js/components/Settings/SettingsIssueLinks.jsx
@@ -10,7 +10,7 @@ import IssueLinkToggle from '../Values/IssueLinkToggle';
 import BrowserPushMessage from '../Widgets/BrowserPushMessage';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 
 const PROCHOICE = 'wv02issue63';
@@ -154,7 +154,7 @@ export default class SettingsIssueLinks extends Component {
       return (
         <Suspense fallback={<></>}>
           <DelayedLoad waitBeforeShow={1000}>
-            <SettingsAccount />
+            <SignInOptionsPanel />
           </DelayedLoad>
         </Suspense>
       );

--- a/src/js/components/Settings/SettingsPromotedOrganizations.jsx
+++ b/src/js/components/Settings/SettingsPromotedOrganizations.jsx
@@ -8,7 +8,7 @@ import OrganizationStore from '../../stores/OrganizationStore';
 import VoterStore from '../../stores/VoterStore';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 export default class SettingsPromotedOrganizations extends Component {
   constructor (props) {
@@ -86,7 +86,7 @@ export default class SettingsPromotedOrganizations extends Component {
       return (
         <Suspense fallback={<></>}>
           <DelayedLoad waitBeforeShow={1000}>
-            <SettingsAccount />
+            <SignInOptionsPanel />
           </DelayedLoad>
         </Suspense>
       );

--- a/src/js/components/Settings/SettingsSharing.jsx
+++ b/src/js/components/Settings/SettingsSharing.jsx
@@ -20,7 +20,7 @@ import SeeTheseSettingsInAction from './SeeTheseSettingsInAction';
 import { Actions, DescriptionText, GiantTextInput, HiddenInput, ImageDescription, PreviewImage, SharingColumn, SharingRow } from './SettingsStyled';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 const SettingsAccountLevelChip = React.lazy(() => import(/* webpackChunkName: 'SettingsAccountLeveLChip' */ './SettingsAccountLevelChip'));
 
 
@@ -279,7 +279,7 @@ class SettingsSharing extends Component {
       return (
         <Suspense fallback={<></>}>
           <DelayedLoad waitBeforeShow={1000}>
-            <SettingsAccount />
+            <SignInOptionsPanel />
           </DelayedLoad>
         </Suspense>
       );

--- a/src/js/components/Settings/SettingsSiteText.jsx
+++ b/src/js/components/Settings/SettingsSiteText.jsx
@@ -13,7 +13,7 @@ import CreateConfiguredVersion from './CreateConfiguredVersion';
 import SeeTheseSettingsInAction from './SeeTheseSettingsInAction';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 
 class SettingsSiteText extends Component {
@@ -182,7 +182,7 @@ class SettingsSiteText extends Component {
       return (
         <Suspense fallback={<></>}>
           <DelayedLoad waitBeforeShow={1000}>
-            <SettingsAccount />
+            <SignInOptionsPanel />
           </DelayedLoad>
         </Suspense>
       );

--- a/src/js/components/Settings/SettingsSubscriptionPlan.jsx
+++ b/src/js/components/Settings/SettingsSubscriptionPlan.jsx
@@ -18,7 +18,7 @@ import VoterStore from '../../stores/VoterStore';
 import CreateConfiguredVersion from './CreateConfiguredVersion';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 
 class SettingsSubscriptionPlan extends Component {
@@ -246,7 +246,7 @@ class SettingsSubscriptionPlan extends Component {
       return (
         <Suspense fallback={<></>}>
           <DelayedLoad waitBeforeShow={1000}>
-            <SettingsAccount />
+            <SignInOptionsPanel />
           </DelayedLoad>
         </Suspense>
       );

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -256,7 +256,7 @@ class VoterEmailAddressEntry extends Component {
     if (cancelShouldCloseModal) {
       this.closeSignInModal();
     } else {
-      // There are Modal display problems that don't seem to be resolvable that prevents us from returning to the full SettingsAccount modal
+      // There are Modal display problems that don't seem to be resolvable that prevents us from returning to the full SignInOptionsPanel modal
       this.hideEmailVerificationButton();
       this.localToggleOtherSignInOptions();
     }

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -234,7 +234,7 @@ class VoterPhoneVerificationEntry extends Component {
     if (cancelShouldCloseModal) {
       this.closeSignInModal();
     } else {
-      // There are Modal display problems that don't seem to be resolvable that prevents us from returning to the full SettingsAccount modal
+      // There are Modal display problems that don't seem to be resolvable that prevents us from returning to the full SignInOptionsPanel modal
       this.hidePhoneVerificationButton();
       this.localToggleOtherSignInOptions();
     }

--- a/src/js/components/Share/ShareModal.jsx
+++ b/src/js/components/Share/ShareModal.jsx
@@ -540,7 +540,7 @@ class ShareModal extends Component {
       //       </IconButton>
       //     </ModalTitleArea>
       //     <DialogContent classes={{ root: classes.dialogContent }}>
-      //       <SettingsAccount inShareModal inModal pleaseSignInTitle="Sign in to share with your friends" />
+      //       <SignInOptionsPanel inShareModal inModal pleaseSignInTitle="Sign in to share with your friends" />
       //     </DialogContent>
       //   </Dialog>
       // );

--- a/src/js/components/Share/SharedItemModal.jsx
+++ b/src/js/components/Share/SharedItemModal.jsx
@@ -30,7 +30,7 @@ import SharedItemIntroduction from './SharedItemIntroduction';
 
 const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ '../Widgets/FollowToggle'));
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 class SharedItemModal extends Component {
   constructor (props) {
@@ -257,7 +257,7 @@ class SharedItemModal extends Component {
             </IntroHeaderOptional>
           </IntroHeader>
           <Suspense fallback={<></>}>
-            <SettingsAccount
+            <SignInOptionsPanel
               pleaseSignInTextOff
               inModal
             />

--- a/src/js/components/SignIn/SignInModal.jsx
+++ b/src/js/components/SignIn/SignInModal.jsx
@@ -1,11 +1,5 @@
 import { Close } from '@mui/icons-material';
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  IconButton,
-  Typography,
-} from '@mui/material';
+import { Dialog, DialogContent, DialogTitle, IconButton, Typography } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
@@ -15,9 +9,9 @@ import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import VoterStore from '../../stores/VoterStore';
 
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ './SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ './SignInOptionsPanel'));
 
-class SignInModalSimple extends Component {
+class SignInModal extends Component {
   constructor (props) {
     super(props);
     this.state = {
@@ -63,12 +57,15 @@ class SignInModalSimple extends Component {
   }
 
   render () {
-    renderLog('SignInModalSimple');  // Set LOG_RENDER_EVENTS to log all renders
+    renderLog('SignInModal');  // Set LOG_RENDER_EVENTS to log all renders
     const {
       classes,
-      settingsAccountIsSignedInTitle, settingsAccountIsSignedInSubTitle,
-      settingsAccountSignInSubTitle, settingsAccountSignInTitle,
-      signedInTitle, signedOutTitle,
+      isSignedInSubTitle = (<></>),
+      isSignedInTitle = (<></>),
+      signInSubTitle = '',
+      signInTitle = '',
+      signedInTitle = (<></>),
+      signedOutTitle = (<></>),
     } = this.props;
     const { isSignedIn, showSignInModalSimple } = this.state;
 
@@ -106,19 +103,19 @@ class SignInModalSimple extends Component {
               {isSignedIn ? (
                 <div className="text-center">
                   <div className="u-f3">
-                    {settingsAccountIsSignedInTitle}
+                    {isSignedInTitle}
                   </div>
                   <br />
                   <div className="u-f6">
-                    {settingsAccountIsSignedInSubTitle}
+                    {isSignedInSubTitle}
                   </div>
                 </div>
               ) : (
                 <div>
                   <Suspense fallback={<></>}>
-                    <SettingsAccount
-                      pleaseSignInTitle={settingsAccountSignInTitle}
-                      pleaseSignInSubTitle={settingsAccountSignInSubTitle}
+                    <SignInOptionsPanel
+                      pleaseSignInTitle={signInTitle}
+                      pleaseSignInSubTitle={signInSubTitle}
                       inModal
                     />
                   </Suspense>
@@ -133,12 +130,12 @@ class SignInModalSimple extends Component {
     );
   }
 }
-SignInModalSimple.propTypes = {
+SignInModal.propTypes = {
   classes: PropTypes.object,
-  settingsAccountIsSignedInSubTitle: PropTypes.node,
-  settingsAccountIsSignedInTitle: PropTypes.node,
-  settingsAccountSignInTitle: PropTypes.string,
-  settingsAccountSignInSubTitle: PropTypes.string,
+  isSignedInSubTitle: PropTypes.node,
+  isSignedInTitle: PropTypes.node,
+  signInSubTitle: PropTypes.string,
+  signInTitle: PropTypes.string,
   signedInTitle: PropTypes.node,
   signedOutTitle: PropTypes.node,
   toggleOnClose: PropTypes.func,
@@ -211,4 +208,4 @@ const SignInModalWrapper = styled('div')`
   width: fit-content;
 `;
 
-export default withStyles(styles)(SignInModalSimple);
+export default withStyles(styles)(SignInModal);

--- a/src/js/components/SignIn/SignInModalOriginal.jsx
+++ b/src/js/components/SignIn/SignInModalOriginal.jsx
@@ -18,14 +18,14 @@ import DeviceURLField from '../../pages/Startup/DeviceURLField';
 import VoterStore from '../../stores/VoterStore';
 import initializeAppleSDK from '../../utils/initializeAppleSDK';
 import initializeFacebookSDK from '../../utils/initializeFacebookSDK';
-import signInModalGlobalState from './signInModalGlobalState';
+import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ './SignInOptionsPanel'));
 
 
 /* global $ */
 
-class SignInModal extends Component {
+class SignInModalOriginal extends Component {
   constructor (props) {
     super(props);
     this.state = {
@@ -65,11 +65,11 @@ class SignInModal extends Component {
 
   componentDidCatch (error, info) {
     // We should get this information to Splunk!
-    console.error('SignInModal caught error: ', `${error} with info: `, info);
+    console.error('SignInModalOriginal caught error: ', `${error} with info: `, info);
   }
 
   componentWillUnmount () {
-    // console.log('SignInModal componentWillUnmount');
+    // console.log('SignInModalOriginal componentWillUnmount');
     signInModalGlobalState.set('textOrEmailSignInInProcess', false);
     // April 2021: Firing off the verification action, also fires off a number of just in case actions,
     // that causes problems here.  So remove the listener before the "changed state while dispatching" trouble happens.
@@ -111,7 +111,7 @@ class SignInModal extends Component {
   };
 
   closeFunction = () => {
-    // console.log('SignInModal closeFunction');
+    // console.log('SignInModalOriginal closeFunction');
     signInModalGlobalState.set('textOrEmailSignInInProcess', false);
 
     if (this.props.closeFunction) {
@@ -119,8 +119,8 @@ class SignInModal extends Component {
     }
 
     if (isCordova()) {
-      // console.log('closeFunction in SignInModal doing restoreStylesAfterCordovaKeyboard and historyPush');
-      restoreStylesAfterCordovaKeyboard('SignInModal');
+      // console.log('closeFunction in SignInModalOriginal doing restoreStylesAfterCordovaKeyboard and historyPush');
+      restoreStylesAfterCordovaKeyboard('SignInModalOriginal');
       if (webAppConfig.SHOW_CORDOVA_URL_FIELD) {   // TODO This is a hack, need to pass back the new path from DeviceURLField
         historyPush('/start');
       } else {
@@ -139,15 +139,15 @@ class SignInModal extends Component {
   };
 
   render () {
-    renderLog('SignInModal');  // Set LOG_RENDER_EVENTS to log all renders
+    renderLog('SignInModalOriginal');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes } = this.props;
     const { focusedInputName, focusedOnSingleInputToggle, voter, voterIsSignedIn } = this.state;
 
     if (!voter) {
-      // console.log('SignInModal render voter NOT found');
+      // console.log('SignInModalOriginal render voter NOT found');
       return <div className="undefined-props" />;
     }
-    // console.log('SignInModal render voter found');
+    // console.log('SignInModalOriginal render voter found');
 
     if (voter && voterIsSignedIn && isCordova()) {
       return false;
@@ -203,7 +203,7 @@ class SignInModal extends Component {
               ) : (
                 <div>
                   <Suspense fallback={<></>}>
-                    <SettingsAccount
+                    <SignInOptionsPanel
                       closeSignInModal={this.closeFunction}
                       focusedOnSingleInputToggle={this.focusedOnSingleInputToggle}
                       inModal
@@ -237,7 +237,7 @@ class SignInModal extends Component {
     );
   }
 }
-SignInModal.propTypes = {
+SignInModalOriginal.propTypes = {
   classes: PropTypes.object,
   show: PropTypes.bool,
   closeFunction: PropTypes.func.isRequired,
@@ -356,4 +356,4 @@ const styles = (theme) => ({
 });
 
 
-export default withTheme(withStyles(styles)(SignInModal));
+export default withTheme(withStyles(styles)(SignInModalOriginal));

--- a/src/js/components/SignIn/SignInOptionsPanel.jsx
+++ b/src/js/components/SignIn/SignInOptionsPanel.jsx
@@ -27,16 +27,16 @@ import TwitterSignIn from '../Twitter/TwitterSignIn';
 import BrowserPushMessage from '../Widgets/BrowserPushMessage';
 import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 import SnackNotifier, { openSnackbar } from '../Widgets/SnackNotifier';
-import VoterEmailAddressEntry from './VoterEmailAddressEntry';
-import VoterPhoneEmailCordovaEntryModal from './VoterPhoneEmailCordovaEntryModal';
-import VoterPhoneVerificationEntry from './VoterPhoneVerificationEntry';
+import VoterEmailAddressEntry from '../Settings/VoterEmailAddressEntry';
+import VoterPhoneEmailCordovaEntryModal from '../Settings/VoterPhoneEmailCordovaEntryModal';
+import VoterPhoneVerificationEntry from '../Settings/VoterPhoneVerificationEntry';
 
 
 /* global $ */
 
 const debugMode = false;
 
-export default class SettingsAccount extends Component {
+export default class SignInOptionsPanel extends Component {
   constructor (props) {
     super(props);
     this.state = {
@@ -72,7 +72,7 @@ export default class SettingsAccount extends Component {
   // Set up this component upon first entry
   // componentWillMount is used in WebApp
   componentDidMount () {
-    // console.log("SettingsAccount componentDidMount");
+    // console.log("SignInOptionsPanel componentDidMount");
     initializeAppleSDK(null);
     this.onVoterStoreChange();
     this.appStateSubscription = messageService.getMessage().subscribe(() => this.onAppObservableStoreChange());
@@ -105,14 +105,14 @@ export default class SettingsAccount extends Component {
       });
       pathname = '/settings/profile';
       signInStartFullUrl = `${origin}${pathname}`;
-      // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
+      // console.log('SignInOptionsPanel getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
       if (origin && stringContains('wevote.us', origin)) {
         Cookies.set('sign_in_start_full_url', signInStartFullUrl, { expires: 31, path: '/', domain: 'wevote.us' });
       }
     } else if (getStartedMode && getStartedMode === 'getStartedForCampaigns') {
       pathname = '/settings/profile';
       signInStartFullUrl = `${origin}${pathname}`;
-      // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
+      // console.log('SignInOptionsPanel getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
       if (origin && stringContains('wevote.us', origin)) {
         Cookies.set('sign_in_start_full_url', signInStartFullUrl, { expires: 31, path: '/', domain: 'wevote.us' });
       } else {
@@ -125,7 +125,7 @@ export default class SettingsAccount extends Component {
     } else if (getStartedMode && getStartedMode === 'getStartedForOrganizations') {
       pathname = '/settings/profile';
       signInStartFullUrl = `${origin}${pathname}`;
-      // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
+      // console.log('SignInOptionsPanel getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
       if (origin && stringContains('wevote.us', origin)) {
         Cookies.set('sign_in_start_full_url', signInStartFullUrl, { expires: 1, path: '/', domain: 'wevote.us' });
       } else {
@@ -138,7 +138,7 @@ export default class SettingsAccount extends Component {
     } else if (getStartedMode && getStartedMode === 'getStartedForVoters') {
       pathname = '/settings/profile';
       signInStartFullUrl = `${origin}${pathname}`;
-      // console.log('SettingsAccount getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
+      // console.log('SignInOptionsPanel getStartedForCampaigns, new origin: ', origin, ', pathname: ', pathname, ', signInStartFullUrl: ', signInStartFullUrl);
       if (origin && stringContains('wevote.us', origin)) {
         Cookies.set('sign_in_start_full_url', signInStartFullUrl, { expires: 1, path: '/', domain: 'wevote.us' });
       } else {
@@ -186,16 +186,16 @@ export default class SettingsAccount extends Component {
       // so we wait for it to be rendered, then move it into place
 
       if (sendButtonSMS.length) {
-        console.log('SettingsAccount componentDidUpdate SEND CODE was rendered. sendButtonSMS:', sendButtonSMS);
+        console.log('SignInOptionsPanel componentDidUpdate SEND CODE was rendered. sendButtonSMS:', sendButtonSMS);
       } else if ((sendButtonSMS.length)) {
-        console.log('SettingsAccount componentDidUpdate SEND CODE was rendered. sendButtonEmail:', sendButtonEmail);
+        console.log('SignInOptionsPanel componentDidUpdate SEND CODE was rendered. sendButtonEmail:', sendButtonEmail);
       }
       if (sendButtonSMS.length || sendButtonSMS.length) {
         if (styleWorking && !stringContains(translate, styleWorking)) {
           $(cont).attr('style', `${styleWorking} ${translate}`);
-          console.log(`SettingsAccount componentDidUpdate was rendered. NEW style: ${$(cont).attr('style')}`);
+          console.log(`SignInOptionsPanel componentDidUpdate was rendered. NEW style: ${$(cont).attr('style')}`);
         } else {
-          console.log(`SettingsAccount componentDidUpdate was rendered. transform was already there. style: ${$(cont).attr('style')}`);
+          console.log(`SignInOptionsPanel componentDidUpdate was rendered. transform was already there. style: ${$(cont).attr('style')}`);
         }
       }
     }
@@ -208,13 +208,13 @@ export default class SettingsAccount extends Component {
   }
 
   componentWillUnmount () {
-    // console.log("SettingsAccount componentWillUnmount");
+    // console.log("SignInOptionsPanel componentWillUnmount");
     signInModalGlobalState.set('textOrEmailSignInInProcess', false);
     this.appStateSubscription.unsubscribe();
     this.facebookStoreListener.remove();
     this.voterStoreListener.remove();
     if (this.timer) clearTimeout(this.timer);
-    restoreStylesAfterCordovaKeyboard('SettingsAccount');
+    restoreStylesAfterCordovaKeyboard('SignInOptionsPanel');
   }
 
   onAppObservableStoreChange () {
@@ -239,14 +239,14 @@ export default class SettingsAccount extends Component {
   }
 
   focusedOnSingleInputToggle = (focusedInputName) => {
-    // console.log('SettingsAccount focusedOnSingleInput');
+    // console.log('SignInOptionsPanel focusedOnSingleInput');
     if (this.props.focusedOnSingleInputToggle) {
       this.props.focusedOnSingleInputToggle(focusedInputName);
     }
   };
 
   localCloseSignInModal = () => {
-    // console.log('SettingsAccount localCloseSignInModal');
+    // console.log('SignInOptionsPanel localCloseSignInModal');
     if (this.props.closeSignInModal) {
       this.props.closeSignInModal();
     }
@@ -265,7 +265,7 @@ export default class SettingsAccount extends Component {
       hideTwitterSignInButton: !hideTwitterSignInButton,
       hideVoterPhoneEntry: !hideVoterPhoneEntry,
     });
-    // console.log('SettingsAccount toggleNonEmailSignInOptions');
+    // console.log('SignInOptionsPanel toggleNonEmailSignInOptions');
     this.focusedOnSingleInputToggle('email');
   };
 
@@ -282,7 +282,7 @@ export default class SettingsAccount extends Component {
       hideTwitterSignInButton: !hideTwitterSignInButton,
       hideVoterEmailAddressEntry: !hideVoterEmailAddressEntry,
     });
-    // console.log('SettingsAccount toggleNonPhoneSignInOptions');
+    // console.log('SignInOptionsPanel toggleNonPhoneSignInOptions');
     this.focusedOnSingleInputToggle('phone');
   };
 
@@ -335,13 +335,13 @@ export default class SettingsAccount extends Component {
   }
 
   signOut () {
-    // console.log('SettingsAccount.jsx signOut');
+    // console.log('SignInOptionsPanel.jsx signOut');
     VoterSessionActions.voterSignOut();
     historyPush('/ballot');
   }
 
   render () {
-    renderLog('SettingsAccount');  // Set LOG_RENDER_EVENTS to log all renders
+    renderLog('SignInOptionsPanel');  // Set LOG_RENDER_EVENTS to log all renders
     const { inModal, externalUniqueId } = this.props;
     const {
       facebookAuthResponse, hideCurrentlySignedInHeader,
@@ -358,13 +358,13 @@ export default class SettingsAccount extends Component {
       signed_in_twitter: voterIsSignedInTwitter, signed_in_with_email: voterIsSignedInWithEmail,
       twitter_screen_name: twitterScreenName, signed_in_with_apple: voterIsSignedInWithApple,
     } = voter;
-    // console.log("SettingsAccount.jsx facebookAuthResponse:", facebookAuthResponse);
-    // console.log("SettingsAccount.jsx voter:", voter);
-    // console.log('SettingsAccount.jsx hideDialogForCordova:', hideDialogForCordova);
+    // console.log("SignInOptionsPanel.jsx facebookAuthResponse:", facebookAuthResponse);
+    // console.log("SignInOptionsPanel.jsx voter:", voter);
+    // console.log('SignInOptionsPanel.jsx hideDialogForCordova:', hideDialogForCordova);
     if (!voterIsSignedInFacebook && facebookAuthResponse && facebookAuthResponse.length && facebookAuthResponse.facebook_retrieve_attempted) {
-      // console.log('SettingsAccount.jsx facebook_retrieve_attempted');
-      oAuthLog('SettingsAccount facebook_retrieve_attempted');
-      // return <span>SettingsAccount.jsx facebook_retrieve_attempted</span>;
+      // console.log('SignInOptionsPanel.jsx facebook_retrieve_attempted');
+      oAuthLog('SignInOptionsPanel facebook_retrieve_attempted');
+      // return <span>SignInOptionsPanel.jsx facebook_retrieve_attempted</span>;
       return LoadingWheel;
     }
 
@@ -382,7 +382,7 @@ export default class SettingsAccount extends Component {
       }
     }
 
-    // console.log('SettingsAccount voterIsSignedIn', voterIsSignedIn, '\nsignedInTwitter', voterIsSignedInTwitter, 'signedInFacebook', voterIsSignedInFacebook,
+    // console.log('SignInOptionsPanel voterIsSignedIn', voterIsSignedIn, '\nsignedInTwitter', voterIsSignedInTwitter, 'signedInFacebook', voterIsSignedInFacebook,
     //   'signedInWithApple', voterIsSignedInWithApple, '\nhideDialogForCordova', hideDialogForCordova, 'hideCurrentlySignedInHeader', hideCurrentlySignedInHeader,
     //   'hideTwitterSignInButton', hideTwitterSignInButton,
     //   'hideFacebookSignInButton', hideFacebookSignInButton, 'hideDialogForCordova', hideDialogForCordova,
@@ -395,7 +395,7 @@ export default class SettingsAccount extends Component {
         {!hideDialogForCordova &&
           <BrowserPushMessage incomingProps={this.props} />}
         <div className={inModal ? 'card-main full-width' : 'card'} style={{ display: `${hideDialogForCordova ? ' none' : 'undefined'}` }}>
-          <Main inModal={inModal} id={`settingsAccountMain-${externalUniqueId}`}>
+          <Main inModal={inModal} id={`SignInOptionsMain-${externalUniqueId}`}>
             {voterIsSignedInTwitter && voterIsSignedInFacebook ?
               null :
               <h1 className="h3">{!hideTwitterSignInButton && !hideFacebookSignInButton && voterIsSignedIn ? <span>{yourAccountTitle}</span> : null}</h1>}
@@ -603,7 +603,7 @@ export default class SettingsAccount extends Component {
     );
   }
 }
-SettingsAccount.propTypes = {
+SignInOptionsPanel.propTypes = {
   externalUniqueId: PropTypes.string,
   inModal: PropTypes.bool,
   pleaseSignInTextOff: PropTypes.bool,

--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -13,7 +13,7 @@ import IssueFollowToggleButton from './IssueFollowToggleButton';
 import IssueImageDisplay from './IssueImageDisplay';
 
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
-const SignInModalSimple = React.lazy(() => import(/* webpackChunkName: 'SignInModalSimple' */ '../Settings/SignInModalSimple'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
 
 const NUMBER_OF_LINKED_ORGANIZATION_IMAGES_TO_SHOW = 3; // Maximum available coming from issueDescriptionsRetrieve is currently 5
 
@@ -158,11 +158,11 @@ class IssueCard extends Component {
       >
         {(showSignInModal && !VoterStore.getVoterIsSignedIn()) && (
           <Suspense fallback={<></>}>
-            <SignInModalSimple
-              settingsAccountIsSignedInSubTitle={<></>}
-              settingsAccountIsSignedInTitle={<></>}
-              settingsAccountSignInTitle="Sign in to save your values."
-              settingsAccountSignInSubTitle=""
+            <SignInModal
+              isSignedInSubTitle={<></>}
+              isSignedInTitle={<></>}
+              signInTitle="Sign in to save your values."
+              signInSubTitle=""
               signedInTitle={<></>}
               signedOutTitle={<></>}
               toggleOnClose={this.toggleShowSignInModal}

--- a/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
+++ b/src/js/components/VoterGuide/OrganizationVoterGuideTabs.jsx
@@ -15,7 +15,7 @@ import VoterGuideEndorsements from './VoterGuideEndorsements';
 import VoterGuideFollowers from './VoterGuideFollowers';
 import VoterGuideFollowing from './VoterGuideFollowing';
 
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../Settings/SettingsAccount'));
+const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../SignIn/SignInOptionsPanel'));
 
 export default class OrganizationVoterGuideTabs extends Component {
   // static getDerivedStateFromProps (props, state) {

--- a/src/js/components/Widgets/ItemActionBar/ChooseOrOpposeIntroModal.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ChooseOrOpposeIntroModal.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import VoterStore from '../../../stores/VoterStore';
 import PositionPublicToggle from '../PositionPublicToggle';
 
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../../Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../../SignIn/SignInOptionsPanel'));
 
 
 class ChooseOrOpposeIntroModal extends Component {
@@ -117,7 +117,7 @@ class ChooseOrOpposeIntroModal extends Component {
       slides.signIn = (
         <Suspense fallback={<></>}>
           <>
-            <SettingsAccount
+            <SignInOptionsPanel
               pleaseSignInTitle="Sign in to save your choices!"
               pleaseSignInSubTitle=""
               toggleSignInModal={this.props.onClose}

--- a/src/js/components/Widgets/PositionPublicToggle.jsx
+++ b/src/js/components/Widgets/PositionPublicToggle.jsx
@@ -11,7 +11,7 @@ import SupportStore from '../../stores/SupportStore';
 import VoterStore from '../../stores/VoterStore';
 import { openSnackbar } from './SnackNotifier';
 
-const SignInModalSimple = React.lazy(() => import(/* webpackChunkName: 'SignInModalSimple' */ '../Settings/SignInModalSimple'));
+const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
 
 class PositionPublicToggle extends Component {
   constructor (props) {
@@ -210,15 +210,15 @@ class PositionPublicToggle extends Component {
       <PositionPublicToggleOuterWrapper className={this.props.className}>
         { showPositionPublicHelpModal && (
           <Suspense fallback={<></>}>
-            <SignInModalSimple
-              settingsAccountIsSignedInSubTitle={<></>}
-              settingsAccountIsSignedInTitle={(
+            <SignInModal
+              isSignedInSubTitle={<></>}
+              isSignedInTitle={(
                 <>
                   Your endorsement is now visible to the public. Click the &quot;Friends&quot; toggle to show to We Vote friends only.
                 </>
               )}
-              settingsAccountSignInTitle="Sign in to make your endorsements public."
-              settingsAccountSignInSubTitle=""
+              signInTitle="Sign in to make your endorsements public."
+              signInSubTitle=""
               signedInTitle={<>Public</>}
               signedOutTitle={<>Show to Public</>}
               toggleOnClose={this.togglePositionPublicHelpModal}

--- a/src/js/constants/CordovaPageConstants.js
+++ b/src/js/constants/CordovaPageConstants.js
@@ -23,7 +23,7 @@ const CordovaPageConstants = {
   opinions: null,
   opinionsFiltered: null,
   ready: null,
-  settingsAccount: null,
+  signInOptions: null,
   settingsHamburger: null,
   settingsNotifications: null,
   settingsProfile: null,

--- a/src/js/pages/Activity/News.jsx
+++ b/src/js/pages/Activity/News.jsx
@@ -44,7 +44,7 @@ const ActivityTidbitItem = React.lazy(() => import(/* webpackChunkName: 'Activit
 const ActivityTidbitReactionsSummary = React.lazy(() => import(/* webpackChunkName: 'ActivityTidbitReactionsSummary' */ '../../components/Activity/ActivityTidbitReactionsSummary'));
 // const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../components/Widgets/DelayedLoad'));
 const FirstAndLastNameRequiredAlert = React.lazy(() => import(/* webpackChunkName: 'FirstAndLastNameRequiredAlert' */ '../../components/Widgets/FirstAndLastNameRequiredAlert'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../../components/Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../../components/SignIn/SignInOptionsPanel'));
 const ShowMoreItems = React.lazy(() => import(/* webpackChunkName: 'ShowMoreItems' */ '../../components/Widgets/ShowMoreItems'));
 
 const STARTING_NUMBER_OF_ACTIVITY_TIDBITS_TO_DISPLAY = 10;
@@ -433,12 +433,12 @@ class News extends Component {
                   {!voterIsSignedIn && (
                     // <DelayedLoad waitBeforeShow={1000}>
                     <Suspense fallback={<></>}>
-                      <SettingsAccountWrapper style={expandSideMarginsIfCordova}>
-                        <SettingsAccount
+                      <SignInOptionsWrapper style={expandSideMarginsIfCordova}>
+                        <SignInOptionsPanel
                           pleaseSignInTitle="Sign In to Join the Discussion"
                           pleaseSignInSubTitle="We Vote is a community of friends who care about voting and democracy."
                         />
-                      </SettingsAccountWrapper>
+                      </SignInOptionsWrapper>
                     </Suspense>
                     // </DelayedLoad>
                   )}
@@ -465,7 +465,7 @@ class News extends Component {
                       />
                     </div>
                   </div>
-                  <SignInOptionsWrapper className="u-show-desktop">
+                  <SignInSmallOptionsWrapper className="u-show-desktop">
                     {!voterSignedInTwitter && (
                       <TwitterSignInWrapper>
                         <TwitterSignInCard />
@@ -476,7 +476,7 @@ class News extends Component {
                         <FacebookSignInCard />
                       </FacebookSignInWrapper>
                     )}
-                  </SignInOptionsWrapper>
+                  </SignInSmallOptionsWrapper>
                 </div>
               </div>
               <ShowMoreItemsWrapper
@@ -570,7 +570,7 @@ const SectionTitle = styled('h2')`
   display: inline;
 `;
 
-const SettingsAccountWrapper = styled('div')(({ theme }) => (`
+const SignInOptionsWrapper = styled('div')(({ theme }) => (`
   ${theme.breakpoints.down('sm')} {
     margin: 0 12px;
   }
@@ -588,7 +588,7 @@ const ShowMoreItemsWrapper = styled('div')(({ theme }) => (`
   }
 `));
 
-const SignInOptionsWrapper = styled('div')`
+const SignInSmallOptionsWrapper = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/js/pages/Friends/Friends.jsx
+++ b/src/js/pages/Friends/Friends.jsx
@@ -38,7 +38,7 @@ import SuggestedFriends from './SuggestedFriends';
 import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 
 const FirstAndLastNameRequiredAlert = React.lazy(() => import(/* webpackChunkName: 'FirstAndLastNameRequiredAlert' */ '../../components/Widgets/FirstAndLastNameRequiredAlert'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../../components/Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../../components/SignIn/SignInOptionsPanel'));
 
 const testimonialPhoto = '../../../img/global/photos/Dale_McGrew-48x48.jpg';
 
@@ -580,14 +580,14 @@ class Friends extends Component {
         ) : (
           // <DelayedLoad waitBeforeShow={1000}>
           <Suspense fallback={<></>}>
-            <OuterSettingsAccountWrapper>
-              <InnerSettingsAccountWrapper style={expandSideMarginsIfCordova}>
-                <SettingsAccount
+            <OuterSignInOptionsWrapper>
+              <InnerSignInOptionsWrapper style={expandSideMarginsIfCordova}>
+                <SignInOptionsPanel
                   pleaseSignInTitle="Sign In to Find Your Friends"
                   pleaseSignInSubTitle="We Vote is a community of friends who care about voting and democracy."
                 />
-              </InnerSettingsAccountWrapper>
-            </OuterSettingsAccountWrapper>
+              </InnerSignInOptionsWrapper>
+            </OuterSignInOptionsWrapper>
           </Suspense>
           // </DelayedLoad>
         )}
@@ -628,7 +628,7 @@ const FriendsHeading = styled('div')`
   // box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
 `;
 
-const OuterSettingsAccountWrapper = styled('div')`
+const OuterSignInOptionsWrapper = styled('div')`
   display: flex;
   justify-content: center;
 `;
@@ -641,7 +641,7 @@ const SectionTitle = styled('h2')`
   display: inline;
 `;
 
-const InnerSettingsAccountWrapper = styled('div')(({ theme }) => (`
+const InnerSignInOptionsWrapper = styled('div')(({ theme }) => (`
   max-width: 500px;
   ${theme.breakpoints.down('sm')} {
     margin: 0 12px;

--- a/src/js/pages/More/ExtensionSignIn.jsx
+++ b/src/js/pages/More/ExtensionSignIn.jsx
@@ -7,7 +7,7 @@ import { renderLog } from '../../common/utils/logging';
 import VoterStore from '../../stores/VoterStore';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../../components/Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../../components/SignIn/SignInOptionsPanel'));
 
 
 class ExtensionSignIn extends Component {
@@ -64,7 +64,7 @@ class ExtensionSignIn extends Component {
                 <SignInIntro>
                   Please sign in here:
                 </SignInIntro>
-                <SettingsAccount />
+                <SignInOptionsPanel />
               </SignInInnerWrapper>
             </SignInOuterWrapper>
           </DelayedLoad>

--- a/src/js/pages/Settings/SettingsDashboard.jsx
+++ b/src/js/pages/Settings/SettingsDashboard.jsx
@@ -32,7 +32,7 @@ import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
 import { isProperlyFormattedVoterGuideWeVoteId } from '../../utils/textFormat';
 
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../../components/Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../../components/SignIn/SignInOptionsPanel'));
 
 
 export default class SettingsDashboard extends Component {
@@ -196,8 +196,8 @@ export default class SettingsDashboard extends Component {
     const { editMode } = this.state;
     switch (editMode) {
       case 'account':
-        settingsComponentToDisplayDesktop = <SettingsAccount externalUniqueId="domainDesktop" />;
-        settingsComponentToDisplayMobile = <SettingsAccount externalUniqueId="domainMobile" />;
+        settingsComponentToDisplayDesktop = <SignInOptionsPanel externalUniqueId="domainDesktop" />;
+        settingsComponentToDisplayMobile = <SignInOptionsPanel externalUniqueId="domainMobile" />;
         break;
       case 'address':
         settingsComponentToDisplayDesktop = <SettingsAddress externalUniqueId="domainDesktop" />;

--- a/src/js/pages/Settings/VoterGuideListDashboard.jsx
+++ b/src/js/pages/Settings/VoterGuideListDashboard.jsx
@@ -13,7 +13,7 @@ import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
-const SettingsAccount = React.lazy(() => import(/* webpackChunkName: 'SettingsAccount' */ '../../components/Settings/SettingsAccount'));
+const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../../components/SignIn/SignInOptionsPanel'));
 
 
 class VoterGuideListDashboard extends Component {
@@ -173,7 +173,7 @@ class VoterGuideListDashboard extends Component {
                 { !voterIsSignedIn && (
                   <Suspense fallback={<></>}>
                     <DelayedLoad waitBeforeShow={1000}>
-                      <SettingsAccount />
+                      <SignInOptionsPanel />
                     </DelayedLoad>
                   </Suspense>
                 )}

--- a/src/js/pages/Startup/SignIn.jsx
+++ b/src/js/pages/Startup/SignIn.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-import SettingsAccount from '../../components/Settings/SettingsAccount';
+import SignInOptionsPanel from '../../components/SignIn/SignInOptionsPanel';
 import AppObservableStore from '../../stores/AppObservableStore';
 import VoterStore from '../../stores/VoterStore';
 
@@ -21,12 +21,12 @@ export default function SignIn (props) {
       return <div style={{ padding: '20px', fontWeight: 600 }}>You are already signed in!</div>;
     } else {
       return (
-        <SettingsAccountWrapper>
-          <SettingsAccount
+        <SignInOptionsWrapper>
+          <SignInOptionsPanel
             inModal={false}
             closeSignInModal={() => console.log('do we need a close callback here?')}
           />
-        </SettingsAccountWrapper>
+        </SignInOptionsWrapper>
       );
     }
   } catch (e) {
@@ -38,6 +38,6 @@ SignIn.propTypes = {
   displayState: PropTypes.number.isRequired,
 };
 
-const SettingsAccountWrapper = styled('div')`
+const SignInOptionsWrapper = styled('div')`
   padding-top: 25px
 `;

--- a/src/js/stores/AppObservableStore.js
+++ b/src/js/stores/AppObservableStore.js
@@ -430,7 +430,7 @@ export default {
 
   isOnWeVoteRootUrl () {
     const weVoteURL = nonFluxState.onWeVoteRootUrl || false;
-    return weVoteURL || isCordovaLocal() || stringContains('localhost:', window.location.href);
+    return weVoteURL || isCordovaLocal() || stringContains('localhost:', window.location.href) || stringContains('ngrok.io', window.location.href);
   },
 
   isOnWeVoteSubdomainUrl () {


### PR DESCRIPTION
SignInModalSimple was a copy of SignInModal with changes, that had diverged from the original, in code and style.
SignInModal has been renamed with this PR to SignInModalOriginal.jsx and is deprecated
SignInModalSimple has been renamed SignInModal
SettingsAccount has been renamed to SettingsOptionPanel
Only WebApp has been tested, and a bunch of Cordova constants and code from SignInModalOriginal still needs to be ported over to Cordova.
The fix from Friday with the Email and Phone entry dialogs has been ported over.
