### PR TITLE
First pass at a Cordova build that uses relative dimensions for header heights, instead of experimentally determined constants.

### DIFF
--- a/node/buildSrcCordova.js
+++ b/node/buildSrcCordova.js
@@ -84,7 +84,7 @@ fs.remove('./build').then(() => {
               fileRewriterForCordova(path);
             }
           }
-          console.log('> Cordova: Files in ./srcCordova, rewritten without React.lazy: ', listOfFiles.length);
+          console.log(`> Cordova: ${listOfFiles.length} files in ./srcCordova, rewritten without React.lazy`);
           exec('egrep -r "React.lazy|Suspense" ./srcCordova | grep -v "//" | grep -v "" | grep -v "(factory)"',
             (error2, stdout2) => {
               const out = stdout2.split('\n');

--- a/src/js/common/components/Widgets/ErrorBoundary.jsx
+++ b/src/js/common/components/Widgets/ErrorBoundary.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { standardBoxShadow } from '../../../components/Style/pageLayoutStyles';
 import { isAndroidSizeFold } from '../../utils/cordovaUtils';
 import { isWebApp } from '../../utils/isCordovaOrWebApp';
 
@@ -31,7 +32,7 @@ class ErrorBoundary extends Component {
           top: '60px',
           position: 'fixed',
           backgroundColor: 'white',
-          boxShadow: 'rgba(0, 0, 0, 0.2) 0 1px 3px 0, rgba(0, 0, 0, 0.14) 0 1px 1px 0, rgba(0, 0, 0, 0.12) 0 2px 1px -1px',
+          boxShadow: standardBoxShadow(),
         }}
         >
           <h1 style={{ margin: '20px', color: 'black', fontSize: '20px' }}>Whoops! Something went wrong.</h1>

--- a/src/js/common/utils/cordovaUtils.js
+++ b/src/js/common/utils/cordovaUtils.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import webAppConfig from '../../config';
-import { cordovaOffsetLog, oAuthLog } from './logging';
 import { isCordova, isWebApp } from './isCordovaOrWebApp';
+import { cordovaOffsetLog, oAuthLog } from './logging';
 
 /* global $  */
 

--- a/src/js/components/Ballot/CandidateStickyHeader.jsx
+++ b/src/js/components/Ballot/CandidateStickyHeader.jsx
@@ -6,6 +6,7 @@ import { isIOSAppOnMac, isIPad } from '../../common/utils/cordovaUtils';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import { cordovaStickyHeaderPaddingTop } from '../../utils/cordovaOffsets';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 
 const BallotItemSupportOpposeComment = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeComment' */ '../Widgets/BallotItemSupportOpposeComment'));
 const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
@@ -95,7 +96,7 @@ const Wrapper = styled('div', {
   background: white;
   z-index: 2;
   width: 100vw;
-  box-shadow: 0 2px 4px -1px rgba(0,0,0,0.2), 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12);
+  box-shadow: ${standardBoxShadow('wide')};
   animation: ${slideDown} 150ms ease-in;
   ${() => (isWebApp() ? 'margin-top: -16px;' : '')};
   ${theme.breakpoints.up('sm')} {

--- a/src/js/components/Ballot/MeasureStickyHeader.jsx
+++ b/src/js/components/Ballot/MeasureStickyHeader.jsx
@@ -6,6 +6,7 @@ import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import MeasureStore from '../../stores/MeasureStore';
 import { cordovaStickyHeaderPaddingTop } from '../../utils/cordovaOffsets';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
 const BallotItemSupportOpposeComment = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeComment' */ '../Widgets/BallotItemSupportOpposeComment'));
@@ -107,7 +108,7 @@ const MeasureStickyHeaderWrapper = styled('div')`
   background: white;
   z-index: 2;
   width: 100vw;
-  box-shadow: 0 2px 4px -1px rgba(0,0,0,0.2), 0px 4px 5px 0px rgba(0,0,0,0.14), 0px 1px 10px 0px rgba(0,0,0,0.12);
+  box-shadow: ${standardBoxShadow('wide')};
   //animation: ${slideDown} 150ms ease-in;
   `;
 

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -25,7 +25,7 @@ import FriendStore from '../../stores/FriendStore';
 import VoterStore from '../../stores/VoterStore';
 import { avatarGeneric, displayTopMenuShadow, weVoteBrandingOff } from '../../utils/applicationUtils';
 import getHeaderObjects from '../../utils/getHeaderObjects';
-import { TopOfPageHeader, TopRowOneLeftContainer, TopRowOneMiddleContainer, TopRowOneRightContainer, TopRowTwoLeftContainer } from '../Style/pageLayoutStyles';
+import { standardBoxShadow, TopOfPageHeader, TopRowOneLeftContainer, TopRowOneMiddleContainer, TopRowOneRightContainer, TopRowTwoLeftContainer } from '../Style/pageLayoutStyles';
 import SignInButton from '../Widgets/SignInButton';
 import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 import FriendsTabs from './FriendsTabs';
@@ -899,7 +899,7 @@ const HeaderBarWrapper = styled('div', {
   shouldForwardProp: (prop) => !['hasNotch', 'scrolledDown', 'hasSubmenu'].includes(prop),
 })(({ hasNotch, scrolledDown, hasSubmenu }) => (`
   margin-top: ${hasNotch ? '1.5rem' : ''};
-  box-shadow: ${(!scrolledDown || !hasSubmenu)  ? '' : '0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12)'};
+  box-shadow: ${(!scrolledDown || !hasSubmenu)  ? '' : standardBoxShadow('wide')};
   border-bottom: ${(!scrolledDown || !hasSubmenu) ? '' : '1px solid #aaa'};
 `));
 

--- a/src/js/components/Navigation/HeaderBarSuspense.jsx
+++ b/src/js/components/Navigation/HeaderBarSuspense.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import getHeaderObjects from '../../utils/getHeaderObjects';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 
 function SmallCloud (params) {
   const styleObj = {
@@ -53,7 +54,7 @@ export default function HeaderBarSuspense () {
       backgroundColor: 'white',
       fontFamily: '"Nunito Sans", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, sans-serif',
       height: '48px',
-      boxShadow: 'rgba(0, 0, 0, 0.2) 0 2px 4px -1px, rgba(0, 0, 0, 0.14) 0 4px 5px 0, rgba(0, 0, 0, 0.12) 0 1px 10px 0',
+      boxShadow: standardBoxShadow('wide'),
     }}
     >
       {headerObjects.logo ?

--- a/src/js/components/OpinionsAndBallotItems/BallotItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/BallotItemForOpinions.jsx
@@ -4,6 +4,7 @@ import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { renderLog } from '../../common/utils/logging';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 import MeasureItemForOpinions from './MeasureItemForOpinions';
 import OfficeItemForOpinions from './OfficeItemForOpinions';
 
@@ -136,7 +137,7 @@ const BallotItemCard = styled('div')(({ theme }) => (`
   $item-padding: 16px;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .2), 0 1px 1px 0 rgba(0, 0, 0, .14), 0 2px 1px -1px rgba(0, 0, 0, .12);
+  box-shadow: ${standardBoxShadow()};
   margin-bottom: 16px;
   overflow-y: none;
   border: none;

--- a/src/js/components/OpinionsAndBallotItems/CandidateSearchItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/CandidateSearchItemForOpinions.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import historyPush from '../../common/utils/historyPush';
 import { renderLog } from '../../common/utils/logging';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 import CandidateItemForOpinions from './CandidateItemForOpinions';
 
 class CandidateSearchItemForOpinions extends Component {
@@ -117,7 +118,7 @@ const BallotItemCard = styled('div')(({ theme }) => (`
   $item-padding: 16px;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .2), 0 1px 1px 0 rgba(0, 0, 0, .14), 0 2px 1px -1px rgba(0, 0, 0, .12);
+  box-shadow: ${standardBoxShadow()};
   margin-bottom: 16px;
   overflow-y: hidden;
   border: none;
@@ -164,7 +165,7 @@ const CandidateInfo = styled('div', {
   cursor: pointer;
   &:hover {
     border: 1px solid ${theme.colors.linkHoverBorder};
-    box-shadow: 0 1px 3px 0 rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12);
+    box-shadow: ${standardBoxShadow()};
   }
   ${theme.breakpoints.down('md')} {
     flex-flow: column;

--- a/src/js/components/OpinionsAndBallotItems/OfficeItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/OfficeItemForOpinions.jsx
@@ -7,6 +7,7 @@ import historyPush from '../../common/utils/historyPush';
 import { renderLog } from '../../common/utils/logging';
 import toTitleCase from '../../common/utils/toTitleCase';
 import CandidateStore from '../../stores/CandidateStore';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 import CandidateItemForOpinions from './CandidateItemForOpinions';
 
 class OfficeItemForOpinions extends Component {
@@ -218,7 +219,7 @@ const CandidateInfo = styled('div', {
   cursor: pointer;
   &:hover {
     border: 1px solid ${theme.colors.linkHoverBorder};
-    box-shadow: 0 1px 3px 0 rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12);
+    box-shadow: ${standardBoxShadow()};
   }
   ${theme.breakpoints.down('md')} {
     flex-flow: column;

--- a/src/js/components/Ready/ReadyTaskBallot.jsx
+++ b/src/js/components/Ready/ReadyTaskBallot.jsx
@@ -13,6 +13,7 @@ import AppObservableStore from '../../stores/AppObservableStore';
 import BallotStore from '../../stores/BallotStore';
 import SupportStore from '../../stores/SupportStore';
 import VoterStore from '../../stores/VoterStore';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 import {
   BallotToDoTitle, ButtonLeft, ButtonText, Icon,
   PercentComplete, ReadyCard, StyledButton, StyledCheckbox,
@@ -879,7 +880,7 @@ const styles = (theme) => ({
   borderTopRightRadius: 4,
   borderTopStyle: 'none',
   borderTopWidth: 0,
-  boxShadow: 'rgba(0, 0, 0, 0.2) 0px 1px 3px 0px, rgba(0, 0, 0, 0.14) 0px 1px 1px 0px, rgba(0, 0, 0, 0.12) 0px 2px 1px -1px',
+  boxShadow: standardBoxShadow(),
   boxSizing: 'content-box',
   color: 'rgb(51, 51, 51)',
   display: 'flex',

--- a/src/js/components/Settings/BallotItemForAddPositions.jsx
+++ b/src/js/components/Settings/BallotItemForAddPositions.jsx
@@ -4,6 +4,7 @@ import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { renderLog } from '../../common/utils/logging';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 import MeasureItemForAddPositions from './MeasureItemForAddPositions';
 import OfficeItemForAddPositions from './OfficeItemForAddPositions';
 
@@ -172,7 +173,7 @@ const BallotItemCard = styled('div')(({ theme }) => (`
   $item-padding: 16px;
   background-color: #fff;
   border-radius: 4px;
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, .2), 0 1px 1px 0 rgba(0, 0, 0, .14), 0 2px 1px -1px rgba(0, 0, 0, .12);
+  box-shadow: ${standardBoxShadow()};
   margin-bottom: 16px;
   overflow-y: none;
   border: none;

--- a/src/js/components/Settings/OfficeItemForAddPositions.jsx
+++ b/src/js/components/Settings/OfficeItemForAddPositions.jsx
@@ -8,6 +8,7 @@ import historyPush from '../../common/utils/historyPush';
 import { renderLog } from '../../common/utils/logging';
 import toTitleCase from '../../common/utils/toTitleCase';
 import CandidateStore from '../../stores/CandidateStore';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 import CandidateItemForAddPositions from './CandidateItemForAddPositions';
 
 class OfficeItemForAddPositions extends Component {
@@ -310,7 +311,7 @@ const CandidateInfo = styled('div', {
   cursor: pointer;
   &:hover {
     border: 1px solid ${theme.colors.linkHoverBorder};
-    box-shadow: 0 1px 3px 0 rgba(0,0,0,.2), 0 1px 1px 0 rgba(0,0,0,.14), 0 2px 1px -1px rgba(0,0,0,.12);
+    box-shadow:${standardBoxShadow()};
   }
   ${theme.breakpoints.down('md')} {
     flex-flow: column;

--- a/src/js/components/Share/SharedItemModal.jsx
+++ b/src/js/components/Share/SharedItemModal.jsx
@@ -25,6 +25,7 @@ import { isSpeakerTypeOrganization, isSpeakerTypePublicFigure } from '../../util
 import { convertToInteger } from '../../utils/textFormat';
 import PersonalizedScoreIntroBody from '../CompleteYourProfile/PersonalizedScoreIntroBody';
 import FriendToggle from '../Friends/FriendToggle';
+import { standardBoxShadow } from '../Style/pageLayoutStyles';
 import StepsChips from '../Widgets/StepsChips';
 import SharedItemIntroduction from './SharedItemIntroduction';
 
@@ -694,7 +695,7 @@ const FooterBarWrapper = styled('div')(({ theme }) => (`
   position: absolute;
   width: 100%;
   ${theme.breakpoints.down('md')} {
-    box-shadow: 0 -4px 4px -1px rgba(0, 0, 0, .2), 0 -4px 5px 0 rgba(0, 0, 0, .14), 0 -1px 10px 0 rgba(0, 0, 0, .12);
+    box-shadow: ${standardBoxShadow('wide')};
   }
   @media print{
     display: none;

--- a/src/js/components/Style/ReadyPageCommonStyles.jsx
+++ b/src/js/components/Style/ReadyPageCommonStyles.jsx
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
+
+export const ReadyCard = styled('div')`
+  padding-bottom: 4px;
+`;
+
+export const ElectionCountdownInnerWrapper = styled('div')`
+  ${isWebApp() ? 'margin-top: -37px' : ''}
+`;
+
+export const IntroAndFindTabletWrapper = styled('div')`
+  display: flex;
+  justify-content: center;
+`;
+
+export const IntroAndFindTabletSpacer = styled('div')`
+  width: 20px;
+`;
+
+export const ReadyParagraph = styled('div')`
+`;
+
+export const PrepareForElectionOuterWrapper = styled('div')`
+  min-height: 150px;
+  margin-bottom: 48px;
+`;
+
+export const ReadyIntroductionMobileWrapper = styled('div')`
+  display: flex;
+  justify-content: start;
+  margin-bottom: 48px;
+  margin-top: 31px;
+`;
+
+export const ElectionCountdownOuterWrapper = styled('div')`
+  height: 280px;
+  position: relative;
+  z-index: 1;
+`;
+
+export const ReadyIntroductionDesktopWrapper = styled('div')`
+  margin-bottom: 48px;
+  margin-top: 31px;
+`;
+
+export const ReadyPageContainer = styled('div')`
+`;
+
+export const ViewBallotButtonWrapper = styled('div')`
+  display: flex;
+  height: 40px;
+  justify-content: center;
+  margin-bottom: 32px;
+`;
+
+export const ReadyTitle = styled('h2')(({ theme }) => (`
+  font-size: 26px;
+  font-weight: 800;
+  margin: 0 0 12px;
+  ${theme.breakpoints.down('sm')} {
+    font-size: 14px;
+    margin: 0 0 4px;
+  }
+`));

--- a/src/js/constants/CordovaPageConstants.js
+++ b/src/js/constants/CordovaPageConstants.js
@@ -24,6 +24,7 @@ const CordovaPageConstants = {
   opinionsFiltered: null,
   ready: null,
   signInOptions: null,
+  settingsAccount: null,
   settingsHamburger: null,
   settingsNotifications: null,
   settingsProfile: null,

--- a/src/js/pages/Activity/News.jsx
+++ b/src/js/pages/Activity/News.jsx
@@ -34,6 +34,7 @@ import AppObservableStore from '../../stores/AppObservableStore';
 import BallotStore from '../../stores/BallotStore';
 import OrganizationStore from '../../stores/OrganizationStore';
 import VoterStore from '../../stores/VoterStore';
+import { cordovaSimplePageContainerTopOffset } from '../../utils/cordovaCalculatedOffsets';
 // Lint is not smart enough to know that lazyPreloadPages will not attempt to preload/reload this page
 // eslint-disable-next-line import/no-cycle
 import lazyPreloadPages from '../../utils/lazyPreloadPages';
@@ -71,6 +72,7 @@ class News extends Component {
   }
 
   componentDidMount () {
+    cordovaSimplePageContainerTopOffset(VoterStore.getVoterIsSignedIn());
     const { match: { params } } = this.props;
     const activityTidbitWeVoteIdForDrawer = params.activity_tidbit_we_vote_id || '';
     let redirectInProgress = false;

--- a/src/js/pages/Ballot/Ballot.jsx
+++ b/src/js/pages/Ballot/Ballot.jsx
@@ -15,14 +15,7 @@ import SupportActions from '../../actions/SupportActions';
 import VoterActions from '../../actions/VoterActions';
 import LoadingWheelComp from '../../common/components/Widgets/LoadingWheelComp';
 import apiCalming from '../../common/utils/apiCalming';
-import {
-  chipLabelText, isAndroid,
-  isAndroidSizeFold,
-  isIOSAppOnMac,
-  isIPad,
-  isIPadGiantSize,
-  isIPhone6p1in,
-} from '../../common/utils/cordovaUtils';
+import { chipLabelText, isAndroid, isAndroidSizeFold, isIOSAppOnMac, isIPad, isIPadGiantSize, isIPhone6p1in } from '../../common/utils/cordovaUtils';
 import getBooleanValue from '../../common/utils/getBooleanValue';
 import historyPush from '../../common/utils/historyPush';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
@@ -46,6 +39,7 @@ import TwitterStore from '../../stores/TwitterStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
 import { dumpCssFromId } from '../../utils/appleSiliconUtils';
+import { setBallotDualHeaderContentContainerTopOffset } from '../../utils/cordovaCalculatedOffsets';
 import isMobile from '../../utils/isMobile';
 // Lint is not smart enough to know that lazyPreloadPages will not attempt to preload/reload this page
 // eslint-disable-next-line import/no-cycle
@@ -122,6 +116,7 @@ class Ballot extends Component {
   }
 
   componentDidMount () {
+    setBallotDualHeaderContentContainerTopOffset(VoterStore.getVoterIsSignedIn());
     const { location: { pathname: currentPathname } } = window;
     // console.log('Ballot componentDidMount, Current pathname:', currentPathname);
     const ballotBaseUrl = '/ballot';
@@ -1413,6 +1408,7 @@ class Ballot extends Component {
                 </div>
               </HeaderContentContainer>
             </HeaderContentOuterContainer>
+            <div id="cordovaHeaderBottomDatum" />
           </DualHeaderContainer>
 
           <PageContentContainer>
@@ -1584,14 +1580,15 @@ Ballot.propTypes = {
   match: PropTypes.object,
 };
 
+/* eslint-disable no-nested-ternary */
 const BallotBottomWrapper = styled('div', {
   shouldForwardProp: (prop) => !['scrolledDown'].includes(prop),
 })(({ scrolledDown, theme }) => (`
-  ${scrolledDown ? 'margin-top: 18px;' : 'margin-top: 38px;'}
-  transition: all 150ms ease-in;
+  ${scrolledDown || isCordova() ? 'margin-top: 18px;' : 'margin-top: 38px;'}
+  ${isWebApp() ? 'transition: all 150ms ease-in;' : ''}
   width: 100%;
-  ${theme.breakpoints.down('sm')} {
-    ${scrolledDown ? 'margin-top: 10px;' : 'margin-top: 20px;'}
+  ${theme.breakpoints.down('sm') && isWebApp()} {
+    ${isWebApp() ? (scrolledDown ? 'margin-top: 10px;' : 'margin-top: 20px;') : ''}
   }
 `));
 
@@ -1624,9 +1621,8 @@ const BallotFilterRow = styled('div')`
 const BallotTitleHeaderWrapper = styled('div', {
   shouldForwardProp: (prop) => !['marginTopOffset'].includes(prop),
 })(({ marginTopOffset }) => (`
-  margin-top: ${marginTopOffset};
-  // height: 80px; // Includes 35px for ballot address
-  transition: all 150ms ease-in;
+  margin-top: ${isWebApp() ? marginTopOffset : ''};
+  transition: ${isWebApp() ? 'all 150ms ease-in' : ''};
 `));
 
 const EmptyBallotCard = styled('div')`

--- a/src/js/pages/Friends/Friends.jsx
+++ b/src/js/pages/Friends/Friends.jsx
@@ -9,6 +9,7 @@ import FriendActions from '../../actions/FriendActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import apiCalming from '../../common/utils/apiCalming';
 import historyPush from '../../common/utils/historyPush';
+import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import FacebookSignInCard from '../../components/Facebook/FacebookSignInCard';
@@ -35,7 +36,6 @@ import FriendInvitationsSentToMe from './FriendInvitationsSentToMe';
 import FriendsCurrent from './FriendsCurrent';
 import InviteByEmail from './InviteByEmail';
 import SuggestedFriends from './SuggestedFriends';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 
 const FirstAndLastNameRequiredAlert = React.lazy(() => import(/* webpackChunkName: 'FirstAndLastNameRequiredAlert' */ '../../components/Widgets/FirstAndLastNameRequiredAlert'));
 const SignInOptionsPanel = React.lazy(() => import(/* webpackChunkName: 'SignInOptionsPanel' */ '../../components/SignIn/SignInOptionsPanel'));
@@ -625,7 +625,7 @@ const FriendsHeading = styled('div')`
   // padding-top: 50px;
   // // transform: translate3d(0, -53px, 0);
   // // transition: all 100ms ease-in-out 0s;
-  // box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.2), 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12);
+  // box-shadow: {standardBoxShadow('wide')};
 `;
 
 const OuterSignInOptionsWrapper = styled('div')`

--- a/src/js/pages/Intro/FriendInvitationOnboarding.jsx
+++ b/src/js/pages/Intro/FriendInvitationOnboarding.jsx
@@ -359,7 +359,7 @@ const FooterBarWrapper = styled('div')`
   background: #fff;
   border-top: 1px solid #eee;
   bottom: 0;
-  // box-shadow: 0 -4px 4px -1px rgba(0, 0, 0, .2), 0 -4px 5px 0 rgba(0, 0, 0, .14), 0 -1px 10px 0 rgba(0, 0, 0, .12);
+  // box-shadow: {standardBoxShadow('wide')};
   max-width: 750px;
   padding-bottom: env(safe-area-inset-bottom);
   position: fixed;

--- a/src/js/pages/More/Donate.jsx
+++ b/src/js/pages/More/Donate.jsx
@@ -15,6 +15,7 @@ import InjectedCheckoutForm from '../../common/components/Donation/InjectedCheck
 import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import DonateStore from '../../common/stores/DonateStore';
 import { renderLog } from '../../common/utils/logging';
+import { standardBoxShadow } from '../../components/Style/pageLayoutStyles';
 import { Section } from '../../components/Welcome/sectionStyles';
 import webAppConfig from '../../config';
 import VoterStore from '../../stores/VoterStore';
@@ -329,7 +330,7 @@ const styles = (theme) => ({
     fontSize: 18,
     color: 'black',
     backgroundColor: 'white',
-    boxShadow: '0 3px 1px -2px rgb(0 0 0 / 20%), 0 2px 2px 0px rgb(0 0 0 / 14%), 0 1px 5px 0 rgb(0 0 0 / 12%)',
+    boxShadow: standardBoxShadow('medium'),
   },
   textFieldInputRoot: {
     fontSize: 18,
@@ -445,7 +446,7 @@ const PaymentCenteredWrapper  = styled('div')(({ theme }) => (`
   }
   display: inline-block;
   background-color: rgb(246, 244,246);
-  box-shadow: 0 3px 1px -2px rgb(0 0 0 / 20%), 0 2px 2px 0px rgb(0 0 0 / 14%), 0 1px 5px 0 rgb(0 0 0 / 12%);
+  box-shadow: ${standardBoxShadow('medium')};
   border: 2px solid darkgrey;
   border-radius: 3px;
   padding: 8px;

--- a/src/js/pages/More/ExtensionSignIn.jsx
+++ b/src/js/pages/More/ExtensionSignIn.jsx
@@ -4,6 +4,7 @@ import React, { Component, Suspense } from 'react';
 import styled from 'styled-components';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { renderLog } from '../../common/utils/logging';
+import { standardBoxShadow } from '../../components/Style/pageLayoutStyles';
 import VoterStore from '../../stores/VoterStore';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
@@ -83,7 +84,7 @@ class ExtensionSignIn extends Component {
                 transition: 'none',
                 color: '#fff',
                 backgroundColor: '#1976d2',
-                boxShadow: '0px 3px 1px -2px rgba(0,0,0,0.2), 0px 2px 2px 0px rgba(0,0,0,0.14), 0px 1px 5px 0px rgba(0,0,0,0.12)',
+                boxShadow: standardBoxShadow('medium'),
                 transitionTimingFunction: 'none !important',
               }}
               >

--- a/src/js/pages/Process/TwitterSignInProcess.jsx
+++ b/src/js/pages/Process/TwitterSignInProcess.jsx
@@ -10,7 +10,7 @@ import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import Cookies from '../../common/utils/js-cookie/Cookies';
 import { oAuthLog, renderLog } from '../../common/utils/logging';
 import stringContains from '../../common/utils/stringContains';
-import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
+import { PageContentContainer, standardBoxShadow } from '../../components/Style/pageLayoutStyles';
 import IPhoneSpacer from '../../components/Widgets/IPhoneSpacer';
 import SnackNotifier from '../../components/Widgets/SnackNotifier';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
@@ -279,5 +279,5 @@ const LoadingDiv = styled('div')`
   padding: 10px;
   background-color: white;
   border: 1px solid #333;
-  box-shadow: 0 2px 4px -1px rgba(0,0,0,0.2), 0 4px 5px 0 rgba(0,0,0,0.14), 0 1px 10px 0 rgba(0,0,0,0.12);
+  box-shadow: ${standardBoxShadow('wide')};
 `;

--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -1,10 +1,9 @@
-import { Button } from '@mui/material';
+import { Button, Card } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import Helmet from 'react-helmet';
-import styled from 'styled-components';
 import ActivityActions from '../actions/ActivityActions';
 import AnalyticsActions from '../actions/AnalyticsActions';
 import BallotActions from '../actions/BallotActions';
@@ -12,7 +11,7 @@ import FriendActions from '../actions/FriendActions';
 import IssueActions from '../actions/IssueActions';
 import ReadyActions from '../actions/ReadyActions';
 import apiCalming from '../common/utils/apiCalming';
-import { isAndroid, isIOS } from '../common/utils/cordovaUtils';
+import { isAndroid } from '../common/utils/cordovaUtils';
 import daysUntil from '../common/utils/daysUntil';
 import historyPush from '../common/utils/historyPush';
 import { isWebApp } from '../common/utils/isCordovaOrWebApp';
@@ -21,13 +20,16 @@ import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
 import ReadyTaskRegister from '../components/Ready/ReadyTaskRegister';
+import { ReadyCard } from '../components/Ready/ReadyTaskStyles';
 import { PageContentContainer } from '../components/Style/pageLayoutStyles';
+import { ElectionCountdownInnerWrapper, ElectionCountdownOuterWrapper, PrepareForElectionOuterWrapper, ReadyIntroductionDesktopWrapper, ReadyIntroductionMobileWrapper, ReadyPageContainer, ReadyParagraph, ReadyTitle, ViewBallotButtonWrapper } from '../components/Style/ReadyPageCommonStyles';
 import BrowserPushMessage from '../components/Widgets/BrowserPushMessage';
 import SnackNotifier, { openSnackbar } from '../components/Widgets/SnackNotifier';
 import webAppConfig from '../config';
 import AppObservableStore, { messageService } from '../stores/AppObservableStore';
 import BallotStore from '../stores/BallotStore';
 import VoterStore from '../stores/VoterStore';
+import { cordovaSimplePageContainerTopOffset } from '../utils/cordovaCalculatedOffsets';
 // Lint is not smart enough to know that lazyPreloadPages will not attempt to preload/reload this page
 // eslint-disable-next-line import/no-cycle
 import lazyPreloadPages from '../utils/lazyPreloadPages';
@@ -56,6 +58,7 @@ class Ready extends Component {
   }
 
   componentDidMount () {
+    window.scrollTo(0, 0);
     this.appStateSubscription = messageService.getMessage().subscribe((msg) => this.onAppObservableStoreChange(msg));
     this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
@@ -112,6 +115,9 @@ class Ready extends Component {
 
   componentDidUpdate () {
     if (AppObservableStore.isSnackMessagePending()) openSnackbar({});
+    // if (cordovaCheckForZeroPageContentContainerPaddingTop()) {
+    //   this.setState();
+    // }
   }
 
   componentDidCatch (error, info) {
@@ -182,12 +188,8 @@ class Ready extends Component {
   getTopPadding = () => {
     if (isWebApp()) {
       return { paddingTop: '0 !important' };
-    } else if (isIOS()) {
-      // TODO: This is a bad place to set a top padding: Move it to Application__Wrapper on the next iOS pass
-      return { paddingTop: '56px !important' };  // SE2: 56px, 11 Pro Max: 56px
-    } else if (isAndroid()) {
-      return { paddingTop: 'unset' };
     }
+    cordovaSimplePageContainerTopOffset(VoterStore.getVoterIsSignedIn());
     return {};
   }
 
@@ -231,21 +233,21 @@ class Ready extends Component {
 
             <div className="col-sm-12 col-lg-8">
               {(chosenReadyIntroductionTitle || chosenReadyIntroductionText) && (
-                <Card className="card u-show-mobile-tablet">
+                <ReadyCard className="card u-show-mobile-tablet">
                   <div className="card-main">
-                    <Title>
+                    <ReadyTitle>
                       {chosenReadyIntroductionTitle}
-                    </Title>
-                    <Paragraph>
+                    </ReadyTitle>
+                    <ReadyParagraph>
                       <Suspense fallback={<></>}>
                         <ReadMore
                           textToDisplay={chosenReadyIntroductionText}
                           numberOfLines={3}
                         />
                       </Suspense>
-                    </Paragraph>
+                    </ReadyParagraph>
                   </div>
-                </Card>
+                </ReadyCard>
               )}
               {isAndroid() && (
                 <ReadyIntroductionMobileWrapper className="u-show-mobile">
@@ -308,12 +310,12 @@ class Ready extends Component {
               {(chosenReadyIntroductionTitle || chosenReadyIntroductionText) && (
                 <Card className="card">
                   <div className="card-main">
-                    <Title>
+                    <ReadyTitle>
                       {chosenReadyIntroductionTitle}
-                    </Title>
-                    <Paragraph>
+                    </ReadyTitle>
+                    <ReadyParagraph>
                       {chosenReadyIntroductionText}
-                    </Paragraph>
+                    </ReadyParagraph>
                   </div>
                 </Card>
               )}
@@ -352,58 +354,5 @@ const styles = (theme) => ({
   },
 });
 
-const Card = styled('div')`
-  padding-bottom: 4px;
-`;
-
-const ElectionCountdownInnerWrapper = styled('div')`
-  margin-top: -37px;
-`;
-
-const ElectionCountdownOuterWrapper = styled('div')`
-  height: 280px;
-  position: relative;
-  z-index: 1;
-`;
-
-const Paragraph = styled('div')`
-`;
-
-const PrepareForElectionOuterWrapper = styled('div')`
-  min-height: 150px;
-  margin-bottom: 48px;
-`;
-
-const ReadyIntroductionDesktopWrapper = styled('div')`
-  margin-bottom: 48px;
-  margin-top: 31px;
-`;
-
-const ReadyIntroductionMobileWrapper = styled('div')`
-  display: flex;
-  justify-content: start;
-  margin-bottom: 48px;
-  margin-top: 31px;
-`;
-
-const ReadyPageContainer = styled('div')`
-`;
-
-const ViewBallotButtonWrapper = styled('div')`
-  display: flex;
-  height: 40px;
-  justify-content: center;
-  margin-bottom: 32px;
-`;
-
-const Title = styled('h2')(({ theme }) => (`
-  font-size: 26px;
-  font-weight: 800;
-  margin: 0 0 12px;
-  ${theme.breakpoints.down('sm')} {
-    font-size: 14px;
-    margin: 0 0 4px;
-  }
-`));
 
 export default withTheme(withStyles(styles)(Ready));

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -3,12 +3,11 @@ import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import Helmet from 'react-helmet';
-import styled from 'styled-components';
 import ActivityActions from '../actions/ActivityActions';
 import AnalyticsActions from '../actions/AnalyticsActions';
 import ReadyActions from '../actions/ReadyActions';
 import apiCalming from '../common/utils/apiCalming';
-import { isAndroid, isIOS } from '../common/utils/cordovaUtils';
+import { isAndroid } from '../common/utils/cordovaUtils';
 import historyPush from '../common/utils/historyPush';
 import { isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
@@ -16,11 +15,14 @@ import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
 import ReadyTaskRegister from '../components/Ready/ReadyTaskRegister';
+import { ReadyCard } from '../components/Ready/ReadyTaskStyles';
 import { PageContentContainer } from '../components/Style/pageLayoutStyles';
+import { ElectionCountdownInnerWrapper, ElectionCountdownOuterWrapper, IntroAndFindTabletSpacer, IntroAndFindTabletWrapper, PrepareForElectionOuterWrapper, ReadyIntroductionDesktopWrapper, ReadyIntroductionMobileWrapper, ReadyPageContainer, ReadyParagraph, ReadyTitle } from '../components/Style/ReadyPageCommonStyles';
 import BrowserPushMessage from '../components/Widgets/BrowserPushMessage';
 import webAppConfig from '../config';
 import AppObservableStore, { messageService } from '../stores/AppObservableStore';
 import VoterStore from '../stores/VoterStore';
+import { cordovaSimplePageContainerTopOffset } from '../utils/cordovaCalculatedOffsets';
 import lazyPreloadPages from '../utils/lazyPreloadPages';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../common/components/Widgets/DelayedLoad'));
@@ -43,6 +45,7 @@ class ReadyLight extends Component {
   }
 
   componentDidMount () {
+    window.scrollTo(0, 0);
     this.appStateSubscription = messageService.getMessage().subscribe((msg) => this.onAppObservableStoreChange(msg));
     this.onAppObservableStoreChange();
     ReadyActions.voterPlansForVoterRetrieve();
@@ -91,12 +94,8 @@ class ReadyLight extends Component {
   getTopPadding = () => {
     if (isWebApp()) {
       return { paddingTop: '0 !important' };
-    } else if (isIOS()) {
-      // TODO: This is a bad place to set a top padding: Move it to Application__Wrapper on the next iOS pass
-      return { paddingTop: '56px !important' };  // SE2: 56px, 11 Pro Max: 56px
-    } else if (isAndroid()) {
-      return { paddingTop: 'unset' };
     }
+    cordovaSimplePageContainerTopOffset(VoterStore.getVoterIsSignedIn());
     return {};
   }
 
@@ -122,21 +121,21 @@ class ReadyLight extends Component {
 
             <div className="col-sm-12 col-lg-8">
               {(chosenReadyIntroductionTitle || chosenReadyIntroductionText) && (
-                <Card className="card u-show-mobile-tablet">
+                <ReadyCard className="card u-show-mobile-tablet">
                   <div className="card-main">
-                    <Title>
+                    <ReadyTitle>
                       {chosenReadyIntroductionTitle}
-                    </Title>
-                    <Paragraph>
+                    </ReadyTitle>
+                    <ReadyParagraph>
                       <Suspense fallback={<></>}>
                         <ReadMore
                           textToDisplay={chosenReadyIntroductionText}
                           numberOfLines={3}
                         />
                       </Suspense>
-                    </Paragraph>
+                    </ReadyParagraph>
                   </div>
-                </Card>
+                </ReadyCard>
               )}
               {isAndroid() && (
                 <ReadyIntroductionMobileWrapper className="u-show-mobile">
@@ -191,16 +190,16 @@ class ReadyLight extends Component {
             </div>
             <div className="col-lg-4 d-none d-lg-block">
               {(chosenReadyIntroductionTitle || chosenReadyIntroductionText) && (
-                <Card className="card">
+                <ReadyCard className="card">
                   <div className="card-main">
-                    <Title>
+                    <ReadyTitle>
                       {chosenReadyIntroductionTitle}
-                    </Title>
-                    <Paragraph>
+                    </ReadyTitle>
+                    <ReadyParagraph>
                       {chosenReadyIntroductionText}
-                    </Paragraph>
+                    </ReadyParagraph>
                   </div>
-                </Card>
+                </ReadyCard>
               )}
               <ReadyIntroductionDesktopWrapper>
                 <ReadyIntroduction showStep3WhenCompressed />
@@ -237,61 +236,5 @@ const styles = (theme) => ({
     },
   },
 });
-
-const Card = styled('div')`
-  padding-bottom: 4px;
-`;
-
-const ElectionCountdownInnerWrapper = styled('div')`
-  margin-top: -37px;
-`;
-
-const ElectionCountdownOuterWrapper = styled('div')`
-  height: 254px;
-  position: relative;
-  z-index: 1;
-`;
-
-const IntroAndFindTabletWrapper = styled('div')`
-  display: flex;
-  justify-content: center;
-`;
-
-const IntroAndFindTabletSpacer = styled('div')`
-  width: 20px;
-`;
-
-const Paragraph = styled('div')`
-`;
-
-const PrepareForElectionOuterWrapper = styled('div')`
-  min-height: 150px;
-  margin-bottom: 48px;
-`;
-
-const ReadyIntroductionDesktopWrapper = styled('div')`
-  margin-bottom: 48px;
-  margin-top: 31px;
-`;
-
-const ReadyIntroductionMobileWrapper = styled('div')`
-  display: flex;
-  justify-content: start;
-  margin-bottom: 48px;
-  margin-top: 31px;
-`;
-
-const ReadyPageContainer = styled('div')`
-`;
-
-const Title = styled('h2')(({ theme }) => (`
-  font-size: 26px;
-  font-weight: 800;
-  margin: 0 0 12px;
-  ${theme.breakpoints.down('sm')} {
-    font-size: 14px;
-    margin: 0 0 4px;
-  }
-`));
 
 export default withTheme(withStyles(styles)(ReadyLight));

--- a/src/js/pages/Register.jsx
+++ b/src/js/pages/Register.jsx
@@ -11,7 +11,7 @@ import ReadyActions from '../actions/ReadyActions';
 import LoadingWheel from '../common/components/Widgets/LoadingWheel';
 import { formatDateToMonthDayYear } from '../common/utils/dateFormat';
 import { renderLog } from '../common/utils/logging';
-import { PageContentContainer } from '../components/Style/pageLayoutStyles';
+import { PageContentContainer, standardBoxShadow } from '../components/Style/pageLayoutStyles';
 import BrowserPushMessage from '../components/Widgets/BrowserPushMessage';
 import { messageService } from '../stores/AppObservableStore';
 import BallotStore from '../stores/BallotStore';
@@ -684,7 +684,7 @@ const StickyFooter = styled('div')`
   display: flex;
   align-items: center;
   padding: 0 32px;
-  box-shadow: 0px -2px 4px -1px rgba(0,0,0,0.2), 0px -4px 5px 0px rgba(0,0,0,0.14), 0px -1px 10px 0px rgba(0,0,0,0.12);
+  box-shadow: ${standardBoxShadow('wide')};
 `;
 
 const Row = styled('div')`

--- a/src/js/pages/VoterGuide/OrganizationVoterGuide.jsx
+++ b/src/js/pages/VoterGuide/OrganizationVoterGuide.jsx
@@ -523,7 +523,7 @@ const BannerOverlayDesktopInnerWrapper = styled('div')(({ theme }) => (`
   }
   ${theme.breakpoints.up('lg')} {
     // background-color: #fff;
-    // box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2), 0 1px 1px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -1px rgba(0, 0, 0, 0.12);
+    // box-shadow: {standardBoxShadow()};
     // min-height: 37px;
     width: 100%;
   }

--- a/src/js/utils/cordovaCalculatedOffsets.js
+++ b/src/js/utils/cordovaCalculatedOffsets.js
@@ -1,0 +1,144 @@
+import { normalizedHrefPage } from '../common/utils/hrefUtils';
+import { isWebApp } from '../common/utils/isCordovaOrWebApp';
+
+/* global $ */
+
+// Static data
+let ballotHeaderOffset = -1;
+let pageData = {};
+let topOffsets = {};
+let offsetsSignedInState;
+const defaultPageData = {
+  previousPage: '',
+  preAdjustDatumMin: 50,
+};
+
+const DEBUG_LOGGING = true;
+function debugLogging (string) {
+  if (DEBUG_LOGGING) {
+    console.log(string);
+  }
+}
+
+// Simple Header
+function setBallotHeaderOffset (bho) {
+  ballotHeaderOffset = bho;
+}
+
+function clearAllOnSignInStateChange (isSignedIn) {
+  // Wipe out all state info if isSignedIn state changes
+  if (offsetsSignedInState !== isSignedIn || $.isEmptyObject(pageData)) {
+    debugLogging('clearAllOnSignInStateChange clearing all data --------');
+    offsetsSignedInState = isSignedIn;
+    ballotHeaderOffset = 0;
+    topOffsets = {};
+    pageData = Object.assign(defaultPageData);
+  }
+}
+
+export function setBallotDualHeaderContentContainerTopOffset (isSignedIn) {
+  if (isWebApp()) return;
+  clearAllOnSignInStateChange(isSignedIn);
+  const dhc = $('div[class*=\'DualHeaderContainer\']');  // none
+  if (ballotHeaderOffset > 0) {
+    dhc.css('top', ballotHeaderOffset);
+  }
+  const page = normalizedHrefPage();
+  if (pageData.previousPage !== page || ballotHeaderOffset <= 0) {
+    pageData.previousPage = page;
+    for (let i = 0; i < 4; i++) {
+      let topOffset = 0;
+      setTimeout(() => {
+        debugLogging('setCordovaCalculatedBallotTopOffset loop, i = ', i);
+        const preAdjustDatumMin = 50;
+        const headerContentContainerMin = 60;
+        const initDatumOffset = $('#cordovaHeaderBottomDatum').offset() || { left: 0, top: 0 };
+        if (initDatumOffset !== undefined && initDatumOffset.top > 0) {
+          const preAdjustDatum = initDatumOffset.top;
+          if (preAdjustDatum >= preAdjustDatumMin) {
+            debugLogging('acceptable preAdjustDatum from dom ', preAdjustDatum);
+            const iosSpacer = $('div[class*=\'IOSNotchedSpacer\']').height();  // 36
+            const headerBarWrapper = $('div[class*=\'HeaderBarWrapper\']').height();   // 82
+            const headerContentContainer = $('div[class*=\'HeaderContentContainer\']').height();  // 119
+            debugLogging('headerContentContainer', headerContentContainer);
+            if (headerContentContainer !== undefined && headerContentContainer > headerContentContainerMin) {
+              topOffset = iosSpacer + headerBarWrapper + headerContentContainer - preAdjustDatum - 2;
+              debugLogging(`calculation ios ${iosSpacer}, headerBarWrapper ${headerBarWrapper}, hcc ${headerContentContainer}, preAdjustDatum ${preAdjustDatum}, calc ${topOffset}`);
+              if (topOffset > 0) {
+                debugLogging('DualHeaderContainer top set to: ', topOffset);
+                setBallotHeaderOffset(topOffset);
+                dhc.css('top', topOffset);
+              }
+            } else {
+              debugLogging('headerContentContainer', headerContentContainer);
+            }
+          } else {
+            debugLogging('preAdjustDatum >= preAdjustDatumMin', preAdjustDatum, preAdjustDatumMin);
+          }
+        }
+      }, 100);  // Wait for Ballot header to render, if initial URL is /ballot
+    }
+  }
+}
+
+export function cordovaComplexHeaderPageContainerTopOffset () {
+  if (isWebApp()) return '';
+  const headroomWrapper = $('div[class*=\'HeadroomWrapper\']');
+  const hrHeight = headroomWrapper.height();
+  const dhc = $('div[class*=\'DualHeaderContainer\']');  // none
+  const dhcHeight = dhc.height() || 0;   // No dhc for Friends when signed in
+
+  // const decorativeUiWhitespaceComplex = 10;
+  const topOffsetValue = hrHeight + dhcHeight;// + decorativeUiWhitespaceComplex;
+  if ($.isNumeric(topOffsetValue)) {
+    pageData.previousPage = normalizedHrefPage();
+    debugLogging('cordovaComplexHeaderPageContainer topOffset success', topOffsetValue);
+    return `${topOffsetValue}px`;
+  }
+  debugLogging('cordovaComplexHeaderPageContainer topOffset not a number', topOffsetValue);
+  return '0';
+}
+
+
+function setCordovaSimplePageContainerTopOffsetValue (topOffsetValue) {
+  const page = normalizedHrefPage() || 'ready';
+  topOffsets[page] = topOffsetValue;
+}
+
+function getCordovaSimplePageContainerTopOffsetValue (isSignedIn = false) {
+  clearAllOnSignInStateChange(isSignedIn);
+  const page = normalizedHrefPage();
+  debugLogging('getCordovaSimplePageContainerTopOffsetValue:', window.location.href);
+  debugLogging('getCordovaSimplePageContainerTopOffsetValue topOffsets:', topOffsets);
+  debugLogging(`getCordovaSimplePageContainerTopOffsetValue: ${page}, isSignedIn: ${isSignedIn}, topOffsets[page] ${topOffsets[normalizedHrefPage()]}`);
+  return topOffsets[normalizedHrefPage()] || 0;
+}
+
+export function cordovaSimplePageContainerTopOffset (isSignedIn) {
+  if (isWebApp()) return;
+  pageData.previousPage = normalizedHrefPage();
+  const storedTopOffsetValue = getCordovaSimplePageContainerTopOffsetValue(isSignedIn);
+  if (storedTopOffsetValue > 50) {  // was 100, does this need to be page sensitive since it is now only for complex pages?
+    const pageContentContainer = $('div[class*=\'PageContentContainer\']');
+    pageContentContainer.css('padding-top', `${storedTopOffsetValue}px`);
+  } else {
+    setTimeout(() => {
+      const headroomWrapper = $('div[class*=\'HeadroomWrapper\']');
+      const height = headroomWrapper.height();
+      debugLogging('cordovaSimplePageContainerTopOffset HeadRoomWrapper height', height, normalizedHrefPage());
+
+      if (height !== undefined && height > 0 && getCordovaSimplePageContainerTopOffsetValue() === 0) {
+        const decorativeUiWhitespaceSimple = 20;
+        const topOffsetValue = height + decorativeUiWhitespaceSimple;
+        setCordovaSimplePageContainerTopOffsetValue(topOffsetValue);
+
+        debugLogging(`cordovaSimplePageContainerTopOffset setting padding-top in PageContentContainer: ${topOffsetValue}`);
+
+        const pageContentContainer = $('div[class*=\'PageContentContainer\']');
+        pageContentContainer.css('padding-top', `${topOffsetValue}px`);
+      } else {
+        debugLogging('cordovaSimplePageContainerTopOffset getCordovaSimplePageContainerTopOffsetValue > 0 or height === 0');
+      }
+    }, 100);
+  }
+}

--- a/src/js/utils/cordovaCalculatedOffsets.js
+++ b/src/js/utils/cordovaCalculatedOffsets.js
@@ -13,7 +13,7 @@ const defaultPageData = {
   preAdjustDatumMin: 50,
 };
 
-const DEBUG_LOGGING = true;
+const DEBUG_LOGGING = false;
 function debugLogging (string) {
   if (DEBUG_LOGGING) {
     console.log(string);

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -1,11 +1,11 @@
+import { getAndroidSize, hasIPhoneNotch, isAndroid, isIOS, isIOSAppOnMac, isIPad, isIPadGiantSize, isIPhone4in, isIPhone4p7in, isIPhone5p5inEarly, isIPhone5p5inMini, isIPhone5p8in, isIPhone6p1in, isIPhone6p5in, isSimulator } from '../common/utils/cordovaUtils';
+import { normalizedHref } from '../common/utils/hrefUtils';
+import { isCordova, isWebApp } from '../common/utils/isCordovaOrWebApp';
+import isMobileScreenSize from '../common/utils/isMobileScreenSize';
+import { cordovaOffsetLog } from '../common/utils/logging';
 import CordovaPageConstants from '../constants/CordovaPageConstants';
 import { getApplicationViewBooleans } from './applicationUtils';
-import { getAndroidSize, hasIPhoneNotch, isAndroid, isIOS, isIOSAppOnMac, isIPad, isIPadGiantSize, isIPhone4in, isIPhone4p7in, isIPhone5p5inEarly, isIPhone5p5inMini, isIPhone5p8in, isIPhone6p1in, isIPhone6p5in, isSimulator } from '../common/utils/cordovaUtils';
-import { isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { pageEnumeration } from './cordovaUtilsPageEnumeration';
-import isMobileScreenSize from '../common/utils/isMobileScreenSize';
-import { normalizedHref } from '../common/utils/hrefUtils';
-import { cordovaOffsetLog } from '../common/utils/logging';
 
 
 //  <PageContentContainer>
@@ -451,6 +451,7 @@ export function cordovaDrawerTopMargin () {
 export function cordovaDualHeaderContainerPadding () {
   if (isIPhone5p5inMini()) return '18px';
   if (hasIPhoneNotch()) return '0px';
+  if (isCordova()) return '80px';
   return '8px';
 }
 


### PR DESCRIPTION
Works well on iPhone Mini and 13 Max Pro, other TBD, and Androids.  Retested WebApp, still good.
Still relies on the older way (cordovaScrollablePaneTopPadding) for WebApp, but that can and should be refactored out.
Made a common component for the many box-shadow styles
Refactored out the styles for the two versions of the Ready page.
I think this resolves the sign in pane positioning in WebApp, but won't know for sure until it gets on the live server.