### PR TITLE
Added maximum email length requirement in validateEmail function

### DIFF
--- a/src/js/utils/regex-checks.js
+++ b/src/js/utils/regex-checks.js
@@ -3,8 +3,12 @@
 
 export function validateEmail (email) {
   const trimmedEmail = email ? email.trim() : '';
-  const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  return re.test(trimmedEmail);
+  if (trimmedEmail.length < 6 || trimmedEmail.length > 254) {
+    return false;
+  } else {
+    const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+    return re.test(trimmedEmail);
+  }
 }
 
 export function validatePhoneOrEmail (contactInfo) {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Now the User can only enter the email address which is 6 to 254 characters long.

### Changes included this pull request?
Added 254 character maximum email address length to validateEmail function in WebApp/src/js/utils/regex-checks.js
