### PR TITLE
Css was not being minimized on quality and in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "commentMay2021": "'production' forces minified libraries (especially react), and 'MINIFIED' passes all our code through the Terser minifier/mangler/compressor tool.",
   "scripts": {
     "automation_tests": "./node_modules/.bin/wdio ./tests/browserstack_automation/conf/test.conf.js",
-    "build": "node node/buildDateFile.js && webpack --mode production",
+    "build": "node node/buildDateFile.js && MINIMIZED=1 webpack --mode production",
     "buildCordova": "node node/buildDateFile.js && node node/buildSrcCordova && CORDOVA=1 && webpack --mode development && node node/logCompileDate.js",
     "lint": "eslint --format stylish --ext .jsx --ext .js src/js",
     "lintCordova": "eslint --format stylish --ext .jsx --ext .js srcCordova/js",
@@ -80,8 +80,8 @@
     "wdio-chromedriver-service": "^7.3.2",
     "webpack": "^5.32.0",
     "webpack-bundle-analyzer": "^4.4.0",
-    "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.7.3",
+    "webpack-cli": "^5.0.1",
+    "webpack-dev-server": "^4.11.1",
     "webpack-shell-plugin-next": "^2.2.2"
   },
   "dependencies": {


### PR DESCRIPTION
Make 'npm run build' minimize css files, like 'npm run prod' already does.

Unrelated to issue, upgrade to Webpack 5.
