### PR TITLE
Not triggering sign in modal until the third ballot choice, or the third topic choice. (13% of people who clicked a ballot choice or topic choice in the first minute, left after seeing the modal. We want to give people more time with the product before asking for sign in.) Wove districtName into OfficeNameText. Fixed some display logic on CampaignsHome page, including properly filtering by year. In ItemActionBar, added "Support" language for when a politician is not currently running for office.

### DIFF
--- a/src/js/actions/CandidateActions.js
+++ b/src/js/actions/CandidateActions.js
@@ -11,6 +11,7 @@ export default {
   candidatesQuery (electionDay = '', raceOfficeLevelList = '', stateCode = '', searchText = '') {
     Dispatcher.loadEndpoint('candidatesQuery',
       {
+        numberRequested: 50,
         electionDay,
         raceOfficeLevelList,
         searchText,

--- a/src/js/actions/RepresentativeActions.js
+++ b/src/js/actions/RepresentativeActions.js
@@ -12,6 +12,7 @@ export default {
     Dispatcher.loadEndpoint('representativesQuery',
       {
         index_start: indexStart,
+        number_requested: 50,
         race_office_level_list: raceOfficeLevelList,
         search_text: searchText,
         state: stateCode,

--- a/src/js/actions/VoterSessionActions.js
+++ b/src/js/actions/VoterSessionActions.js
@@ -17,8 +17,17 @@ export default {
     Cookies.remove('location_guess_closed');
     Cookies.remove('location_guess_closed', { path: '/' });
     Cookies.remove('location_guess_closed', { path: '/', domain: 'wevote.us' });
+    Cookies.remove('number_of_ballot_choices_made');
+    Cookies.remove('number_of_ballot_choices_made', { path: '/' });
+    Cookies.remove('number_of_ballot_choices_made', { path: '/', domain: 'wevote.us' });
+    Cookies.remove('number_of_topic_choices_made');
+    Cookies.remove('number_of_topic_choices_made', { path: '/' });
+    Cookies.remove('number_of_topic_choices_made', { path: '/', domain: 'wevote.us' });
     Cookies.remove('show_full_navigation');
     Cookies.remove('show_full_navigation', { path: '/' });
+    Cookies.remove('sign_in_opened_from_issue_follow');
+    Cookies.remove('sign_in_opened_from_issue_follow', { path: '/' });
+    Cookies.remove('sign_in_opened_from_issue_follow', { path: '/', domain: 'wevote.us' });
     Cookies.remove('sign_in_start_full_url', { path: '/' });
     Cookies.remove('sign_in_start_full_url', { path: '/', domain: 'wevote.us' });
   },

--- a/src/js/common/components/Style/CampaignCardStyles.jsx
+++ b/src/js/common/components/Style/CampaignCardStyles.jsx
@@ -108,6 +108,7 @@ export const OneCampaignOuterWrapper = styled('div', {
   shouldForwardProp: (prop) => !['limitCardWidth'].includes(prop),
 })(({ limitCardWidth, theme }) => (`
   ${limitCardWidth ? 'margin-right: 15px;' : 'margin-bottom: 15px;'}
+  ${limitCardWidth ? 'height: 400px;' : ''}
   // border-top: 1px solid #ddd;
   // margin-top: 15px;
   ${theme.breakpoints.up('sm')} {

--- a/src/js/common/components/Widgets/OfficeHeldNameText.jsx
+++ b/src/js/common/components/Widgets/OfficeHeldNameText.jsx
@@ -2,30 +2,37 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
+import adjustDistrictNameAndOfficeName from '../../utils/adjustDistrictNameAndOfficeName';
 import { renderLog } from '../../utils/logging';
+import toTitleCase from '../../utils/toTitleCase';
+
+function isAllUpperCase (str) {
+  return str === str.toUpperCase();
+}
 
 // React functional component example
 export default function OfficeHeldNameText (props) {
   renderLog('OfficeHeldNameText');  // Set LOG_RENDER_EVENTS to log all renders
-  let nameText = '';
-  let { districtName, officeHeldName } = props; // Mar 2023: Turning off officeLink until we can do design review
-  if (officeHeldName && officeHeldName.includes(districtName)) {
-    // This removes districtName in cases like 'Governor of California for California'
-    districtName = '';
-  } else if (districtName && districtName.includes(officeHeldName)) {
-    // This removes officeHeldName: 'Alcorn County Supervisor' with districtName: 'Alcorn County Supervisor District 2'
-    officeHeldName = '';
-  } else if (districtName && districtName.endsWith(' city')) {
-    const districtNameWithoutCity = districtName.slice(0, districtName.length - 5);
-    if (officeHeldName && officeHeldName.includes(districtNameWithoutCity)) {
-      // This removes districtName in cases like officeHeldName: 'Mayor of Los Angeles' with districtName: 'Los Angeles city'
-      districtName = '';
-    }
+  let districtNameFiltered;
+  let nameHtml;
+  let officeNameFiltered;
+  const { districtName: incomingDistrictName, officeName: incomingOfficeHeldName } = props; // Mar 2023: Turning off officeLink until we can do design review
+  if (isAllUpperCase(incomingDistrictName)) {
+    districtNameFiltered = toTitleCase(incomingDistrictName);
+  } else {
+    districtNameFiltered = incomingDistrictName;
   }
+  if (isAllUpperCase(incomingOfficeHeldName)) {
+    officeNameFiltered = toTitleCase(incomingOfficeHeldName);
+  } else {
+    officeNameFiltered = incomingOfficeHeldName;
+  }
+  const { districtName, officeName } = adjustDistrictNameAndOfficeName(districtNameFiltered, officeNameFiltered);
+  // console.log('districtName: ', districtName, 'officeName: ', officeName);
   const officeLink = null;
   if (districtName) {
-    if (officeHeldName === undefined) {
-      nameText = (
+    if (officeName === undefined) {
+      nameHtml = (
         <NoPoliticalPartySpan>
           <span>Representative for </span>
           {officeLink ? (
@@ -36,10 +43,10 @@ export default function OfficeHeldNameText (props) {
         </NoPoliticalPartySpan>
       );
     } else {
-      nameText = (
+      nameHtml = (
         <PartyAndOfficeWrapper>
           <span className="u-gray-darker">
-            {officeHeldName}
+            {officeName}
             {' '}
           </span>
           <span>for </span>
@@ -52,28 +59,28 @@ export default function OfficeHeldNameText (props) {
       );
     }
   } else {
-    nameText = (
+    nameHtml = (
       <PartyAndYearWrapper>
         <span className="u-gray-darker">
-          {officeHeldName}
+          {officeName}
         </span>
       </PartyAndYearWrapper>
     );
   }
 
-  return nameText;
+  return nameHtml;
 }
 OfficeHeldNameText.propTypes = {
-  officeHeldName: PropTypes.string,
-  // officeLink: PropTypes.string,
   districtName: PropTypes.string,
+  officeName: PropTypes.string,
+  // officeLink: PropTypes.string,
 };
-
-const NoPoliticalPartySpan = styled('span')`
-`;
 
 const DistrictNameSpan = styled('span')`
   color: #333;
+`;
+
+const NoPoliticalPartySpan = styled('span')`
 `;
 
 const PartyAndYearWrapper = styled('div')`

--- a/src/js/common/components/Widgets/OfficeNameText.jsx
+++ b/src/js/common/components/Widgets/OfficeNameText.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import YearState from './YearState';
+import adjustDistrictNameAndOfficeName from '../../utils/adjustDistrictNameAndOfficeName';
 import { renderLog } from '../../utils/logging';
 import toTitleCase from '../../utils/toTitleCase';
 
@@ -13,28 +14,78 @@ function isAllUpperCase (str) {
 // React functional component example
 export default function OfficeNameText (props) {
   renderLog('OfficeNameText');  // Set LOG_RENDER_EVENTS to log all renders
-  let nameText;
+  let districtNameFiltered;
+  let nameHtml;
+  let officeAndDistrictHtml;
+  let officeNameFiltered;
   const { politicalParty, showOfficeName, stateName, year } = props; // officeLink, // Dec 2022: Turning off officeLink until we can do design review
-  let { officeName } = props;
-  const officeLink = null;
-  if (isAllUpperCase(officeName)) {
-    officeName = toTitleCase(officeName);
+  const { districtName: incomingDistrictName, officeName: incomingOfficeName } = props; // Mar 2023: Turning off officeLink until we can do design review
+  if (isAllUpperCase(incomingDistrictName)) {
+    districtNameFiltered = toTitleCase(incomingDistrictName);
+  } else {
+    districtNameFiltered = incomingDistrictName;
   }
+  if (isAllUpperCase(incomingOfficeName)) {
+    officeNameFiltered = toTitleCase(incomingOfficeName);
+  } else {
+    officeNameFiltered = incomingOfficeName;
+  }
+  const { districtName, officeName } = adjustDistrictNameAndOfficeName(districtNameFiltered, officeNameFiltered);
+  // console.log('districtName: ', districtName, 'officeName: ', officeName);
+  const officeLink = null;
+  if (districtName) {
+    if (officeName === undefined) {
+      officeAndDistrictHtml = (
+        <NoPoliticalPartySpan>
+          <span>Representative for </span>
+          {officeLink ? (
+            <Link to={officeLink}>
+              <DistrictNameSpan>{districtName}</DistrictNameSpan>
+            </Link>
+          ) : <DistrictNameSpan>{districtName}</DistrictNameSpan>}
+        </NoPoliticalPartySpan>
+      );
+    } else {
+      officeAndDistrictHtml = (
+        <OfficeAndDistrictSpan>
+          <span className="u-gray-darker">
+            {officeName}
+            ,
+            {' '}
+          </span>
+          {officeLink ? (
+            <Link id="officeNameTextContestOfficeName" to={officeLink}>
+              <DistrictNameSpan>{districtName}</DistrictNameSpan>
+            </Link>
+          ) : <DistrictNameSpan>{districtName}</DistrictNameSpan>}
+        </OfficeAndDistrictSpan>
+      );
+    }
+  } else {
+    officeAndDistrictHtml = (
+      <PartyAndYearWrapper>
+        <span className="u-gray-darker">
+          {officeName}
+        </span>
+      </PartyAndYearWrapper>
+    );
+  }
+
   if (showOfficeName) {
     if (politicalParty === undefined || politicalParty === '') {
-      nameText = (
+      nameHtml = (
         <NoPoliticalPartyWrapper>
           <span>Candidate for </span>
           {officeLink ? (
             <Link to={officeLink}>
-              <OfficeNameSpan>{officeName}</OfficeNameSpan>
+              <OfficeNameSpan>{officeAndDistrictHtml}</OfficeNameSpan>
             </Link>
-          ) : <OfficeNameSpan>{officeName}</OfficeNameSpan>}
+          ) : <OfficeNameSpan>{officeAndDistrictHtml}</OfficeNameSpan>}
           <YearState year={year} stateName={stateName} />
         </NoPoliticalPartyWrapper>
       );
     } else {
-      nameText = (
+      nameHtml = (
         <PartyAndOfficeWrapper>
           <span className="u-bold u-gray-darker">
             {politicalParty}
@@ -43,15 +94,15 @@ export default function OfficeNameText (props) {
           <span>candidate for </span>
           {officeLink ? (
             <Link id="officeNameTextContestOfficeName" to={officeLink}>
-              <OfficeNameSpan>{officeName}</OfficeNameSpan>
+              <OfficeNameSpan>{officeAndDistrictHtml}</OfficeNameSpan>
             </Link>
-          ) : <OfficeNameSpan>{officeName}</OfficeNameSpan>}
+          ) : <OfficeNameSpan>{officeAndDistrictHtml}</OfficeNameSpan>}
           <YearState year={year} stateName={stateName} />
         </PartyAndOfficeWrapper>
       );
     }
   } else {
-    nameText = (
+    nameHtml = (
       <PartyAndYearWrapper>
         <span className="u-gray-darker">
           {politicalParty}
@@ -61,9 +112,10 @@ export default function OfficeNameText (props) {
     );
   }
 
-  return nameText;
+  return nameHtml;
 }
 OfficeNameText.propTypes = {
+  districtName: PropTypes.string,
   officeName: PropTypes.string,
   // officeLink: PropTypes.string,
   politicalParty: PropTypes.string,
@@ -72,8 +124,19 @@ OfficeNameText.propTypes = {
   year: PropTypes.string,
 };
 
+const DistrictNameSpan = styled('span')`
+  color: #333;
+  font-weight: 600;
+`;
+
+const NoPoliticalPartySpan = styled('span')`
+`;
+
 const NoPoliticalPartyWrapper = styled('div')`
   line-height: 1.2;
+`;
+
+const OfficeAndDistrictSpan = styled('span')`
 `;
 
 const OfficeNameSpan = styled('span')`

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -424,6 +424,7 @@ class PoliticianDetailsPage extends Component {
     let priorCandidateCampaignsHtml = '';
     if (candidateCampaignList && candidateCampaignList.length > 0) {
       let contestOfficeName;
+      let districtName;
       let year;
       const yearsAndNamesAlreadySeen = [];
       const candidateCampaignListFiltered = candidateCampaignList.filter((candidateCampaign) => {
@@ -452,12 +453,16 @@ class PoliticianDetailsPage extends Component {
             contestOfficeName = candidateCampaign.contest_office_list[0].contest_office_name;
           }
         }
+        if (candidateCampaign.contest_office_list) {
+          districtName = candidateCampaign.contest_office_list[0].district_name;
+        }
         const showOfficeName = !!(contestOfficeName);
         const stateName = convertStateCodeToStateText(candidateCampaign.state_code);
         year = getYearFromUltimateElectionDate(candidateCampaign.candidate_ultimate_election_date);
         return (
           <CandidateCampaignWrapper key={key}>
             <OfficeNameText
+              districtName={districtName}
               officeName={contestOfficeName}
               politicalParty={candidateCampaign.party}
               showOfficeName={showOfficeName}
@@ -533,7 +538,7 @@ class PoliticianDetailsPage extends Component {
                     <OfficeHeldNameText
                       districtName={officeHeld.district_name}
                       key={officeHeld.office_held_we_vote_id}
-                      officeHeldName={officeHeld.office_held_name}
+                      officeName={officeHeld.office_held_name}
                     />
                   ))}
                 </OfficeHeldNameMobile>
@@ -629,7 +634,7 @@ class PoliticianDetailsPage extends Component {
                     <OfficeHeldNameText
                       districtName={officeHeld.district_name}
                       key={officeHeld.office_held_we_vote_id}
-                      officeHeldName={officeHeld.office_held_name}
+                      officeName={officeHeld.office_held_name}
                     />
                   ))}
                 </OfficeHeldNameDesktop>

--- a/src/js/common/utils/adjustDistrictNameAndOfficeName.js
+++ b/src/js/common/utils/adjustDistrictNameAndOfficeName.js
@@ -1,0 +1,20 @@
+// adjustDistrictNameAndOfficeName.js
+
+export default function adjustDistrictNameAndOfficeName (districtNameIncoming, officeNameIncoming) {
+  let districtName = districtNameIncoming;
+  let officeName = officeNameIncoming;
+  if (officeName && officeName.includes(districtName)) {
+    // This removes districtName in cases like 'Governor of California for California'
+    districtName = '';
+  } else if (districtName && districtName.includes(officeName)) {
+    // This removes officeName: 'Alcorn County Supervisor' with districtName: 'Alcorn County Supervisor District 2'
+    officeName = '';
+  } else if (districtName && districtName.endsWith(' city')) {
+    const districtNameWithoutCity = districtName.slice(0, districtName.length - 5);
+    if (officeName && officeName.includes(districtNameWithoutCity)) {
+      // This removes districtName in cases like officeName: 'Mayor of Los Angeles' with districtName: 'Los Angeles city'
+      districtName = '';
+    }
+  }
+  return { districtName, officeName };
+}

--- a/src/js/common/utils/dateFormat.js
+++ b/src/js/common/utils/dateFormat.js
@@ -62,6 +62,21 @@ export function getTodayAsInteger (daysInPast = 0) {
   return convertToInteger(dateAsString);
 }
 
+export function isThisYearInOfficeSetTrue (year, representative) {
+  const yearInOfficeKey = `year_in_office_${year}`;
+  // console.log('yearInOfficeKey: ', yearInOfficeKey);
+  return ((yearInOfficeKey in representative) && representative[yearInOfficeKey]);
+}
+
+export function isAnyYearInOfficeSetTrue (yearList, representative) {
+  for (let i = 0; i < yearList.length; i += 1) {
+    if (isThisYearInOfficeSetTrue(yearList[i], representative)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function getYearFromUltimateElectionDate (ultimateElectionDate) {
   if (ultimateElectionDate) {
     const tempYear = String(ultimateElectionDate).slice(0, 4);

--- a/src/js/components/CandidateListRoot/CandidateCardForList.jsx
+++ b/src/js/components/CandidateListRoot/CandidateCardForList.jsx
@@ -253,11 +253,13 @@ class CandidateCardForList extends Component {
       candidate_photo_url_large: candidatePhotoLargeUrl,
       candidate_ultimate_election_date: candidateUltimateElectionDate,
       contest_office_name: contestOfficeName,
+      contest_office_list: contestOfficeList,
       // in_draft_mode: inDraftMode,
       // is_blocked_by_we_vote: isBlockedByWeVote,
       // is_in_team_review_mode: isInTeamReviewMode,
       // is_supporters_count_minimum_exceeded: isSupportersCountMinimumExceeded,
       party: politicalParty,
+      politician_we_vote_id: politicianWeVoteId,
       state_code: stateCode,
       supporters_count: supportersCount,
       supporters_count_next_goal: supportersCountNextGoal,
@@ -269,6 +271,10 @@ class CandidateCardForList extends Component {
     if (!candidateWeVoteId) {
       return null;
     }
+    let districtName;
+    if (contestOfficeList) {
+      districtName = contestOfficeList[0].district_name;
+    }
     const stateName = convertStateCodeToStateText(stateCode);
     const year = getYearFromUltimateElectionDate(candidateUltimateElectionDate);
     const todayAsInteger = getTodayAsInteger();
@@ -278,7 +284,7 @@ class CandidateCardForList extends Component {
         <OneCampaignOuterWrapper limitCardWidth={limitCardWidth}>
           <OneCampaignInnerWrapper limitCardWidth={limitCardWidth || isMobileScreenSize()}>
             <OneCampaignTextColumn>
-              <div>
+              <TitleAndTextWrapper>
                 <OneCampaignTitle>
                   <Link to={this.getCandidateBasePath()}>
                     {ballotItemDisplayName}
@@ -288,6 +294,7 @@ class CandidateCardForList extends Component {
                   <div className="u-cursor--pointer" onClick={this.onCandidateClick}>
                     <Suspense fallback={<></>}>
                       <OfficeNameText
+                        districtName={districtName}
                         officeName={contestOfficeName}
                         politicalParty={politicalParty}
                         showOfficeName
@@ -358,21 +365,21 @@ class CandidateCardForList extends Component {
                   <CampaignOwnersList campaignXWeVoteId={campaignXWeVoteId} compressedMode />
                 </CampaignOwnersWrapper>
                 */}
-              </div>
-              {/*
-              <IndicatorRow>
-                {finalElectionDateInPast && (
-                  <IndicatorButtonWrapper>
-                    <ElectionInPast>
-                      Election in Past
-                    </ElectionInPast>
-                  </IndicatorButtonWrapper>
-                )}
-              </IndicatorRow>
-              */}
-              {!finalElectionDateInPast && (
-                <ItemActionBarOutsideWrapper>
-                  <Suspense fallback={<></>}>
+              </TitleAndTextWrapper>
+              <ItemActionBarOutsideWrapper>
+                <Suspense fallback={<></>}>
+                  {finalElectionDateInPast ? (
+                    <ItemActionBar
+                      ballotItemWeVoteId={politicianWeVoteId}
+                      ballotItemDisplayName={ballotItemDisplayName}
+                      commentButtonHide
+                      // externalUniqueId={`CandidateCardForList-ItemActionBar-${oneCandidate.we_vote_id}-${externalUniqueId}`}
+                      hidePositionPublicToggle
+                      positionPublicToggleWrapAllowed
+                      shareButtonHide
+                      useSupportWording
+                    />
+                  ) : (
                     <ItemActionBar
                       ballotItemWeVoteId={candidateWeVoteId}
                       ballotItemDisplayName={ballotItemDisplayName}
@@ -382,9 +389,9 @@ class CandidateCardForList extends Component {
                       positionPublicToggleWrapAllowed
                       shareButtonHide
                     />
-                  </Suspense>
-                </ItemActionBarOutsideWrapper>
-              )}
+                  )}
+                </Suspense>
+              </ItemActionBarOutsideWrapper>
             </OneCampaignTextColumn>
             <OneCampaignPhotoWrapperMobile className="u-cursor--pointer u-show-mobile" onClick={this.onCandidateClick}>
               {candidatePhotoLargeUrl ? (
@@ -443,12 +450,17 @@ const styles = (theme) => ({
 });
 
 const ItemActionBarOutsideWrapper = styled('div')`
-  display: flex;
+  align-items: flex-end;
   cursor: pointer;
+  display: flex;
   flex-direction: row;
-  justify-content: flex-start;
-  margin-top: 12px;
+  height: 166px;
+  justify-content: center;
   width: 100%;
+`;
+
+const TitleAndTextWrapper = styled('div')`
+  height: 60px;
 `;
 
 export default withStyles(styles)(CandidateCardForList);

--- a/src/js/components/CandidateListRoot/CandidateListRoot.jsx
+++ b/src/js/components/CandidateListRoot/CandidateListRoot.jsx
@@ -26,7 +26,20 @@ class CandidateListRoot extends Component {
   componentDidMount () {
     // console.log('CandidateListRoot componentDidMount');
     this.candidateStoreListener = CandidateStore.addListener(this.onCandidateStoreChange.bind(this));
-    this.onIncomingListChange();
+    const { incomingList } = this.props;
+    // console.log('CandidateListRoot componentDidMount incomingList:', incomingList);
+    if (incomingList) {
+      const filteredCandidateList = [];
+      incomingList.forEach((oneCandidate) => {
+        if (oneCandidate.id && oneCandidate.id > 0) {
+          filteredCandidateList.push(oneCandidate);
+        }
+      });
+      // console.log('CandidateListRoot candidateList with id > 0:', filteredCandidateList);
+      this.setState({
+        candidateList: filteredCandidateList,
+      }, () => this.onFilterOrListChange());
+    }
   }
 
   componentDidUpdate (prevProps) {
@@ -112,7 +125,7 @@ class CandidateListRoot extends Component {
     // Start over with full list, and apply all active filters
     const { listModeFilters, searchText, stateCode } = this.props;
     const { candidateList } = this.state;
-    // console.log('candidateList:', candidateList);
+    // console.log('CandidateListRoot onFilterOrListChange candidateList:', candidateList);
     let candidateAlreadyFoundThisYear = false;
     const candidateDisplayedThisYear = {};
     let filteredCandidateList = candidateList;
@@ -176,6 +189,7 @@ class CandidateListRoot extends Component {
         filteredCandidateListModified.push(modifiedCandidate);
       }
     });
+    // console.log('CandidateListRoot onFilterOrListChange filteredCandidateListModified:', filteredCandidateListModified);
     filteredCandidateList = filteredCandidateListModified;
     // //////////////////////
     // Now filter candidates
@@ -268,6 +282,7 @@ class CandidateListRoot extends Component {
         return null;
       }
     }
+    // console.log('CandidateListRoot actually rendering hideDisplayBecauseNoSearchResults', hideDisplayBecauseNoSearchResults);
     return (
       <CandidateListWrapper>
         {!!(!hideTitle &&

--- a/src/js/components/Ready/ElectionCountdown.jsx
+++ b/src/js/components/Ready/ElectionCountdown.jsx
@@ -164,7 +164,9 @@ class ElectionCountdown extends React.Component {
       <CardCountdownInternalWrapper>
         <div>
           <CardTitleUpcoming
-          className="u-cursor--pointer" onClick={() => this.onClickFunctionLocal()}>
+            className="u-cursor--pointer"
+            onClick={() => this.onClickFunctionLocal()}
+          >
             {daysUntilNextElection ? (
               <>
                 {daysUntilNextElection}
@@ -282,7 +284,7 @@ class ElectionCountdown extends React.Component {
       </CardCountdownInternalWrapper>
     );
 
-    let htmlToShow = <></>;
+    let htmlToShow;
     if (electionIsToday) {
       htmlToShow = electionIsTodayHtml;
     } else if (electionInPast || !daysUntilNextElection || daysUntilNextElection < 0) {

--- a/src/js/components/RepresentativeListRoot/RepresentativeCardForList.jsx
+++ b/src/js/components/RepresentativeListRoot/RepresentativeCardForList.jsx
@@ -4,14 +4,14 @@ import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import TruncateMarkup from 'react-truncate-markup';
 import styled from 'styled-components';
-import { convertStateCodeToStateText } from '../../common/utils/addressFunctions';
+// import { convertStateCodeToStateText } from '../../common/utils/addressFunctions';
 import {
   CampaignImageMobile, CampaignImagePlaceholderText, CampaignImageMobilePlaceholder, CampaignImageDesktopPlaceholder, CampaignImageDesktop,
   CandidateCardForListWrapper,
   OneCampaignPhotoWrapperMobile, OneCampaignPhotoDesktopColumn, OneCampaignTitle, OneCampaignOuterWrapper, OneCampaignTextColumn, OneCampaignInnerWrapper, OneCampaignDescription,
   SupportersWrapper, SupportersCount, SupportersActionLink,
 } from '../../common/components/Style/CampaignCardStyles';
-import { getTodayAsInteger, getYearFromUltimateElectionDate } from '../../common/utils/dateFormat';
+import { getTodayAsInteger } from '../../common/utils/dateFormat';
 import historyPush from '../../common/utils/historyPush';
 import { renderLog } from '../../common/utils/logging';
 import RepresentativeStore from '../../stores/RepresentativeStore';
@@ -22,7 +22,7 @@ import numberWithCommas from '../../common/utils/numberWithCommas';
 // import { ElectionInPast, IndicatorButtonWrapper, IndicatorRow } from '../../common/components/Style/CampaignIndicatorStyles';
 
 const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ '../Widgets/ItemActionBar/ItemActionBar'));
-const OfficeNameText = React.lazy(() => import(/* webpackChunkName: 'OfficeNameText' */ '../../common/components/Widgets/OfficeNameText'));
+const OfficeHeldNameText = React.lazy(() => import(/* webpackChunkName: 'OfficeHeldNameText' */ '../../common/components/Widgets/OfficeHeldNameText'));
 // const SupportButtonBeforeCompletionScreen = React.lazy(() => import(/* webpackChunkName: 'SupportButtonBeforeCompletionScreen' */ '../../common/components/CampaignSupport/SupportButtonBeforeCompletionScreen'));
 
 class RepresentativeCardForList extends Component {
@@ -249,14 +249,16 @@ class RepresentativeCardForList extends Component {
       ballot_item_display_name: ballotItemDisplayName,
       representative_photo_url_large: representativePhotoLargeUrl,
       representative_ultimate_election_date: representativeUltimateElectionDate,
-      contest_office_name: contestOfficeName,
+      office_held_name: officeHeldName,
+      office_held_district_name: districtName,
       // in_draft_mode: inDraftMode,
       // is_blocked_by_we_vote: isBlockedByWeVote,
       // is_in_team_review_mode: isInTeamReviewMode,
       // is_supporters_count_minimum_exceeded: isSupportersCountMinimumExceeded,
-      party: politicalParty,
+      political_party: politicalParty,
+      politician_we_vote_id: politicianWeVoteId,
       // seo_friendly_path: politicianSEOFriendlyPath,
-      state_code: stateCode,
+      // state_code: stateCode,
       supporters_count: supportersCount,
       supporters_count_next_goal: supportersCountNextGoal,
       twitter_description: twitterDescription,
@@ -267,8 +269,8 @@ class RepresentativeCardForList extends Component {
     if (!representativeWeVoteId) {
       return null;
     }
-    const stateName = convertStateCodeToStateText(stateCode);
-    const year = getYearFromUltimateElectionDate(representativeUltimateElectionDate);
+    // const stateName = convertStateCodeToStateText(stateCode);
+    // const year = getYearFromUltimateElectionDate(representativeUltimateElectionDate);
     const todayAsInteger = getTodayAsInteger();
     const finalElectionDateInPast = representativeUltimateElectionDate && (representativeUltimateElectionDate <= todayAsInteger);
     return (
@@ -276,21 +278,18 @@ class RepresentativeCardForList extends Component {
         <OneCampaignOuterWrapper limitCardWidth={limitCardWidth}>
           <OneCampaignInnerWrapper limitCardWidth={limitCardWidth || isMobileScreenSize()}>
             <OneCampaignTextColumn>
-              <div>
+              <TitleAndTextWrapper>
                 <OneCampaignTitle>
                   <Link to={this.getRepresentativeBasePath()}>
                     {ballotItemDisplayName}
                   </Link>
                 </OneCampaignTitle>
-                {(contestOfficeName || politicalParty) && (
+                {(officeHeldName || politicalParty) && (
                   <div className="u-cursor--pointer" onClick={this.onRepresentativeClick}>
                     <Suspense fallback={<></>}>
-                      <OfficeNameText
-                        officeName={contestOfficeName}
-                        politicalParty={politicalParty}
-                        showOfficeName
-                        stateName={stateName}
-                        year={`${year}`}
+                      <OfficeHeldNameText
+                        districtName={districtName}
+                        officeName={officeHeldName}
                       />
                     </Suspense>
                   </div>
@@ -356,33 +355,21 @@ class RepresentativeCardForList extends Component {
                   <CampaignOwnersList campaignXWeVoteId={campaignXWeVoteId} compressedMode />
                 </CampaignOwnersWrapper>
                 */}
-              </div>
-              {/*
-              <IndicatorRow>
-                {finalElectionDateInPast && (
-                  <IndicatorButtonWrapper>
-                    <ElectionInPast>
-                      Election in Past
-                    </ElectionInPast>
-                  </IndicatorButtonWrapper>
-                )}
-              </IndicatorRow>
-              */}
-              {!finalElectionDateInPast && (
-                <ItemActionBarOutsideWrapper>
-                  <Suspense fallback={<></>}>
-                    <ItemActionBar
-                      ballotItemWeVoteId={representativeWeVoteId}
-                      ballotItemDisplayName={ballotItemDisplayName}
-                      commentButtonHide
-                      // externalUniqueId={`RepresentativeCardForList-ItemActionBar-${oneRepresentative.we_vote_id}-${externalUniqueId}`}
-                      hidePositionPublicToggle
-                      positionPublicToggleWrapAllowed
-                      shareButtonHide
-                    />
-                  </Suspense>
-                </ItemActionBarOutsideWrapper>
-              )}
+              </TitleAndTextWrapper>
+              <ItemActionBarOutsideWrapper>
+                <Suspense fallback={<></>}>
+                  <ItemActionBar
+                    ballotItemWeVoteId={politicianWeVoteId}
+                    ballotItemDisplayName={ballotItemDisplayName}
+                    commentButtonHide
+                    // externalUniqueId={`RepresentativeCardForList-ItemActionBar-${oneRepresentative.we_vote_id}-${externalUniqueId}`}
+                    hidePositionPublicToggle
+                    positionPublicToggleWrapAllowed
+                    shareButtonHide
+                    useSupportWording
+                  />
+                </Suspense>
+              </ItemActionBarOutsideWrapper>
             </OneCampaignTextColumn>
             <OneCampaignPhotoWrapperMobile className="u-cursor--pointer u-show-mobile" onClick={this.onRepresentativeClick}>
               {representativePhotoLargeUrl ? (
@@ -437,12 +424,17 @@ const styles = (theme) => ({
 });
 
 const ItemActionBarOutsideWrapper = styled('div')`
-  display: flex;
+  align-items: flex-end;
   cursor: pointer;
+  display: flex;
   flex-direction: row;
-  justify-content: flex-start;
-  margin-top: 12px;
+  height: 166px;
+  justify-content: center;
   width: 100%;
+`;
+
+const TitleAndTextWrapper = styled('div')`
+  height: 60px;
 `;
 
 export default withStyles(styles)(RepresentativeCardForList);

--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -12,7 +12,7 @@ import { renderLog } from '../../common/utils/logging';
 import IssueStore from '../../stores/IssueStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
-import { convertNameToSlug } from '../../common/utils/textFormat';
+import { convertNameToSlug, convertToInteger } from '../../common/utils/textFormat';
 import IssueFollowToggleButton from './IssueFollowToggleButton';
 import IssueImageDisplay from './IssueImageDisplay';
 
@@ -21,6 +21,7 @@ const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' *
 
 const NUMBER_OF_LINKED_ORGANIZATION_IMAGES_TO_SHOW = 3; // Maximum available coming from issueDescriptionsRetrieve is currently 5
 const NUMBER_OF_LINKED_ORGANIZATION_NAMES_TO_SHOW = 10;
+const NUMBER_OF_TOPIC_CHOICES_ALLOWED_BEFORE_SHOW_MODAL = 3;
 
 class IssueCard extends Component {
   constructor (props) {
@@ -119,7 +120,12 @@ class IssueCard extends Component {
 
   onIssueFollowClick = () => {
     const signInOpenedFromPreviousIssueFollow = Cookies.get('sign_in_opened_from_issue_follow') || 0;
-    if (!signInOpenedFromPreviousIssueFollow) {
+    // const signInOpenedFromPreviousIssueFollow = false; // For testing
+    let numberOfTopicChoicesMade = convertToInteger(Cookies.get('number_of_topic_choices_made')) || 0;
+    numberOfTopicChoicesMade += 1;
+    // console.log('numberOfTopicChoicesMade', numberOfTopicChoicesMade);
+    Cookies.set('number_of_topic_choices_made', numberOfTopicChoicesMade, { expires: 1, path: '/' });
+    if (!signInOpenedFromPreviousIssueFollow && numberOfTopicChoicesMade >= NUMBER_OF_TOPIC_CHOICES_ALLOWED_BEFORE_SHOW_MODAL) {
       Cookies.set('sign_in_opened_from_issue_follow', '1', { expires: 1, path: '/' });
       this.toggleShowSignInModal();
     }

--- a/src/js/constants/OfficeHeldConstants.js
+++ b/src/js/constants/OfficeHeldConstants.js
@@ -1,0 +1,9 @@
+// import keyMirror from 'keymirror';
+//
+// const OfficeHeldConstants = {
+//   OFFICE_HELD_YEARS_AVAILABLE: [2023, 2024, 2025, 2026],
+// };
+//
+// export default keyMirror(OfficeHeldConstants);
+
+// export const OFFICE_HELD_YEARS_AVAILABLE = [2023, 2024, 2025, 2026]; // Mirrors constant of same name from WeVoteServer


### PR DESCRIPTION
Not triggering sign in modal until the third ballot choice, or the third topic choice. (13% of people who clicked a ballot choice or topic choice in the first minute, left after seeing the modal. We want to give people more time with the product before asking for sign in.) Wove districtName into OfficeNameText. Fixed some display logic on CampaignsHome page, including properly filtering by year. In ItemActionBar, added "Support" language for when a politician is not currently running for office.