### PR TITLE
Name and Photo Settings: Added space between radio buttons and organization type

### DIFF
--- a/src/js/components/Settings/SettingsWidgetAccountType.jsx
+++ b/src/js/components/Settings/SettingsWidgetAccountType.jsx
@@ -189,7 +189,7 @@ export default class SettingsWidgetAccountType extends Component {
           className="form-check-label create-voter-guide__radio-label"
           htmlFor={organizationTypeId}
         >
-          {organizationTypeLabel}
+          &nbsp;{organizationTypeLabel}
         </label>
       </div>
     );


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixed lack of spacing between radio buttons and organization type in "Name and Photo Settings: Type of Profile" edit menu.
### Changes included this pull request?
Added spacing between JSX elements in code.
