### PR TITLE
Put ScoreSummaryListController at the top of the OrganizationModal. Converted "reload app" to "refresh browser" in WebApp ErrorBoundary. Put Score display components into their own folder. Renamed BallotItemSupportOpposeScoreDisplay. Moved candidates back to the left. Turned off positionListForOpinionMaker when in lists to reduce browser overwhelm.

### DIFF
--- a/src/js/common/components/Widgets/ErrorBoundary.jsx
+++ b/src/js/common/components/Widgets/ErrorBoundary.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { isAndroidSizeFold } from '../../utils/cordovaUtils';
+import { isWebApp } from '../../utils/isCordovaOrWebApp';
 
 class ErrorBoundary extends Component {
   constructor (props) {
@@ -34,11 +35,19 @@ class ErrorBoundary extends Component {
         }}
         >
           <h1 style={{ margin: '20px', color: 'black', fontSize: '20px' }}>Whoops! Something went wrong.</h1>
-          <h1 style={{ margin: '20px', color: 'black' }}>
-            Try&nbsp;
-            <a style={{ color: 'blue' }} href="/">restarting</a>
-            &nbsp;the app.
-          </h1>
+          {isWebApp() ? (
+            <h1 style={{ margin: '20px', color: 'black' }}>
+              Try&nbsp;
+              <span style={{ color: 'blue', cursor: 'pointer' }} onClick={() => document.location.reload()}>refreshing</span>
+              &nbsp;your browser.
+            </h1>
+          ) : (
+            <h1 style={{ margin: '20px', color: 'black' }}>
+              Try&nbsp;
+              <a style={{ color: 'blue' }} href="/ready">restarting</a>
+              &nbsp;the app.
+            </h1>
+          )}
           <h1 style={{ margin: '20px', color: 'black' }}>
             Please send us an email at &nbsp;
             <a

--- a/src/js/components/Ballot/CandidateItem.jsx
+++ b/src/js/components/Ballot/CandidateItem.jsx
@@ -19,7 +19,7 @@ import isMobileAndTabletScreenSize from '../../utils/isMobileAndTabletScreenSize
 import { stripHtmlFromString } from '../../utils/textFormat';
 
 const BallotItemSupportOpposeComment = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeComment' */ '../Widgets/BallotItemSupportOpposeComment'));
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
 const IssuesByBallotItemDisplayList = React.lazy(() => import(/* webpackChunkName: 'IssuesByBallotItemDisplayList' */ '../Values/IssuesByBallotItemDisplayList'));
 const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ '../Widgets/ItemActionBar/ItemActionBar'));
