### PR TITLE
Popovers now close when opening PositionDrawer

### DIFF
--- a/src/js/components/Ballot/PositionRowLogoAndText.jsx
+++ b/src/js/components/Ballot/PositionRowLogoAndText.jsx
@@ -86,6 +86,7 @@ class PositionRowLogoAndText extends Component {
     AppObservableStore.setPositionDrawerOrganizationWeVoteId(organizationWeVoteId);
     // AppObservableStore.setShowOrganizationModal(true);
     AppObservableStore.setShowPositionDrawer(true);
+    this.StickyPopover.closePopover();
   }
 
   onShowMoreAlternateFunction = () => {
@@ -178,6 +179,7 @@ class PositionRowLogoAndText extends Component {
               key={`positionItemScoreDesktopPopover-${organizationWeVoteId}`}
               // openOnClick
               // showCloseIcon
+              ref={(instance) => { this.StickyPopover = instance; }}
             >
               <div>
                 <OrganizationOverlayOuterWrapper>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixes #3492 
### Changes included this pull request?
Added a reference to StickyPopover, so every time onClickShowPositionDrawer is called, it will also call the closePopover method in the StickyPopover component and close the popover before opening the PositionDrawer.