### PR TITLE
Detect AppleId with no contacts, and put up appropriate message.

### DIFF
--- a/src/js/common/utils/isMobileScreenSize.js
+++ b/src/js/common/utils/isMobileScreenSize.js
@@ -19,6 +19,12 @@ export function isTablet () {
   return innerWidth > tabMin && innerWidth < tabMax;
 }
 
+export function isLargerThanTablet () {
+  const { innerWidth, muiThemeGlobal: { breakpoints: { values: { tabMax } } } } = window;
+  // console.log('isLargerThanTablet isCordova, innerWidth, tabMin, tabMax return value:', isCordova(), innerWidth, tabMin, tabMax,  innerWidth > tabMin && innerWidth < tabMax);
+  return innerWidth > tabMax;
+}
+
 export function isSmallTablet () {
   const { innerWidth, muiThemeGlobal: { breakpoints: { values: { tabMin, tabMdMin } } } } = window;
   return innerWidth > tabMin && innerWidth < tabMdMin;

--- a/src/js/components/Navigation/HeaderLogoImage.jsx
+++ b/src/js/components/Navigation/HeaderLogoImage.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
-import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
+import { isLargerThanTablet, isTablet } from '../../common/utils/isMobileScreenSize';
 
 const HeaderLogoImage = ({ src }) => (
   <LogoImg id="HeaderLogoImage" alt="We Vote Logo" src={src} />
@@ -18,7 +18,8 @@ HeaderLogoImage.propTypes = {
 }
 */
 const LogoImg = styled('img')`
-  ${isMobileScreenSize() ? 'padding: 3px;' : 'padding: 4px;'}
+  ${isTablet() ? 'padding: 4px;' : ''}
+  ${isLargerThanTablet() ? 'padding: 2px;' : ''}
 `;
 
 export default HeaderLogoImage;

--- a/src/js/components/SetUpAccount/SetUpAccountImportContacts.jsx
+++ b/src/js/components/SetUpAccount/SetUpAccountImportContacts.jsx
@@ -86,7 +86,7 @@ class SetUpAccountImportContacts extends React.Component {
                       </>
                     ) : (
                       <>
-                        We couldn&apos;t find any of your contacts
+                        We couldn&apos;t match any of your contacts with other members of
                         {' '}
                         <span className="u-no-break">We Vote</span>
                       </>


### PR DESCRIPTION
Was unable to setState, within a native (iOS) callback, so added a workaround. 
Better padding for WeVote logo at different screen sizes
