### PR TITLE
profile footer links fixed

### DIFF
--- a/src/js/components/Navigation/SettingsSectionFooter.jsx
+++ b/src/js/components/Navigation/SettingsSectionFooter.jsx
@@ -106,7 +106,15 @@ const TermsAndPrivacyText = styled('span')`
   color: #999;
   font-size: .9em;
   font-weight: 400;
+  .u-cursor--pointer:hover {
+    color: #0156b3;
+    text-decoration: underline;
+  }
   * {
+    span:hover {
+      color: #0156b3;
+      text-decoration: underline;
+    }
     color: #999;
     font-weight: 400;
   }

--- a/src/js/components/Widgets/CopyLinkModal.jsx
+++ b/src/js/components/Widgets/CopyLinkModal.jsx
@@ -34,7 +34,7 @@ export default class CopyLinkModal extends Component {
 
   render () {
     renderLog('CopyLinkModal');  // Set LOG_RENDER_EVENTS to log all renders
-    const { urlBeingShared } = this.props;
+    const { urlBeingShared, show, onHide } = this.props;
     const browserSupportsCopyToClipboard = false; // latest iOS update supports CopyToClipboard, check for users version and let them copy if latest, perhaps with npm pckg "mobile-detect"
     let copyBtnClassName;
     if (browserSupportsCopyToClipboard) {
@@ -44,7 +44,7 @@ export default class CopyLinkModal extends Component {
     }
 
     return (
-      <Modal {...this.props} size="large" aria-labelledby="contained-modal-title-lg">
+      <Modal Cosize="large" aria-labelledby="contained-modal-title-lg">
         <Modal.Header closeButton>
           <Modal.Title id="contained-modal-title-lg">Copy link to clipboard</Modal.Title>
         </Modal.Header>
@@ -54,6 +54,8 @@ export default class CopyLinkModal extends Component {
               readOnly="true"
               value={urlBeingShared}
               className="form-control"
+              show={show}
+              onHide={onHide}
             />
             <span className="input-group-btn">
               <CopyToClipboard text={urlBeingShared} onCopy={this.updateWasCopied}>
@@ -73,4 +75,6 @@ export default class CopyLinkModal extends Component {
 }
 CopyLinkModal.propTypes = {
   urlBeingShared: PropTypes.string,
+  show: PropTypes.bool,
+  onHide: PropTypes.func,
 };


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
fixes #3477
### Changes included this pull request?
all footer links in the profile section now have consistent coloring and underline when hovered over