### PR TITLE
Intermediate checkin #2 for Cordova release

### DIFF
--- a/src/js/components/Ballot/SelectBallotModal.jsx
+++ b/src/js/components/Ballot/SelectBallotModal.jsx
@@ -109,11 +109,11 @@ class SelectBallotModal extends Component {
         </DialogTitle>
         <DialogContent classes={{ root: classes.dialogContent }}>
           {!editingAddress && (
-            <BallotTitleHeaderWrapper>
+            <SelectBallotTitleHeaderWrapper>
               <BallotTitleHeader
                 linksOff
               />
-            </BallotTitleHeaderWrapper>
+            </SelectBallotTitleHeaderWrapper>
           )}
           <Row>
             <div className="u-show-mobile-tablet">
@@ -300,7 +300,7 @@ const styles = (theme) => ({
   },
 });
 
-const BallotTitleHeaderWrapper = styled('div')`
+const SelectBallotTitleHeaderWrapper = styled('div')`
   margin-bottom: 32px;
 `;
 

--- a/src/js/components/Navigation/FooterBar.jsx
+++ b/src/js/components/Navigation/FooterBar.jsx
@@ -4,6 +4,7 @@ import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
+import { isIOS } from '../../common/utils/cordovaUtils';
 import historyPush from '../../common/utils/historyPush';
 import { normalizedHref } from '../../common/utils/hrefUtils';
 import { isCordova } from '../../common/utils/isCordovaOrWebApp';
@@ -151,6 +152,7 @@ class FooterBar extends React.Component {
             value={this.getSelectedTab()}
             onChange={this.handleChange}
             showLabels
+            style={{ width: `${isIOS() ? '95%' : ''}` }}
           >
             <BottomNavigationAction className="no-outline" id="readyTabFooterBar" label="Home" showLabel icon={<Home />} />
             <BottomNavigationAction className="no-outline" id="ballotTabFooterBar" label="Ballot" showLabel icon={<HowToVote />} />

--- a/src/js/components/Navigation/HamburgerMenuRowCentered.jsx
+++ b/src/js/components/Navigation/HamburgerMenuRowCentered.jsx
@@ -3,6 +3,7 @@ import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 
 const SettingsAccountLevelChip = React.lazy(() => import(/* webpackChunkName: 'SettingsAccountLeveLChip' */ '../Settings/SettingsAccountLevelChip'));
@@ -47,7 +48,7 @@ const styles = () => ({
 });
 
 const CenteredTD = styled('td')`
