### PR TITLE
Testing the /friends/remind page starting with an "Edit message" interface instead of asking people to import their contacts first. Refactored messageToFriendQueuedToSave system to store multiple kinds of messageToFriendQueuedToSave values, including askFriend, inviteFriend, remindContacts and shareWithFriend. (Next step, store that custom value with voter's profile.)

### DIFF
--- a/src/js/actions/FriendActions.js
+++ b/src/js/actions/FriendActions.js
@@ -171,8 +171,8 @@ export default {
     });
   },
 
-  messageToFriendQueuedToSave (messageToFriend) {
-    Dispatcher.dispatch({ type: 'messageToFriendQueuedToSave', payload: messageToFriend });
+  messageToFriendQueuedToSave (messageToFriend, messageToFriendType) {
+    Dispatcher.dispatch({ type: 'messageToFriendQueuedToSave', messageToFriend, messageToFriendType });
   },
 
   messageToFriendSend (otherVoterWeVoteId, messageToFriend, electionDateInFutureFormatted, electionDateIsToday) {

--- a/src/js/components/FriendIntro/NextStepButtons.jsx
+++ b/src/js/components/FriendIntro/NextStepButtons.jsx
@@ -1,0 +1,46 @@
+import { Button } from '@mui/material';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { renderLog } from '../../common/utils/logging';
+
+// React functional component example
+export default function NextStepButtons (props) {
+  renderLog('NextStepButtons functional component');
+  return (
+    <>
+      <Button
+        color="primary"
+        onClick={props.onClickNextButton}
+        style={props.desktopMode ? {
+          boxShadow: 'none !important',
+          textTransform: 'none',
+          width: 250,
+        } : {
+          boxShadow: 'none !important',
+          textTransform: 'none',
+          width: '100%',
+        }}
+        variant="contained"
+      >
+        {props.nextStepButtonText}
+      </Button>
+      {!props.skipForNowOff && (
+        <Button
+          classes={props.desktopMode ? { root: props.classes.desktopSimpleLink } : { root: props.classes.mobileSimpleLink }}
+          color="primary"
+          onClick={props.goToSkipForNow}
+        >
+          Skip for now
+        </Button>
+      )}
+    </>
+  );
+}
+NextStepButtons.propTypes = {
+  classes: PropTypes.object,
+  desktopMode: PropTypes.bool,
+  goToSkipForNow: PropTypes.func,
+  nextStepButtonText: PropTypes.string,
+  onClickNextButton: PropTypes.func,
+  skipForNowOff: PropTypes.bool,
+};

--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -20,7 +20,7 @@ class AddFriendsByEmail extends Component {
   constructor (props) {
     super(props);
     this.state = {
-      addFriendsMessage: 'I\'m getting ready to vote. Would you like to join me in deciding how to vote?',
+      messageToFriend: 'I\'m getting ready to vote. Would you like to join me in deciding how to vote?',
       emailAddressesError: false,
       emailsOrPhonesBrokenString: '',
       friendContactInfoArray: [],
@@ -99,7 +99,7 @@ class AddFriendsByEmail extends Component {
 
   cacheAddFriendsByEmailMessage = (e) => {
     this.setState({
-      addFriendsMessage: e.target.value,
+      messageToFriend: e.target.value,
     });
   };
 
@@ -176,7 +176,7 @@ class AddFriendsByEmail extends Component {
     e.preventDefault();
     // console.log('friendInvitationByEmailSend');
     const {
-      addFriendsMessage, friendContactInfoArray,
+      messageToFriend, friendContactInfoArray,
       friendFirstName, friendLastName,
       senderEmailAddress,
     } = this.state;
@@ -201,7 +201,7 @@ class AddFriendsByEmail extends Component {
     // console.log('lastNameArray: ', lastNameArray);
     FriendActions.clearErrorMessageToShowVoter();
     FriendActions.friendInvitationByEmailSend(emailAddressArray, firstNameArray,
-      lastNameArray, '', addFriendsMessage,
+      lastNameArray, '', messageToFriend,
       senderEmailAddress);
     // After calling the API, reset the form
     this.setState({
@@ -221,10 +221,11 @@ class AddFriendsByEmail extends Component {
     renderLog('AddFriendsByEmail');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes, inSideColumn, uniqueExternalId } = this.props;
     const {
-      addFriendsMessage, emailAddressesError, emailsOrPhonesBrokenString, errorMessage, errorMessageToShowVoter,
+      emailAddressesError, emailsOrPhonesBrokenString, errorMessage, errorMessageToShowVoter,
       friendContactInfoArray,
       friendFirstName, friendInvitationsWaitingForVerification, friendLastName,
       incomingEmailsOrPhonesString, invitationEmailsAlreadyScheduledStepFromApi, loading,
+      messageToFriend,
       numberOfMessagesSent, onEnterEmailAddressesStep, onFriendInvitationsSentStep,
       senderEmailAddressError, successMessageToShowVoter, voterIsSignedIn,
     } = this.state;
@@ -378,9 +379,9 @@ class AddFriendsByEmail extends Component {
                             onChange={this.cacheAddFriendsByEmailMessage}
                             onFocus={focusTextFieldAndroid}
                             onBlur={blurTextFieldAndroid}
-                            placeholder={addFriendsMessage}
+                            placeholder={messageToFriend}
                             type="text"
-                            value={addFriendsMessage}
+                            value={messageToFriend}
                             variant="outlined"
                           />
                         </>

--- a/src/js/components/Friends/AskFriendsModal.jsx
+++ b/src/js/components/Friends/AskFriendsModal.jsx
@@ -10,6 +10,8 @@ import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import SearchBar from '../Search/SearchBar';
+import FriendList from './FriendList';
 import FriendActions from '../../actions/FriendActions';
 import apiCalming from '../../common/utils/apiCalming';
 import { formatDateMMMDoYYYY } from '../../common/utils/dateFormat';
@@ -20,8 +22,6 @@ import { ModalTitleType1 } from '../Style/ModalType1Styles';
 import BallotStore from '../../stores/BallotStore';
 import FriendStore from '../../stores/FriendStore';
 import sortFriendListByMutualFriends from '../../utils/friendFunctions';
-import SearchBar from '../Search/SearchBar';
-import FriendList from './FriendList';
 
 const MessageToFriendInputField = React.lazy(() => import(/* webpackChunkName: 'MessageToFriendInputField' */ './MessageToFriendInputField'));
 const SuggestedContacts = React.lazy(() => import(/* webpackChunkName: 'SuggestedContacts' */ './SuggestedContacts'));
@@ -34,7 +34,6 @@ class AskFriendsModal extends Component {
       currentFriendListFilteredBySearch: [],
       electionDateInFutureFormatted: '',
       electionDateIsToday: false,
-      messageToFriendDefault: '',
       numberOfIncreases: 0,
       numberOfItemsToDisplay: 20,
       searchFilterOn: false,
@@ -118,43 +117,6 @@ class AskFriendsModal extends Component {
     }, 250);
   }
 
-  createMessageToFriendDefault = () => {
-    const { electionDateInFutureFormatted } = this.state;
-    let messageToFriendDefault = '';
-    // const electionDayText = ElectionStore.getElectionDayText(VoterStore.electionId());
-    const electionDayText = BallotStore.currentBallotElectionDate;
-    let electionDateFound = false;
-    if (electionDayText !== undefined && electionDateInFutureFormatted) {
-      const daysUntilElection = daysUntil(electionDayText);
-      if (daysUntilElection === 0) {
-        messageToFriendDefault += "I'm getting ready to vote today.";
-        electionDateFound = true;
-      } else if (daysUntilElection > 0) {
-        messageToFriendDefault += `I'm getting ready for the election on ${electionDateInFutureFormatted}.`;
-        electionDateFound = true;
-      }
-    }
-    if (!electionDateFound) {
-      messageToFriendDefault += "I'm getting ready to vote.";
-    }
-    messageToFriendDefault += ' Would you like to compare notes about how to vote?';
-    this.setState({
-      messageToFriendDefault,
-    }, () => this.setMessageToFriendQueuedToSave());
-  }
-
-  setMessageToFriendQueuedToSave = () => {
-    if (this.setMessageTimer) clearTimeout(this.setMessageTimer);
-    this.setMessageTimer = setTimeout(() => {
-      const { messageToFriendDefault } = this.state;
-      const messageToFriendQueuedToSave = FriendStore.getMessageToFriendQueuedToSave();
-      if (messageToFriendDefault !== messageToFriendQueuedToSave) {
-        // If voter hasn't changed this, update this.
-        FriendActions.messageToFriendQueuedToSave(messageToFriendDefault);
-      }
-    }, 500);
-  }
-
   setElectionDateInformation = () => {
     // const electionDayText = ElectionStore.getElectionDayText(VoterStore.electionId());
     const electionDayText = BallotStore.currentBallotElectionDate;
@@ -173,7 +135,7 @@ class AskFriendsModal extends Component {
     this.setState({
       electionDateInFutureFormatted,
       electionDateIsToday,
-    }, () => this.createMessageToFriendDefault());
+    });
   }
 
   searchFriends = (searchTerm) => {
@@ -222,8 +184,7 @@ class AskFriendsModal extends Component {
     if (searchFilterOn) {
       currentFriendList = currentFriendListFilteredBySearch;
     }
-    const messageToFriend = FriendStore.getMessageToFriendQueuedToSave();
-
+    const messageToFriendType = 'askFriend';
     return (
       <Dialog
         classes={{ paper: classes.dialogPaper }}
@@ -256,7 +217,7 @@ class AskFriendsModal extends Component {
           <div className="full-width">
             {totalCurrentFriendListCount > 0 && (
               <Suspense fallback={<></>}>
-                <MessageToFriendInputField />
+                <MessageToFriendInputField messageToFriendType={messageToFriendType} />
               </Suspense>
             )}
           </div>
@@ -291,7 +252,7 @@ class AskFriendsModal extends Component {
                 friendToggleOff
                 increaseNumberOfItemsToDisplay={this.increaseNumberOfItemsToDisplay}
                 messageToFriendButtonOn
-                messageToFriendDefault={messageToFriend}
+                messageToFriendType={messageToFriendType}
                 numberOfItemsToDisplay={numberOfItemsToDisplay}
               />
             </FriendListExternalWrapper>

--- a/src/js/components/Friends/FriendDisplayForList.jsx
+++ b/src/js/components/Friends/FriendDisplayForList.jsx
@@ -26,7 +26,7 @@ class FriendDisplayForList extends Component {
       electionDateIsToday,
       friendToggleOff,
       messageToFriendButtonOn,
-      messageToFriendDefault,
+      messageToFriendType,
       mutualFriendCount,
       mutualFriendPreviewList,
       positionsTaken,
@@ -69,7 +69,7 @@ class FriendDisplayForList extends Component {
               <MessageToFriendButton
                 electionDateInFutureFormatted={electionDateInFutureFormatted}
                 electionDateIsToday={electionDateIsToday}
-                messageToFriendDefault={messageToFriendDefault}
+                messageToFriendType={messageToFriendType}
                 otherVoterWeVoteId={voterWeVoteId}
                 voterEmailAddressMissing={!voterEmailAddress}
               />
@@ -146,7 +146,7 @@ FriendDisplayForList.propTypes = {
   friendToggleOff: PropTypes.bool,
   linkedOrganizationWeVoteId: PropTypes.string,
   messageToFriendButtonOn: PropTypes.bool,
-  messageToFriendDefault: PropTypes.string,
+  messageToFriendType: PropTypes.string,
   mutualFriendCount: PropTypes.number,
   mutualFriendPreviewList: PropTypes.array,
   positionsTaken: PropTypes.number,

--- a/src/js/components/Friends/FriendInvitationEmailLinkDisplayForList.jsx
+++ b/src/js/components/Friends/FriendInvitationEmailLinkDisplayForList.jsx
@@ -54,7 +54,7 @@ class FriendInvitationEmailLinkDisplayForList extends Component {
     const emailAddressArray = '';
     const firstNameArray = '';
     const lastNameArray = '';
-    const invitationMessage = FriendStore.getMessageToFriendQueuedToSave();
+    const invitationMessage = FriendStore.getMessageToFriendQueuedToSave('inviteFriend');
     const senderEmailAddress = VoterStore.getVoterEmail();
     FriendActions.friendInvitationByEmailSend(emailAddressArray, firstNameArray, lastNameArray, emailAddresses, invitationMessage, senderEmailAddress);
     this.setState({

--- a/src/js/components/Friends/FriendInvitationVoterLinkDisplayForList.jsx
+++ b/src/js/components/Friends/FriendInvitationVoterLinkDisplayForList.jsx
@@ -63,7 +63,7 @@ class FriendInvitationVoterLinkDisplayForList extends Component {
     const emailAddressArray = '';
     const firstNameArray = '';
     const lastNameArray = '';
-    const invitationMessage = FriendStore.getMessageToFriendQueuedToSave();
+    const invitationMessage = FriendStore.getMessageToFriendQueuedToSave('inviteFriend');
     const senderEmailAddress = VoterStore.getVoterEmail();
     FriendActions.friendInvitationByEmailSend(emailAddressArray, firstNameArray, lastNameArray, emailAddresses, invitationMessage, senderEmailAddress);
     this.setState({

--- a/src/js/components/Friends/FriendList.jsx
+++ b/src/js/components/Friends/FriendList.jsx
@@ -18,7 +18,7 @@ export default class FriendList extends Component {
     renderLog('FriendList');  // Set LOG_RENDER_EVENTS to log all renders
     const {
       electionDateInFutureFormatted, electionDateIsToday, friendList,
-      friendToggleOff, messageToFriendButtonOn, messageToFriendDefault,
+      friendToggleOff, messageToFriendButtonOn, messageToFriendType,
       numberOfItemsToDisplay, previewMode,
     } = this.props;
     // console.log('friendList:', friendList);
@@ -51,7 +51,7 @@ export default class FriendList extends Component {
               key={`friendDisplay-${friend.voter_we_vote_id}`}
               linkedOrganizationWeVoteId={friend.linked_organization_we_vote_id}
               messageToFriendButtonOn={messageToFriendButtonOn}
-              messageToFriendDefault={messageToFriendDefault}
+              messageToFriendType={messageToFriendType}
               mutualFriendCount={friend.mutual_friend_count}
               mutualFriendPreviewList={friend.mutual_friend_preview_list}
               positionsTaken={friend.positions_taken}
@@ -87,7 +87,7 @@ FriendList.propTypes = {
   friendToggleOff: PropTypes.bool,
   increaseNumberOfItemsToDisplay: PropTypes.func,
   messageToFriendButtonOn: PropTypes.bool,
-  messageToFriendDefault: PropTypes.string,
+  messageToFriendType: PropTypes.string,
   numberOfItemsToDisplay: PropTypes.number,
   previewMode: PropTypes.bool,
 };

--- a/src/js/components/Friends/FriendsCurrentPreview.jsx
+++ b/src/js/components/Friends/FriendsCurrentPreview.jsx
@@ -49,7 +49,7 @@ export default class FriendsCurrentPreview extends Component {
 
     const FRIENDS_TO_SHOW = 3;
     const currentFriendListLimited = currentFriendList.slice(0, FRIENDS_TO_SHOW);
-
+    const messageToFriendType = 'remindContacts';
     return ((currentFriendListLimited && currentFriendListLimited.length > 0) && (
       <YourFriendsPreviewWrapper>
         <section>
@@ -65,6 +65,7 @@ export default class FriendsCurrentPreview extends Component {
               <FriendList
                 friendList={currentFriendListLimited}
                 friendToggleOff
+                messageToFriendType={messageToFriendType}
                 previewMode
               />
               {currentFriendList.length > FRIENDS_TO_SHOW && <Link to="/friends/current">See All</Link>}

--- a/src/js/components/Friends/MessageToFriendInputField.jsx
+++ b/src/js/components/Friends/MessageToFriendInputField.jsx
@@ -5,13 +5,18 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import FriendActions from '../../actions/FriendActions';
 import { renderLog } from '../../common/utils/logging';
+import BallotStore from '../../stores/BallotStore';
 import FriendStore from '../../stores/FriendStore';
+import createMessageToFriendDefaults from '../../utils/createMessageToFriendDefaults';
+
 
 class MessageToFriendInputField extends Component {
   constructor (props) {
     super(props);
     this.state = {
       messageToFriend: '',
+      messageToFriendChangedLocally: false,
+      messageToFriendDefault: '',
     };
 
     this.handleKeyPress = this.handleKeyPress.bind(this);
@@ -20,42 +25,93 @@ class MessageToFriendInputField extends Component {
 
   componentDidMount () {
     // console.log('MessageToFriendInputField, componentDidMount');
-    this.onFriendStoreChange();
-    this.friendStoreListener = FriendStore.addListener(this.onFriendStoreChange.bind(this));
+    // this.onFriendStoreChange();
+    this.createMessageToFriendDefault();
+    this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
+    // this.friendStoreListener = FriendStore.addListener(this.onFriendStoreChange.bind(this));
   }
 
   componentWillUnmount () {
-    if (this.friendStoreUpdateTimer) clearTimeout(this.friendStoreUpdateTimer);
-    this.friendStoreListener.remove();
+    // if (this.friendStoreUpdateTimer) clearTimeout(this.friendStoreUpdateTimer);
+    // this.friendStoreListener.remove();
+    if (this.setMessageTimer) clearTimeout(this.setMessageTimer);
+    this.ballotStoreListener.remove();
   }
 
   handleKeyPress () {
     //
   }
 
-  onFriendStoreChange () {
-    const { messageToFriendDefault } = this.props;
-    const messageToFriendQueuedToSave = FriendStore.getMessageToFriendQueuedToSave();
-    const messageToFriendQueuedToSaveSet = FriendStore.getMessageToFriendQueuedToSaveSet();
-    let messageToFriendAdjusted = messageToFriendDefault;
-    if (messageToFriendQueuedToSaveSet) {
-      messageToFriendAdjusted = messageToFriendQueuedToSave;
+  onBallotStoreChange () {
+    this.createMessageToFriendDefault();
+  }
+
+  // onFriendStoreChange () {
+  //   let { messageToFriendType } = this.props;
+  //   const { messageToFriendDefault } = this.state;
+  //   messageToFriendType = messageToFriendType || 'inviteMessage';
+  //   const messageToFriendQueuedToSave = FriendStore.getMessageToFriendQueuedToSave(messageToFriendType);
+  //   const messageToFriendQueuedToSaveSet = FriendStore.getMessageToFriendQueuedToSaveSet(messageToFriendType);
+  //   let messageToFriendAdjusted = messageToFriendDefault;
+  //   if (messageToFriendQueuedToSaveSet) {
+  //     messageToFriendAdjusted = messageToFriendQueuedToSave;
+  //   }
+  //   // console.log('onFriendStoreChange messageToFriendDefault: ', messageToFriendDefault, ', messageToFriendQueuedToSave: ', messageToFriendQueuedToSave, ', messageToFriendQueuedToSaveSet: ', messageToFriendQueuedToSaveSet, ', messageToFriendAdjusted:', messageToFriendAdjusted);
+  //   this.setState({
+  //     messageToFriend: messageToFriendAdjusted,
+  //   });
+  // }
+
+  createMessageToFriendDefault = () => {
+    const { messageToFriendType } = this.props;
+    const { messageToFriendChangedLocally } = this.state;
+    let { messageToFriend } = this.state;
+    const messageToFriendQueuedToSaveSetPreviously = FriendStore.getMessageToFriendQueuedToSaveSet(messageToFriendType);
+    const messageToFriendQueuedToSave = FriendStore.getMessageToFriendQueuedToSave(messageToFriendType);
+    const results = createMessageToFriendDefaults(messageToFriendType);
+    const { messageToFriendDefault } = results;
+    // const { messageToFriendDefaultAsk, messageToFriendDefaultRemind, messageToFriendDefaultInviteFriend } = results;
+    if (messageToFriendQueuedToSaveSetPreviously) {
+      messageToFriend = messageToFriendQueuedToSave;
+    } else if (!messageToFriendChangedLocally) {
+      messageToFriend = messageToFriendDefault;
     }
-    // console.log('onFriendStoreChange messageToFriendDefault: ', messageToFriendDefault, ', messageToFriendQueuedToSave: ', messageToFriendQueuedToSave, ', messageToFriendQueuedToSaveSet: ', messageToFriendQueuedToSaveSet, ', messageToFriendAdjusted:', messageToFriendAdjusted);
     this.setState({
-      messageToFriend: messageToFriendAdjusted,
-    });
+      messageToFriend,
+      messageToFriendDefault,
+    }, () => this.setMessageToFriendQueuedToSave());
+  }
+
+  setMessageToFriendQueuedToSave = () => {
+    const { messageToFriendType } = this.props;
+    const messageToFriendQueuedToSaveSetPreviously = FriendStore.getMessageToFriendQueuedToSaveSet(messageToFriendType);
+    if (!messageToFriendQueuedToSaveSetPreviously) {
+      // Only proceed if it hasn't already been set
+      if (this.setMessageTimer) clearTimeout(this.setMessageTimer);
+      this.setMessageTimer = setTimeout(() => {
+        const { messageToFriendDefault } = this.state;
+        const messageToFriendQueuedToSave = FriendStore.getMessageToFriendQueuedToSave(messageToFriendType);
+        if (messageToFriendDefault !== messageToFriendQueuedToSave) {
+          // If voter hasn't changed this, update this.
+          FriendActions.messageToFriendQueuedToSave(messageToFriendDefault, messageToFriendType);
+        }
+      }, 500);
+    }
   }
 
   updateMessageToFriend (event) {
+    let { messageToFriendType } = this.props;
+    messageToFriendType = messageToFriendType || 'inviteFriend';
     const delayBeforeSentToFriendStore = 1200;
+    // console.log('updateMessageToFriend');
     if (event.target.name === 'messageToFriend') {
       this.setState({
         messageToFriend: event.target.value,
+        messageToFriendChangedLocally: true,
       });
       if (this.friendStoreUpdateTimer) clearTimeout(this.friendStoreUpdateTimer);
       this.friendStoreUpdateTimer = setTimeout(() => {
-        FriendActions.messageToFriendQueuedToSave(event.target.value);
+        FriendActions.messageToFriendQueuedToSave(event.target.value, messageToFriendType);
       }, delayBeforeSentToFriendStore);
     }
   }
@@ -94,9 +150,9 @@ class MessageToFriendInputField extends Component {
   }
 }
 MessageToFriendInputField.propTypes = {
-  messageToFriendDefault: PropTypes.string,
   classes: PropTypes.object,
   externalUniqueId: PropTypes.string,
+  messageToFriendType: PropTypes.string,
 };
 
 const styles = () => ({

--- a/src/js/components/Friends/ShareWithFriendsModalBodyWithController.jsx
+++ b/src/js/components/Friends/ShareWithFriendsModalBodyWithController.jsx
@@ -168,7 +168,7 @@ class ShareWithFriendsModalBodyWithController extends Component {
     if (searchFilterOn) {
       currentFriendList = currentFriendListFilteredBySearch;
     }
-    const messageToFriend = FriendStore.getMessageToFriendQueuedToSave();
+    const messageToFriendType = 'shareWithFriend';
 
     return (
       <ShareWithFriendsModalBody>
@@ -201,7 +201,7 @@ class ShareWithFriendsModalBodyWithController extends Component {
               friendToggleOff
               increaseNumberOfItemsToDisplay={this.increaseNumberOfItemsToDisplay}
               messageToFriendButtonOn
-              messageToFriendDefault={messageToFriend}
+              messageToFriendType={messageToFriendType}
               numberOfItemsToDisplay={numberOfItemsToDisplay}
             />
           </FriendListExternalWrapper>

--- a/src/js/components/Friends/SuggestedFriendDisplayForList.jsx
+++ b/src/js/components/Friends/SuggestedFriendDisplayForList.jsx
@@ -36,12 +36,18 @@ class SuggestedFriendDisplayForList extends Component {
   }
 
   friendInvitationByEmailSend = () => {
-    const { emailAddressForDisplay } = this.props;
+    const { askMode, emailAddressForDisplay, remindMode } = this.props;
+    let messageToFriendType = 'inviteFriend'; // default
+    if (askMode) {
+      messageToFriendType = 'askFriend';
+    } else if (remindMode) {
+      messageToFriendType = 'remindContacts';
+    }
     // console.log('SuggestedFriendDisplayForList friendInvitationByEmailSend');
     const emailAddressArray = '';
     const firstNameArray = '';
     const lastNameArray = '';
-    const invitationMessage = FriendStore.getMessageToFriendQueuedToSave();
+    const invitationMessage = FriendStore.getMessageToFriendQueuedToSave(messageToFriendType);
     const senderEmailAddress = VoterStore.getVoterEmail();
     FriendActions.friendInvitationByEmailSend(emailAddressArray, firstNameArray, lastNameArray, emailAddressForDisplay, invitationMessage, senderEmailAddress);
     this.setState({
@@ -68,7 +74,7 @@ class SuggestedFriendDisplayForList extends Component {
     } = this.props;
     const hostname = AppObservableStore.getHostname();
     const destinationFullUrl = `https://${hostname}/`; // We must provide a destinationFullUrl, so we know what hostname to use in sharedItemRetrieve
-    const sharedMessage = FriendStore.getMessageToFriendQueuedToSave();
+    const sharedMessage = FriendStore.getMessageToFriendQueuedToSave('remindContacts');
     ShareActions.sharedItemSaveRemindContact(destinationFullUrl, emailAddressText, otherVoterWeVoteId, sharedMessage, otherVoterDisplayName, otherVoterFirstName, otherVoterLastName);
     this.setState({
       friendInvitationByEmailSent: true,

--- a/src/js/components/Friends/SuggestedFriendToggle.jsx
+++ b/src/js/components/Friends/SuggestedFriendToggle.jsx
@@ -50,11 +50,15 @@ export default class SuggestedFriendToggle extends Component {
   }
 
   addSuggestedFriend = () => {
-    const { otherVoterWeVoteId } = this.props;
+    const { askMode, otherVoterWeVoteId } = this.props;
     const { voterIsSignedIn } = this.state;
+    let messageToFriendType = 'inviteFriend'; // default
+    if (askMode) {
+      messageToFriendType = 'askFriend';
+    }
     // console.log('addSuggestedFriend');
     if (voterIsSignedIn) {
-      const invitationMessage = FriendStore.getMessageToFriendQueuedToSave();
+      const invitationMessage = FriendStore.getMessageToFriendQueuedToSave(messageToFriendType);
       FriendActions.friendInvitationByWeVoteIdSend(otherVoterWeVoteId, invitationMessage);
       this.setState({
         addSuggestedFriendSent: true,

--- a/src/js/components/Remind/RemindContactsStart.jsx
+++ b/src/js/components/Remind/RemindContactsStart.jsx
@@ -15,6 +15,8 @@ import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import DownloadAppsButtons from './DownloadAppsButtons';
 import Reassurance from '../SetUpAccount/Reassurance';
 import { reassuranceTextRemindContacts } from './reassuranceTextRemindContacts';
+import NextStepButtons from '../FriendIntro/NextStepButtons';
+import AppObservableStore from '../../stores/AppObservableStore';
 import VoterStore from '../../stores/VoterStore';
 import {
   DesktopNextButtonsInnerWrapper, DesktopNextButtonsOuterWrapperUShowDesktopTablet,
@@ -27,6 +29,7 @@ import {
 import SuggestedContactListWithController from '../Friends/SuggestedContactListWithController';
 
 const AddContactsFromGoogleButton = React.lazy(() => import(/* webpackChunkName: 'AddContactsFromGoogleButton' */ '../SetUpAccount/AddContactsFromGoogleButton'));
+const MessageToFriendInputField = React.lazy(() => import(/* webpackChunkName: 'MessageToFriendInputField' */ '../Friends/MessageToFriendInputField'));
 
 const addressBookSVG = '../../../img/get-started/address-book.svg';
 
@@ -68,6 +71,14 @@ class RemindContactsStart extends Component {
     historyPush('/remind/addcontacts');
   }
 
+  goToNextStep = () => {
+    const { location: { pathname: currentPathname } } = window;
+    AppObservableStore.setSetUpAccountBackLinkPath(currentPathname);
+    const setUpAccountEntryPath = '/remind/importcontacts';
+    AppObservableStore.setSetUpAccountEntryPath(setUpAccountEntryPath);
+    historyPush(setUpAccountEntryPath);
+  }
+
   render () {
     renderLog('RemindContactsStart');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes } = this.props;
@@ -82,6 +93,7 @@ class RemindContactsStart extends Component {
       desktopInlineButtonsOnBreakValue = isCordovaWide() ? 1000 : 'sm';
     }
     const pigsCanFly = false;
+    const startWithImportContacts = false;
     return (
       <>
         {(voterContactEmailListCount > 0) ? (
@@ -113,33 +125,62 @@ class RemindContactsStart extends Component {
                 <span className="u-no-break">
                   Let&apos;s change that!
                 </span>
+                {!startWithImportContacts && (
+                  <>
+                    <br />
+                    What do you want to say to your friends?
+                  </>
+                )}
               </RemindContactsImportText>
             </SetUpAccountContactsTextWrapper>
-            <ImageOuterWrapper>
-              <MainImageWrapper>
+            {startWithImportContacts ? (
+              <>
+                <ImageOuterWrapper>
+                  <MainImageWrapper>
+                    <div>
+                      <RemindMainImageImg src={addressBookSVGSrc} alt="" />
+                    </div>
+                  </MainImageWrapper>
+                </ImageOuterWrapper>
                 <div>
-                  <RemindMainImageImg src={addressBookSVGSrc} alt="" />
+                  <Suspense fallback={<></>}>
+                    <AddContactsFromGoogleButton darkButton />
+                  </Suspense>
                 </div>
-              </MainImageWrapper>
-            </ImageOuterWrapper>
-            <div>
-              <Suspense fallback={<></>}>
-                <AddContactsFromGoogleButton darkButton />
-              </Suspense>
-            </div>
-            <DesktopNextButtonsOuterWrapperUShowDesktopTablet breakValue={desktopInlineButtonsOnBreakValue}>
-              <DesktopNextButtonsInnerWrapper>
-                <Button
-                  classes={{ root: classes.addContactsManuallyLink }}
-                  onClick={this.goToAddContactsManually}
-                >
-                  Or add contacts manually
-                </Button>
-              </DesktopNextButtonsInnerWrapper>
-            </DesktopNextButtonsOuterWrapperUShowDesktopTablet>
-            <Reassurance displayState={1} reassuranceText={reassuranceTextRemindContacts} />
-            {(isWebApp() && pigsCanFly) && (
-              <DownloadAppsButtons />
+                <DesktopNextButtonsOuterWrapperUShowDesktopTablet breakValue={desktopInlineButtonsOnBreakValue}>
+                  <DesktopNextButtonsInnerWrapper>
+                    <Button
+                      classes={{ root: classes.addContactsManuallyLink }}
+                      onClick={this.goToAddContactsManually}
+                    >
+                      Or add contacts manually
+                    </Button>
+                  </DesktopNextButtonsInnerWrapper>
+                </DesktopNextButtonsOuterWrapperUShowDesktopTablet>
+                <Reassurance displayState={1} reassuranceText={reassuranceTextRemindContacts} />
+                {(isWebApp() && pigsCanFly) && (
+                  <DownloadAppsButtons />
+                )}
+              </>
+            ) : (
+              <>
+                <MessageToSendWrapper>
+                  <Suspense fallback={<></>}>
+                    <MessageToFriendInputField messageToFriendType="remindContacts" />
+                  </Suspense>
+                </MessageToSendWrapper>
+                <DesktopNextButtonsOuterWrapperUShowDesktopTablet>
+                  <DesktopNextButtonsInnerWrapper>
+                    <NextStepButtons
+                      classes={classes}
+                      desktopMode
+                      nextStepButtonText="Choose who to remind"
+                      onClickNextButton={this.goToNextStep}
+                      skipForNowOff
+                    />
+                  </DesktopNextButtonsInnerWrapper>
+                </DesktopNextButtonsOuterWrapperUShowDesktopTablet>
+              </>
             )}
           </RemindContactsStartWrapper>
         )}
@@ -174,6 +215,12 @@ const MainImageWrapper = styled('div')`
 const ImageOuterWrapper = styled('div')`
   margin-bottom: 24px;
   margin-top: 24px;
+  width: 100%;
+`;
+
+const MessageToSendWrapper = styled('div')`
+  margin-top: 24px;
+  margin-bottom: 24px;
   width: 100%;
 `;
 

--- a/src/js/components/Remind/RemindEditMessage.jsx
+++ b/src/js/components/Remind/RemindEditMessage.jsx
@@ -1,0 +1,67 @@
+import PropTypes from 'prop-types';
+import React, { Suspense } from 'react';
+import styled from 'styled-components';
+import { renderLog } from '../../common/utils/logging';
+import {
+  SetUpAccountContactsText,
+  SetUpAccountContactsTextWrapper,
+  SetUpAccountTitle,
+  SetUpAccountTop,
+  StepCenteredWrapper,
+} from '../Style/SetUpAccountStyles';
+
+const MessageToFriendInputField = React.lazy(() => import(/* webpackChunkName: 'MessageToFriendInputField' */ '../Friends/MessageToFriendInputField'));
+
+class RemindEditMessage extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+  componentDidMount () {
+    window.scrollTo(0, 0);
+  }
+
+  componentDidUpdate (prevProps) {
+    // console.log('RemindEditMessage componentDidUpdate prevProps.nextButtonClicked:', prevProps.nextButtonClicked, ', this.props.nextButtonClicked:', this.props.nextButtonClicked);
+    if (prevProps.nextButtonClicked === false && this.props.nextButtonClicked === true) {
+      this.props.goToNextStep();
+    }
+  }
+
+  render () {
+    renderLog('RemindEditMessage');  // Set LOG_RENDER_EVENTS to log all renders
+    return (
+      <StepCenteredWrapper>
+        <SetUpAccountTop>
+          <SetUpAccountTitle>
+            Remind 3 of your friends to vote today
+          </SetUpAccountTitle>
+          <SetUpAccountContactsTextWrapper>
+            <SetUpAccountContactsText>
+              What do you want to say to your friends?
+            </SetUpAccountContactsText>
+          </SetUpAccountContactsTextWrapper>
+        </SetUpAccountTop>
+        <MessageToSendWrapper>
+          <Suspense fallback={<></>}>
+            <MessageToFriendInputField messageToFriendType="remindContacts" />
+          </Suspense>
+        </MessageToSendWrapper>
+      </StepCenteredWrapper>
+    );
+  }
+}
+RemindEditMessage.propTypes = {
+  goToNextStep: PropTypes.func.isRequired,
+  nextButtonClicked: PropTypes.bool,
+};
+
+const MessageToSendWrapper = styled('div')`
+  margin-top: 24px;
+  margin-bottom: 24px;
+  width: 100%;
+`;
+
+export default RemindEditMessage;

--- a/src/js/pages/FriendIntro/FriendIntroLanding.jsx
+++ b/src/js/pages/FriendIntro/FriendIntroLanding.jsx
@@ -15,6 +15,7 @@ import {
   DesktopNextButtonsInnerWrapper, DesktopNextButtonsOuterWrapperUShowDesktopTablet,
   MobileStaticNextButtonsInnerWrapper, MobileStaticNextButtonsOuterWrapperUShowMobile,
 } from '../../components/Style/NextButtonStyles';
+import NextStepButtons from '../../components/FriendIntro/NextStepButtons';
 import AppObservableStore from '../../stores/AppObservableStore';
 import FriendStore from '../../stores/FriendStore';
 import VoterStore from '../../stores/VoterStore';
@@ -348,47 +349,6 @@ class FriendIntroLanding extends Component {
 FriendIntroLanding.propTypes = {
   classes: PropTypes.object,
   match: PropTypes.object,
-};
-
-function NextStepButtons (props) {
-  renderLog('NextStepButtons functional component');
-  return (
-    <>
-      <Button
-        color="primary"
-        onClick={props.onClickNextButton}
-        style={props.desktopMode ? {
-          boxShadow: 'none !important',
-          textTransform: 'none',
-          width: 250,
-        } : {
-          boxShadow: 'none !important',
-          textTransform: 'none',
-          width: '100%',
-        }}
-        variant="contained"
-      >
-        {props.nextStepButtonText}
-      </Button>
-      {!props.skipForNowOff && (
-        <Button
-          classes={props.desktopMode ? { root: props.classes.desktopSimpleLink } : { root: props.classes.mobileSimpleLink }}
-          color="primary"
-          onClick={props.goToSkipForNow}
-        >
-          Skip for now
-        </Button>
-      )}
-    </>
-  );
-}
-NextStepButtons.propTypes = {
-  classes: PropTypes.object,
-  desktopMode: PropTypes.bool,
-  goToSkipForNow: PropTypes.func,
-  nextStepButtonText: PropTypes.string,
-  onClickNextButton: PropTypes.func,
-  skipForNowOff: PropTypes.bool,
 };
 
 const styles = () => ({

--- a/src/js/pages/Friends/Friends.jsx
+++ b/src/js/pages/Friends/Friends.jsx
@@ -83,6 +83,10 @@ class Friends extends Component {
     this.onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     this.friendStoreListener = FriendStore.addListener(this.onFriendStoreChange.bind(this));
+    const { location: { pathname: currentPathname } } = window;
+    AppObservableStore.setSetUpAccountBackLinkPath(currentPathname);
+    const { setUpAccountEntryPath } = this.state;
+    AppObservableStore.setSetUpAccountEntryPath(setUpAccountEntryPath);
     if (apiCalming('friendListsAll', 30000)) {
       FriendActions.friendListsAll();
     }

--- a/src/js/pages/Friends/FriendsCurrent.jsx
+++ b/src/js/pages/Friends/FriendsCurrent.jsx
@@ -85,7 +85,7 @@ export default class FriendsCurrent extends Component {
     if (searchFilterOn) {
       friendListForDisplay = currentFriendListFilteredBySearch;
     }
-
+    const messageToFriendType = 'remindContacts';
     return (
       <FriendsCurrentWrapper>
         <Helmet title="Your Friends - We Vote" />
@@ -119,6 +119,7 @@ export default class FriendsCurrent extends Component {
         <div>
           <FriendList
             friendList={friendListForDisplay}
+            messageToFriendType={messageToFriendType}
           />
         </div>
       </FriendsCurrentWrapper>

--- a/src/js/stores/FriendStore.js
+++ b/src/js/stores/FriendStore.js
@@ -14,8 +14,20 @@ class FriendStore extends ReduceStore {
       friendInvitationsSentByMe: [],
       friendInvitationsSentToMe: [],
       friendInvitationsWaitingForVerification: [],
-      messageToFriendQueuedToSave: '',
-      messageToFriendQueuedToSaveSet: false,
+      messageToFriendQueuedToSaveDict: {
+        askFriend: '',
+        inviteFriend: '',
+        remindContacts: '',
+        shareWithFriend: '',
+        shareWithFriendAllOpinions: '',
+      },
+      messageToFriendQueuedToSaveSetDict: {
+        askFriend: false,
+        inviteFriend: false,
+        remindContacts: false,
+        shareWithFriend: false,
+        shareWithFriendAllOpinions: false,
+      },
       numberOfMessagesSent: 0,
       successMessageToShowVoter: '',
     };
@@ -86,12 +98,12 @@ class FriendStore extends ReduceStore {
     return this.getState().facebookInvitationStatus;
   }
 
-  getMessageToFriendQueuedToSave () {
-    return this.getState().messageToFriendQueuedToSave;
+  getMessageToFriendQueuedToSave (messageToFriendType = 'inviteFriend') {
+    return this.getState().messageToFriendQueuedToSaveDict[messageToFriendType];
   }
 
-  getMessageToFriendQueuedToSaveSet () {
-    return this.getState().messageToFriendQueuedToSaveSet;
+  getMessageToFriendQueuedToSaveSet (messageToFriendType = 'inviteFriend') {
+    return this.getState().messageToFriendQueuedToSaveSetDict[messageToFriendType];
   }
 
   getNumberOfMessagesSent () {
@@ -141,26 +153,28 @@ class FriendStore extends ReduceStore {
   reduce (state, action) {
     // Exit if we don't receive a response
     if (!action.res && !action.type) return state;  //  || !action.res.success // We deal with failures below
+    const { messageToFriendQueuedToSaveDict, messageToFriendQueuedToSaveSetDict } = state;
     let { currentFriendsByVoterWeVoteIdDict } = state;
     let count = 0;
     let currentFriendsOrganizationWeVoteIds = [];
+    let messageToFriendType = '';
 
     switch (action.type) {
       case 'messageToFriendQueuedToSave':
-        // console.log('FriendStore messageToFriendQueuedToSave: ', action.payload);
-        if (action.payload === undefined) {
-          return {
-            ...state,
-            messageToFriendQueuedToSave: '',
-            messageToFriendQueuedToSaveSet: false,
-          };
+        // console.log('FriendStore messageToFriend: ', action.messageToFriend, ', messageToFriendType:', action.messageToFriendType);
+        messageToFriendType = action.messageToFriendType;
+        if (action.messageToFriend === undefined) {
+          messageToFriendQueuedToSaveDict[messageToFriendType] = '';
+          messageToFriendQueuedToSaveSetDict[messageToFriendType] = false;
         } else {
-          return {
-            ...state,
-            messageToFriendQueuedToSave: action.payload,
-            messageToFriendQueuedToSaveSet: true,
-          };
+          messageToFriendQueuedToSaveDict[messageToFriendType] = action.messageToFriend;
+          messageToFriendQueuedToSaveSetDict[messageToFriendType] = true;
         }
+        return {
+          ...state,
+          messageToFriendQueuedToSaveDict,
+          messageToFriendQueuedToSaveSetDict,
+        };
 
       case 'clearErrorMessageToShowVoter':
         // console.log('FriendStore clearErrorMessageToShowVoter');

--- a/src/js/utils/createMessageToFriendDefaults.jsx
+++ b/src/js/utils/createMessageToFriendDefaults.jsx
@@ -1,0 +1,60 @@
+import BallotStore from '../stores/BallotStore';
+import { formatDateMMMDoYYYY } from '../common/utils/dateFormat';
+import daysUntil from '../common/utils/daysUntil';
+
+export default function createMessageToFriendDefaults (messageToFriendType) {
+  // console.log('createMessageToFriendDefaults, originalString: ', originalString, 'item.ballot_item_display_name:', item.ballot_item_display_name);
+  let messageToFriendDefault = '';
+  let messageToFriendDefaultAsk = '';
+  let messageToFriendDefaultInviteFriend = '';
+  let messageToFriendDefaultRemind = '';
+  // const electionDayText = ElectionStore.getElectionDayText(VoterStore.electionId());
+  const electionDayText = BallotStore.currentBallotElectionDate;
+  const electionDateFormatted = formatDateMMMDoYYYY(electionDayText);
+  let electionDateInFutureFormatted = '';
+  // let electionDateIsToday = false;
+  if (electionDayText !== undefined && electionDateFormatted) {
+    const daysUntilElection = daysUntil(electionDayText);
+    if (daysUntilElection === 0) {
+      electionDateInFutureFormatted = electionDateFormatted;
+      // electionDateIsToday = true;
+    } else if (daysUntilElection > 0) {
+      electionDateInFutureFormatted = electionDateFormatted;
+    }
+  }
+  let electionDateFound = false;
+  if (electionDayText !== undefined && electionDateInFutureFormatted) {
+    const daysUntilElection = daysUntil(electionDayText);
+    if (daysUntilElection === 0) {
+      messageToFriendDefaultAsk += "I'm getting ready to vote today.";
+      messageToFriendDefaultInviteFriend += "I'm getting ready to vote today.";
+      messageToFriendDefaultRemind += 'I hope you join me and vote today.';
+      electionDateFound = true;
+    } else if (daysUntilElection > 0) {
+      messageToFriendDefaultAsk += `I'm getting ready for the election on ${electionDateInFutureFormatted}.`;
+      messageToFriendDefaultInviteFriend += `I'm getting ready for the election on ${electionDateInFutureFormatted}.`;
+      messageToFriendDefaultRemind += `I'm planning to vote by ${electionDateInFutureFormatted}. I hope you join me!`;
+      electionDateFound = true;
+    }
+  }
+  if (!electionDateFound) {
+    messageToFriendDefaultAsk += "I'm getting ready to vote.";
+    messageToFriendDefaultInviteFriend += "I'm getting ready to vote.";
+  }
+  messageToFriendDefaultAsk += ' Would you like to join me in deciding how to vote?';
+  messageToFriendDefaultInviteFriend += ' Would you like to join me in deciding how to vote?';
+  if (messageToFriendType === 'askFriend') {
+    messageToFriendDefault = messageToFriendDefaultAsk;
+  } else if (messageToFriendType === 'remindContacts') {
+    messageToFriendDefault = messageToFriendDefaultRemind;
+  } else { // inviteFriend and shareWithFriend
+    messageToFriendDefault = messageToFriendDefaultInviteFriend;
+  }
+  // Note: shareWithFriend and shareWithFriendAllOpinions is generated in ShareWithFriendsModalTitleWithController
+  return {
+    messageToFriendDefault,
+    messageToFriendDefaultAsk,
+    messageToFriendDefaultRemind,
+    messageToFriendDefaultInviteFriend,
+  };
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -92,7 +92,8 @@ module.exports = (env, argv) => ({
     filename: isWebApp ? '[name].[contenthash].js' : 'bundle.js',
     publicPath: isWebApp ? '/' : undefined,
   },
-  devtool: false,
+  // source-map is for OpenReplay
+  devtool: 'source-map',
   plugins: [
     new CleanWebpackPlugin(),
     new ESLintPlugin({ failOnError: false, failOnWarning: false  }),


### PR DESCRIPTION
Testing the /friends/remind page starting with an "Edit message" interface instead of asking people to import their contacts first. Refactored messageToFriendQueuedToSave system to store multiple kinds of messageToFriendQueuedToSave values, including askFriend, inviteFriend, remindContacts and shareWithFriend. (Next step, store that custom value with voter's profile.)