### PR TITLE
Fixed twitter sign in for WebApp

### DIFF
--- a/src/js/components/Ballot/CandidateItemCompressed.jsx
+++ b/src/js/components/Ballot/CandidateItemCompressed.jsx
@@ -2,14 +2,13 @@ import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import TextTruncate from 'react-text-truncate'; // Replace with: import TruncateMarkup from 'react-truncate-markup';
+import historyPush from '../../common/utils/historyPush';
+import { renderLog } from '../../common/utils/logging';
+import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import CandidateStore from '../../stores/CandidateStore';
 import OrganizationStore from '../../stores/OrganizationStore';
 import SupportStore from '../../stores/SupportStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
-import normalizedImagePath from '../../common/utils/normalizedImagePath';
-import historyPush from '../../common/utils/historyPush';
-import { renderLog } from '../../common/utils/logging';
 
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
 const BallotItemSupportOpposeScoreDisplay = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeScoreDisplay' */ '../Widgets/ScoreDisplay/BallotItemSupportOpposeScoreDisplay'));
@@ -113,7 +112,7 @@ export default class CandidateItemCompressed extends Component {
     const candidatePartyText = this.state.oneCandidate.party && this.state.oneCandidate.party.length ? `${this.state.oneCandidate.party}. ` : '';
     const candidateDescriptionText = this.state.oneCandidate.twitter_description && this.state.oneCandidate.twitter_description.length ? this.state.oneCandidate.twitter_description : '';
     const candidateText = candidatePartyText + candidateDescriptionText;
-    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? '-cordova' : ''} o-media-object__anchor u-cursor--pointer u-self-start u-push--sm`;
+    const avatarCompressed = 'card-main__avatar-compressed o-media-object__anchor u-cursor--pointer u-self-start u-push--sm';
     const avatarBackgroundImage = normalizedImagePath('../img/global/svg-icons/avatar-generic.svg');
 
     return (

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -7,26 +7,16 @@ import Tooltip from 'react-bootstrap/Tooltip';
 import styled from 'styled-components';
 import OfficeActions from '../../actions/OfficeActions';
 import historyPush from '../../common/utils/historyPush';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import toTitleCase from '../../common/utils/toTitleCase';
-import InfoCircleIcon from '../Widgets/InfoCircleIcon';
 import AppObservableStore from '../../stores/AppObservableStore';
 import BallotStore from '../../stores/BallotStore';
 import CandidateStore from '../../stores/CandidateStore';
 import SupportStore from '../../stores/SupportStore';
 import { sortCandidateList } from '../../utils/positionFunctions';
-import {
-  OverflowContainer,
-  PositionRowListEmptyWrapper,
-  PositionRowListInnerWrapper,
-  PositionRowListOneWrapper,
-  PositionRowListOuterWrapper,
-  PositionRowListScoreColumn,
-  PositionRowListScoreHeader,
-  PositionRowListScoreSpacer,
-} from '../Style/PositionRowListStyles';
+import { OverflowContainer, PositionRowListEmptyWrapper, PositionRowListInnerWrapper, PositionRowListOneWrapper, PositionRowListOuterWrapper, PositionRowListScoreColumn, PositionRowListScoreHeader, PositionRowListScoreSpacer, } from '../Style/PositionRowListStyles';
+import InfoCircleIcon from '../Widgets/InfoCircleIcon';
 import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 import PositionRowEmpty from './PositionRowEmpty';
 import PositionRowList from './PositionRowList';
@@ -289,7 +279,7 @@ class OfficeItemCompressed extends Component {
             }
             candidateCount += 1;
             const candidatePartyText = oneCandidate.party && oneCandidate.party.length ? `${oneCandidate.party}` : '';
-            const avatarCompressed = `card-main__avatar-compressed${isCordova() ? '-cordova' : ''}`;
+            const avatarCompressed = 'card-main__avatar-compressed';
             const avatarBackgroundImage = normalizedImagePath('../img/global/svg-icons/avatar-generic.svg');
             const scoreExplanationTooltip = (
               <Tooltip className="u-z-index-9020" id={`scoreDescription-${oneCandidate.we_vote_id}`}>

--- a/src/js/components/Ballot/PositionRowEmpty.jsx
+++ b/src/js/components/Ballot/PositionRowEmpty.jsx
@@ -20,8 +20,10 @@ import {
   PositionRowItemEmptyWrapper,
 } from '../Style/PositionRowListStyles';
 
-const NUMBER_OF_POSITIONS_REQUIRED_TO_TURN_OFF = 5;
 const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../SignIn/SignInModal'));
+
+const NUMBER_OF_POSITIONS_REQUIRED_TO_TURN_OFF = 5;
+
 
 class PositionRowEmpty extends Component {
   constructor (props) {

--- a/src/js/components/OpinionsAndBallotItems/CandidateItemForOpinions.jsx
+++ b/src/js/components/OpinionsAndBallotItems/CandidateItemForOpinions.jsx
@@ -1,13 +1,12 @@
 import { Twitter } from '@mui/icons-material';
-import styled from 'styled-components';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 import abbreviateNumber from '../../common/utils/abbreviateNumber';
 import historyPush from '../../common/utils/historyPush';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import numberWithCommas from '../../common/utils/numberWithCommas';
@@ -202,7 +201,7 @@ class CandidateItemForOpinions extends Component {
       null;
 
     const candidatePartyText = oneCandidate.party && oneCandidate.party.length ? `${oneCandidate.party}` : '';
-    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? '-cordova' : ''}`;
+    const avatarCompressed = 'card-main__avatar-compressed';
     const avatarBackgroundImage = normalizedImagePath('../img/global/svg-icons/avatar-generic.svg');
 
     return (

--- a/src/js/components/Settings/CandidateItemForAddPositions.jsx
+++ b/src/js/components/Settings/CandidateItemForAddPositions.jsx
@@ -1,9 +1,8 @@
-import styled from 'styled-components';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
+import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import CandidateStore from '../../stores/CandidateStore';
@@ -178,7 +177,7 @@ class CandidateItemForAddPositions extends Component {
     ) :
       null;
 
-    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? '-cordova' : ''}`;
+    const avatarCompressed = 'card-main__avatar-compressed';
     const avatarBackgroundImage = normalizedImagePath('../img/global/svg-icons/avatar-generic.svg');
     const candidatePartyText = oneCandidate.party && oneCandidate.party.length ? `${oneCandidate.party}` : '';
     return (

--- a/src/js/components/Share/SharedItemModal.jsx
+++ b/src/js/components/Share/SharedItemModal.jsx
@@ -406,7 +406,7 @@ class SharedItemModal extends Component {
     let textNextToInfoIcon = null;
     const nameForNextToInfoIcon = organizationName || 'This person';
     const nameForNextToInfoIconMidSentence = organizationName || 'this person';
-    const avatarCompressed = `card-main__avatar-compressed${isCordova() ? '-cordova' : ''}`;
+    const avatarCompressed = 'card-main__avatar-compressed';
     const avatarBackgroundImage = normalizedImagePath('../img/global/svg-icons/avatar-generic.svg');
 
     if (isFriend) {

--- a/src/js/components/Style/BallotTitleHeaderStyles.jsx
+++ b/src/js/components/Style/BallotTitleHeaderStyles.jsx
@@ -4,6 +4,9 @@ const BallotAddress = styled('div', {
   shouldForwardProp: (prop) => !['centerText'].includes(prop),
 })(({ centerText }) => (`
   margin-left: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   ${centerText ? 'text-align: center;' : ''}
 `));
 

--- a/src/js/pages/Process/TwitterSignInProcess.jsx
+++ b/src/js/pages/Process/TwitterSignInProcess.jsx
@@ -62,6 +62,8 @@ export default class TwitterSignInProcess extends Component {
           severity: 'warning',
         },
       });
+    } else if (twitterAuthResponse.twitter_retrieve_attempted === undefined && twitterAuthResponse.twitter_sign_in_failed === undefined) {
+      oAuthLog('TwitterStore listener tripped before receiving a relevant reduce action, ignoring the event');
     } else if (!twitterAuthResponse.twitter_sign_in_found) {
       // This process starts when we return from attempting voterTwitterSignInRetrieve
       // If twitter_sign_in_found NOT True, go back to the sign in page to try again

--- a/src/js/pages/Settings/HamburgerMenu.jsx
+++ b/src/js/pages/Settings/HamburgerMenu.jsx
@@ -292,7 +292,7 @@ export default class HamburgerMenu extends Component {
             <tr className="hamburger-terms__tr-terms">
               <td className="hamburger-terms__td" colSpan={3}>
                 <div>
-                  <span className="hamburger-terms__text" onClick={() => this.deviceTableVisibilityOn()} style={{ color: 'black' }}>
+                  <span className="hamburger-terms__text" onClick={() => this.deviceTableVisibilityOn()} style={{ color: 'black', opacity: '0.7', fontSize: '10px' }}>
                     Device Information
                   </span>
                   <DeviceDialog visibilityOffFunction={this.deviceTableVisibilityOff} show={this.state.showDeviceDialog} />
@@ -304,7 +304,7 @@ export default class HamburgerMenu extends Component {
             <tr className="hamburger-terms__tr-terms">
               <td className="hamburger-terms__td" colSpan={3}>
                 <div>
-                  <span className="hamburger-terms__text" style={{ color: 'black', opacity: '0.7' }}>
+                  <span className="hamburger-terms__text" style={{ color: 'black', opacity: '0.7', fontSize: '10px' }}>
                     Version:&nbsp;&nbsp;
                     {window.weVoteAppVersion}
                   </span>

--- a/src/js/stores/TwitterStore.js
+++ b/src/js/stores/TwitterStore.js
@@ -7,9 +7,9 @@ import Dispatcher from '../common/dispatcher/Dispatcher';
 
 class TwitterStore extends ReduceStore {
   getInitialState () {
-    return {
-      success: true,
-    };
+  //   return {
+  //     success: true,
+  //   };
   }
 
   get () {


### PR DESCRIPTION
Some early changes for the Cordova release
No longer need to suppress the round avatars in Cordova, so removed that code.
In PositionRowEmpty.jsx, needed to have the static const NUMBER_OF_POSITIONS_REQUIRED_TO_TURN_OFF follow the react.lazy, otherwise the Cordova build script fails.
If the "Ballot for 37 Lake Shore Drive, Oakland, CA 94611, USA" string is too long, use css to truncate it with ellipses, in both Cordova and WebApp.

