### PR TITLE
Rework of the SettingsDashboard for iPads and Android "fold" phones.

### DIFF
--- a/src/js/common/utils/cordovaUtils.js
+++ b/src/js/common/utils/cordovaUtils.js
@@ -755,6 +755,10 @@ export function polyfillFixes (file) {
   }
 }
 
+export function isCordovaWide () {
+  return isIPad() || isAndroidSizeFold();
+}
+
 export function cordovaLinkToBeSharedFixes (link) {
   let linkToBeShared = link;
   linkToBeShared = linkToBeShared.replace('https://file:/', 'https://wevote.us/');  // Cordova

--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import VoterActions from '../../actions/VoterActions';
-import { isIOSAppOnMac, isIPad } from '../../common/utils/cordovaUtils';
+import { isIOSAppOnMac, isIPad, isCordovaWide } from '../../common/utils/cordovaUtils';
 import historyPush from '../../common/utils/historyPush';
 import { normalizedHref } from '../../common/utils/hrefUtils';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
@@ -334,7 +334,7 @@ export default class Header extends Component {
               )}
               { showBackToSettingsMobile && (
                 <span>
-                  <span className={isWebApp() ? 'u-show-mobile' : ''}>
+                  <span className={isWebApp() || isCordovaWide() ? 'u-show-mobile' : ''}>
                     <Suspense fallback={<></>}>
                       <HeaderBackTo
                         backToLink={backToSettingsLinkMobile}

--- a/src/js/components/Style/NextButtonStyles.jsx
+++ b/src/js/components/Style/NextButtonStyles.jsx
@@ -16,6 +16,18 @@ const DesktopNextButtonsOuterWrapper = styled('div')`
   width: 100%;
 `;
 
+const DesktopNextButtonsOuterWrapperUShowDesktopTablet  = styled('div', {
+  shouldForwardProp: (prop) => !['breakValue'].includes(prop),
+})(({ breakValue, theme }) => ({
+  display: 'flex',
+  justifyContent: 'center',
+  margin: '20px 0 0 0',
+  width: '100%',
+  [theme.breakpoints.down(breakValue)]: {
+    display: 'none !important',
+  },
+}));
+
 const MobileStaticNextButtonsInnerWrapper = styled('div')`
   align-items: center;
   background-color: #fff;
@@ -33,9 +45,23 @@ const MobileStaticNextButtonsOuterWrapper = styled('div')`
   display: block;
 `;
 
+const MobileStaticNextButtonsOuterWrapperUShowMobile   = styled('div', {
+  shouldForwardProp: (prop) => !['breakValue'].includes(prop),
+})(({ breakValue, theme }) => ({
+  position: 'fixed',
+  width: '100%',
+  bottom: 0,
+  display: 'block',
+  [theme.breakpoints.down(breakValue)]: {
+    display: 'none !important',
+  },
+}));
+
 export {
   DesktopNextButtonsInnerWrapper,
   DesktopNextButtonsOuterWrapper,
+  DesktopNextButtonsOuterWrapperUShowDesktopTablet,
   MobileStaticNextButtonsInnerWrapper,
   MobileStaticNextButtonsOuterWrapper,
+  MobileStaticNextButtonsOuterWrapperUShowMobile,
 };

--- a/src/js/pages/Process/TwitterSignInProcess.jsx
+++ b/src/js/pages/Process/TwitterSignInProcess.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 import TwitterActions from '../../actions/TwitterActions';
 import VoterActions from '../../actions/VoterActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
-import { isAndroidSizeFold, isIPad } from '../../common/utils/cordovaUtils';
+import { isCordovaWide } from '../../common/utils/cordovaUtils';
 import historyPush from '../../common/utils/historyPush';
 import { normalizedHref } from '../../common/utils/hrefUtils';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
@@ -271,7 +271,7 @@ export default class TwitterSignInProcess extends Component {
 const LoadingDiv = styled('div')`
   font-size: 18px;
   margin-top: 50px;
-  ${() => (isIPad() || isAndroidSizeFold() ? {
+  ${() => (isCordovaWide() ? {
     marginLeft: '80px',
     marginRight: '80px',
   } : {})};

--- a/src/js/pages/SetUpAccount/SetUpAccountRoot.jsx
+++ b/src/js/pages/SetUpAccount/SetUpAccountRoot.jsx
@@ -3,19 +3,16 @@ import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Suspense } from 'react';
 import styled from 'styled-components';
+import { isCordovaWide } from '../../common/utils/cordovaUtils';
 import historyPush from '../../common/utils/historyPush';
 import { renderLog } from '../../common/utils/logging';
 import normalizedImagePath from '../../common/utils/normalizedImagePath';
+import HeaderBackToButton from '../../components/Navigation/HeaderBackToButton';
+import { reassuranceText } from '../../components/SetUpAccount/reassuranceText';
+import { DesktopNextButtonsInnerWrapper, DesktopNextButtonsOuterWrapperUShowDesktopTablet,
+  MobileStaticNextButtonsInnerWrapper, MobileStaticNextButtonsOuterWrapperUShowMobile } from '../../components/Style/NextButtonStyles';
 import VoterStore from '../../stores/VoterStore';
 import Reassurance from '../Startup/Reassurance';
-import HeaderBackToButton from '../../components/Navigation/HeaderBackToButton';
-import {
-  DesktopNextButtonsInnerWrapper,
-  DesktopNextButtonsOuterWrapper,
-  MobileStaticNextButtonsInnerWrapper,
-  MobileStaticNextButtonsOuterWrapper,
-} from '../../components/Style/NextButtonStyles';
-import { reassuranceText } from '../../components/SetUpAccount/reassuranceText';
 
 const logoColorOnWhite = '../../../img/global/svg-icons/we-vote-icon-square-color-dark.svg';
 
@@ -416,18 +413,18 @@ class SetUpAccountRoot extends React.Component {
           <StepHtmlWrapper>
             {stepHtml}
           </StepHtmlWrapper>
-          <DesktopNextButtonsOuterWrapper className="u-show-desktop-tablet">
+          <DesktopNextButtonsOuterWrapperUShowDesktopTablet breakValue={isCordovaWide() ? 1000 : 768}>
             <DesktopNextButtonsInnerWrapper>
               {desktopButtonsHtml}
             </DesktopNextButtonsInnerWrapper>
-          </DesktopNextButtonsOuterWrapper>
+          </DesktopNextButtonsOuterWrapperUShowDesktopTablet>
           <Reassurance displayState={displayStep} reassuranceText={reassuranceText} />
         </AccountSetUpRootWrapper>
-        <MobileStaticNextButtonsOuterWrapper className="u-show-mobile">
+        <MobileStaticNextButtonsOuterWrapperUShowMobile breakValue={isCordovaWide() ? 1000 : 576}>
           <MobileStaticNextButtonsInnerWrapper>
             {mobileButtonsHtml}
           </MobileStaticNextButtonsInnerWrapper>
-        </MobileStaticNextButtonsOuterWrapper>
+        </MobileStaticNextButtonsOuterWrapperUShowMobile>
       </PageContentContainerAccountSetUp>
     );
   }

--- a/src/js/pages/Settings/SettingsDashboard.jsx
+++ b/src/js/pages/Settings/SettingsDashboard.jsx
@@ -6,6 +6,7 @@ import OrganizationActions from '../../actions/OrganizationActions';
 import VoterActions from '../../actions/VoterActions';
 import VoterGuideActions from '../../actions/VoterGuideActions';
 import apiCalming from '../../common/utils/apiCalming';
+import { isCordovaWide } from '../../common/utils/cordovaUtils';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import SelectVoterGuidesSideBar from '../../components/Navigation/SelectVoterGuidesSideBar';
@@ -256,21 +257,25 @@ export default class SettingsDashboard extends Component {
         break;
     }
 
+    let innerDivClass = '';   // prior to May 2022, was isWebApp()  ? 'settings-dashboard u-stack--xl' : 'settings-dashboard SettingsCardBottomCordova'
+    innerDivClass += (isWebApp() || isCordovaWide()) ? 'u-stack--xl ' : '';
+    innerDivClass += isCordovaWide() ? 'SettingsCardBottomCordova ' : '';
+
     return (
       <PageContentContainer>
         <SnackNotifier />
-        <div className={isWebApp() ? 'settings-dashboard u-stack--xl' : 'settings-dashboard SettingsCardBottomCordova'}>
+        <div className={innerDivClass}>
           {/* Desktop left navigation + Settings content.
             WebApp only, since the dashboard doesn't go well with the HamburgerMenu on iPad */}
-          { isWebApp() && (
-          <div className="d-none d-md-block">
+          { (isWebApp() || isCordovaWide()) && (
+          <div className={isWebApp() ? "d-none d-md-block" : ''}>
             <div className="container-fluid">
               <div className="row">
-                {/* Desktop mode left navigation */}
-                <div className="col-md-4 sidebar-menu">
+                {/* Desktop mode (and cordova wide) left navigation, the bootstrap breakpoints don't work well in Cordova, please don't add more of them */}
+                <SettingsSidebarMenu breakValue={isCordovaWide() ? 1 : 678}>
                   <SettingsPersonalSideBar
                     editMode={editMode}
-                    isSignedIn={this.state.voter.is_signed_in}
+                    isSignedIn={VoterStore.getVoterIsSignedIn()}
                     organizationType={this.state.organizationType}
                   />
 
@@ -283,35 +288,27 @@ export default class SettingsDashboard extends Component {
                       voterGuideWeVoteIdSelected={this.state.voterGuideWeVoteId}
                     />
                   </div>
-                </div>
+                </SettingsSidebarMenu>
                 {/* Desktop mode content */}
-                <div className="col-md-8">
+                <SettingsDesktopRightPane breakValue={isCordovaWide() ? 1 : 678}>
                   <Suspense fallback={<></>}>
                     {settingsComponentToDisplayDesktop}
                   </Suspense>
-                </div>
+                </SettingsDesktopRightPane>
               </div>
             </div>
           </div>
           )}
 
-          {/* Mobile Settings content */}
-          { isWebApp() ? (
-            <div className="d-block d-md-none">
-              {/* Mobile mode content */}
-              <div className="col-12">
-                <Suspense fallback={<></>}>
-                  {settingsComponentToDisplayMobile}
-                </Suspense>
-              </div>
-            </div>
-          ) : (
+          {/* Mobile and not cordovaWide Settings content */}
+          <div className={isWebApp() || isCordovaWide() ? 'd-block d-md-none' : ''}>
+            {/* Mobile mode content */}
             <div className="col-12">
               <Suspense fallback={<></>}>
                 {settingsComponentToDisplayMobile}
               </Suspense>
             </div>
-          )}
+          </div>
         </div>
       </PageContentContainer>
     );
@@ -325,3 +322,33 @@ const SettingsSectionFooterWrapper = styled('div')`
   margin-top: 35px;
   padding-left: 15px;
 `;
+
+// Same as bootstrap 'col-md-4 sidebar-menu' which uses a min 768px breakpoint, that doesn't work for cordova
+export const SettingsSidebarMenu = styled('div', {
+  shouldForwardProp: (prop) => !['breakValue'].includes(prop),
+})(({ breakValue, theme }) => ({
+  [theme.breakpoints.up(breakValue)]: {
+    flex: '0 0 33.333333%',
+    maxWidth: '33.333333%',
+    position: 'relative',
+    width: '100%',
+    paddingRight: '15px',
+    paddingLeft: '15px',
+  },
+}));
+
+// May 2022: Same as 'col-md-8 sidebar-menu' min 768px for Webapp, but needs about 850px for Cordova,
+// so instead we just pass in a very low value if isCordovaWide, so it basically always trips the breakpoint
+export const SettingsDesktopRightPane = styled('div', {
+  shouldForwardProp: (prop) => !['breakValue'].includes(prop),
+})(({ breakValue, theme }) => ({
+  [theme.breakpoints.up(breakValue)]: {
+    flex: '0 0 66.666667%',
+    maxWidth: '0 0 66.666667%',
+    position: 'relative',
+    width: '100%',
+    paddingRight: '15px',
+    paddingLeft: '15px',
+  },
+}));
+

--- a/src/js/pages/Settings/SettingsDashboard.jsx
+++ b/src/js/pages/Settings/SettingsDashboard.jsx
@@ -268,7 +268,7 @@ export default class SettingsDashboard extends Component {
           {/* Desktop left navigation + Settings content.
             WebApp only, since the dashboard doesn't go well with the HamburgerMenu on iPad */}
           { (isWebApp() || isCordovaWide()) && (
-          <div className={isWebApp() ? "d-none d-md-block" : ''}>
+          <div className={isWebApp() ? 'd-none d-md-block' : ''}>
             <div className="container-fluid">
               <div className="row">
                 {/* Desktop mode (and cordova wide) left navigation, the bootstrap breakpoints don't work well in Cordova, please don't add more of them */}

--- a/src/js/pages/Settings/VoterGuideListDashboard.jsx
+++ b/src/js/pages/Settings/VoterGuideListDashboard.jsx
@@ -151,7 +151,7 @@ class VoterGuideListDashboard extends Component {
         <PageContentContainer>
           <div className="container-fluid">
             <div className="row">
-              {/* Mobile and Desktop mode */}
+              {/* Mobile and Desktop mode, these bootstrap breakpoints don't work well in Cordova, please don't add more of them */}
               <div className="col-12 col-md-4 sidebar-menu">
                 <div className="u-show-mobile">
                   <VoterGuideListSearchResults

--- a/src/js/utils/cordovaCalculatedOffsets.js
+++ b/src/js/utils/cordovaCalculatedOffsets.js
@@ -1,4 +1,5 @@
-import { normalizedHrefPage } from '../common/utils/hrefUtils';
+import { isIPad } from '../common/utils/cordovaUtils';
+import { normalizedHref, normalizedHrefPage } from '../common/utils/hrefUtils';
 import { isWebApp } from '../common/utils/isCordovaOrWebApp';
 
 /* global $ */
@@ -13,11 +14,21 @@ const defaultPageData = {
   preAdjustDatumMin: 50,
 };
 
-const DEBUG_LOGGING = false;
+const DEBUG_LOGGING = true;
 function debugLogging (string) {
   if (DEBUG_LOGGING) {
     console.log(string);
   }
+}
+
+function getPageKey () {
+  const useLongerPath = ['settings', 'more'];
+  let page = normalizedHrefPage() || 'ready';
+  if (useLongerPath.includes(page)) {
+    page = normalizedHref();
+  }
+  debugLogging(`getPageKey page: ${page}`);
+  return page;
 }
 
 // Simple Header
@@ -43,37 +54,47 @@ export function setBallotDualHeaderContentContainerTopOffset (isSignedIn) {
   if (ballotHeaderOffset > 0) {
     dhc.css('top', ballotHeaderOffset);
   }
-  const page = normalizedHrefPage();
+  const page = getPageKey();
   if (pageData.previousPage !== page || ballotHeaderOffset <= 0) {
     pageData.previousPage = page;
     for (let i = 0; i < 4; i++) {
       let topOffset = 0;
       setTimeout(() => {
-        debugLogging('setCordovaCalculatedBallotTopOffset loop, i = ', i);
+        debugLogging(`setCordovaCalculatedBallotTopOffset loop, i = ${i}`);
         const preAdjustDatumMin = 50;
         const headerContentContainerMin = 60;
         const initDatumOffset = $('#cordovaHeaderBottomDatum').offset() || { left: 0, top: 0 };
         if (initDatumOffset !== undefined && initDatumOffset.top > 0) {
           const preAdjustDatum = initDatumOffset.top;
           if (preAdjustDatum >= preAdjustDatumMin) {
-            debugLogging('acceptable preAdjustDatum from dom ', preAdjustDatum);
-            const iosSpacer = $('div[class*=\'IOSNotchedSpacer\']').height();  // 36
-            const headerBarWrapper = $('div[class*=\'HeaderBarWrapper\']').height();   // 82
-            const headerContentContainer = $('div[class*=\'HeaderContentContainer\']').height();  // 119
-            debugLogging('headerContentContainer', headerContentContainer);
-            if (headerContentContainer !== undefined && headerContentContainer > headerContentContainerMin) {
-              topOffset = iosSpacer + headerBarWrapper + headerContentContainer - preAdjustDatum - 2;
-              debugLogging(`calculation ios ${iosSpacer}, headerBarWrapper ${headerBarWrapper}, hcc ${headerContentContainer}, preAdjustDatum ${preAdjustDatum}, calc ${topOffset}`);
+            debugLogging(`acceptable preAdjustDatum from dom ${preAdjustDatum}`);
+            const headerContentContainerHeight = $('div[class*=\'HeaderContentContainer\']').height();
+            let iOsSpacerHeight = 0;
+            const iosSpacerElem = $('div[class*=\'IOSNotchedSpacer\']');
+            const hasNoNotch = $('div[class*=\'IOSNoNotchSpacer\']').length > 0;
+            debugLogging(`calculation --------- hasNoNotch ${hasNoNotch}`);
+            if (hasNoNotch) {  // ipads and old iPhones and Androids
+              const headroomWrapper = $('div[class*=\'HeadroomWrapper\']');
+              topOffset = headroomWrapper.height();
+            } else if (iosSpacerElem.length) {
+              iOsSpacerHeight = iosSpacerElem.height;
+              const headerBarWrapperHeight = $('div[class*=\'HeaderBarWrapper\']').height();
+              topOffset = iOsSpacerHeight + headerBarWrapperHeight + headerContentContainerHeight - preAdjustDatum - 2;
+            }
+
+            debugLogging(`headerContentContainerHeight ${headerContentContainerHeight}`);
+            if (headerContentContainerHeight !== undefined && headerContentContainerHeight > headerContentContainerMin) {
+              debugLogging(`calculation ios ${iOsSpacerHeight}, hcc ${headerContentContainerHeight}, preAdjustDatum ${preAdjustDatum}, calc ${topOffset}`);
               if (topOffset > 0) {
-                debugLogging('DualHeaderContainer top set to: ', topOffset);
+                debugLogging(`DualHeaderContainer top set to: ${topOffset}`);
                 setBallotHeaderOffset(topOffset);
                 dhc.css('top', topOffset);
               }
             } else {
-              debugLogging('headerContentContainer', headerContentContainer);
+              debugLogging(`headerContentContainer ${headerContentContainerHeight}`);
             }
           } else {
-            debugLogging('preAdjustDatum >= preAdjustDatumMin', preAdjustDatum, preAdjustDatumMin);
+            debugLogging(`preAdjustDatum >= preAdjustDatumMin ${preAdjustDatum} ${preAdjustDatumMin}`);
           }
         }
       }, 100);  // Wait for Ballot header to render, if initial URL is /ballot
@@ -84,32 +105,31 @@ export function setBallotDualHeaderContentContainerTopOffset (isSignedIn) {
 export function cordovaComplexHeaderPageContainerTopOffset () {
   if (isWebApp()) return '';
   const headroomWrapper = $('div[class*=\'HeadroomWrapper\']');
-  const hrHeight = headroomWrapper.height();
+  const hrHeight = getPageKey() === 'ballot' && isIPad() ? 0 : headroomWrapper.height();
   const dhc = $('div[class*=\'DualHeaderContainer\']');  // none
   const dhcHeight = dhc.height() || 0;   // No dhc for Friends when signed in
+  const nonDhcHeight = getPageKey() === 'friends' ? 20 : 0;
 
-  // const decorativeUiWhitespaceComplex = 10;
-  const topOffsetValue = hrHeight + dhcHeight;// + decorativeUiWhitespaceComplex;
+  const topOffsetValue = hrHeight + dhcHeight + nonDhcHeight;
   if ($.isNumeric(topOffsetValue)) {
-    pageData.previousPage = normalizedHrefPage();
-    debugLogging('cordovaComplexHeaderPageContainer topOffset success', topOffsetValue);
+    pageData.previousPage = getPageKey();
+    debugLogging(`cordovaComplexHeaderPageContainer topOffset success ${topOffsetValue}`);
     return `${topOffsetValue}px`;
   }
-  debugLogging('cordovaComplexHeaderPageContainer topOffset not a number', topOffsetValue);
+  debugLogging(`cordovaComplexHeaderPageContainer topOffset not a number ${topOffsetValue}`);
   return '0';
 }
 
 
 function setCordovaSimplePageContainerTopOffsetValue (topOffsetValue) {
-  const page = normalizedHrefPage() || 'ready';
+  const page = getPageKey();
   topOffsets[page] = topOffsetValue;
 }
 
 function getCordovaSimplePageContainerTopOffsetValue (isSignedIn = false) {
   clearAllOnSignInStateChange(isSignedIn);
-  const page = normalizedHrefPage();
-  debugLogging('getCordovaSimplePageContainerTopOffsetValue:', window.location.href);
-  debugLogging('getCordovaSimplePageContainerTopOffsetValue topOffsets:', topOffsets);
+  const page = getPageKey();
+  debugLogging(`getCordovaSimplePageContainerTopOffsetValue: ${window.location.href}`);
   debugLogging(`getCordovaSimplePageContainerTopOffsetValue: ${page}, isSignedIn: ${isSignedIn}, topOffsets[page] ${topOffsets[normalizedHrefPage()]}`);
   return topOffsets[normalizedHrefPage()] || 0;
 }
@@ -125,7 +145,7 @@ export function cordovaSimplePageContainerTopOffset (isSignedIn) {
     setTimeout(() => {
       const headroomWrapper = $('div[class*=\'HeadroomWrapper\']');
       const height = headroomWrapper.height();
-      debugLogging('cordovaSimplePageContainerTopOffset HeadRoomWrapper height', height, normalizedHrefPage());
+      debugLogging(`cordovaSimplePageContainerTopOffset HeadRoomWrapper height ${height}, ${getPageKey()}`);
 
       if (height !== undefined && height > 0 && getCordovaSimplePageContainerTopOffsetValue() === 0) {
         const decorativeUiWhitespaceSimple = 20;

--- a/src/js/utils/cordovaCalculatedOffsets.js
+++ b/src/js/utils/cordovaCalculatedOffsets.js
@@ -14,7 +14,7 @@ const defaultPageData = {
   preAdjustDatumMin: 50,
 };
 
-const DEBUG_LOGGING = true;
+const DEBUG_LOGGING = false;
 function debugLogging (string) {
   if (DEBUG_LOGGING) {
     console.log(string);

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -389,12 +389,11 @@ export function cordovaFriendsWrapper () {
     if (isIPhone6p5in()) {
       if (window.location.href.indexOf('/index.html#/friends/invite') > 0) {
         return {
-          // paddingTop: '20%',
           paddingBottom: '625px',
         };
       }
       return {
-        paddingTop: '81px',
+        paddingTop: '20px',
         paddingBottom: '90px',
       };
     }


### PR DESCRIPTION
Now looks "the same" as it does in desktop mode.
The breakpoints that Bootstrap uses are bad for Cordova, sometimes we are lucky and they are close enough and work, sometimes they are useless.  On the SettingsDashboard, the page goes into side-by-side mode at 768px in the WebApp, but would need something like 850px in Cordova for iPads, so I replaced Bootstrap, with Cordova sensitive code in a few places.
We should not create any more Bootstrap based pages, with Bootstrap that "the page is done" feeling is an illusion.  Changing the breakpoints in Bootstrap is a mess, it would be possible to copy and rewrite the library on the fly for Cordova, but that would be fragile.
Cordova is in decent shape in iOS, Android has some new build dependency problem that needs to be resolved -- those build issues can be very time consuming for a 5% of the time on Android engineer.