-  text-align: center;
+  text-align: ${isWebApp() ? 'center' : 'unset'};
   vertical-align: middle !important;
 `;
 

--- a/src/js/components/Navigation/HeaderBackTo.jsx
+++ b/src/js/components/Navigation/HeaderBackTo.jsx
@@ -208,7 +208,7 @@ class HeaderBackTo extends Component {
 
     const pathname = normalizedHref();
     const shareButtonInHeader = pathname && stringContains('/office', pathname.toLowerCase());
-    const cordovaOverrides = isWebApp() ? {} : { marginLeft: 0, paddingLeft: '15px', right: 'unset' };
+    const cordovaOverrides = isWebApp() ? {} : { marginLeft: 0, padding: '34px 15px 0 0', right: 'unset' };
     if (isIOSAppOnMac() || isIPad()) {
       cordovaOverrides.height = shareButtonInHeader ? '87px !important' : '68px';
     }
@@ -229,7 +229,6 @@ class HeaderBackTo extends Component {
             id="backToLinkTabHeaderBackTo"
           />
 
-          {isWebApp() && (
           <TopRowOneRightContainer
             className="u-cursor--pointer"
             style={{ paddingLeft: `${isCordova() ? '0 !important' : ''}` }}
@@ -273,7 +272,6 @@ class HeaderBackTo extends Component {
               <SignInButton toggleSignInModal={this.toggleSignInModal} />
             )}
           </TopRowOneRightContainer>
-          )}
         </Toolbar>
         {showSignInModal && (
           <Suspense fallback={<></>}>

--- a/src/js/components/Navigation/HeaderBackToButton.jsx
+++ b/src/js/components/Navigation/HeaderBackToButton.jsx
@@ -1,10 +1,9 @@
-import { ArrowBack, ArrowBackIos } from '@mui/icons-material';
+import { ArrowBack } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import styled from 'styled-components';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { isIOS } from '../../common/utils/cordovaUtils';
 import historyPush from '../../common/utils/historyPush';
 import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
@@ -24,13 +23,9 @@ class HeaderBackToButton extends Component {
         className={`${className}`}
         id="backToLinkTabHeaderBackToButton"
         onClick={() => historyPush(backToLink)}
-        style={leftAligned ? { paddingLeft: `${isMobileScreenSize() ? '0' : ''}`, marginLeft: '0 !important', minWidth: 24, width: 24 } : { paddingLeft: `${isMobileScreenSize() ? '0' : ''}` }}
+        style={leftAligned ? { paddingLeft: `${isMobileScreenSize() || isCordova() ? '20px' : ''}`, marginLeft: '0 !important', minWidth: 24, width: 24 } : { paddingLeft: `${isMobileScreenSize() || isCordova() ? '20px' : ''}` }}
       >
-        {isIOS() ? (
-          <ArrowBackIos className="button-icon" />
-        ) : (
-          <ArrowBack className="button-icon" />
-        )}
+        <ArrowBack className="button-icon" />
         <span className="u-show-desktop-tablet u-no-break">{shortenText(backToLinkText, 60)}</span>
         <span className="u-show-mobile-bigger-than-iphone5 u-no-break">{shortenText(backToLinkText, 23)}</span>
         <span className="u-show-mobile-iphone5-or-smaller u-no-break">{shortenText(backToLinkText, 18)}</span>

--- a/src/js/components/Navigation/SettingsSectionFooter.jsx
+++ b/src/js/components/Navigation/SettingsSectionFooter.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
+import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import AppObservableStore from '../../stores/AppObservableStore';
 
@@ -26,52 +27,61 @@ class SettingsSectionFooter extends Component {
     return (
       <Wrapper>
         <OneRow centered={centered}>
-          <TermsAndPrivacyText>
-            <span className="u-cursor--pointer" onClick={this.openHowItWorksModal}>How It Works</span>
-            <span style={{ paddingLeft: 15 }} />
-            <OpenExternalWebSite
-              linkIdAttribute="footerLinkWeVoteHelp"
-              url="https://help.wevote.us/hc/en-us"
-              target="_blank"
-              body={(
-                <span>Help</span>
-              )}
-            />
-            <span style={{ paddingLeft: 15 }} />
-            <Link to="/more/privacy">Privacy</Link>
-            <span style={{ paddingLeft: 15 }} />
-            <Link to="/more/terms">Terms</Link>
-          </TermsAndPrivacyText>
+          <span className="u-cursor--pointer" onClick={this.openHowItWorksModal}><TermsAndPrivacyText>How It Works</TermsAndPrivacyText></span>
+          <span style={{ paddingLeft: 15 }} />
+          <OpenExternalWebSite
+            linkIdAttribute="footerLinkWeVoteHelp"
+            url="https://help.wevote.us/hc/en-us"
+            target="_blank"
+            body={(
+              <TermsAndPrivacyText>Help</TermsAndPrivacyText>
+            )}
+            color="#0156b3"
+          />
+          <span style={{ paddingLeft: 15 }} />
+          <Link to="/more/privacy"><TermsAndPrivacyText>Privacy</TermsAndPrivacyText></Link>
+          <span style={{ paddingLeft: 15 }} />
+          <Link to="/more/terms"><TermsAndPrivacyText>Terms</TermsAndPrivacyText></Link>
         </OneRow>
         <OneRow centered={centered}>
-          <TermsAndPrivacyText>
-            <OpenExternalWebSite
-              linkIdAttribute="footerLinkAbout"
-              url="https://wevote.us/more/about"
-              target="_blank"
-              body={(
-                <span>About</span>
-              )}
-            />
-            <span style={{ paddingLeft: 15 }} />
-            <OpenExternalWebSite
-              linkIdAttribute="footerLinkTeam"
-              url="https://wevote.us/more/about"
-              target="_blank"
-              body={(
-                <span>Team</span>
-              )}
-            />
-            <span style={{ paddingLeft: 15 }} />
-            <OpenExternalWebSite
-              linkIdAttribute="footerLinkTeam"
-              url="https://wevote.us/more/credits"
-              target="_blank"
-              body={(
-                <span className="u-no-break">Credits &amp; Thanks</span>
-              )}
-            />
-          </TermsAndPrivacyText>
+          { isWebApp() ? (
+            <>
+              <OpenExternalWebSite
+                linkIdAttribute="footerLinkAbout"
+                url="https://wevote.us/more/about"
+                target="_blank"
+                body={(
+                  <TermsAndPrivacyText>About</TermsAndPrivacyText>
+                 )}
+              />
+              <span style={{ paddingLeft: 15 }} />
+              <OpenExternalWebSite
+                linkIdAttribute="footerLinkTeam"
+                url="https://wevote.us/more/about"
+                target="_blank"
+                body={(
+                  <TermsAndPrivacyText>Team</TermsAndPrivacyText>
+                )}
+              />
+              <span style={{ paddingLeft: 15 }} />
+              <OpenExternalWebSite
+                linkIdAttribute="footerLinkTeam"
+                url="https://wevote.us/more/credits"
+                target="_blank"
+                body={(
+                  <TermsAndPrivacyText className="u-no-break">Credits &amp; Thanks</TermsAndPrivacyText>
+                )}
+              />
+            </>
+          ) : (
+            <>
+              <Link to="/more/about"><TermsAndPrivacyText>About</TermsAndPrivacyText></Link>
+              <span style={{ paddingLeft: 15 }} />
+              <Link to="/more/about"><TermsAndPrivacyText>Team</TermsAndPrivacyText></Link>
+              <span style={{ paddingLeft: 15 }} />
+              <Link to="/more/credits"><TermsAndPrivacyText>Credits &amp; Thanks</TermsAndPrivacyText></Link>
+            </>
+          )}
         </OneRow>
         <DoesNotSupport centered={centered}>
           We Vote does not support or oppose any political candidate or party.

--- a/src/js/components/Ready/ElectionCountdown.jsx
+++ b/src/js/components/Ready/ElectionCountdown.jsx
@@ -204,14 +204,14 @@ class ElectionCountdown extends React.Component {
             ) : (<></>)}
           </CardSubTitle>
         </div>
-        <BallotTitleHeaderWrapper>
+        <CountdownTitleHeaderWrapper>
           <BallotTitleHeader
             centerText
             electionDateBelow
             toggleSelectBallotModal={this.toggleSelectBallotModal}
             turnOffVoteByBelow
           />
-        </BallotTitleHeaderWrapper>
+        </CountdownTitleHeaderWrapper>
       </CardCountdownInternalWrapper>
     );
     const electionIsTodayHtml = (
@@ -227,13 +227,13 @@ class ElectionCountdown extends React.Component {
               {electionDateMDY || ''}
             </CardSubTitle>
           </div>
-          <BallotTitleHeaderWrapper>
+          <CountdownTitleHeaderWrapper>
             <BallotTitleHeader
               centerText
               electionDateBelow
               toggleSelectBallotModal={this.toggleSelectBallotModal}
             />
-          </BallotTitleHeaderWrapper>
+          </CountdownTitleHeaderWrapper>
         </div>
       </CardCountdownInternalWrapper>
     );
@@ -268,7 +268,7 @@ class ElectionCountdown extends React.Component {
             ) : (<></>)}
           </CardSubTitle>
         </div>
-        <BallotTitleHeaderWrapper>
+        <CountdownTitleHeaderWrapper>
           <BallotTitleHeaderNationalPlaceholder
             centerText
             electionDateBelow
@@ -277,7 +277,7 @@ class ElectionCountdown extends React.Component {
             // toggleSelectBallotModal={this.toggleSelectBallotModal}
             turnOffVoteByBelow
           />
-        </BallotTitleHeaderWrapper>
+        </CountdownTitleHeaderWrapper>
       </CardCountdownInternalWrapper>
     );
 
@@ -305,7 +305,7 @@ ElectionCountdown.propTypes = {
   onClickFunction: PropTypes.func,
 };
 
-const BallotTitleHeaderWrapper = styled('div')(({ theme }) => (`
+const CountdownTitleHeaderWrapper = styled('div')(({ theme }) => (`
   margin-top: 60px;
   ${theme.breakpoints.down('sm')} {
     margin-top: 42px;

--- a/src/js/components/Settings/SettingsProfile.jsx
+++ b/src/js/components/Settings/SettingsProfile.jsx
@@ -1,10 +1,10 @@
 import { Info } from '@mui/icons-material';
-import styled from 'styled-components';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import Helmet from 'react-helmet';
 import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 import AnalyticsActions from '../../actions/AnalyticsActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { renderLog } from '../../common/utils/logging';

--- a/src/js/components/SignIn/SignInOptionsPanel.jsx
+++ b/src/js/components/SignIn/SignInOptionsPanel.jsx
@@ -13,7 +13,7 @@ import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { isIPhone4in, isIPhone4p7in, restoreStylesAfterCordovaKeyboard } from '../../common/utils/cordovaUtils';
 import historyPush from '../../common/utils/historyPush';
 import { normalizedHref } from '../../common/utils/hrefUtils';
-import { isCordova } from '../../common/utils/isCordovaOrWebApp';
+import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import Cookies from '../../common/utils/js-cookie/Cookies';
 import { oAuthLog, renderLog } from '../../common/utils/logging';
 import stringContains from '../../common/utils/stringContains';
@@ -550,7 +550,7 @@ export default class SignInOptionsPanel extends Component {
                 hideDialogForCordova={this.hideDialogForCordovaLocal}
               />
             )}
-            {(!hideVoterPhoneEntry && !hideVoterEmailAddressEntry) && (
+            {(!hideVoterPhoneEntry && !hideVoterEmailAddressEntry && isWebApp()) && (
               <OrWrapper>
                 &mdash;
                 or

--- a/src/js/components/Style/pageLayoutStyles.js
+++ b/src/js/components/Style/pageLayoutStyles.js
@@ -50,8 +50,18 @@ function getPaddingTop () {
   return cordovaScrollablePaneTopPadding();  // 5/14/22 TODO: Refactor this...  Funny that this is no longer used for Cordova, only for the WebApp
 }
 
+function getPaddingBottom () {
+  if (isCordova()) {
+    if (normalizedHrefPage() === 'settings') {
+      return '50px';
+    }
+  }
+  return '';
+}
+
 export const PageContentContainer = styled('div')(({ theme }) => (`
   padding-top: ${getPaddingTop()};
+  padding-bottom: ${getPaddingBottom()};
   position: relative;
   max-width: 960px;
   z-index: 0;

--- a/src/js/pages/Activity/News.jsx
+++ b/src/js/pages/Activity/News.jsx
@@ -81,7 +81,7 @@ class News extends Component {
       const { pathname: pathnameRaw, href: hrefRaw } = window.location;
       let pathname = pathnameRaw;
       if (isCordova()) {
-        pathname = hrefRaw.replace(/file:\/\/.*?Vote.app\/www\/index.html#\//, '');
+        pathname = hrefRaw.replace(/.*?index.html#/, '');
       }
       // console.log('pathname:', pathname, ', destinationLocalUrlWithModal:', destinationLocalUrlWithModal, ', activityTidbitWeVoteIdForDrawer:', activityTidbitWeVoteIdForDrawer);
       if (pathname && pathname !== destinationLocalUrlWithModal) {

--- a/src/js/pages/Ballot/Ballot.jsx
+++ b/src/js/pages/Ballot/Ballot.jsx
@@ -16,7 +16,7 @@ import SupportActions from '../../actions/SupportActions';
 import VoterActions from '../../actions/VoterActions';
 import LoadingWheelComp from '../../common/components/Widgets/LoadingWheelComp';
 import apiCalming from '../../common/utils/apiCalming';
-import { chipLabelText, isAndroid, isAndroidSizeFold, isIOSAppOnMac, isIPad, isIPadGiantSize, isIPhone6p1in } from '../../common/utils/cordovaUtils';
+import { chipLabelText, isAndroid, isAndroidSizeFold, isIOS, isIOSAppOnMac, isIPad, isIPadGiantSize, isIPhone6p1in } from '../../common/utils/cordovaUtils';
 import getBooleanValue from '../../common/utils/getBooleanValue';
 import historyPush from '../../common/utils/historyPush';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
@@ -26,6 +26,7 @@ import { renderLog } from '../../common/utils/logging';
 import AddressBox from '../../components/AddressBox';
 import BallotItemCompressed from '../../components/Ballot/BallotItemCompressed';
 import BallotStatusMessage from '../../components/Ballot/BallotStatusMessage';
+import BallotTitleHeader from '../../components/Ballot/BallotTitleHeader';
 import BallotDecisionsTabs from '../../components/Navigation/BallotDecisionsTabs';
 import BallotShowAllItemsFooter from '../../components/Navigation/BallotShowAllItemsFooter';
 import { DualHeaderContainer, HeaderContentContainer, HeaderContentOuterContainer, PageContentContainer } from '../../components/Style/pageLayoutStyles';
@@ -47,7 +48,6 @@ import isMobile from '../../utils/isMobile';
 import lazyPreloadPages from '../../utils/lazyPreloadPages';
 import mapCategoryFilterType from '../../utils/map-category-filter-type';
 import showBallotDecisionsTabs from '../../utilsApi/showBallotDecisionsTabs';
-import BallotTitleHeader from '../../components/Ballot/BallotTitleHeader';
 import { checkShouldUpdate, formatVoterBallotList } from './utils/ballotUtils';
 
 const CompleteYourProfile = React.lazy(() => import(/* webpackChunkName: 'CompleteYourProfile' */ '../../components/CompleteYourProfile/CompleteYourProfile'));
@@ -1091,6 +1091,8 @@ class Ballot extends Component {
       return '44px';
     } else if (isIPad()) {
       return '12px';
+    } else if (isIOS()) {
+      return '85px';
     } else if (isWebApp() && isMobileScreenSize()) {
       if (scrolledDown) {
         return '50px';
@@ -1732,7 +1734,7 @@ const BallotFilterRow = styled('div')`
 const BallotTitleHeaderWrapper = styled('div', {
   shouldForwardProp: (prop) => !['marginTopOffset'].includes(prop),
 })(({ marginTopOffset }) => (`
-  margin-top: ${isWebApp() ? marginTopOffset : ''};
+  margin-top: ${marginTopOffset};
   transition: ${isWebApp() ? 'all 150ms ease-in' : ''};
 `));
 

--- a/src/js/utils/cordovaCalculatedOffsets.js
+++ b/src/js/utils/cordovaCalculatedOffsets.js
@@ -1,4 +1,4 @@
-import { isIPad } from '../common/utils/cordovaUtils';
+import { isIPad, hasIPhoneNotch } from '../common/utils/cordovaUtils';
 import { normalizedHref, normalizedHrefPage } from '../common/utils/hrefUtils';
 import { isWebApp } from '../common/utils/isCordovaOrWebApp';
 
@@ -104,13 +104,23 @@ export function setBallotDualHeaderContentContainerTopOffset (isSignedIn) {
 
 export function cordovaComplexHeaderPageContainerTopOffset () {
   if (isWebApp()) return '';
+  const iOSNotchedSpacer = $('div[class*=\'IOSNotchedSpacer\']');
   const headroomWrapper = $('div[class*=\'HeadroomWrapper\']');
-  const hrHeight = getPageKey() === 'ballot' && isIPad() ? 0 : headroomWrapper.height();
-  const dhc = $('div[class*=\'DualHeaderContainer\']');  // none
-  const dhcHeight = dhc.height() || 0;   // No dhc for Friends when signed in
-  const nonDhcHeight = getPageKey() === 'friends' ? 20 : 0;
+  const dualHeaderCont = $('div[class*=\'DualHeaderContainer\']');
+  let hrHeight = 0;
+  if (hasIPhoneNotch()) {
+    if (getPageKey() === 'friends') {
+      hrHeight = headroomWrapper.height();
+    } else if (getPageKey() === 'ballot' && isIPad()) {
+      hrHeight = 0;
+    } else {
+      hrHeight = iOSNotchedSpacer.height();
+    }
+  }
 
-  const topOffsetValue = hrHeight + dhcHeight + nonDhcHeight;
+  const dhcHeight = dualHeaderCont.height() || 0;   // No dualHeaderCont for Friends when signed in
+  const topOffsetValue = hrHeight + dhcHeight;
+
   if ($.isNumeric(topOffsetValue)) {
     pageData.previousPage = getPageKey();
     debugLogging(`cordovaComplexHeaderPageContainer topOffset success ${topOffsetValue}`);
@@ -144,12 +154,15 @@ export function cordovaSimplePageContainerTopOffset (isSignedIn) {
   } else {
     setTimeout(() => {
       const headroomWrapper = $('div[class*=\'HeadroomWrapper\']');
+      const iosSpacerElem = $('div[class*=\'IOSNotchedSpacer\']');
+      const notchHeight = iosSpacerElem.length > 0 ? iosSpacerElem.height() : 0;
+
       const height = headroomWrapper.height();
       debugLogging(`cordovaSimplePageContainerTopOffset HeadRoomWrapper height ${height}, ${getPageKey()}`);
 
       if (height !== undefined && height > 0 && getCordovaSimplePageContainerTopOffsetValue() === 0) {
         const decorativeUiWhitespaceSimple = 20;
-        const topOffsetValue = height + decorativeUiWhitespaceSimple;
+        const topOffsetValue = height + decorativeUiWhitespaceSimple + notchHeight;
         setCordovaSimplePageContainerTopOffsetValue(topOffsetValue);
 
         debugLogging(`cordovaSimplePageContainerTopOffset setting padding-top in PageContentContainer: ${topOffsetValue}`);


### PR DESCRIPTION
Various page size and header size adjustments if Cordova
Reworked HeaderBackTo for Cordova, we now use the same back arrow (and header layout) as WebApp
Reworked SettingsSectionFooter, so that all the links have the same style, removed OpenExternalWebsite for these links in Cordova, since they open completely new contexts that don't share cookies and allow one to navigate to the ballot page in the webapp in those contexts.