@@ -418,12 +418,12 @@ class CandidateItem extends Component {
           </CandidateInfo>
           <BallotItemSupportOpposeCountDisplayWrapper isClickable={!blockOnClickShowOrganizationModalWithPositions}>
             <Suspense fallback={<></>}>
-              <BallotItemSupportOpposeCountDisplay
+              <BallotItemSupportOpposeScoreDisplay
                 ballotItemWeVoteId={candidateWeVoteId}
                 blockOnClickShowOrganizationModalWithPositions={blockOnClickShowOrganizationModalWithPositions}
                 closeSupportOpposeCountDisplayModal={closeSupportOpposeCountDisplayModal}
                 controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
-                goToBallotItem={this.props.goToBallotItem}
+                showAllPositions={this.props.goToBallotItem}
                 handleLeaveCandidateCard={forDesktop ? this.handleLeave : null}
                 handleEnterCandidateCard={forDesktop ? this.handleEnter : null}
                 hideEndorsementsOverview={this.props.hideEndorsementsOverview}
@@ -432,7 +432,6 @@ class CandidateItem extends Component {
                 openSupportOpposeCountDisplayModal={openSupportOpposeCountDisplayModal}
                 supportOpposeCountDisplayModalTutorialOn={supportOpposeCountDisplayModalTutorialOn}
                 supportOpposeCountDisplayModalTutorialText={supportOpposeCountDisplayModalTutorialText}
-                uniqueExternalId={forDesktop ? 'CandidateItem-Desktop' : 'CandidateItem-MobileTablet'}
                 showDownArrow={showDownArrow}
                 showUpArrow={showUpArrow}
               />

--- a/src/js/components/Ballot/CandidateItemCompressed.jsx
+++ b/src/js/components/Ballot/CandidateItemCompressed.jsx
@@ -12,7 +12,7 @@ import historyPush from '../../common/utils/historyPush';
 import { renderLog } from '../../common/utils/logging';
 
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 const LearnMore = React.lazy(() => import(/* webpackChunkName: 'LearnMore' */ '../../common/components/Widgets/LearnMore'));
 
 export default class CandidateItemCompressed extends Component {
@@ -120,7 +120,7 @@ export default class CandidateItemCompressed extends Component {
       <div key={oneCandidateWeVoteId} className="u-stack--md">
         <div className="u-float-right">
           <Suspense fallback={<></>}>
-            <BallotItemSupportOpposeCountDisplay ballotItemWeVoteId={oneCandidateWeVoteId} />
+            <BallotItemSupportOpposeScoreDisplay ballotItemWeVoteId={oneCandidateWeVoteId} />
           </Suspense>
         </div>
         <div className="o-media-object u-flex-auto u-min-50 u-push--sm u-stack--sm">

--- a/src/js/components/Ballot/CandidateStickyHeader.jsx
+++ b/src/js/components/Ballot/CandidateStickyHeader.jsx
@@ -8,7 +8,7 @@ import { renderLog } from '../../common/utils/logging';
 import { cordovaStickyHeaderPaddingTop } from '../../utils/cordovaOffsets';
 
 const BallotItemSupportOpposeComment = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeComment' */ '../Widgets/BallotItemSupportOpposeComment'));
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 
 
 class CandidateStickyHeader extends Component {
@@ -50,7 +50,7 @@ class CandidateStickyHeader extends Component {
             </ColumnOne>
             <ColumnTwo>
               <Suspense fallback={<></>}>
-                <BallotItemSupportOpposeCountDisplay ballotItemWeVoteId={candidateWeVoteId} blockOnClickShowOrganizationModalWithPositions />
+                <BallotItemSupportOpposeScoreDisplay ballotItemWeVoteId={candidateWeVoteId} blockOnClickShowOrganizationModalWithPositions />
               </Suspense>
             </ColumnTwo>
           </Flex>

--- a/src/js/components/Ballot/MeasureItem.jsx
+++ b/src/js/components/Ballot/MeasureItem.jsx
@@ -12,7 +12,7 @@ import MeasureStore from '../../stores/MeasureStore';
 
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
 const BallotItemSupportOpposeComment = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeComment' */ '../Widgets/BallotItemSupportOpposeComment'));
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
 
@@ -144,7 +144,7 @@ class MeasureItem extends Component {
           </MeasureInfoWrapper>
           <BallotItemSupportOpposeCountDisplayWrapper isClickable={!blockOnClickShowOrganizationModalWithPositions}>
             <Suspense fallback={<></>}>
-              <BallotItemSupportOpposeCountDisplay
+              <BallotItemSupportOpposeScoreDisplay
                 ballotItemWeVoteId={measureWeVoteId}
                 blockOnClickShowOrganizationModalWithPositions={blockOnClickShowOrganizationModalWithPositions}
               />

--- a/src/js/components/Ballot/MeasureItemCompressed.jsx
+++ b/src/js/components/Ballot/MeasureItemCompressed.jsx
@@ -27,7 +27,7 @@ import {
 import PositionRowList from './PositionRowList';
 import PositionRowEmpty from './PositionRowEmpty';
 
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
 const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ '../Widgets/ItemActionBar/ItemActionBar'));
 const TopCommentByBallotItem = React.lazy(() => import(/* webpackChunkName: 'TopCommentByBallotItem' */ '../Widgets/TopCommentByBallotItem'));
@@ -269,9 +269,9 @@ class MeasureItemCompressed extends Component {
             </MeasureInfoWrapper>
             <BallotItemSupportOpposeCountDisplayWrapper>
               <Suspense fallback={<></>}>
-                <BallotItemSupportOpposeCountDisplay
+                <BallotItemSupportOpposeScoreDisplay
                   ballotItemWeVoteId={measureWeVoteId}
-                  goToBallotItem={this.onClickShowOrganizationModalWithPositions}
+                  onClickFunction={this.onClickShowOrganizationModalWithPositions}
                 />
               </Suspense>
             </BallotItemSupportOpposeCountDisplayWrapper>
@@ -331,9 +331,9 @@ class MeasureItemCompressed extends Component {
                       </PositionRowListScoreHeader>
                       <PositionRowListScoreSpacer>
                         <Suspense fallback={<></>}>
-                          <BallotItemSupportOpposeCountDisplay
+                          <BallotItemSupportOpposeScoreDisplay
                             ballotItemWeVoteId={measureWeVoteId}
-                            goToBallotItem={this.onClickShowOrganizationModalWithPositions}
+                            onClickFunction={this.onClickShowOrganizationModalWithPositions}
                             hideEndorsementsOverview
                             hideNumbersOfAllPositions
                           />
@@ -421,9 +421,9 @@ class MeasureItemCompressed extends Component {
                       </PositionRowListScoreHeader>
                       <PositionRowListScoreSpacer>
                         <Suspense fallback={<></>}>
-                          <BallotItemSupportOpposeCountDisplay
+                          <BallotItemSupportOpposeScoreDisplay
                             ballotItemWeVoteId={measureWeVoteId}
-                            goToBallotItem={this.onClickShowOrganizationModalWithPositions}
+                            onClickFunction={this.onClickShowOrganizationModalWithPositions}
                             hideEndorsementsOverview
                             hideNumbersOfAllPositions
                           />

--- a/src/js/components/Ballot/MeasureStickyHeader.jsx
+++ b/src/js/components/Ballot/MeasureStickyHeader.jsx
@@ -9,7 +9,7 @@ import { cordovaStickyHeaderPaddingTop } from '../../utils/cordovaOffsets';
 
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
 const BallotItemSupportOpposeComment = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeComment' */ '../Widgets/BallotItemSupportOpposeComment'));
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 
 
 class MeasureStickyHeader extends Component {
@@ -65,7 +65,7 @@ class MeasureStickyHeader extends Component {
             </ColumnOne>
             <ColumnTwo>
               <Suspense fallback={<></>}>
-                <BallotItemSupportOpposeCountDisplay ballotItemWeVoteId={measureWeVoteId} />
+                <BallotItemSupportOpposeScoreDisplay ballotItemWeVoteId={measureWeVoteId} />
               </Suspense>
             </ColumnTwo>
           </Flex>

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -28,7 +28,7 @@ import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 import PositionRowEmpty from './PositionRowEmpty';
 import PositionRowList from './PositionRowList';
 
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
 const IssuesByBallotItemDisplayList = React.lazy(() => import(/* webpackChunkName: 'IssuesByBallotItemDisplayList' */ '../Values/IssuesByBallotItemDisplayList'));
@@ -277,50 +277,6 @@ class OfficeItemCompressed extends Component {
             return (
               <div key={`candidate_preview-${oneCandidate.we_vote_id}-${externalUniqueId}`}>
                 <CandidateContainer>
-                  <PositionRowListOuterWrapper className="u-show-desktop-tablet">
-                    <OverflowContainer>
-                      <PositionRowListInnerWrapper>
-                        <PositionRowListOneWrapper>
-                          <PositionRowList
-                            ballotItemWeVoteId={oneCandidate.we_vote_id}
-                            showSupport
-                          />
-                        </PositionRowListOneWrapper>
-                        <PositionRowListOneWrapper>
-                          <PositionRowList
-                            ballotItemWeVoteId={oneCandidate.we_vote_id}
-                            showOppose
-                          />
-                        </PositionRowListOneWrapper>
-                        <PositionRowListOneWrapper>
-                          <PositionRowList
-                            ballotItemWeVoteId={oneCandidate.we_vote_id}
-                            showInfoOnly
-                          />
-                        </PositionRowListOneWrapper>
-                        <PositionRowListEmptyWrapper>
-                          <PositionRowEmpty
-                            ballotItemWeVoteId={oneCandidate.we_vote_id}
-                          />
-                        </PositionRowListEmptyWrapper>
-                        <PositionRowListScoreColumn>
-                          <PositionRowListScoreHeader>
-                            Score
-                          </PositionRowListScoreHeader>
-                          <PositionRowListScoreSpacer>
-                            <Suspense fallback={<></>}>
-                              <BallotItemSupportOpposeCountDisplay
-                                ballotItemWeVoteId={oneCandidate.we_vote_id}
-                                goToBallotItem={this.onClickShowOrganizationModalWithPositions}
-                                hideEndorsementsOverview
-                                hideNumbersOfAllPositions
-                              />
-                            </Suspense>
-                          </PositionRowListScoreSpacer>
-                        </PositionRowListScoreColumn>
-                      </PositionRowListInnerWrapper>
-                    </OverflowContainer>
-                  </PositionRowListOuterWrapper>
                   <CandidateWrapper>
                     <CandidateInfo>
                       <CandidateTopRow>
@@ -352,9 +308,9 @@ class OfficeItemCompressed extends Component {
                         {/*  /!* Show check mark or score *!/ */}
                         <BallotItemSupportOpposeCountDisplayWrapper className="u-show-mobile">
                           <Suspense fallback={<></>}>
-                            <BallotItemSupportOpposeCountDisplay
+                            <BallotItemSupportOpposeScoreDisplay
                               ballotItemWeVoteId={oneCandidate.we_vote_id}
-                              goToBallotItem={this.onClickShowOrganizationModalWithPositions}
+                              onClickFunction={this.onClickShowOrganizationModalWithPositions}
                             />
                           </Suspense>
                         </BallotItemSupportOpposeCountDisplayWrapper>
@@ -401,6 +357,50 @@ class OfficeItemCompressed extends Component {
                       </CandidateBottomRow>
                     </CandidateInfo>
                   </CandidateWrapper>
+                  <PositionRowListOuterWrapper className="u-show-desktop-tablet">
+                    <OverflowContainer>
+                      <PositionRowListInnerWrapper>
+                        <PositionRowListOneWrapper>
+                          <PositionRowList
+                            ballotItemWeVoteId={oneCandidate.we_vote_id}
+                            showSupport
+                          />
+                        </PositionRowListOneWrapper>
+                        <PositionRowListOneWrapper>
+                          <PositionRowList
+                            ballotItemWeVoteId={oneCandidate.we_vote_id}
+                            showOppose
+                          />
+                        </PositionRowListOneWrapper>
+                        <PositionRowListOneWrapper>
+                          <PositionRowList
+                            ballotItemWeVoteId={oneCandidate.we_vote_id}
+                            showInfoOnly
+                          />
+                        </PositionRowListOneWrapper>
+                        <PositionRowListEmptyWrapper>
+                          <PositionRowEmpty
+                            ballotItemWeVoteId={oneCandidate.we_vote_id}
+                          />
+                        </PositionRowListEmptyWrapper>
+                        <PositionRowListScoreColumn>
+                          <PositionRowListScoreHeader>
+                            Score
+                          </PositionRowListScoreHeader>
+                          <PositionRowListScoreSpacer>
+                            <Suspense fallback={<></>}>
+                              <BallotItemSupportOpposeScoreDisplay
+                                ballotItemWeVoteId={oneCandidate.we_vote_id}
+                                onClickFunction={this.onClickShowOrganizationModalWithPositions}
+                                hideEndorsementsOverview
+                                hideNumbersOfAllPositions
+                              />
+                            </Suspense>
+                          </PositionRowListScoreSpacer>
+                        </PositionRowListScoreColumn>
+                      </PositionRowListInnerWrapper>
+                    </OverflowContainer>
+                  </PositionRowListOuterWrapper>
                 </CandidateContainer>
                 {((candidateCount < candidatesToRenderLength) && (candidateCount < limitNumberOfCandidatesShownToThisNumber)) && (
                   <div>
@@ -565,6 +565,7 @@ const CandidateBottomRow = styled('div')`
 
 const CandidateContainer = styled('div')`
   display: flex;
+  // flex-direction: row-reverse;
   justify-content: space-between;
   padding: 10px 5px;
 `;
@@ -616,7 +617,7 @@ const CandidateWrapper = styled('div')(({ theme }) => (`
     width: 100%;
   }
   ${theme.breakpoints.up('sm')} {
-    margin-left: 48px;
+    // margin-left: 48px;
     min-width: 320px;
   }
 `));

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -6,7 +6,6 @@ import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import OrganizationActions from '../../actions/OrganizationActions';
 import SvgImage from '../../common/components/Widgets/SvgImage';
 import abbreviateNumber from '../../common/utils/abbreviateNumber';
 import { renderLog } from '../../common/utils/logging';
@@ -25,7 +24,7 @@ import PositionItemSquare from './PositionItemSquare';
 const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ '../Widgets/FollowToggle'));
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
-const PositionItemScorePopover = React.lazy(() => import(/* webpackChunkName: 'PositionItemScorePopover' */ '../Widgets/PositionItemScorePopover'));
+const PositionItemScorePopover = React.lazy(() => import(/* webpackChunkName: 'PositionItemScorePopover' */ '../Widgets/ScoreDisplay/PositionItemScorePopover'));
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
 const StickyPopover = React.lazy(() => import(/* webpackChunkName: 'StickyPopover' */ './StickyPopover'));
 
@@ -102,24 +101,25 @@ class PositionItem extends Component {
   }
 
   onVoterGuideStoreChange () {
-    const { position } = this.props;
-    const { ballot_item_we_vote_id: ballotItemWeVoteId, speaker_we_vote_id: organizationWeVoteId } = position;
+    // const { position } = this.props;
+    // const { ballot_item_we_vote_id: ballotItemWeVoteId, speaker_we_vote_id: organizationWeVoteId } = position;
 
-    // We want to make sure we have all of the position information so that comments show up
-    if (ballotItemWeVoteId) {
-      const voterGuidesForThisBallotItem = VoterGuideStore.getVoterGuidesToFollowForBallotItemId(ballotItemWeVoteId);
-
-      if (voterGuidesForThisBallotItem) {
-        voterGuidesForThisBallotItem.forEach((oneVoterGuide) => {
-          // console.log('oneVoterGuide: ', oneVoterGuide);
-          if (organizationWeVoteId === oneVoterGuide.organization_we_vote_id) {  // Request position list for the organization of this position
-            if (!OrganizationStore.positionListForOpinionMakerHasBeenRetrievedOnce(oneVoterGuide.google_civic_election_id, oneVoterGuide.organization_we_vote_id)) {
-              OrganizationActions.positionListForOpinionMaker(oneVoterGuide.organization_we_vote_id, false, true, oneVoterGuide.google_civic_election_id);
-            }
-          }
-        });
-      }
-    }
+    // This puts too much strain on the browser since PositionItems are in a list
+    // // We want to make sure we have all of the position information so that comments show up
+    // if (ballotItemWeVoteId) {
+    //   const voterGuidesForThisBallotItem = VoterGuideStore.getVoterGuidesToFollowForBallotItemId(ballotItemWeVoteId);
+    //
+    //   if (voterGuidesForThisBallotItem) {
+    //     voterGuidesForThisBallotItem.forEach((oneVoterGuide) => {
+    //       // console.log('oneVoterGuide: ', oneVoterGuide);
+    //       if (organizationWeVoteId === oneVoterGuide.organization_we_vote_id) {  // Request position list for the organization of this position
+    //         if (!OrganizationStore.positionListForOpinionMakerHasBeenRetrievedOnce(oneVoterGuide.google_civic_election_id, oneVoterGuide.organization_we_vote_id)) {
+    //           OrganizationActions.positionListForOpinionMaker(oneVoterGuide.organization_we_vote_id, false, true, oneVoterGuide.google_civic_election_id);
+    //         }
+    //       }
+    //     });
+    //   }
+    // }
   }
 
   closeDrawer () {

--- a/src/js/components/Ballot/PositionList.jsx
+++ b/src/js/components/Ballot/PositionList.jsx
@@ -49,7 +49,7 @@ const islandFilters = [
   },
 ];
 
-const STARTING_NUMBER_OF_POSITIONS_TO_DISPLAY = 6;
+const STARTING_NUMBER_OF_POSITIONS_TO_DISPLAY = 10;
 const TURN_ON_FILTERS_WHEN_MORE_THAN_THIS_NUMBER_OF_ITEMS = 10;
 
 class PositionList extends Component {

--- a/src/js/components/Ballot/PositionRowLogoAndText.jsx
+++ b/src/js/components/Ballot/PositionRowLogoAndText.jsx
@@ -23,7 +23,7 @@ import {
 
 const FollowToggleCheckPlus = React.lazy(() => import(/* webpackChunkName: 'FollowToggleCheckPlus' */ '../Widgets/FollowToggleCheckPlus'));
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
-const PositionItemScorePopover = React.lazy(() => import(/* webpackChunkName: 'PositionItemScorePopover' */ '../Widgets/PositionItemScorePopover'));
+const PositionItemScorePopover = React.lazy(() => import(/* webpackChunkName: 'PositionItemScorePopover' */ '../Widgets/ScoreDisplay/PositionItemScorePopover'));
 const StickyPopover = React.lazy(() => import(/* webpackChunkName: 'StickyPopover' */ './StickyPopover'));
 
 

--- a/src/js/components/Ballot/PositionRowSupportOpposeCountDisplay.jsx
+++ b/src/js/components/Ballot/PositionRowSupportOpposeCountDisplay.jsx
@@ -449,15 +449,7 @@ const EndorsementRow = styled('div')`
   flex-flow: row nowrap;
   justify-content: space-between;
   margin-left: 6px;
-  margin-right: 24px;
-`;
-
-const EndorsementsOuterWrapper = styled('div')`
-  display: flex;
-  justify-content: flex-start;
-`;
-
-const EndorsementsOverviewShowOrNotShow = styled('div')`
+  min-width: 70px;
 `;
 
 const EndorsementsContainer = styled('div')`
@@ -470,6 +462,14 @@ const EndorsementsInnerWrapper = styled('div')`
   display: flex;
   justify-content: flex-start;
   user-select: none;
+`;
+
+const EndorsementsOuterWrapper = styled('div')`
+  display: flex;
+  justify-content: flex-start;
+`;
+
+const EndorsementsOverviewShowOrNotShow = styled('div')`
 `;
 
 const EndorsementsOverviewSpacer = styled('div')`

--- a/src/js/components/Navigation/BallotShowAllItemsFooter.jsx
+++ b/src/js/components/Navigation/BallotShowAllItemsFooter.jsx
@@ -45,19 +45,17 @@ class BallotShowAllItemsFooter extends Component {
     const { classes } = this.props;
     if (ballot && ballot.length > 0) {
       return (
-        <div className={classes.card}>
-          <div className={classes.cardBody}>
+        <BallotShowAllItemsFooterWrapper>
+          <ContentBody>
             <Typography id="ballotSummaryFooter-showMoreBallotItems" variant="h2" classes={{ root: classes.typography }}>
               <Ballot className={classes.icon} location={window.location} />
               Show All Ballot Items
             </Typography>
-            <Row className="row">
-              <Button onClick={() => this.jumpToNewSection()} variant="outlined" classes={{ root: classes.button }}>
-                Show all Ballot Items
-              </Button>
-            </Row>
-          </div>
-        </div>
+            <Button onClick={() => this.jumpToNewSection()} variant="outlined" classes={{ root: classes.button }}>
+              Show all
+            </Button>
+          </ContentBody>
+        </BallotShowAllItemsFooterWrapper>
       );
     } else {
       return <div />;
@@ -81,21 +79,6 @@ const styles = (theme) => ({
     display: 'flex',
     alignItems: 'center',
   },
-  card: {
-    backgroundColor: '#fff',
-    borderRadius: '0px',
-    boxShadow: '0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12)',
-    marginBottom: '16px',
-    [theme.breakpoints.down('md')]: {
-      marginLeft: '-16px',
-      marginRight: '-16px',
-    },
-    overflowY: 'none',
-    border: 'none',
-  },
-  cardBody: {
-    padding: '20px',
-  },
   icon: {
     marginRight: 12,
     color: '#2E3C5D',
@@ -103,8 +86,24 @@ const styles = (theme) => ({
   },
 });
 
-const Row = styled('div')`
-  margin: 0 !important;
+const BallotShowAllItemsFooterWrapper = styled('div')(({ theme }) => (`
+  background-color: #fff;
+  border: none;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 16px;
+  overflow-y: none;
+  ${theme.breakpoints.down('md')} {
+      margin-left: -16px;
+      margin-right: -16px;
+  }
+`));
+
+const ContentBody = styled('div')`
+  align-items: center;
+  flex-direction: column;
+  display: flex;
+  justify-content: center;
 `;
 
 export default withStyles(styles)(BallotShowAllItemsFooter);

--- a/src/js/components/Style/ScoreDisplayStyles.jsx
+++ b/src/js/components/Style/ScoreDisplayStyles.jsx
@@ -1,0 +1,86 @@
+import styled from 'styled-components';
+
+
+const DecidedIconWrapper = styled('span')`
+  margin-right: 6px;
+`;
+
+const NetworkScore = styled('div', {
+  shouldForwardProp: (prop) => !['hideNumbersOfAllPositions', 'voterOpposesBallotItem', 'voterPersonalNetworkScoreIsNegative', 'voterPersonalNetworkScoreIsPositive', 'voterSupportsBallotItem'].includes(prop),
+})(({ hideNumbersOfAllPositions, voterOpposesBallotItem, voterPersonalNetworkScoreIsNegative, voterPersonalNetworkScoreIsPositive, voterSupportsBallotItem }) => (`
+  background: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
+  align-items: center;
+  border-radius: 5px;
+  color: white;
+  cursor: pointer;
+  display: flex;
+  flex-wrap: wrap;
+  font-size: 16px;
+  font-weight: bold;
+  justify-content: center;
+  margin-top: 2px;
+  width: 40px;
+  height: 40px;
+  @media print{
+    border-width: 1px;
+    border-style: solid;
+    border-color: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
+  }
+`));
+
+const NetworkScoreSmall = styled('div', {
+  shouldForwardProp: (prop) => !['hideNumbersOfAllPositions', 'voterOpposesBallotItem', 'voterPersonalNetworkScoreIsNegative', 'voterPersonalNetworkScoreIsPositive', 'voterSupportsBallotItem'].includes(prop),
+})(({ hideNumbersOfAllPositions, voterOpposesBallotItem, voterPersonalNetworkScoreIsNegative, voterPersonalNetworkScoreIsPositive, voterSupportsBallotItem }) => (`
+  background: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
+  color: white;
+  box-shadow: 0 1px 3px 0 rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 5px;
+  float: left;
+  font-size: 10px;
+  font-weight: bold;
+  @media print{
+    border-width: 1px;
+    border-style: solid;
+    border-color: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
+  }
+`));
+
+const PopoverBodyText = styled('div')`
+  margin-bottom: 8px;
+`;
+
+const RenderedOrganizationsWrapper = styled('div')`
+  margin-top: 6px;
+`;
+
+const ShowCandidateFooterWrapper = styled('div')`
+  margin-top: 10px;
+`;
+
+const TutorialTextBlue = styled('div')`
+`;
+
+const YourOpinion = styled('div')`
+  margin-bottom: 8px;
+`;
+
+const YourPersonalNetworkIntroText = styled('div')`
+  margin-top: 6px;
+`;
+
+export {
+  DecidedIconWrapper,
+  NetworkScore,
+  NetworkScoreSmall,
+  PopoverBodyText,
+  RenderedOrganizationsWrapper,
+  ShowCandidateFooterWrapper,
+  TutorialTextBlue,
+  YourOpinion,
+  YourPersonalNetworkIntroText,
+};

--- a/src/js/components/Values/ValueIconAndText.jsx
+++ b/src/js/components/Values/ValueIconAndText.jsx
@@ -13,7 +13,7 @@ import StickyPopover from '../Ballot/StickyPopover';
 import IssueFollowToggleButton from './IssueFollowToggleButton';
 
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
-const PositionSummaryListForPopover = React.lazy(() => import(/* webpackChunkName: 'PositionSummaryListForPopover' */ '../Widgets/PositionSummaryListForPopover'));
+const PositionSummaryListForPopover = React.lazy(() => import(/* webpackChunkName: 'PositionSummaryListForPopover' */ '../Widgets/ScoreDisplay/PositionSummaryListForPopover'));
 
 
 class ValueIconAndText extends Component {

--- a/src/js/components/Vote/MeasureItemReadyToVote.jsx
+++ b/src/js/components/Vote/MeasureItemReadyToVote.jsx
@@ -6,7 +6,7 @@ import { renderLog } from '../../common/utils/logging';
 import SupportStore from '../../stores/SupportStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 
 
 class MeasureItemReadyToVote extends Component {
@@ -73,7 +73,7 @@ class MeasureItemReadyToVote extends Component {
               </BioColumn>
               <OfficeColumn>
                 <Suspense fallback={<></>}>
-                  <BallotItemSupportOpposeCountDisplay ballotItemWeVoteId={measureWeVoteId} />
+                  <BallotItemSupportOpposeScoreDisplay ballotItemWeVoteId={measureWeVoteId} />
                 </Suspense>
               </OfficeColumn>
             </InnerWrapper>

--- a/src/js/components/Vote/OfficeItemReadyToVote.jsx
+++ b/src/js/components/Vote/OfficeItemReadyToVote.jsx
@@ -10,7 +10,7 @@ import SupportStore from '../../stores/SupportStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 
 
 class OfficeItemReadyToVote extends Component {
@@ -126,7 +126,7 @@ class OfficeItemReadyToVote extends Component {
                       </DesktopTabletView>
                       <BallotItemSupportOpposeCountDisplayWrapper>
                         <Suspense fallback={<></>}>
-                          <BallotItemSupportOpposeCountDisplay ballotItemWeVoteId={oneCandidate.we_vote_id} />
+                          <BallotItemSupportOpposeScoreDisplay ballotItemWeVoteId={oneCandidate.we_vote_id} />
                         </Suspense>
                       </BallotItemSupportOpposeCountDisplayWrapper>
                     </OfficeColumn>

--- a/src/js/components/VoterGuide/OrganizationCard.jsx
+++ b/src/js/components/VoterGuide/OrganizationCard.jsx
@@ -58,10 +58,11 @@ export default class OrganizationCard extends Component {
           organizationPosition,
         });
       } else {
-        OrganizationActions.positionListForOpinionMaker(this.props.organization.organization_we_vote_id, true);
-        this.setState({
-          organizationPositionsRequested: true,
-        });
+        // OrganizationCard is used in lists, and this puts strain on the browser
+        // OrganizationActions.positionListForOpinionMaker(this.props.organization.organization_we_vote_id, true);
+        // this.setState({
+        //   organizationPositionsRequested: true,
+        // });
       }
     }
     // If no position, we need to call positionListForOpinionMaker here

--- a/src/js/components/VoterGuide/OrganizationModal.jsx
+++ b/src/js/components/VoterGuide/OrganizationModal.jsx
@@ -21,7 +21,6 @@ import BallotStore from '../../stores/BallotStore';
 import CandidateStore from '../../stores/CandidateStore';
 import IssueStore from '../../stores/IssueStore';
 import MeasureStore from '../../stores/MeasureStore';
-import OrganizationStore from '../../stores/OrganizationStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
 import { cordovaDrawerTopMargin } from '../../utils/cordovaOffsets';
@@ -31,6 +30,7 @@ const CandidateItem = React.lazy(() => import(/* webpackChunkName: 'CandidateIte
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
 const MeasureItem = React.lazy(() => import(/* webpackChunkName: 'MeasureItem' */ '../Ballot/MeasureItem'));
 const PositionList = React.lazy(() => import(/* webpackChunkName: 'PositionList' */ '../Ballot/PositionList'));
+const ScoreSummaryListController = React.lazy(() => import(/* webpackChunkName: 'ScoreSummaryListController' */ '../Widgets/ScoreDisplay/ScoreSummaryListController'));
 
 
 class OrganizationModal extends Component {
@@ -134,17 +134,18 @@ class OrganizationModal extends Component {
       OrganizationActions.organizationsFollowedRetrieve();
     }
 
-    // We want to make sure we have all of the position information so that comments show up
-    const voterGuidesForThisBallotItem = VoterGuideStore.getVoterGuidesToFollowForBallotItemId(ballotItemWeVoteId);
-
-    if (voterGuidesForThisBallotItem) {
-      voterGuidesForThisBallotItem.forEach((oneVoterGuide) => {
-        // console.log('oneVoterGuide: ', oneVoterGuide);
-        if (!OrganizationStore.positionListForOpinionMakerHasBeenRetrievedOnce(oneVoterGuide.google_civic_election_id, oneVoterGuide.organization_we_vote_id)) {
-          OrganizationActions.positionListForOpinionMaker(oneVoterGuide.organization_we_vote_id, false, true, oneVoterGuide.google_civic_election_id);
-        }
-      });
-    }
+    // This puts too much strain on the browser
+    // // We want to make sure we have all of the position information so that comments show up
+    // const voterGuidesForThisBallotItem = VoterGuideStore.getVoterGuidesToFollowForBallotItemId(ballotItemWeVoteId);
+    //
+    // if (voterGuidesForThisBallotItem) {
+    //   voterGuidesForThisBallotItem.forEach((oneVoterGuide) => {
+    //     // console.log('oneVoterGuide: ', oneVoterGuide);
+    //     if (!OrganizationStore.positionListForOpinionMakerHasBeenRetrievedOnce(oneVoterGuide.google_civic_election_id, oneVoterGuide.organization_we_vote_id)) {
+    //       OrganizationActions.positionListForOpinionMaker(oneVoterGuide.organization_we_vote_id, false, true, oneVoterGuide.google_civic_election_id);
+    //     }
+    //   });
+    // }
 
     IssueActions.issueDescriptionsRetrieve(VoterStore.getVoterWeVoteId());
     IssueActions.issuesFollowedRetrieve(VoterStore.getVoterWeVoteId());
@@ -272,26 +273,43 @@ class OrganizationModal extends Component {
         </IconButton>
         {(isCandidate && !hideBallotItemInfo) && (
           <Suspense fallback={<></>}>
-            <CandidateItem
-              blockOnClickShowOrganizationModalWithPositions
-              candidateWeVoteId={ballotItemWeVoteId}
-              expandIssuesByDefault
-              forMoreInformationTextOff
-              hideShowMoreFooter
-              inModal
-              linksOpenNewPage
-              linkToBallotItemPage
-              organizationWeVoteId={organizationWeVoteId}
-              showLargeImage
-              showOfficeName
-              showPositionStatementActionBar
-            />
+            <>
+              <CandidateItem
+                blockOnClickShowOrganizationModalWithPositions
+                candidateWeVoteId={ballotItemWeVoteId}
+                expandIssuesByDefault
+                forMoreInformationTextOff
+                hideShowMoreFooter
+                inModal
+                linksOpenNewPage
+                linkToBallotItemPage
+                organizationWeVoteId={organizationWeVoteId}
+                showLargeImage
+                showOfficeName
+                showPositionStatementActionBar
+              />
+              <BallotItemBottomSpacer />
+            </>
           </Suspense>
         )}
         {(isMeasure && !hideBallotItemInfo) && (
           <Suspense fallback={<></>}>
-            <MeasureItem blockOnClickShowOrganizationModalWithPositions forMoreInformationTextOff measureWeVoteId={ballotItemWeVoteId} />
+            <>
+              <MeasureItem blockOnClickShowOrganizationModalWithPositions forMoreInformationTextOff measureWeVoteId={ballotItemWeVoteId} />
+              <BallotItemBottomSpacer />
+            </>
           </Suspense>
+        )}
+        { (!hidePositions || unFurlPositions) && (
+          <>
+            <Suspense fallback={<></>}>
+              <ScoreSummaryListController
+                ballotItemDisplayName={ballotItemDisplayName || ''}
+                ballotItemWeVoteId={ballotItemWeVoteId}
+              />
+            </Suspense>
+            <ScoreSummaryListControllerBottomSpacer />
+          </>
         )}
         { !!(allCachedPositionsForThisBallotItem.length) && (
           <>
@@ -427,8 +445,16 @@ const styles = () => ({
   },
 });
 
+const BallotItemBottomSpacer = styled('div')`
+  margin-bottom: 32px;
+`;
+
 const PositionListIntroductionText = styled('div')`
   color: #999;
+`;
+
+const ScoreSummaryListControllerBottomSpacer = styled('div')`
+  margin-bottom: 42px;
 `;
 
 const ShowMoreWrapper = styled('div')`

--- a/src/js/components/VoterGuide/VoterGuidePositionItem.jsx
+++ b/src/js/components/VoterGuide/VoterGuidePositionItem.jsx
@@ -16,9 +16,9 @@ import BallotStore from '../../stores/BallotStore';
 import CandidateStore from '../../stores/CandidateStore';
 import MeasureStore from '../../stores/MeasureStore';
 import OrganizationStore from '../../stores/OrganizationStore';
-import BallotItemVoterGuideSupportOpposeDisplay from '../Widgets/BallotItemVoterGuideSupportOpposeDisplay';
+import BallotItemVoterGuideSupportOpposeDisplay from '../Widgets/ScoreDisplay/BallotItemVoterGuideSupportOpposeDisplay';
 
-const BallotItemSupportOpposeCountDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeCountDisplay' */ '../Widgets/BallotItemSupportOpposeCountDisplay'));
+const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
 const OfficeNameText = React.lazy(() => import(/* webpackChunkName: 'OfficeNameText' */ '../Widgets/OfficeNameText'));
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
@@ -318,7 +318,7 @@ class VoterGuidePositionItem extends Component {
                 </DesktopItemNameAndOfficeContainer>
                 <BallotItemSupportOpposeCountDisplayWrapper>
                   <Suspense fallback={<></>}>
-                    <BallotItemSupportOpposeCountDisplay
+                    <BallotItemSupportOpposeScoreDisplay
                       ballotItemDisplayName={ballotItemDisplayName}
                       ballotItemWeVoteId={ballotItemWeVoteId}
                       // hideEndorsementsOverview
@@ -435,7 +435,7 @@ class VoterGuidePositionItem extends Component {
                 <MobileItemEndorsementDisplay>
                   <BallotItemSupportOpposeCountDisplayWrapper>
                     <Suspense fallback={<></>}>
-                      <BallotItemSupportOpposeCountDisplay
+                      <BallotItemSupportOpposeScoreDisplay
                         ballotItemDisplayName={ballotItemDisplayName}
                         ballotItemWeVoteId={ballotItemWeVoteId}
                         // hideEndorsementsOverview

--- a/src/js/components/Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay.jsx
+++ b/src/js/components/Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay.jsx
@@ -4,26 +4,34 @@ import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
-import SupportActions from '../../actions/SupportActions';
-import { renderLog } from '../../common/utils/logging';
-import stringContains from '../../common/utils/stringContains';
-import AppObservableStore from '../../stores/AppObservableStore';
-import CandidateStore from '../../stores/CandidateStore';
-import FriendStore from '../../stores/FriendStore';
-import IssueStore from '../../stores/IssueStore';
-import MeasureStore from '../../stores/MeasureStore';
-import OrganizationStore from '../../stores/OrganizationStore';
-import SupportStore from '../../stores/SupportStore';
-import { getPositionListSummaryIncomingDataStats, getPositionSummaryListForBallotItem } from '../../utils/positionFunctions';
-import StickyPopover from '../Ballot/StickyPopover';
-import { openSnackbar } from './SnackNotifier';
+import SupportActions from '../../../actions/SupportActions';
+import { renderLog } from '../../../common/utils/logging';
+import stringContains from '../../../common/utils/stringContains';
+import {
+  DecidedIconWrapper,
+  NetworkScore,
+  NetworkScoreSmall,
+  PopoverBodyText,
+  RenderedOrganizationsWrapper,
+  TutorialTextBlue,
+  YourOpinion,
+  YourPersonalNetworkIntroText,
+} from '../../Style/ScoreDisplayStyles';
+import AppObservableStore from '../../../stores/AppObservableStore';
+import CandidateStore from '../../../stores/CandidateStore';
+import FriendStore from '../../../stores/FriendStore';
+import IssueStore from '../../../stores/IssueStore';
+import MeasureStore from '../../../stores/MeasureStore';
+import OrganizationStore from '../../../stores/OrganizationStore';
+import SupportStore from '../../../stores/SupportStore';
+import { getPositionListSummaryIncomingDataStats, getPositionSummaryListForBallotItem } from '../../../utils/positionFunctions';
+import StickyPopover from '../../Ballot/StickyPopover';
+import { openSnackbar } from '../SnackNotifier';
 
-const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ './ItemActionBar/ItemActionBar'));
 const PositionSummaryListForPopover = React.lazy(() => import(/* webpackChunkName: 'PositionSummaryListForPopover' */ './PositionSummaryListForPopover'));
-const ShowMoreFooter = React.lazy(() => import(/* webpackChunkName: 'ShowMoreFooter' */ '../Navigation/ShowMoreFooter'));
 
 
-class BallotItemSupportOpposeCountDisplay extends Component {
+class BallotItemSupportOpposeScoreDisplay extends Component {
   static closePositionsPopover () {
     document.body.click();
   }
@@ -49,14 +57,15 @@ class BallotItemSupportOpposeCountDisplay extends Component {
       voterOpposesBallotItem: false,
       voterSupportsBallotItem: false,
     };
-    this.goToBallotItemLinkLocal = this.goToBallotItemLinkLocal.bind(this);
+    this.onClickFunctionLinkLocal = this.onClickFunctionLinkLocal.bind(this);
     this.onClickShowOrganizationModalWithPositions = this.onClickShowOrganizationModalWithPositions.bind(this);
+    this.showAllPositionsLocal = this.showAllPositionsLocal.bind(this);
     this.stopOpposingItem = this.stopOpposingItem.bind(this);
     this.stopSupportingItem = this.stopSupportingItem.bind(this);
   }
 
   componentDidMount () {
-    // console.log('BallotItemSupportOpposeCountDisplay componentDidMount');
+    // console.log('BallotItemSupportOpposeScoreDisplay componentDidMount');
     this.candidateStoreListener = CandidateStore.addListener(this.onCandidateStoreChange.bind(this));
     this.friendStoreListener = FriendStore.addListener(this.onFriendStoreChange.bind(this));
     this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
@@ -179,7 +188,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
 
   componentDidCatch (error, info) {
     // We should get this information to Splunk!
-    console.error('BallotItemSupportOpposeCountDisplay caught error: ', `${error} with info: `, info);
+    console.error('BallotItemSupportOpposeScoreDisplay caught error: ', `${error} with info: `, info);
   }
 
   componentWillUnmount () {
@@ -386,6 +395,14 @@ class BallotItemSupportOpposeCountDisplay extends Component {
     }
   };
 
+  onClickFunctionLinkLocal () {
+    const { ballotItemWeVoteId } = this.props;
+    // console.log('BallotItemSupportOpposeScoreDisplay onClickFunctionLinkLocal, ballotItemWeVoteId:', ballotItemWeVoteId);
+    if (this.props.onClickFunction) {
+      this.props.onClickFunction(ballotItemWeVoteId);
+    }
+  }
+
   onClickShowOrganizationModalWithPositions () {
     const { ballotItemWeVoteId, blockOnClickShowOrganizationModalWithPositions } = this.props;
     // console.log('onClickShowOrganizationModalWithPositions, ballotItemWeVoteId:', ballotItemWeVoteId);
@@ -419,22 +436,22 @@ class BallotItemSupportOpposeCountDisplay extends Component {
     openSnackbar({ message: 'Support removed!' });
   }
 
-  goToBallotItemLinkLocal (ballotItemWeVoteId) {
-    // console.log('BallotItemSupportOpposeCountDisplay goToBallotItemLinkLocal, ballotItemWeVoteId:', ballotItemWeVoteId);
-    if (this.props.goToBallotItem) {
-      this.props.goToBallotItem(ballotItemWeVoteId);
+  showAllPositionsLocal (ballotItemWeVoteId) {
+    // console.log('BallotItemSupportOpposeScoreDisplay showAllPositionsLocal, ballotItemWeVoteId:', ballotItemWeVoteId);
+    if (this.props.showAllPositions) {
+      this.props.showAllPositions(ballotItemWeVoteId);
     }
   }
 
   render () {
-    renderLog('BallotItemSupportOpposeCountDisplay');  // Set LOG_RENDER_EVENTS to log all renders
+    renderLog('BallotItemSupportOpposeScoreDisplay');  // Set LOG_RENDER_EVENTS to log all renders
     const {
       ballotItemWeVoteId, classes, closeSupportOpposeCountDisplayModal, controlAdviserMaterialUIPopoverFromProp,
-      hideEndorsementsOverview, hideNumbersOfAllPositions, hideShowMoreLink, inModal,
+      hideEndorsementsOverview, hideNumbersOfAllPositions,
       openAdviserMaterialUIPopover, openSupportOpposeCountDisplayModal, supportOpposeCountDisplayModalTutorialOn,
-      supportOpposeCountDisplayModalTutorialText, showDownArrow, showUpArrow, uniqueExternalId,
+      supportOpposeCountDisplayModalTutorialText, showDownArrow, showUpArrow,
     } = this.props;
-    // console.log('BallotItemSupportOpposeCountDisplay, controlAdviserMaterialUIPopoverFromProp: ', controlAdviserMaterialUIPopoverFromProp,  ', openAdviserMaterialUIPopover:', openAdviserMaterialUIPopover);
+    // console.log('BallotItemSupportOpposeScoreDisplay, controlAdviserMaterialUIPopoverFromProp: ', controlAdviserMaterialUIPopoverFromProp,  ', openAdviserMaterialUIPopover:', openAdviserMaterialUIPopover);
     const {
       ballotItemDisplayName,
       numberOfAllSupportPositions, numberOfAllOpposePositions, numberOfAllInfoOnlyPositions,
@@ -449,7 +466,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
       voterOpposesBallotItem,
       voterSupportsBallotItem,
     } = this.state;
-    // console.log('BallotItemSupportOpposeCountDisplay render, voterSupportsBallotItem/voterOpposesBallotItem:', voterSupportsBallotItem, voterOpposesBallotItem);
+    // console.log('BallotItemSupportOpposeScoreDisplay render, voterSupportsBallotItem/voterOpposesBallotItem:', voterSupportsBallotItem, voterOpposesBallotItem);
 
     if (!ballotItemWeVoteId) return null;
 
@@ -491,7 +508,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                 <YourOpinion>
                   <DecidedIconWrapper>
                     <NetworkScoreSmall
-                      onClick={this.stopSupportingItem}
+                      // onClick={this.stopSupportingItem}
                       voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                       voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
                       voterSupportsBallotItem={voterSupportsBallotItem}
@@ -513,7 +530,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                 <YourOpinion>
                   <DecidedIconWrapper>
                     <NetworkScoreSmall
-                      onClick={this.stopOpposingItem}
+                      // onClick={this.stopOpposingItem}
                       voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                       voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
                       voterOpposesBallotItem={voterOpposesBallotItem}
@@ -531,19 +548,6 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                   )}
                 </YourOpinion>
               )}
-              <ItemActionBarWrapper>
-                <Suspense fallback={<></>}>
-                  <ItemActionBar
-                    inModal={inModal}
-                    ballotItemWeVoteId={ballotItemWeVoteId}
-                    commentButtonHide
-                    externalUniqueId={`BallotItemSupportOrOpposeCountDisplay-ItemActionBar-${uniqueExternalId}-${ballotItemWeVoteId}`}
-                    hidePositionPublicToggle
-                    positionPublicToggleWrapAllowed
-                    shareButtonHide
-                  />
-                </Suspense>
-              </ItemActionBarWrapper>
               <YourPersonalNetworkIntroText>
                 Your personal network also has
                 {' '}
@@ -561,7 +565,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                       controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
                       openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
                       positionSummaryList={positionsInNetworkSummaryList}
-                      showAllPositions={this.props.goToBallotItem}
+                      showAllPositions={this.props.showAllPositions}
                       voterPersonalNetworkScore={voterPersonalNetworkScore}
                       voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                       voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -601,19 +605,6 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                 </TutorialTextBlue>
               ) : (
                 <>
-                  <ItemActionBarWrapper>
-                    <Suspense fallback={<></>}>
-                      <ItemActionBar
-                        inModal={inModal}
-                        ballotItemWeVoteId={ballotItemWeVoteId}
-                        commentButtonHide
-                        externalUniqueId={`BallotItemSupportOrOpposeCountDisplay-ItemActionBar-${uniqueExternalId}-${ballotItemWeVoteId}`}
-                        hidePositionPublicToggle
-                        positionPublicToggleWrapAllowed
-                        shareButtonHide
-                      />
-                    </Suspense>
-                  </ItemActionBarWrapper>
                   {positionsInNetworkVoterNotDecidedIntro}
                 </>
               )}
@@ -625,7 +616,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                       controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
                       openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
                       positionSummaryList={positionsInNetworkSummaryList}
-                      showAllPositions={this.props.goToBallotItem}
+                      showAllPositions={this.props.showAllPositions}
                       voterPersonalNetworkScore={voterPersonalNetworkScore}
                       voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                       voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -645,19 +636,6 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             <PopoverTitleText>Your Personalized Score</PopoverTitleText>
           </PopoverHeader>
           <PopoverBody>
-            <ItemActionBarWrapper>
-              <Suspense fallback={<></>}>
-                <ItemActionBar
-                  inModal={inModal}
-                  ballotItemWeVoteId={ballotItemWeVoteId}
-                  commentButtonHide
-                  externalUniqueId={`BallotItemSupportOrOpposeCountDisplay-ItemActionBar-${uniqueExternalId}-${ballotItemWeVoteId}`}
-                  hidePositionPublicToggle
-                  positionPublicToggleWrapAllowed
-                  shareButtonHide
-                />
-              </Suspense>
-            </ItemActionBarWrapper>
             Your personalized score about
             {' '}
             <strong>{ballotItemDisplayName}</strong>
@@ -684,30 +662,6 @@ class BallotItemSupportOpposeCountDisplay extends Component {
               {' '}
               yet.
             </PopoverBodyText>
-            <ItemActionBarWrapper>
-              <Suspense fallback={<></>}>
-                <ItemActionBar
-                  inModal={inModal}
-                  ballotItemWeVoteId={ballotItemWeVoteId}
-                  commentButtonHide
-                  externalUniqueId={`BallotItemSupportOrOpposeCountDisplay-ItemActionBar-${uniqueExternalId}-${ballotItemWeVoteId}`}
-                  hidePositionPublicToggle
-                  positionPublicToggleWrapAllowed
-                  shareButtonHide
-                />
-              </Suspense>
-            </ItemActionBarWrapper>
-            {!hideShowMoreLink && (
-              <ShowCandidateFooterWrapper>
-                <Suspense fallback={<></>}>
-                  <ShowMoreFooter
-                    showMoreId={`noPositionsForPopoverShowAllPositions-${ballotItemWeVoteId}`}
-                    showMoreLink={() => this.goToBallotItemLinkLocal(ballotItemWeVoteId)}
-                    showMoreText="Show More"
-                  />
-                </Suspense>
-              </ShowCandidateFooterWrapper>
-            )}
           </PopoverBody>
         </PopoverWrapper>
       );
@@ -722,7 +676,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
               <YourOpinion>
                 <DecidedIconWrapper>
                   <NetworkScoreSmall
-                    onClick={this.stopSupportingItem}
+                    // onClick={this.stopSupportingItem}
                     voterSupportsBallotItem={voterSupportsBallotItem}
                     voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                     voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -745,7 +699,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
               <YourOpinion>
                 <DecidedIconWrapper>
                   <NetworkScoreSmall
-                    onClick={this.stopOpposingItem}
+                    // onClick={this.stopOpposingItem}
                     voterOpposesBallotItem={voterOpposesBallotItem}
                     voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                     voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -760,19 +714,6 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                 {' '}
               </YourOpinion>
             )}
-            <ItemActionBarWrapper>
-              <Suspense fallback={<></>}>
-                <ItemActionBar
-                  inModal={inModal}
-                  ballotItemWeVoteId={ballotItemWeVoteId}
-                  commentButtonHide
-                  externalUniqueId={`BallotItemSupportOrOpposeCountDisplay-ItemActionBar-${uniqueExternalId}-${ballotItemWeVoteId}`}
-                  hidePositionPublicToggle
-                  positionPublicToggleWrapAllowed
-                  shareButtonHide
-                />
-              </Suspense>
-            </ItemActionBarWrapper>
           </PopoverBody>
         </PopoverWrapper>
       );
@@ -787,19 +728,6 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             </PopoverTitleText>
           </PopoverHeader>
           <PopoverBody>
-            <ItemActionBarWrapper>
-              <Suspense fallback={<></>}>
-                <ItemActionBar
-                  inModal={inModal}
-                  ballotItemWeVoteId={ballotItemWeVoteId}
-                  commentButtonHide
-                  externalUniqueId={`BallotItemSupportOrOpposeCountDisplay-ItemActionBar-${uniqueExternalId}-${ballotItemWeVoteId}`}
-                  hidePositionPublicToggle
-                  positionPublicToggleWrapAllowed
-                  shareButtonHide
-                />
-              </Suspense>
-            </ItemActionBarWrapper>
             <div>
               Follow opinions to build your personalized score
               {(ballotItemDisplayName) && (
@@ -823,7 +751,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                       controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
                       openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
                       positionSummaryList={positionsOutOfNetworkSummaryList}
-                      showAllPositions={this.props.goToBallotItem}
+                      showAllPositions={this.props.showAllPositions}
                       voterPersonalNetworkScore={voterPersonalNetworkScore}
                       voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                       voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -847,19 +775,6 @@ class BallotItemSupportOpposeCountDisplay extends Component {
           </PopoverTitleText>
         </PopoverHeader>
         <PopoverBody>
-          <ItemActionBarWrapper>
-            <Suspense fallback={<></>}>
-              <ItemActionBar
-                inModal={inModal}
-                ballotItemWeVoteId={ballotItemWeVoteId}
-                commentButtonHide
-                externalUniqueId={`BallotItemSupportOrOpposeCountDisplay-ItemActionBar-${uniqueExternalId}-${ballotItemWeVoteId}`}
-                hidePositionPublicToggle
-                positionPublicToggleWrapAllowed
-                shareButtonHide
-              />
-            </Suspense>
-          </ItemActionBarWrapper>
           <div>
             Follow opinions to build your personalized score
             {(ballotItemDisplayName) && (
@@ -883,7 +798,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                     controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
                     openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
                     positionSummaryList={positionsOutOfNetworkSummaryList}
-                    showAllPositions={this.props.goToBallotItem}
+                    showAllPositions={this.props.showAllPositions}
                     voterPersonalNetworkScore={voterPersonalNetworkScore}
                     voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                     voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -912,7 +827,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
     // console.log('(!showVoterPersonalScore && !voterSupportsBallotItem && !voterOpposesBallotItem):', (!showVoterPersonalScore && !voterSupportsBallotItem && !voterOpposesBallotItem));
     // console.log('(showVoterPersonalScore && !voterSupportsBallotItem && !voterOpposesBallotItem):', (showVoterPersonalScore && !voterSupportsBallotItem && !voterOpposesBallotItem));
     return (
-      <Wrapper
+      <BallotItemSupportOpposeScoreDisplayWrapper
         onMouseEnter={this.handleEnterHoverLocalArea}
         onMouseLeave={this.handleLeaveHoverLocalArea}
       >
@@ -963,12 +878,13 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             popoverComponent={positionsPopover}
             placement="bottom"
             id="ballot-support-oppose-count-trigger-click-root-close"
-            openOnClick
+            openOnClick={!this.props.onClickFunction}
             openPopoverByProp={openSupportOpposeCountDisplayModal}
             closePopoverByProp={closeSupportOpposeCountDisplayModal}
             showCloseIcon
           >
             <NetworkScore
+              onClick={this.onClickFunctionLinkLocal}
               voterOpposesBallotItem={voterOpposesBallotItem}
               voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
               voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -1007,12 +923,13 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             popoverComponent={positionsPopover}
             placement="bottom"
             id="ballot-support-oppose-count-trigger-click-root-close"
-            openOnClick
+            openOnClick={!this.props.onClickFunction}
             openPopoverByProp={openSupportOpposeCountDisplayModal}
             closePopoverByProp={closeSupportOpposeCountDisplayModal}
             showCloseIcon
           >
             <NetworkScore
+              onClick={this.onClickFunctionLinkLocal}
               voterOpposesBallotItem={voterOpposesBallotItem}
               voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
               voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
@@ -1051,13 +968,17 @@ class BallotItemSupportOpposeCountDisplay extends Component {
             popoverComponent={positionsPopover}
             placement="bottom"
             id="ballot-support-oppose-count-trigger-click-root-close"
-            openOnClick
+            openOnClick={!this.props.onClickFunction}
             openPopoverByProp={openSupportOpposeCountDisplayModal}
             closePopoverByProp={closeSupportOpposeCountDisplayModal}
             showCloseIcon
           >
             { voterPersonalNetworkScore === 0 ? (
-              <NetworkScore voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative} voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}>
+              <NetworkScore
+                onClick={this.onClickFunctionLinkLocal}
+                voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+              >
                 <ScoreLabel>
                   score
                 </ScoreLabel>
@@ -1066,7 +987,7 @@ class BallotItemSupportOpposeCountDisplay extends Component {
                 </ScoreNumberWrapper>
               </NetworkScore>
             ) : (
-              <NetworkScoreWrapper>
+              <NetworkScoreWrapper onClick={this.onClickFunctionLinkLocal}>
                 <NetworkScore
                   voterOpposesBallotItem={voterOpposesBallotItem}
                   voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
@@ -1102,11 +1023,12 @@ class BallotItemSupportOpposeCountDisplay extends Component {
               popoverComponent={endorsementsOverviewPopover}
               placement="auto"
               id="endorsements-overview-trigger-click-root-close"
-              openOnClick
+              openOnClick={!this.props.onClickFunction}
               showCloseIcon
             >
               <NetworkScore
                 hideNumbersOfAllPositions
+                onClick={this.onClickFunctionLinkLocal}
                 voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
                 voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
               >
@@ -1121,31 +1043,30 @@ class BallotItemSupportOpposeCountDisplay extends Component {
           {voterPersonalNetworkScore > 0 ? `${voterPersonalNetworkScore} Support` : null }
           {voterPersonalNetworkScore < 0 ? `${voterPersonalNetworkScore} Oppose` : null }
         </span>
-      </Wrapper>
+      </BallotItemSupportOpposeScoreDisplayWrapper>
     );
   }
 }
-BallotItemSupportOpposeCountDisplay.propTypes = {
+BallotItemSupportOpposeScoreDisplay.propTypes = {
   ballotItemDisplayName: PropTypes.string,
   ballotItemWeVoteId: PropTypes.string.isRequired,
   blockOnClickShowOrganizationModalWithPositions: PropTypes.bool,
   classes: PropTypes.object,
   closeSupportOpposeCountDisplayModal: PropTypes.bool,
   controlAdviserMaterialUIPopoverFromProp: PropTypes.bool,
-  goToBallotItem: PropTypes.func, // We don't require this because sometimes we don't want the link to do anything
   handleLeaveCandidateCard: PropTypes.func,
   handleEnterCandidateCard: PropTypes.func,
   hideEndorsementsOverview: PropTypes.bool,
   hideNumbersOfAllPositions: PropTypes.bool,
-  hideShowMoreLink: PropTypes.bool,
-  inModal: PropTypes.bool,
+  // hideShowMoreLink: PropTypes.bool,
+  onClickFunction: PropTypes.func, // This overrides the click on the score box
   openAdviserMaterialUIPopover: PropTypes.bool,
   openSupportOpposeCountDisplayModal: PropTypes.bool,
   supportOpposeCountDisplayModalTutorialOn: PropTypes.bool,
   supportOpposeCountDisplayModalTutorialText: PropTypes.object,
+  showAllPositions: PropTypes.func, // We don't require this because sometimes we don't want the link to do anything
   showDownArrow: PropTypes.bool,
   showUpArrow: PropTypes.bool,
-  uniqueExternalId: PropTypes.string,
 };
 
 // ${theme.colors.opposeRedRgb}  // Why doesn't this pull from WebApp/src/js/styled-theme.js ?
@@ -1190,15 +1111,11 @@ const styles = (theme) => ({
   },
 });
 
-const Wrapper = styled('div')`
+const BallotItemSupportOpposeScoreDisplayWrapper = styled('div')`
   align-items: flex-start;
   display: flex;
   justify-content: flex-end;
   margin-top: .1rem;
-`;
-
-const DecidedIconWrapper = styled('span')`
-  margin-right: 6px;
 `;
 
 const EndorsementRow = styled('div')`
@@ -1253,62 +1170,10 @@ const EndorsementsInnerWrapper = styled('div')`
   justify-content: flex-start;
 `;
 
-const ItemActionBarWrapper = styled('div')`
-  margin-bottom: 8px;
-  width: 100%;
-`;
-
 const NetworkScoreWrapper = styled('div')`
   position: relative;
   z-index: 1;
 `;
-
-// TODO:  This is almost identical to BallotItemVoterGuideSupportOpposeDisplay, it should be a reused component
-const NetworkScore = styled('div', {
-  shouldForwardProp: (prop) => !['hideNumbersOfAllPositions', 'voterOpposesBallotItem', 'voterPersonalNetworkScoreIsNegative', 'voterPersonalNetworkScoreIsPositive', 'voterSupportsBallotItem'].includes(prop),
-})(({ hideNumbersOfAllPositions, voterOpposesBallotItem, voterPersonalNetworkScoreIsNegative, voterPersonalNetworkScoreIsPositive, voterSupportsBallotItem }) => (`
-  background: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
-  align-items: center;
-  border-radius: 5px;
-  box-shadow: 0 1px 3px 0 rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12);
-  color: white;
-  cursor: pointer;
-  display: flex;
-  flex-wrap: wrap;
-  font-size: 16px;
-  font-weight: bold;
-  justify-content: center;
-  margin-top: 2px;
-  width: 40px;
-  height: 40px;
-  @media print{
-    border-width: 1px;
-    border-style: solid;
-    border-color: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
-  }
-`));
-
-const NetworkScoreSmall = styled('div', {
-  shouldForwardProp: (prop) => !['hideNumbersOfAllPositions', 'voterOpposesBallotItem', 'voterPersonalNetworkScoreIsNegative', 'voterPersonalNetworkScoreIsPositive', 'voterSupportsBallotItem'].includes(prop),
-})(({ hideNumbersOfAllPositions, voterOpposesBallotItem, voterPersonalNetworkScoreIsNegative, voterPersonalNetworkScoreIsPositive, voterSupportsBallotItem }) => (`
-  background: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
-  color: white;
-  box-shadow: 0 1px 3px 0 rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 5px;
-  float: left;
-  font-size: 10px;
-  font-weight: bold;
-  @media print{
-    border-width: 1px;
-    border-style: solid;
-    border-color: ${(voterSupportsBallotItem && 'rgb(31, 192, 111)') || (voterOpposesBallotItem && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (hideNumbersOfAllPositions && 'rgb(211, 211, 211)') || '#888'};
-  }
-`));
 
 const PopoverWrapper = styled('div')`
   width: 100%;
@@ -1343,14 +1208,6 @@ const PopoverBody = styled('div')`
   border-bottom-right-radius: 5px;
 `;
 
-const PopoverBodyText = styled('div')`
-  margin-bottom: 8px;
-`;
-
-const RenderedOrganizationsWrapper = styled('div')`
-  margin-top: 6px;
-`;
-
 const ScoreLabel = styled('div')`
   font-size: 13px;
   margin-top: -4px;
@@ -1375,12 +1232,6 @@ const ScoreNumberWrapper = styled('div')`
   font-size: 18px;
   margin-top: -8px;
 `;
-const ShowCandidateFooterWrapper = styled('div')`
-  margin-top: 10px;
-`;
-
-const TutorialTextBlue = styled('div')`
-`;
 
 const VoterChoiceWrapper = styled('div')`
   color: white;
@@ -1388,14 +1239,6 @@ const VoterChoiceWrapper = styled('div')`
     color: #1fc06f;
   }
   margin-top: 0;
-`;
-
-const YourOpinion = styled('div')`
-  margin-bottom: 8px;
-`;
-
-const YourPersonalNetworkIntroText = styled('div')`
-  margin-top: 6px;
 `;
 
 const YourScoreWrapper = styled('div')`
@@ -1421,4 +1264,4 @@ const UpArrow = styled('div')`
   z-index: 2;
 `;
 
-export default withTheme(withStyles(styles)(BallotItemSupportOpposeCountDisplay));
+export default withTheme(withStyles(styles)(BallotItemSupportOpposeScoreDisplay));

--- a/src/js/components/Widgets/ScoreDisplay/BallotItemVoterGuideSupportOpposeDisplay.jsx
+++ b/src/js/components/Widgets/ScoreDisplay/BallotItemVoterGuideSupportOpposeDisplay.jsx
@@ -4,14 +4,17 @@ import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
-import { renderLog } from '../../common/utils/logging';
-import OrganizationStore from '../../stores/OrganizationStore';
-import StickyPopover from '../Ballot/StickyPopover';
-import FriendsOnlyIndicator from './FriendsOnlyIndicator';
+import { isCordova } from '../../../common/utils/isCordovaOrWebApp';
+import { renderLog } from '../../../common/utils/logging';
+import {
+  NetworkScore,
+} from '../../Style/ScoreDisplayStyles';
+import OrganizationStore from '../../../stores/OrganizationStore';
+import StickyPopover from '../../Ballot/StickyPopover';
+import FriendsOnlyIndicator from '../FriendsOnlyIndicator';
 import PositionItemScorePopover from './PositionItemScorePopover';
 
-const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
+const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../../ImageHandler'));
 
 class BallotItemVoterGuideSupportOpposeDisplay extends Component {
   static closePositionsPopover () {
@@ -110,7 +113,7 @@ class BallotItemVoterGuideSupportOpposeDisplay extends Component {
             popoverComponent={positionsPopover}
             placement="bottom"
             id="ballot-support-oppose-count-trigger-click-root-close"
-            openOnClick
+            openOnClick={!this.props.onClickFunction}
             showCloseIcon
           >
             <OrganizationSupportWrapper>
@@ -146,7 +149,7 @@ class BallotItemVoterGuideSupportOpposeDisplay extends Component {
             popoverComponent={positionsPopover}
             placement="bottom"
             id="ballot-support-oppose-count-trigger-click-root-close"
-            openOnClick
+            openOnClick={!this.props.onClickFunction}
             showCloseIcon
           >
             <OrganizationOpposeWrapper>
@@ -182,7 +185,7 @@ class BallotItemVoterGuideSupportOpposeDisplay extends Component {
             popoverComponent={positionsPopover}
             placement="bottom"
             id="ballot-support-oppose-count-trigger-click-root-close"
-            openOnClick
+            openOnClick={!this.props.onClickFunction}
             showCloseIcon
           >
             <OrganizationInformationOnlyWrapper>
@@ -219,7 +222,7 @@ class BallotItemVoterGuideSupportOpposeDisplay extends Component {
             popoverComponent={positionsPopover}
             placement="bottom"
             id="ballot-support-oppose-count-trigger-click-root-close"
-            openOnClick
+            openOnClick={!this.props.onClickFunction}
             showCloseIcon
           >
             <NetworkScore
@@ -236,6 +239,7 @@ class BallotItemVoterGuideSupportOpposeDisplay extends Component {
 BallotItemVoterGuideSupportOpposeDisplay.propTypes = {
   handleLeaveCandidateCard: PropTypes.func,
   handleEnterCandidateCard: PropTypes.func,
+  onClickFunction: PropTypes.func,
   positionWeVoteId: PropTypes.string,
 };
 
@@ -261,29 +265,6 @@ const Wrapper = styled('div')`
   margin-top: .1rem;
   width: 100%;
 `;
-
-// TODO:  This is almost identical to BallotItemSupportOpposeDisplay, it should be a reused component
-const NetworkScore = styled('div', {
-  shouldForwardProp: (prop) => !['hideNumbersOfAllPositions', 'voterPersonalNetworkScoreIsNegative', 'voterPersonalNetworkScoreIsPositive'].includes(prop),
-})(({ hideNumbersOfAllPositions, voterPersonalNetworkScoreIsNegative, voterPersonalNetworkScoreIsPositive }) => (`
-
-  background: ${(voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (hideNumbersOfAllPositions && 'rgb(240, 240, 240)') || '#888'};
-  border-radius: 5px;
-  box-shadow: 0 1px 3px 0 rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12);
-  color: white;
-  cursor: pointer;
-  display: flex;
-  font-size: 16px;
-  font-weight: bold;
-  height: 40px;
-  justify-content: center;
-  width: 40px;
-  @media print{
-    border-width: 1px;
-    border-style: solid;
-    border-color: ${(voterPersonalNetworkScoreIsNegative && 'rgb(255, 73, 34)') || (voterPersonalNetworkScoreIsPositive && 'rgb(31, 192, 111)') || (hideNumbersOfAllPositions && 'rgb(240, 240, 240)') || '#888'};
-  }
-`));
 
 const OrganizationSupportWrapper = styled('div')`
   position: relative;

--- a/src/js/components/Widgets/ScoreDisplay/PositionItemScorePopover.jsx
+++ b/src/js/components/Widgets/ScoreDisplay/PositionItemScorePopover.jsx
@@ -4,15 +4,15 @@ import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
-import SvgImage from '../../common/components/Widgets/SvgImage';
-import FriendStore from '../../stores/FriendStore';
-import IssueStore from '../../stores/IssueStore';
-import OrganizationStore from '../../stores/OrganizationStore';
-import { isOrganizationInVotersNetwork } from '../../utils/positionFunctions';
-import FriendsIcon from './FriendsIcon';
+import SvgImage from '../../../common/components/Widgets/SvgImage';
+import FriendStore from '../../../stores/FriendStore';
+import IssueStore from '../../../stores/IssueStore';
+import OrganizationStore from '../../../stores/OrganizationStore';
+import { isOrganizationInVotersNetwork } from '../../../utils/positionFunctions';
+import FriendsIcon from '../FriendsIcon';
 
-const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ './FollowToggle'));
-const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
+const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ '../FollowToggle'));
+const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../../common/components/Widgets/ReadMore'));
 
 class PositionItemScorePopover extends Component {
   constructor (props) {

--- a/src/js/components/Widgets/ScoreDisplay/PositionItemScorePopoverTextOnly.jsx
+++ b/src/js/components/Widgets/ScoreDisplay/PositionItemScorePopoverTextOnly.jsx
@@ -5,12 +5,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { ReactSVG } from 'react-svg';
 import styled from 'styled-components';
-import FriendStore from '../../stores/FriendStore';
-import IssueStore from '../../stores/IssueStore';
-import OrganizationStore from '../../stores/OrganizationStore';
-import normalizedImagePath from '../../common/utils/normalizedImagePath';
-import { isOrganizationInVotersNetwork } from '../../utils/positionFunctions';
-import FriendsIcon from './FriendsIcon';
+import FriendStore from '../../../stores/FriendStore';
+import IssueStore from '../../../stores/IssueStore';
+import OrganizationStore from '../../../stores/OrganizationStore';
+import normalizedImagePath from '../../../common/utils/normalizedImagePath';
+import { isOrganizationInVotersNetwork } from '../../../utils/positionFunctions';
+import FriendsIcon from '../FriendsIcon';
 
 class PositionItemScorePopoverTextOnly extends Component {
   constructor (props) {

--- a/src/js/components/Widgets/ScoreDisplay/PositionSummaryListForPopover.jsx
+++ b/src/js/components/Widgets/ScoreDisplay/PositionSummaryListForPopover.jsx
@@ -5,14 +5,14 @@ import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { ReactSVG } from 'react-svg';
-import normalizedImagePath from '../../common/utils/normalizedImagePath';
-import { cleanArray } from '../../utils/textFormat';
-import FriendsIcon from './FriendsIcon';
+import normalizedImagePath from '../../../common/utils/normalizedImagePath';
+import { cleanArray } from '../../../utils/textFormat';
+import FriendsIcon from '../FriendsIcon';
 import PositionItemScorePopoverTextOnly from './PositionItemScorePopoverTextOnly';
 
-const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ './FollowToggle'));
-const MaterialUIPopover = React.lazy(() => import(/* webpackChunkName: 'MaterialUIPopover' */ './MaterialUIPopover'));
-const ShowMoreFooter = React.lazy(() => import(/* webpackChunkName: 'ShowMoreFooter' */ '../Navigation/ShowMoreFooter'));
+const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ '../FollowToggle'));
+const MaterialUIPopover = React.lazy(() => import(/* webpackChunkName: 'MaterialUIPopover' */ '../MaterialUIPopover'));
+const ShowMoreFooter = React.lazy(() => import(/* webpackChunkName: 'ShowMoreFooter' */ '../../Navigation/ShowMoreFooter'));
 
 class PositionSummaryListForPopover extends Component {
   constructor (props) {

--- a/src/js/components/Widgets/ScoreDisplay/ScoreSummaryListController.jsx
+++ b/src/js/components/Widgets/ScoreDisplay/ScoreSummaryListController.jsx
@@ -1,0 +1,595 @@
+import { Done, NotInterested } from '@mui/icons-material';
+import styled from 'styled-components';
+import withStyles from '@mui/styles/withStyles';
+import withTheme from '@mui/styles/withTheme';
+import PropTypes from 'prop-types';
+import React, { Component, Suspense } from 'react';
+import { renderLog } from '../../../common/utils/logging';
+import stringContains from '../../../common/utils/stringContains';
+import {
+  DecidedIconWrapper,
+  NetworkScoreSmall,
+  PopoverBodyText,
+  RenderedOrganizationsWrapper,
+  YourOpinion,
+  YourPersonalNetworkIntroText,
+} from '../../Style/ScoreDisplayStyles';
+import AppObservableStore from '../../../stores/AppObservableStore';
+import CandidateStore from '../../../stores/CandidateStore';
+import FriendStore from '../../../stores/FriendStore';
+import IssueStore from '../../../stores/IssueStore';
+import MeasureStore from '../../../stores/MeasureStore';
+import OrganizationStore from '../../../stores/OrganizationStore';
+import SupportStore from '../../../stores/SupportStore';
+import { getPositionListSummaryIncomingDataStats, getPositionSummaryListForBallotItem } from '../../../utils/positionFunctions';
+
+const PositionSummaryListForPopover = React.lazy(() => import(/* webpackChunkName: 'PositionSummaryListForPopover' */ './PositionSummaryListForPopover'));
+
+
+class ScoreSummaryListController extends Component {
+  static closePositionsPopover () {
+    document.body.click();
+  }
+
+  constructor (props) {
+    super(props);
+    this.mobile = 'ontouchstart' in document.documentElement;
+    this.state = {
+      allCachedPositionsLength: 0,
+      allIssuesVoterIsFollowingLength: 0,
+      ballotItemDisplayName: '',
+      ballotItemWeVoteId: '',
+      issueWeVoteIdsLinkedToByOrganizationDictLength: 0,
+      organizationWeVoteIdsVoterIsFollowingLength: 0,
+      positionsInNetworkSummaryList: [],
+      positionsInNetworkSummaryListLength: 0,
+      positionsOutOfNetworkSummaryList: [],
+      voterOpposesListLength: 0,
+      voterSupportsListLength: 0,
+      voterPersonalNetworkScore: 0,
+      voterOpposesBallotItem: false,
+      voterSupportsBallotItem: false,
+    };
+    this.onClickFunctionLinkLocal = this.onClickFunctionLinkLocal.bind(this);
+    this.onClickShowOrganizationModalWithPositions = this.onClickShowOrganizationModalWithPositions.bind(this);
+  }
+
+  componentDidMount () {
+    // console.log('ScoreSummaryListController componentDidMount');
+    this.candidateStoreListener = CandidateStore.addListener(this.onCandidateStoreChange.bind(this));
+    this.friendStoreListener = FriendStore.addListener(this.onFriendStoreChange.bind(this));
+    this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
+    this.measureStoreListener = MeasureStore.addListener(this.onMeasureStoreChange.bind(this));
+    this.organizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
+    this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
+    let ballotItemDisplayName = '';
+    const { ballotItemWeVoteId } = this.props;
+    const isCandidate = stringContains('cand', ballotItemWeVoteId);
+    const isMeasure = stringContains('meas', ballotItemWeVoteId);
+    // console.log('isCandidate:', isCandidate, 'isMeasure:', isMeasure);
+    if (isCandidate) {
+      const candidate = CandidateStore.getCandidate(ballotItemWeVoteId);
+      ballotItemDisplayName = candidate.ballot_item_display_name || this.props.ballotItemDisplayName;
+      const countResults = CandidateStore.getNumberOfPositionsByCandidateWeVoteId(ballotItemWeVoteId);
+      const { numberOfAllSupportPositions, numberOfAllOpposePositions, numberOfAllInfoOnlyPositions } = countResults;
+      this.setState({
+        ballotItemDisplayName,
+        numberOfAllSupportPositions,
+        numberOfAllOpposePositions,
+        numberOfAllInfoOnlyPositions,
+      });
+    } else if (isMeasure) {
+      const measure = MeasureStore.getMeasure(ballotItemWeVoteId);
+      ballotItemDisplayName = measure.ballot_item_display_name || this.props.ballotItemDisplayName;
+      const countResults = MeasureStore.getNumberOfPositionsByMeasureWeVoteId(ballotItemWeVoteId);
+      const { numberOfAllSupportPositions, numberOfAllOpposePositions, numberOfAllInfoOnlyPositions } = countResults;
+      this.setState({
+        ballotItemDisplayName,
+        numberOfAllSupportPositions,
+        numberOfAllOpposePositions,
+        numberOfAllInfoOnlyPositions,
+      });
+    }
+    this.setState({
+      ballotItemWeVoteId,
+      isCandidate,
+      isMeasure,
+    });
+    this.onCachedPositionsOrIssueStoreChange();
+  }
+
+  componentDidCatch (error, info) {
+    // We should get this information to Splunk!
+    console.error('ScoreSummaryListController caught error: ', `${error} with info: `, info);
+  }
+
+  componentWillUnmount () {
+    this.candidateStoreListener.remove();
+    this.friendStoreListener.remove();
+    this.issueStoreListener.remove();
+    this.measureStoreListener.remove();
+    this.organizationStoreListener.remove();
+    this.supportStoreListener.remove();
+  }
+
+  // See https://reactjs.org/docs/error-boundaries.html
+  static getDerivedStateFromError (error) {       // eslint-disable-line no-unused-vars
+    // Update state so the next render will show the fallback UI, We should have a 'Oh snap' page
+    return { hasError: true };
+  }
+
+  onCachedPositionsOrIssueStoreChange () {
+    const { ballotItemWeVoteId } = this.props;
+    const {
+      allCachedPositionsLength: priorAllCachedPositionsLength,
+      allIssuesVoterIsFollowingLength: priorAllIssuesVoterIsFollowingLength,
+      currentFriendsOrganizationWeVoteIdsLength: priorCurrentFriendsOrganizationWeVoteIdsLength,
+      issueWeVoteIdsLinkedToByOrganizationDictLength: priorIssueWeVoteIdsLinkedToByOrganizationDictLength,
+      organizationWeVoteIdsVoterIsFollowingLength: priorOrganizationWeVoteIdsVoterIsFollowingLength,
+      voterOpposesBallotItem: priorVoterOpposesBallotItem,
+      voterOpposesListLength: priorVoterOpposesListLength,
+      voterSupportsBallotItem: priorVoterSupportsBallotItem,
+      voterSupportsListLength: priorVoterSupportsListLength,
+    } = this.state;
+
+    // Before we try to update the PositionSummaryList, make sure we have minimum data and that there has been a change
+    const results = getPositionListSummaryIncomingDataStats(ballotItemWeVoteId);
+    const {
+      allCachedPositionsLength, allIssuesVoterIsFollowingLength,
+      currentFriendsOrganizationWeVoteIdsLength, issueWeVoteIdsLinkedToByOrganizationDictLength, organizationWeVoteIdsVoterIsFollowingLength,
+      voterOpposesListLength, voterSupportsListLength,
+    } = results;
+    // console.log('allCachedPositionsLength:', allCachedPositionsLength, ', priorAllCachedPositionsLength:', priorAllCachedPositionsLength);
+    // console.log('allIssuesVoterIsFollowingLength:', allIssuesVoterIsFollowingLength, ', priorAllIssuesVoterIsFollowingLength:', priorAllIssuesVoterIsFollowingLength);
+    // console.log('issueWeVoteIdsLinkedToByOrganizationDictLength:', issueWeVoteIdsLinkedToByOrganizationDictLength, ', priorIssueWeVoteIdsLinkedToByOrganizationDictLength:', priorIssueWeVoteIdsLinkedToByOrganizationDictLength);
+    // console.log('organizationWeVoteIdsVoterIsFollowingLength:', organizationWeVoteIdsVoterIsFollowingLength, ', priorOrganizationWeVoteIdsVoterIsFollowingLength:', priorOrganizationWeVoteIdsVoterIsFollowingLength);
+    // console.log('voterOpposesListLength:', voterOpposesListLength, ', priorVoterOpposesListLength:', priorVoterOpposesListLength);
+    // console.log('voterSupportsListLength:', voterSupportsListLength, ', priorVoterSupportsListLength:', priorVoterSupportsListLength);
+
+    let voterSupportsBallotItem = SupportStore.voterSupportsList[ballotItemWeVoteId] || false;
+    let voterOpposesBallotItem = SupportStore.voterOpposesList[ballotItemWeVoteId] || false;
+
+    const minimumPositionSummaryListVariablesFound = !!(allCachedPositionsLength !== undefined && (currentFriendsOrganizationWeVoteIdsLength || issueWeVoteIdsLinkedToByOrganizationDictLength || organizationWeVoteIdsVoterIsFollowingLength));
+    const changedPositionSummaryListVariablesFound = !!((allCachedPositionsLength !== priorAllCachedPositionsLength) || (allIssuesVoterIsFollowingLength !== priorAllIssuesVoterIsFollowingLength) || (currentFriendsOrganizationWeVoteIdsLength !== priorCurrentFriendsOrganizationWeVoteIdsLength) || (issueWeVoteIdsLinkedToByOrganizationDictLength !== priorIssueWeVoteIdsLinkedToByOrganizationDictLength) || (organizationWeVoteIdsVoterIsFollowingLength !== priorOrganizationWeVoteIdsVoterIsFollowingLength) || (voterOpposesListLength !== priorVoterOpposesListLength) || (voterSupportsListLength !== priorVoterSupportsListLength));
+    const changedVoterPosition = !!((voterOpposesBallotItem !== priorVoterOpposesBallotItem) || (voterSupportsBallotItem !== priorVoterSupportsBallotItem));
+    // console.log('minimumPositionSummaryListVariablesFound:', minimumPositionSummaryListVariablesFound, ', changedPositionSummaryListVariablesFound:', changedPositionSummaryListVariablesFound, ', changedVoterPosition:', changedVoterPosition);
+
+    const refreshPositionSummaryList = !!((minimumPositionSummaryListVariablesFound && changedPositionSummaryListVariablesFound) || changedVoterPosition);
+    // console.log('refreshPositionSummaryList: ', refreshPositionSummaryList, ballotItemWeVoteId);
+    let firstStateBatch;
+    let secondStateBatch;
+    if (refreshPositionSummaryList) {
+      const limitToThisIssue = false;
+      const showPositionsInVotersNetwork = true;
+      const doNotShowPositionsInVotersNetwork = false;
+      const showPositionsOutOfVotersNetwork = true;
+      const positionsInNetworkSummaryList = getPositionSummaryListForBallotItem(ballotItemWeVoteId, limitToThisIssue, showPositionsInVotersNetwork);
+      // console.log('positionsInNetworkSummaryList: ', positionsInNetworkSummaryList);
+      const positionsInNetworkSummaryListLength = positionsInNetworkSummaryList.length;
+      const positionsOutOfNetworkSummaryList = getPositionSummaryListForBallotItem(ballotItemWeVoteId, limitToThisIssue, doNotShowPositionsInVotersNetwork, showPositionsOutOfVotersNetwork);
+      const positionsOutOfNetworkSummaryListLength = positionsOutOfNetworkSummaryList.length;
+      firstStateBatch = {
+        allCachedPositionsLength,
+        allIssuesVoterIsFollowingLength,
+        currentFriendsOrganizationWeVoteIdsLength,
+        issueWeVoteIdsLinkedToByOrganizationDictLength,
+        organizationWeVoteIdsVoterIsFollowingLength,
+        positionsInNetworkSummaryList,
+        positionsInNetworkSummaryListLength,
+        positionsOutOfNetworkSummaryList,
+        positionsOutOfNetworkSummaryListLength,
+        voterOpposesListLength,
+        voterSupportsListLength,
+      };
+      const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);
+      // Network Score
+      let numberOfSupportPositionsForScore = 0;
+      let numberOfOpposePositionsForScore = 0;
+      let voterPersonalNetworkScore = 0;
+      let voterPersonalScoreHasBeenCalculated = false;
+      let voterPersonalNetworkScoreWithSign;
+      let voterPersonalNetworkScoreIsNegative = false;
+      let voterPersonalNetworkScoreIsPositive = false;
+      if (ballotItemStatSheet) {
+        ({ voterOpposesBallotItem, voterSupportsBallotItem } = ballotItemStatSheet);
+        numberOfSupportPositionsForScore = parseInt(ballotItemStatSheet.numberOfSupportPositionsForScore) || 0;
+        numberOfOpposePositionsForScore = parseInt(ballotItemStatSheet.numberOfOpposePositionsForScore) || 0;
+        // console.log('numberOfSupportPositionsForScore:', numberOfSupportPositionsForScore);
+        // console.log('numberOfOpposePositionsForScore:', numberOfOpposePositionsForScore);
+        voterPersonalNetworkScore = numberOfSupportPositionsForScore - numberOfOpposePositionsForScore;
+        if (voterPersonalNetworkScore > 0) {
+          voterPersonalNetworkScoreWithSign = `+${voterPersonalNetworkScore}`;
+          voterPersonalNetworkScoreIsPositive = true;
+        } else if (voterPersonalNetworkScore < 0) {
+          voterPersonalNetworkScoreWithSign = `${voterPersonalNetworkScore}`; // Minus sign '-' is already built into the number
+          voterPersonalNetworkScoreIsNegative = true;
+        } else {
+          voterPersonalNetworkScoreWithSign = `${voterPersonalNetworkScore}`;
+        }
+      }
+
+      let showVoterPersonalScore = true;
+      if (numberOfSupportPositionsForScore === 0 && numberOfOpposePositionsForScore === 0) {
+        // There is NOT an issue score, and BOTH network_support and network_oppose must be zero to hide Network Score
+        showVoterPersonalScore = false;
+      }
+      if (numberOfSupportPositionsForScore || numberOfOpposePositionsForScore) {
+        voterPersonalScoreHasBeenCalculated = true;
+      }
+      secondStateBatch = {
+        showVoterPersonalScore,
+        voterPersonalNetworkScore,
+        voterPersonalNetworkScoreIsNegative,
+        voterPersonalNetworkScoreIsPositive,
+        voterPersonalNetworkScoreWithSign,
+        voterPersonalScoreHasBeenCalculated,
+        voterOpposesBallotItem,
+        voterSupportsBallotItem,
+      };
+    }
+    // Don't set state twice in the same function
+    const combinedState = Object.assign({}, firstStateBatch, secondStateBatch); // eslint-disable-line prefer-object-spread
+    this.setState(combinedState);
+  }
+
+  onCandidateStoreChange () {
+    const { isCandidate } = this.state;
+    if (isCandidate) {
+      const { ballotItemWeVoteId: candidateWeVoteId } = this.state;
+      const countResults = CandidateStore.getNumberOfPositionsByCandidateWeVoteId(candidateWeVoteId);
+      const { numberOfAllSupportPositions, numberOfAllOpposePositions, numberOfAllInfoOnlyPositions } = countResults;
+      this.setState({
+        numberOfAllSupportPositions,
+        numberOfAllOpposePositions,
+        numberOfAllInfoOnlyPositions,
+      });
+      this.onCachedPositionsOrIssueStoreChange();
+    }
+  }
+
+  onMeasureStoreChange () {
+    const { isMeasure } = this.state;
+    if (isMeasure) {
+      const { ballotItemWeVoteId: measureWeVoteId } = this.state;
+      const countResults = MeasureStore.getNumberOfPositionsByMeasureWeVoteId(measureWeVoteId);
+      const { numberOfAllSupportPositions, numberOfAllOpposePositions, numberOfAllInfoOnlyPositions } = countResults;
+      this.setState({
+        numberOfAllSupportPositions,
+        numberOfAllOpposePositions,
+        numberOfAllInfoOnlyPositions,
+      });
+      this.onCachedPositionsOrIssueStoreChange();
+    }
+  }
+
+  onFriendStoreChange () {
+    // We want to re-render so friend data can update
+    this.onCachedPositionsOrIssueStoreChange();
+  }
+
+  onIssueStoreChange () {
+    // We want to re-render so issue data can update
+    this.onCachedPositionsOrIssueStoreChange();
+    const issueWeVoteIdsLinkedToByOrganizationDictLength = IssueStore.getIssueWeVoteIdsLinkedToByOrganizationDictLength();
+    this.setState({
+      issueWeVoteIdsLinkedToByOrganizationDictLength,
+    });
+  }
+
+  onOrganizationStoreChange () {
+    // We want to re-render so organization data can update
+    this.onCachedPositionsOrIssueStoreChange();
+    const organizationWeVoteIdsVoterIsFollowingLength = OrganizationStore.getOrganizationWeVoteIdsVoterIsFollowingLength();
+    this.setState({
+      organizationWeVoteIdsVoterIsFollowingLength,
+    });
+  }
+
+  onSupportStoreChange () {
+    this.onCachedPositionsOrIssueStoreChange();
+  }
+
+  onClickFunctionLinkLocal (ballotItemWeVoteId) {
+    // console.log('ScoreSummaryListController onClickFunctionLinkLocal, ballotItemWeVoteId:', ballotItemWeVoteId);
+    if (this.props.onClickFunction) {
+      this.props.onClickFunction(ballotItemWeVoteId);
+    }
+  }
+
+  onClickShowOrganizationModalWithPositions () {
+    const { ballotItemWeVoteId, blockOnClickShowOrganizationModalWithPositions } = this.props;
+    // console.log('onClickShowOrganizationModalWithPositions, ballotItemWeVoteId:', ballotItemWeVoteId);
+    if (!blockOnClickShowOrganizationModalWithPositions) {
+      AppObservableStore.setOrganizationModalBallotItemWeVoteId(ballotItemWeVoteId);
+      AppObservableStore.setShowOrganizationModal(true);
+      AppObservableStore.setHideOrganizationModalBallotItemInfo(true);
+    }
+  }
+
+  render () {
+    renderLog('ScoreSummaryListController');  // Set LOG_RENDER_EVENTS to log all renders
+    const {
+      ballotItemWeVoteId, classes, controlAdviserMaterialUIPopoverFromProp,
+      openAdviserMaterialUIPopover,
+    } = this.props;
+    // console.log('ScoreSummaryListController, controlAdviserMaterialUIPopoverFromProp: ', controlAdviserMaterialUIPopoverFromProp,  ', openAdviserMaterialUIPopover:', openAdviserMaterialUIPopover);
+    const {
+      ballotItemDisplayName,
+      numberOfAllSupportPositions, numberOfAllOpposePositions, numberOfAllInfoOnlyPositions,
+      positionsInNetworkSummaryList, positionsInNetworkSummaryListLength,
+      positionsOutOfNetworkSummaryList,
+      voterPersonalNetworkScore,
+      voterPersonalNetworkScoreIsNegative,
+      voterPersonalNetworkScoreIsPositive,
+      voterPersonalNetworkScoreWithSign,
+      voterOpposesBallotItem,
+      voterSupportsBallotItem,
+    } = this.state;
+    // console.log('ScoreSummaryListController render, voterSupportsBallotItem/voterOpposesBallotItem:', voterSupportsBallotItem, voterOpposesBallotItem);
+
+    if (!ballotItemWeVoteId) return null;
+
+    const numberOfAllPositions = numberOfAllSupportPositions + numberOfAllOpposePositions + numberOfAllInfoOnlyPositions;
+    const voterDecidedItem = voterSupportsBallotItem || voterOpposesBallotItem;
+    const positionsInNetworkSummaryListExists = positionsInNetworkSummaryListLength && positionsInNetworkSummaryListLength > 0;
+    const youHaveTheOnlyOpinion = !!(!numberOfAllPositions && voterDecidedItem);
+    const noOpinionsExist = !voterDecidedItem && !numberOfAllPositions;
+
+    let scoreSummaryHtml;
+    if (youHaveTheOnlyOpinion) {
+      scoreSummaryHtml = (
+        <ScoreSummaryHtmlWrapper>
+          You have the only opinion
+          {ballotItemDisplayName ? ' about ' : ''}
+          <strong>{ballotItemDisplayName ? `${ballotItemDisplayName}` : ''}</strong>
+          {' '}
+          so far.
+        </ScoreSummaryHtmlWrapper>
+      );
+    } else if (positionsInNetworkSummaryListExists) {
+      if (voterDecidedItem) {
+        scoreSummaryHtml = (
+          <ScoreSummaryHtmlWrapper>
+            {voterSupportsBallotItem && (
+              <YourOpinion>
+                <DecidedIconWrapper>
+                  <NetworkScoreSmall
+                    voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                    voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                    voterSupportsBallotItem={voterSupportsBallotItem}
+                  >
+                    <Done classes={{ root: classes.decidedIconSmall }} />
+                  </NetworkScoreSmall>
+                </DecidedIconWrapper>
+                You support
+                {ballotItemDisplayName && (
+                  <>
+                    {' '}
+                    <strong>{ballotItemDisplayName}</strong>
+                  </>
+                )}
+                .
+              </YourOpinion>
+            )}
+            {voterOpposesBallotItem && (
+              <YourOpinion>
+                <DecidedIconWrapper>
+                  <NetworkScoreSmall
+                    voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                    voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                    voterOpposesBallotItem={voterOpposesBallotItem}
+                  >
+                    <NotInterested classes={{ root: classes.decidedIconSmall }} />
+                  </NetworkScoreSmall>
+                </DecidedIconWrapper>
+                You oppose
+                {ballotItemDisplayName && (
+                  <>
+                    {' '}
+                    <strong>{ballotItemDisplayName}</strong>
+                    .
+                  </>
+                )}
+              </YourOpinion>
+            )}
+            <YourPersonalNetworkIntroText>
+              Your personal network also has
+              {' '}
+              {positionsInNetworkSummaryListLength > 1 ? (
+                <span> these opinions:</span>
+              ) : (
+                <span> this opinion:</span>
+              )}
+            </YourPersonalNetworkIntroText>
+            {positionsInNetworkSummaryList && (
+              <RenderedOrganizationsWrapper>
+                <Suspense fallback={<></>}>
+                  <PositionSummaryListForPopover
+                    ballotItemWeVoteId={ballotItemWeVoteId}
+                    controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
+                    openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
+                    positionSummaryList={positionsInNetworkSummaryList}
+                    showAllPositions={this.props.onClickFunction}
+                    voterPersonalNetworkScore={voterPersonalNetworkScore}
+                    voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                    voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                    voterPersonalNetworkScoreWithSign={voterPersonalNetworkScoreWithSign}
+                  />
+                </Suspense>
+              </RenderedOrganizationsWrapper>
+            )}
+          </ScoreSummaryHtmlWrapper>
+        );
+      } else {
+        const positionsInNetworkVoterNotDecidedIntro = (
+          <div>
+            Your personalized score about
+            {' '}
+            <strong>{ballotItemDisplayName}</strong>
+            {' '}
+            is calculated from opinions in your personal network:
+          </div>
+        );
+        scoreSummaryHtml = (
+          <ScoreSummaryHtmlWrapper>
+            {positionsInNetworkVoterNotDecidedIntro}
+            {positionsInNetworkSummaryList && (
+              <RenderedOrganizationsWrapper>
+                <Suspense fallback={<></>}>
+                  <PositionSummaryListForPopover
+                    ballotItemWeVoteId={ballotItemWeVoteId}
+                    controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
+                    openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
+                    positionSummaryList={positionsInNetworkSummaryList}
+                    showAllPositions={this.props.onClickFunction}
+                    voterPersonalNetworkScore={voterPersonalNetworkScore}
+                    voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                    voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                    voterPersonalNetworkScoreWithSign={voterPersonalNetworkScoreWithSign}
+                  />
+                </Suspense>
+              </RenderedOrganizationsWrapper>
+            )}
+          </ScoreSummaryHtmlWrapper>
+        );
+      }
+    } else if (voterPersonalNetworkScore) { // We have a voterPersonalNetworkScore, but don't have positionsInNetworkSummaryList, so this is generic explanation
+      scoreSummaryHtml = (
+        <ScoreSummaryHtmlWrapper>
+          Your personalized score about
+          {' '}
+          <strong>{ballotItemDisplayName}</strong>
+          {' '}
+          is calculated from the Values you follow, the opinions of your friends, and the public opinions you follow.
+        </ScoreSummaryHtmlWrapper>
+      );
+    } else if (noOpinionsExist) {
+      scoreSummaryHtml = (
+        <ScoreSummaryHtmlWrapper>
+          <PopoverBodyText>
+            There are no opinions
+            {ballotItemDisplayName ? ' about ' : ''}
+            <strong>{ballotItemDisplayName ? `${ballotItemDisplayName}` : ''}</strong>
+            {' '}
+            yet.
+          </PopoverBodyText>
+        </ScoreSummaryHtmlWrapper>
+      );
+    } else if (voterDecidedItem) {
+      scoreSummaryHtml = (
+        <ScoreSummaryHtmlWrapper>
+          {voterSupportsBallotItem && (
+            <YourOpinion>
+              <DecidedIconWrapper>
+                <NetworkScoreSmall
+                  voterSupportsBallotItem={voterSupportsBallotItem}
+                  voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                  voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                >
+                  <Done classes={{ root: classes.decidedIconSmall }} />
+                </NetworkScoreSmall>
+              </DecidedIconWrapper>
+              You support
+              {ballotItemDisplayName && (
+                <>
+                  {' '}
+                  <strong>{ballotItemDisplayName}</strong>
+                </>
+              )}
+              .
+              <br />
+            </YourOpinion>
+          )}
+          {voterOpposesBallotItem && (
+            <YourOpinion>
+              <DecidedIconWrapper>
+                <NetworkScoreSmall
+                  voterOpposesBallotItem={voterOpposesBallotItem}
+                  voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                  voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                >
+                  <NotInterested classes={{ root: classes.decidedIconSmall }} />
+                </NetworkScoreSmall>
+              </DecidedIconWrapper>
+              You oppose
+              {' '}
+              <strong>{ballotItemDisplayName}</strong>
+              .
+              {' '}
+            </YourOpinion>
+          )}
+        </ScoreSummaryHtmlWrapper>
+      );
+    } else {
+      scoreSummaryHtml = (
+        <ScoreSummaryHtmlWrapper>
+          <div>
+            Follow opinions to build your personalized score
+            {(ballotItemDisplayName) && (
+              <span>
+                {' '}
+                about
+                {' '}
+                <strong>
+                  {ballotItemDisplayName}
+                </strong>
+              </span>
+            )}
+            .
+          </div>
+          <div>
+            {positionsOutOfNetworkSummaryList && (
+              <RenderedOrganizationsWrapper>
+                <Suspense fallback={<></>}>
+                  <PositionSummaryListForPopover
+                    ballotItemWeVoteId={ballotItemWeVoteId}
+                    controlAdviserMaterialUIPopoverFromProp={controlAdviserMaterialUIPopoverFromProp}
+                    openAdviserMaterialUIPopover={openAdviserMaterialUIPopover}
+                    positionSummaryList={positionsOutOfNetworkSummaryList}
+                    showAllPositions={this.props.onClickFunction}
+                    voterPersonalNetworkScore={voterPersonalNetworkScore}
+                    voterPersonalNetworkScoreIsNegative={voterPersonalNetworkScoreIsNegative}
+                    voterPersonalNetworkScoreIsPositive={voterPersonalNetworkScoreIsPositive}
+                    voterPersonalNetworkScoreWithSign={voterPersonalNetworkScoreWithSign}
+                  />
+                </Suspense>
+              </RenderedOrganizationsWrapper>
+            )}
+          </div>
+        </ScoreSummaryHtmlWrapper>
+      );
+    }
+    return (
+      <ScoreSummaryListControllerWrapper>
+        {scoreSummaryHtml}
+      </ScoreSummaryListControllerWrapper>
+    );
+  }
+}
+ScoreSummaryListController.propTypes = {
+  ballotItemDisplayName: PropTypes.string,
+  ballotItemWeVoteId: PropTypes.string.isRequired,
+  blockOnClickShowOrganizationModalWithPositions: PropTypes.bool,
+  classes: PropTypes.object,
+  controlAdviserMaterialUIPopoverFromProp: PropTypes.bool,
+  onClickFunction: PropTypes.func, // We don't require this because sometimes we don't want the link to do anything
+  openAdviserMaterialUIPopover: PropTypes.bool,
+};
+
+const styles = (theme) => ({
+  decidedIconSmall: {
+    fontSize: 16,
+    [theme.breakpoints.down('lg')]: {
+      fontSize: 16,
+    },
+  },
+});
+
+const ScoreSummaryListControllerWrapper = styled('div')`
+  margin: 0 15px;
+`;
+
+const ScoreSummaryHtmlWrapper = styled('div')`
+`;
+
+export default withTheme(withStyles(styles)(ScoreSummaryListController));

--- a/src/js/pages/Friends/FriendInvitationsSentToMe.jsx
+++ b/src/js/pages/Friends/FriendInvitationsSentToMe.jsx
@@ -40,9 +40,9 @@ class FriendInvitationsSentToMe extends Component {
     const { friendInvitationsSentToMe } = this.state;
     // console.log(this.state.suggestedFriends);
     return (
-      <div className="opinion-view">
+      <div>
         <Helmet title="Friend Requests - We Vote" />
-        <div>
+        <FriendInvitationsWrapper>
           { friendInvitationsSentToMe && friendInvitationsSentToMe.length > 0 ? (
             <span>
               <SectionTitle>
@@ -74,11 +74,14 @@ class FriendInvitationsSentToMe extends Component {
               </p>
             </>
           )}
-        </div>
+        </FriendInvitationsWrapper>
       </div>
     );
   }
 }
+
+const FriendInvitationsWrapper = styled('div')`
+`;
 
 const SectionTitle = styled('h2')`
   font-weight: bold;

--- a/src/js/pages/Friends/FriendsCurrent.jsx
+++ b/src/js/pages/Friends/FriendsCurrent.jsx
@@ -85,7 +85,7 @@ export default class FriendsCurrent extends Component {
     }
 
     return (
-      <div className="opinion-view">
+      <FriendsCurrentWrapper>
         <Helmet title="Your Friends - We Vote" />
         <SectionTitle>
           Your Friends
@@ -121,10 +121,13 @@ export default class FriendsCurrent extends Component {
             />
           </span>
         </div>
-      </div>
+      </FriendsCurrentWrapper>
     );
   }
 }
+
+const FriendsCurrentWrapper = styled('div')`
+`;
 
 const SectionTitle = styled('h2')`
   width: fit-content;  font-weight: bold;

--- a/src/js/pages/Friends/SuggestedFriends.jsx
+++ b/src/js/pages/Friends/SuggestedFriends.jsx
@@ -42,7 +42,7 @@ export default class SuggestedFriends extends Component {
     const { suggestedFriendList } = this.state;
 
     return (
-      <div className="opinion-view">
+      <SuggestedFriendsWrapper>
         <Helmet title="People You May Know - We Vote" />
         <SectionTitle>
           People You May Know
@@ -71,7 +71,7 @@ export default class SuggestedFriends extends Component {
             />
           )}
         </div>
-      </div>
+      </SuggestedFriendsWrapper>
     );
   }
 }
@@ -80,4 +80,7 @@ const SectionTitle = styled('h2')`
   width: fit-content;  font-weight: bold;
   font-size: 18px;
   margin-bottom: 16px;
+`;
+
+const SuggestedFriendsWrapper = styled('div')`
 `;


### PR DESCRIPTION
Put ScoreSummaryListController at the top of the OrganizationModal. Converted "reload app" to "refresh browser" in WebApp ErrorBoundary. Put Score display components into their own folder. Renamed BallotItemSupportOpposeScoreDisplay. Moved candidates back to the left. Turned off positionListForOpinionMaker when in lists to reduce browser overwhelm.