### PR TITLE
Updated 'Show your support' button language to 'Help them win by endorsing'. Added getPoliticianBasePath distinct from getCampaignBasePath. Did navigation (Campaign top nav) cleanup, including jumping back to Politician page from Campaign pages for linked campaigns. Refactored the CampaignListRoot, CandidateListRoot and RepresentativeListRoot to use more generic internal variables, so we can compare those files and more easily see the significant differences. Updated the CampaignsHome to remove filters by year.

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,6 +44,7 @@ const CampaignUpdatesPage = React.lazy(() => import(/* webpackChunkName: 'Campai
 const Candidate = React.lazy(() => import(/* webpackChunkName: 'Candidate' */ './js/pages/Ballot/Candidate'));
 const CandidateForExtension = React.lazy(() => import(/* webpackChunkName: 'EditCandidateForExtension' */ './js/pages/Ballot/EditCandidateForExtension/EditCandidateForExtension'));
 const ClaimYourPage = React.lazy(() => import(/* webpackChunkName: 'ClaimYourPage' */ './js/pages/Settings/ClaimYourPage'));
+const CompleteYourProfileMobile = React.lazy(() => import(/* webpackChunkName: 'CompleteYourProfileMobile' */ './js/common/pages/Settings/CompleteYourProfileMobile'));
 const Credits = React.lazy(() => import(/* webpackChunkName: 'Credits' */ './js/pages/More/Credits'));
 const Donate = React.lazy(() => import(/* webpackChunkName: 'Donate' */ './js/pages/More/Donate'));
 const ElectionReminder = React.lazy(() => import(/* webpackChunkName: 'ElectionReminder' */ './js/pages/More/ElectionReminder'));
@@ -358,6 +359,8 @@ class App extends Component {
                     <Route exact path="/c/:campaignSEOFriendlyPath" render={(props) => <CampaignDetailsPage match={props.match} />} />
                     <Route exact path="/c/:campaignSEOFriendlyPath/comments" render={(props) => <CampaignCommentsPage match={props.match} />} />
                     <Route exact path="/c/:campaignSEOFriendlyPath/i-will-share-campaign" render={(props) => <CampaignSupportShare match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} iWillShare />} />
+                    <Route exact path="/c/:campaignSEOFriendlyPath/complete-your-profile-for-news-item" render={(props) => <CompleteYourProfileMobile match={props.match} createNewsItem setShowHeaderFooter={this.setShowHeaderFooter} />} />
+                    <Route exact path="/c/:campaignSEOFriendlyPath/complete-your-support-for-this-campaign" render={(props) => <CompleteYourProfileMobile match={props.match} supportCampaign setShowHeaderFooter={this.setShowHeaderFooter} />} />
                     <Route exact path="/c/:campaignSEOFriendlyPath/pay-to-promote" render={(props) => <CampaignSupportPayToPromote match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} />} />
                     <Route exact path="/c/:campaignSEOFriendlyPath/pay-to-promote-process" render={(props) => <CampaignSupportPayToPromoteProcess match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} />} />
                     <Route exact path="/c/:campaignSEOFriendlyPath/recommended-campaigns" render={(props) => <CampaignRecommendedCampaigns match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} />} />
@@ -398,6 +401,8 @@ class App extends Component {
                     <Route exact path="/id/:campaignXWeVoteId" render={(props) => <CampaignDetailsPage match={props.match} />} />
                     <Route exact path="/id/:campaignXWeVoteId/comments" render={(props) => <CampaignCommentsPage match={props.match} />} />
                     <Route exact path="/id/:campaignXWeVoteId/i-will-share-campaign" render={(props) => <CampaignSupportShare match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} iWillShare />} />
+                    <Route exact path="/id/:campaignXWeVoteId/complete-your-profile-for-news-item" render={(props) => <CompleteYourProfileMobile match={props.match} createNewsItem setShowHeaderFooter={this.setShowHeaderFooter} />} />
+                    <Route exact path="/id/:campaignXWeVoteId/complete-your-support-for-this-campaign" render={(props) => <CompleteYourProfileMobile match={props.match} supportCampaign setShowHeaderFooter={this.setShowHeaderFooter} />} />
                     <Route exact path="/id/:campaignXWeVoteId/pay-to-promote" render={(props) => <CampaignSupportPayToPromote match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} />} />
                     <Route exact path="/id/:campaignXWeVoteId/pay-to-promote-process" render={(props) => <CampaignSupportPayToPromoteProcess match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} />} />
                     <Route exact path="/id/:campaignXWeVoteId/recommended-campaigns" render={(props) => <CampaignRecommendedCampaigns match={props.match} setShowHeaderFooter={this.setShowHeaderFooter} />} />

--- a/src/js/common/components/Campaign/CampaignCardForList.jsx
+++ b/src/js/common/components/Campaign/CampaignCardForList.jsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import TruncateMarkup from 'react-truncate-markup';
 import styled from 'styled-components';
 // import { convertStateCodeToStateText } from '../../utils/addressFunctions';
-import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
+// import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import {
   CampaignImageMobile, CampaignImagePlaceholderText, CampaignImageMobilePlaceholder, CampaignImageDesktopPlaceholder, CampaignImageDesktop,
   CandidateCardForListWrapper, CampaignActionButtonsWrapper,
@@ -17,12 +17,12 @@ import historyPush from '../../utils/historyPush';
 import { renderLog } from '../../utils/logging';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
 import CampaignStore from '../../stores/CampaignStore';
+import CampaignOwnersList from '../CampaignSupport/CampaignOwnersList';
 import CampaignSupporterStore from '../../stores/CampaignSupporterStore';
-import initializejQuery from '../../utils/initializejQuery';
 import isMobileScreenSize from '../../utils/isMobileScreenSize';
 import keepHelpingDestination from '../../utils/keepHelpingDestination';
 import numberWithCommas from '../../utils/numberWithCommas';
-import CampaignOwnersList from '../CampaignSupport/CampaignOwnersList';
+import saveCampaignSupportAndGoToNextPage from '../../utils/saveCampaignSupportAndGoToNextPage';
 // import { BlockedIndicator, DraftModeIndicator, EditIndicator, ElectionInPast, IndicatorButtonWrapper, IndicatorDefaultButtonWrapper, IndicatorRow } from '../Style/CampaignIndicatorStyles';
 
 const SupportButtonBeforeCompletionScreen = React.lazy(() => import(/* webpackChunkName: 'SupportButtonBeforeCompletionScreen' */ '../CampaignSupport/SupportButtonBeforeCompletionScreen'));
@@ -41,8 +41,7 @@ class CampaignCardForList extends Component {
     };
     this.functionToUseToKeepHelping = this.functionToUseToKeepHelping.bind(this);
     this.functionToUseWhenProfileComplete = this.functionToUseWhenProfileComplete.bind(this);
-    this.getCampaignBasePath = this.getCampaignBasePath.bind(this);
-    this.goToNextPage = this.goToNextPage.bind(this);
+    this.getCampaignXBasePath = this.getCampaignXBasePath.bind(this);
     this.onCampaignClick = this.onCampaignClick.bind(this);
     this.onCampaignClickLink = this.onCampaignClickLink.bind(this);
     this.onCampaignEditClick = this.onCampaignEditClick.bind(this);
@@ -105,18 +104,8 @@ class CampaignCardForList extends Component {
     const { campaignXWeVoteId } = this.props;
     const campaignX = CampaignStore.getCampaignXByWeVoteId(campaignXWeVoteId);
     // const voterCanEditThisCampaign = CampaignStore.getVoterCanEditThisCampaign(campaignXWeVoteId);
-    const {
-      seo_friendly_path: campaignSEOFriendlyPath,
-    } = campaignX;
-    let pathToUseWhenProfileComplete;
-    if (campaignSEOFriendlyPath) {
-      pathToUseWhenProfileComplete = `/c/${campaignSEOFriendlyPath}/why-do-you-support`;
-    } else if (campaignXWeVoteId) {
-      pathToUseWhenProfileComplete = `/id/${campaignXWeVoteId}/why-do-you-support`;
-    }
     this.setState({
       campaignX,
-      pathToUseWhenProfileComplete,
       // voterCanEditThisCampaign,
     });
   }
@@ -138,15 +127,11 @@ class CampaignCardForList extends Component {
     }
     const {
       in_draft_mode: inDraftMode,
-      seo_friendly_path: campaignSEOFriendlyPath,
-      campaignx_we_vote_id: campaignXWeVoteId,
     } = campaignX;
     if (inDraftMode) {
       return '/start-a-campaign-preview';
-    } else if (campaignSEOFriendlyPath) {
-      return `/c/${campaignSEOFriendlyPath}`;
     } else {
-      return `/id/${campaignXWeVoteId}`;
+      return `${this.getCampaignXBasePath()}`;
     }
   }
 
@@ -163,15 +148,11 @@ class CampaignCardForList extends Component {
     }
     const {
       in_draft_mode: inDraftMode,
-      seo_friendly_path: campaignSEOFriendlyPath,
-      campaignx_we_vote_id: campaignXWeVoteId,
     } = campaignX;
     if (inDraftMode) {
       historyPush('/start-a-campaign-preview');
-    } else if (campaignSEOFriendlyPath) {
-      historyPush(`/c/${campaignSEOFriendlyPath}/edit`);
     } else {
-      historyPush(`/id/${campaignXWeVoteId}/edit`);
+      historyPush(`${this.getCampaignXBasePath()}/edit`);
     }
     return null;
   }
@@ -182,15 +163,7 @@ class CampaignCardForList extends Component {
     if (!campaignX) {
       return null;
     }
-    const {
-      seo_friendly_path: campaignSEOFriendlyPath,
-      campaignx_we_vote_id: campaignXWeVoteId,
-    } = campaignX;
-    if (campaignSEOFriendlyPath) {
-      historyPush(`/c/${campaignSEOFriendlyPath}/share-campaign`);
-    } else {
-      historyPush(`/id/${campaignXWeVoteId}/share-campaign`);
-    }
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
     return null;
   }
 
@@ -200,19 +173,11 @@ class CampaignCardForList extends Component {
     if (!campaignX) {
       return null;
     }
-    const {
-      seo_friendly_path: campaignSEOFriendlyPath,
-      campaignx_we_vote_id: campaignXWeVoteId,
-    } = campaignX;
-    if (campaignSEOFriendlyPath) {
-      historyPush(`/c/${campaignSEOFriendlyPath}/share-campaign`);
-    } else {
-      historyPush(`/id/${campaignXWeVoteId}/share-campaign`);
-    }
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
     return null;
   }
 
-  getCampaignBasePath () {
+  getCampaignXBasePath () {
     const { campaignX } = this.state;
     // console.log('campaignX:', campaignX);
     if (!campaignX) {
@@ -228,7 +193,6 @@ class CampaignCardForList extends Component {
     } else {
       campaignBasePath = `/id/${campaignXWeVoteId}`;
     }
-
     return campaignBasePath;
   }
 
@@ -259,38 +223,22 @@ class CampaignCardForList extends Component {
     }
   }
 
-  goToNextPage () {
-    const { pathToUseWhenProfileComplete } = this.state;
-    this.timer = setTimeout(() => {
-      historyPush(pathToUseWhenProfileComplete);
-    }, 500);
-    return null;
-  }
-
   functionToUseToKeepHelping () {
     const { payToPromoteStepCompleted, payToPromoteStepTurnedOn, sharingStepCompleted, step2Completed } = this.state;
     // console.log(payToPromoteStepCompleted, payToPromoteStepTurnedOn, sharingStepCompleted, step2Completed);
     const keepHelpingDestinationString = keepHelpingDestination(step2Completed, payToPromoteStepCompleted, payToPromoteStepTurnedOn, sharingStepCompleted);
-    console.log('functionToUseToKeepHelping keepHelpingDestinationString:', keepHelpingDestinationString);
-    historyPush(`${this.getCampaignBasePath()}/${keepHelpingDestinationString}`);
+    // console.log('functionToUseToKeepHelping keepHelpingDestinationString:', keepHelpingDestinationString);
+    historyPush(`${this.getCampaignXBasePath()}/${keepHelpingDestinationString}`);
   }
 
   functionToUseWhenProfileComplete () {
     const { campaignXWeVoteId } = this.props;
-    const campaignSupported = true;
-    const campaignSupportedChanged = true;
-    // From this page we always send value for 'visibleToPublic'
-    let visibleToPublic = CampaignSupporterStore.getVisibleToPublic();
-    const visibleToPublicChanged = CampaignSupporterStore.getVisibleToPublicQueuedToSaveSet();
-    if (visibleToPublicChanged) {
-      // If it has changed, use new value
-      visibleToPublic = CampaignSupporterStore.getVisibleToPublicQueuedToSave();
+    if (campaignXWeVoteId) {
+      const campaignXBaseBath = this.getCampaignXBasePath();
+      saveCampaignSupportAndGoToNextPage(campaignXWeVoteId, campaignXBaseBath);
+    } else {
+      console.log('CampaignCardForList functionToUseWhenProfileComplete campaignXWeVoteId not found');
     }
-    console.log('functionToUseWhenProfileComplete, visibleToPublic:', visibleToPublic, ', visibleToPublicChanged:', visibleToPublicChanged);
-    const saveVisibleToPublic = true;
-    initializejQuery(() => {
-      CampaignSupporterActions.supportCampaignSave(campaignXWeVoteId, campaignSupported, campaignSupportedChanged, visibleToPublic, saveVisibleToPublic);
-    }, this.goToNextPage());
   }
 
   render () {
@@ -310,7 +258,6 @@ class CampaignCardForList extends Component {
       // is_blocked_by_we_vote: isBlockedByWeVote,
       // is_in_team_review_mode: isInTeamReviewMode,
       // is_supporters_count_minimum_exceeded: isSupportersCountMinimumExceeded,
-      seo_friendly_path: campaignSEOFriendlyPath,
       supporters_count: supportersCount,
       supporters_count_next_goal: supportersCountNextGoal,
       // visible_on_this_site: visibleOnThisSite,
@@ -327,7 +274,10 @@ class CampaignCardForList extends Component {
             <OneCampaignTextColumn>
               <TitleAndTextWrapper>
                 <OneCampaignTitle>
-                  <Link to={this.onCampaignClickLink()}>
+                  <Link
+                    id="campaignCardDisplayName"
+                    to={this.onCampaignClickLink()}
+                  >
                     {campaignTitle}
                   </Link>
                 </OneCampaignTitle>
@@ -343,7 +293,11 @@ class CampaignCardForList extends Component {
                       Thank you for supporting!
                     </SupportersActionLink>
                   ) : (
-                    <SupportersActionLink className="u-link-color u-link-underline u-cursor--pointer" onClick={this.onCampaignClick}>
+                    <SupportersActionLink
+                      className="u-link-color u-link-underline u-cursor--pointer"
+                      id="campaignCardLetsGetTo"
+                      onClick={this.onCampaignClick}
+                    >
                       Let&apos;s get to
                       {' '}
                       {numberWithCommas(supportersCountNextGoalWithFloor)}
@@ -351,7 +305,11 @@ class CampaignCardForList extends Component {
                     </SupportersActionLink>
                   )}
                 </SupportersWrapper>
-                <OneCampaignDescription className="u-cursor--pointer" onClick={this.onCampaignClick}>
+                <OneCampaignDescription
+                  className="u-cursor--pointer"
+                  id="campaignCardDescription"
+                  onClick={this.onCampaignClick}
+                >
                   <TruncateMarkup
                     ellipsis="..."
                     lines={2}
@@ -452,7 +410,6 @@ class CampaignCardForList extends Component {
                 {!inDraftMode && (
                   <Suspense fallback={<span>&nbsp;</span>}>
                     <SupportButtonBeforeCompletionScreen
-                      campaignSEOFriendlyPath={campaignSEOFriendlyPath}
                       campaignXWeVoteId={campaignXWeVoteId}
                       functionToUseToKeepHelping={this.functionToUseToKeepHelping}
                       functionToUseWhenProfileComplete={this.functionToUseWhenProfileComplete}

--- a/src/js/common/components/Campaign/CampaignCardList.jsx
+++ b/src/js/common/components/Campaign/CampaignCardList.jsx
@@ -1,15 +1,15 @@
 import styled from 'styled-components';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
-import React, { Component, Suspense } from 'react';
+import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import { CampaignsNotAvailableToShow, ListWrapper, LoadMoreItemsManuallyWrapper, StartACampaignWrapper } from '../Style/CampaignCardStyles';
+import { ListWrapper, LoadMoreItemsManuallyWrapper, StartACampaignWrapper } from '../Style/CampaignCardStyles'; // CampaignsNotAvailableToShow
 import isMobileScreenSize from '../../utils/isMobileScreenSize';
 import { renderLog } from '../../utils/logging';
 import CampaignCardForList from './CampaignCardForList';
 import LoadMoreItemsManually from '../Widgets/LoadMoreItemsManually';
 
-const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../Widgets/DelayedLoad'));
+// const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../Widgets/DelayedLoad'));
 
 const STARTING_NUMBER_TO_DISPLAY = 7;
 const STARTING_NUMBER_TO_DISPLAY_MOBILE = 5;

--- a/src/js/common/components/Campaign/CampaignListRoot.jsx
+++ b/src/js/common/components/Campaign/CampaignListRoot.jsx
@@ -24,7 +24,7 @@ class CampaignListRoot extends Component {
     this.state = {
       campaignList: [],
       campaignSearchResults: [],
-      filteredCampaignList: [],
+      filteredList: [],
       timeStampOfChange: 0,
     };
   }
@@ -81,65 +81,65 @@ class CampaignListRoot extends Component {
   }
 
   orderByAlphabetical = (firstEntry, secondEntry) => {
-    let firstEntryName;
-    let secondEntryName = 'x';
+    let firstEntryValue;
+    let secondEntryValue = 'x';
     if (firstEntry && firstEntry.campaign_title) {
-      firstEntryName = firstEntry.campaign_title;
+      firstEntryValue = firstEntry.campaign_title;
     }
     if (secondEntry && secondEntry.campaign_title) {
-      secondEntryName = secondEntry.campaign_title;
+      secondEntryValue = secondEntry.campaign_title;
     }
-    if (firstEntryName < secondEntryName) { return -1; }
-    if (firstEntryName > secondEntryName) { return 1; }
+    if (firstEntryValue < secondEntryValue) { return -1; }
+    if (firstEntryValue > secondEntryValue) { return 1; }
     return 0;
   };
 
   // Order by 1, 2, 3. Push 0's to the bottom in the same order.
-  orderByOrderInList = (firstCampaign, secondCampaign) => (firstCampaign.order_in_list || Number.MAX_VALUE) - (secondCampaign.order_in_list || Number.MAX_VALUE);
+  orderByOrderInList = (firstEntry, secondEntry) => (firstEntry.order_in_list || Number.MAX_VALUE) - (secondEntry.order_in_list || Number.MAX_VALUE);
 
-  orderBySupportersCount = (firstCampaign, secondCampaign) => secondCampaign.supporters_count - firstCampaign.supporters_count;
+  orderBySupportersCount = (firstEntry, secondEntry) => secondEntry.supporters_count - firstEntry.supporters_count;
 
   orderCandidatesByUltimateDate = (firstEntry, secondEntry) => secondEntry.candidate_ultimate_election_date - firstEntry.candidate_ultimate_election_date;
 
   onFilterOrListChange = () => {
     // console.log('onFilterOrListChange');
     // Start over with full list, and apply all active filters
-    const { listModeFilters, searchText, stateCode } = this.props;
+    const { hideCampaignsLinkedToPoliticians, listModeFilters, searchText, stateCode } = this.props;
     const { campaignList } = this.state;
-    // console.log('campaignList:', campaignList);
-    let filteredCampaignList = campaignList;
+    let filteredList = campaignList;
+    // console.log('filteredList:', filteredList);
     // //////////////////////////////////////////
     // Make sure we have all required variables
-    const filteredCampaignListModified = [];
-    let modifiedCampaign;
-    filteredCampaignList.forEach((oneCampaign) => {
-      modifiedCampaign = { ...oneCampaign };
-      // modifiedCampaign = {
-      //   ...modifiedCampaign,
-      //   campaign_state_name: convertStateCodeToStateText(oneCampaign.state_code),
-      //   state_code: oneCampaign.state_code || '',
+    const filteredListModified = [];
+    let modifiedEntry;
+    filteredList.forEach((oneEntry) => {
+      modifiedEntry = { ...oneEntry };
+      // modifiedEntry = {
+      //   ...modifiedEntry,
+      //   campaign_state_name: convertStateCodeToStateText(oneEntry.state_code),
+      //   state_code: oneEntry.state_code || '',
       // };
-      if (!oneCampaign.campaign_description) {
-        modifiedCampaign = {
-          ...modifiedCampaign,
+      if (!oneEntry.campaign_description) {
+        modifiedEntry = {
+          ...modifiedEntry,
           campaign_description: '',
         };
       }
-      if (!oneCampaign.campaign_title) {
-        modifiedCampaign = {
-          ...modifiedCampaign,
+      if (!oneEntry.campaign_title) {
+        modifiedEntry = {
+          ...modifiedEntry,
           campaign_title: '',
         };
       }
-      if (!oneCampaign.contest_office_name) {
-        modifiedCampaign = {
-          ...modifiedCampaign,
+      if (!oneEntry.contest_office_name) {
+        modifiedEntry = {
+          ...modifiedEntry,
           contest_office_name: '',
         };
       }
-      filteredCampaignListModified.push(modifiedCampaign);
+      filteredListModified.push(modifiedEntry);
     });
-    filteredCampaignList = filteredCampaignListModified;
+    filteredList = filteredListModified;
     // //////////////////////
     // Now filter candidates
     if (listModeFilters && listModeFilters.length > 0) {
@@ -147,54 +147,54 @@ class CampaignListRoot extends Component {
       listModeFilters.forEach((oneFilter) => {
         // console.log('oneFilter:', oneFilter);
         if ((oneFilter.filterType === 'showUpcomingEndorsements') && (oneFilter.filterSelected === true)) {
-          filteredCampaignList = filteredCampaignList.filter((oneCampaign) => oneCampaign.final_election_date_as_integer >= todayAsInteger);
+          filteredList = filteredList.filter((oneEntry) => oneEntry.final_election_date_as_integer >= todayAsInteger);
         }
         if ((oneFilter.filterType === 'showYear') && (oneFilter.filterSelected === true)) {
-          filteredCampaignList = filteredCampaignList.filter((oneCampaign) => getYearFromUltimateElectionDate(oneCampaign.final_election_date_as_integer) === oneFilter.filterYear);
+          filteredList = filteredList.filter((oneEntry) => getYearFromUltimateElectionDate(oneEntry.final_election_date_as_integer) === oneFilter.filterYear);
         }
       });
     }
     if (stateCode && stateCode.toLowerCase() !== 'all') {
-      filteredCampaignList = filteredCampaignList.filter((oneCampaign) => {
-        const politicianStateCodeList = extractAttributeValueListFromObjectList('state_code', oneCampaign.campaignx_politician_list, true);
+      filteredList = filteredList.filter((oneEntry) => {
+        const politicianStateCodeList = extractAttributeValueListFromObjectList('state_code', oneEntry.campaignx_politician_list, true);
         return arrayContains(stateCode.toLowerCase(), politicianStateCodeList);
       });
     }
     // //////////
     // Now sort
     // We need to add support for ballot_item_twitter_followers_count
-    // filteredCampaignList = filteredCampaignList.sort(this.orderPositionsByBallotItemTwitterFollowers);
-    filteredCampaignList = filteredCampaignList.sort(this.orderByAlphabetical);
-    filteredCampaignList = filteredCampaignList.sort(this.orderBySupportersCount);
-    filteredCampaignList = filteredCampaignList.sort(this.orderByOrderInList);
+    // filteredList = filteredList.sort(this.orderPositionsByBallotItemTwitterFollowers);
+    filteredList = filteredList.sort(this.orderByAlphabetical);
+    filteredList = filteredList.sort(this.orderBySupportersCount);
+    filteredList = filteredList.sort(this.orderByOrderInList);
     let campaignSearchResults = [];
     if (searchText && searchText.length > 0) {
       const searchTextLowercase = searchText.toLowerCase();
       // console.log('searchTextLowercase:', searchTextLowercase);
       const searchWordArray = searchTextLowercase.match(/\b(\w+)\b/g);
       // console.log('searchWordArray:', searchWordArray);
-      let foundInThisCampaign;
+      let foundInThisEntry;
       let foundInThisCampaignsPoliticians;
       let isFirstWord;
       let politicianStateName;
       let thisWordFound;
-      campaignSearchResults = filter(filteredCampaignList,
-        (oneCampaign) => {
-          foundInThisCampaign = false;
+      campaignSearchResults = filter(filteredList,
+        (oneEntry) => {
+          foundInThisEntry = false;
           isFirstWord = true;
           searchWordArray.forEach((oneSearchWordLowerCase) => {
             thisWordFound = (
               // We should add these fields on API server:
-              // oneCampaign.state_code.toLowerCase().includes(oneSearchWordLowerCase) ||
-              // oneCampaign.campaign_state_name.toLowerCase().includes(oneSearchWordLowerCase) ||
-              oneCampaign.campaign_description.toLowerCase().includes(oneSearchWordLowerCase) ||
-              oneCampaign.campaign_title.toLowerCase().includes(oneSearchWordLowerCase)
+              // oneEntry.state_code.toLowerCase().includes(oneSearchWordLowerCase) ||
+              // oneEntry.campaign_state_name.toLowerCase().includes(oneSearchWordLowerCase) ||
+              oneEntry.campaign_description.toLowerCase().includes(oneSearchWordLowerCase) ||
+              oneEntry.campaign_title.toLowerCase().includes(oneSearchWordLowerCase)
             );
             if (!thisWordFound) {
               foundInThisCampaignsPoliticians = false;
               // Go on to search in the campaignx_politician_list
-              if (oneCampaign.campaignx_politician_list && oneCampaign.campaignx_politician_list.length > 0) {
-                oneCampaign.campaignx_politician_list.forEach((onePolitician) => {
+              if (oneEntry.campaignx_politician_list && oneEntry.campaignx_politician_list.length > 0) {
+                oneEntry.campaignx_politician_list.forEach((onePolitician) => {
                   politicianStateName = convertStateCodeToStateText(onePolitician.state_code);
                   foundInThisCampaignsPoliticians = (
                     foundInThisCampaignsPoliticians ||
@@ -209,20 +209,25 @@ class CampaignListRoot extends Component {
               thisWordFound = foundInThisCampaignsPoliticians;
             }
             if (isFirstWord) {
-              foundInThisCampaign = thisWordFound;
+              foundInThisEntry = thisWordFound;
               isFirstWord = false;
             } else {
-              foundInThisCampaign = foundInThisCampaign && thisWordFound;
+              foundInThisEntry = foundInThisEntry && thisWordFound;
             }
           });
-          return foundInThisCampaign;
+          // console.log('oneEntry:', oneEntry);
+          if (hideCampaignsLinkedToPoliticians && oneEntry.linked_politician_we_vote_id) {
+            return false;
+          } else {
+            return foundInThisEntry;
+          }
         });
     }
     // console.log('onFilterOrListChange, campaignSearchResults:', campaignSearchResults);
-    // console.log('onFilterOrListChange, filteredCampaignList:', filteredCampaignList);
+    // console.log('onFilterOrListChange, filteredList:', filteredList);
     this.setState({
       campaignSearchResults,
-      filteredCampaignList,
+      filteredList,
       timeStampOfChange: Date.now(),
     });
   }
@@ -231,15 +236,16 @@ class CampaignListRoot extends Component {
     renderLog('CampaignListRoot');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes, hideIfNoResults, hideTitle, listModeFilters, searchText, titleTextForList } = this.props;
     const isSearching = searchText && searchText.length > 0;
-    const { campaignList, campaignSearchResults, filteredCampaignList, timeStampOfChange } = this.state;
-    const filteredCampaignListLength = (filteredCampaignList) ? filteredCampaignList.length : 0;
+    const { campaignList, campaignSearchResults, filteredList, timeStampOfChange } = this.state;
+    const filteredListLength = (filteredList) ? filteredList.length : 0;
     let hideDisplayBecauseNoResults = false;
+    // console.log('hideIfNoResults:', hideIfNoResults, 'filteredList:', filteredList, 'filteredListLength:', filteredListLength);
     if (hideIfNoResults) {
       if (isSearching) {
         if (campaignSearchResults && campaignSearchResults.length === 0) {
           hideDisplayBecauseNoResults = true;
         }
-      } else if (filteredCampaignListLength && filteredCampaignListLength.length === 0) {
+      } else if (filteredListLength === 0) {
         hideDisplayBecauseNoResults = true;
       }
       if (hideDisplayBecauseNoResults) {
@@ -261,7 +267,7 @@ class CampaignListRoot extends Component {
           <CampaignsScrollingInnerWrapper>
             <CampaignsHorizontallyScrollingContainer>
               <CampaignCardList
-                incomingCampaignList={(isSearching ? campaignSearchResults : filteredCampaignList)}
+                incomingCampaignList={(isSearching ? campaignSearchResults : filteredList)}
                 listModeFilters={listModeFilters}
                 listModeFiltersTimeStampOfChange={timeStampOfChange}
                 searchText={searchText}
@@ -282,6 +288,7 @@ class CampaignListRoot extends Component {
 }
 CampaignListRoot.propTypes = {
   classes: PropTypes.object,
+  hideCampaignsLinkedToPoliticians: PropTypes.bool,
   hideIfNoResults: PropTypes.bool,
   hideTitle: PropTypes.bool,
   incomingList: PropTypes.array,

--- a/src/js/common/components/Campaign/CampaignNewsItemForList.jsx
+++ b/src/js/common/components/Campaign/CampaignNewsItemForList.jsx
@@ -86,7 +86,7 @@ class CampaignNewsItemForList extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignXWeVoteId } = this.props;
     const { campaignSEOFriendlyPath } = this.state;
     let campaignBasePath;
@@ -100,25 +100,25 @@ class CampaignNewsItemForList extends Component {
 
   onCampaignNewsItemDraftOrBlockedClick = () => {
     const { campaignXNewsItemWeVoteId } = this.props;
-    historyPush(`${this.getCampaignBasePath()}/add-update/${campaignXNewsItemWeVoteId}`);
+    historyPush(`${this.getCampaignXBasePath()}/add-update/${campaignXNewsItemWeVoteId}`);
     return null;
   }
 
   onCampaignNewsItemEditClick = () => {
     const { campaignXNewsItemWeVoteId } = this.props;
-    historyPush(`${this.getCampaignBasePath()}/add-update/${campaignXNewsItemWeVoteId}`);
+    historyPush(`${this.getCampaignXBasePath()}/add-update/${campaignXNewsItemWeVoteId}`);
     return null;
   }
 
   onCampaignNewsItemShareClick = () => {
     const { campaignXNewsItemWeVoteId } = this.props;
-    historyPush(`${this.getCampaignBasePath()}/share-it/${campaignXNewsItemWeVoteId}`);
+    historyPush(`${this.getCampaignXBasePath()}/share-it/${campaignXNewsItemWeVoteId}`);
     return null;
   }
 
   goToDedicatedPublicNewsItemPage = () => {
     const { campaignXNewsItemWeVoteId } = this.props;
-    historyPush(`${this.getCampaignBasePath()}/u/${campaignXNewsItemWeVoteId}`);
+    historyPush(`${this.getCampaignXBasePath()}/u/${campaignXNewsItemWeVoteId}`);
     return null;
   }
 

--- a/src/js/common/components/Campaign/CampaignShareChunk.jsx
+++ b/src/js/common/components/Campaign/CampaignShareChunk.jsx
@@ -23,7 +23,7 @@ class CampaignShareChunk extends Component {
     // console.log('CampaignShareChunk componentDidMount');
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.props;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -36,9 +36,9 @@ class CampaignShareChunk extends Component {
 
   superSharingIntro = (sms = false) => {
     if (sms) {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-campaign-sms`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-campaign-sms`);
     } else {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-campaign-email`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-campaign-email`);
     }
   }
 

--- a/src/js/common/components/CampaignSupport/SupportButton.jsx
+++ b/src/js/common/components/CampaignSupport/SupportButton.jsx
@@ -112,7 +112,7 @@ class SupportButton extends Component {
                 </span>
               ) : (
                 <span>
-                  Show your support
+                  Help them win by endorsing
                 </span>
               )}
             </Button>

--- a/src/js/common/components/CampaignSupport/SupportButtonBeforeCompletionScreen.jsx
+++ b/src/js/common/components/CampaignSupport/SupportButtonBeforeCompletionScreen.jsx
@@ -38,22 +38,14 @@ class SupportButtonBeforeCompletionScreen extends Component {
   componentDidUpdate (prevProps) {
     // console.log('SupportButtonBeforeCompletionScreen componentDidUpdate');
     const {
-      campaignSEOFriendlyPath: campaignSEOFriendlyPathPrevious,
       campaignXWeVoteId: campaignXWeVoteIdPrevious,
     } = prevProps;
     const {
-      campaignSEOFriendlyPath,
       campaignXWeVoteId,
     } = this.props;
     if (campaignXWeVoteId) {
       if (campaignXWeVoteId !== campaignXWeVoteIdPrevious) {
         this.onCampaignOrCampaignSupporterChange(campaignXWeVoteId);
-      }
-    } else if (campaignSEOFriendlyPath) {
-      if (campaignSEOFriendlyPath !== campaignSEOFriendlyPathPrevious) {
-        const campaignXWeVoteIdCalculated = CampaignStore.getCampaignXWeVoteIdFromCampaignSEOFriendlyPath(campaignSEOFriendlyPath);
-        // console.log('campaignXWeVoteIdCalculated:', campaignXWeVoteIdCalculated);
-        this.onCampaignOrCampaignSupporterChange(campaignXWeVoteIdCalculated);
       }
     }
   }
@@ -83,15 +75,11 @@ class SupportButtonBeforeCompletionScreen extends Component {
 
   onCampaignSupporterStoreChange () {
     const {
-      campaignSEOFriendlyPath,
       campaignXWeVoteId,
     } = this.props;
-    // console.log('SupportButtonBeforeCompletionScreen onCampaignSupporterStoreChange campaignXWeVoteId:', campaignXWeVoteId, ', campaignSEOFriendlyPath:', campaignSEOFriendlyPath);
+    // console.log('SupportButtonBeforeCompletionScreen onCampaignSupporterStoreChange campaignXWeVoteId:', campaignXWeVoteId);
     if (campaignXWeVoteId) {
       this.onCampaignOrCampaignSupporterChange(campaignXWeVoteId);
-    } else if (campaignSEOFriendlyPath) {
-      const campaignXWeVoteIdCalculated = CampaignStore.getCampaignXWeVoteIdFromCampaignSEOFriendlyPath(campaignSEOFriendlyPath);
-      this.onCampaignOrCampaignSupporterChange(campaignXWeVoteIdCalculated);
     }
   }
 
@@ -142,11 +130,13 @@ class SupportButtonBeforeCompletionScreen extends Component {
   }
 
   submitSupportButtonMobile = () => {
-    const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.props;
+    const { campaignXWeVoteId } = this.props;
     console.log('SupportButtonBeforeCompletionScreen submitSupportButtonMobile');
     const { voterFirstName, voterLastName, voterIsSignedInWithEmail } = this.state;
     if (!voterFirstName || !voterLastName || !voterIsSignedInWithEmail) {
       // Navigate to the mobile complete your profile page
+      const campaignX = CampaignStore.getCampaignXByWeVoteId(campaignXWeVoteId);
+      const { seo_friendly_path: campaignSEOFriendlyPath } = campaignX;
       if (campaignSEOFriendlyPath) {
         historyPush(`/c/${campaignSEOFriendlyPath}/complete-your-support-for-this-campaign`);
       } else {
@@ -165,7 +155,7 @@ class SupportButtonBeforeCompletionScreen extends Component {
 
   render () {
     renderLog('SupportButtonBeforeCompletionScreen');  // Set LOG_RENDER_EVENTS to log all renders
-    const { campaignSEOFriendlyPath, campaignXWeVoteId, classes, inButtonFullWidthMode, inCompressedMode } = this.props;
+    const { campaignXWeVoteId, classes, inButtonFullWidthMode, inCompressedMode } = this.props;
     const hideFooterBehindModal = false;
     let supportButtonClasses;
     const inWebApp = true; // isWebApp();
@@ -180,8 +170,8 @@ class SupportButtonBeforeCompletionScreen extends Component {
     } else {
       supportButtonClasses = classes.buttonDefaultCordova;
     }
-    // console.log('SupportButtonBeforeCompletionScreen render campaignXWeVoteId:', campaignXWeVoteId, ', campaignSEOFriendlyPath:', campaignSEOFriendlyPath);
-    if (!campaignSEOFriendlyPath && !campaignXWeVoteId && !nextReleaseFeaturesEnabled) {
+    // console.log('SupportButtonBeforeCompletionScreen render campaignXWeVoteId:', campaignXWeVoteId);
+    if (!campaignXWeVoteId && !nextReleaseFeaturesEnabled) {
       // console.log('SupportButtonBeforeCompletionScreen render voter NOT found');
       return <div className="undefined-campaign-state" />;
     }
@@ -214,7 +204,7 @@ class SupportButtonBeforeCompletionScreen extends Component {
             <Button
               classes={{ root: supportButtonClasses }}
               color="primary"
-              id="supportButtonFooter"
+              id="helpThemWinButton"
               onClick={this.submitSupportButtonMobile}
               variant={inButtonFullWidthMode || !inCompressedMode ? 'contained' : 'outline'}
             >
@@ -238,14 +228,11 @@ class SupportButtonBeforeCompletionScreen extends Component {
 }
 SupportButtonBeforeCompletionScreen.propTypes = {
   campaignXWeVoteId: PropTypes.string,
-  campaignSEOFriendlyPath: PropTypes.string,
   classes: PropTypes.object,
   functionToUseToKeepHelping: PropTypes.func.isRequired,
   functionToUseWhenProfileComplete: PropTypes.func.isRequired,
   inButtonFullWidthMode: PropTypes.bool,
   inCompressedMode: PropTypes.bool,
-  politicianWeVoteId: PropTypes.string,
-  politicianSEOFriendlyPath: PropTypes.string,
 };
 
 const styles = () => ({

--- a/src/js/common/components/Navigation/CampaignSupportSteps.jsx
+++ b/src/js/common/components/Navigation/CampaignSupportSteps.jsx
@@ -2,6 +2,7 @@ import withStyles from '@mui/styles/withStyles';
 import { Done } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import styled from 'styled-components';
 import commonMuiStyles from '../Style/commonMuiStyles';
 import { InnerWrapper, OuterWrapperPageTitle, OuterWrapperSteps, PageTitle, StepCircle, StepNumber, StepWrapper } from '../Style/stepDisplayStyles';
 import historyPush from '../../utils/historyPush';
@@ -82,14 +83,14 @@ class CampaignSupportSteps extends Component {
     renderLog('CampaignSupportSteps');  // Set LOG_RENDER_EVENTS to log all renders
     const {
       atStepNumber1, atStepNumber2, atPayToPromoteStep, atSharingStep,
-      campaignBasePath, classes,
+      campaignBasePath, classes, politicianBasePath,
     } = this.props;
     const {
       step1Completed, step2Completed, payToPromoteStepCompleted,
       payToPromoteStepTurnedOn, sharingStepCompleted, siteConfigurationHasBeenRetrieved,
     } = this.state;
     return (
-      <div>
+      <CampaignSupportStepsWrapper>
         <OuterWrapperPageTitle>
           <InnerWrapper>
             <PageTitle>
@@ -104,7 +105,7 @@ class CampaignSupportSteps extends Component {
                 {step1Completed ? (
                   <StepCircle
                     className="u-cursor--pointer"
-                    onClick={() => historyPush(`${campaignBasePath}`)}
+                    onClick={() => historyPush(`${politicianBasePath || campaignBasePath}`)}
                   >
                     <StepNumber>
                       <Done classes={{ root: classes.doneIcon }} />
@@ -190,18 +191,22 @@ class CampaignSupportSteps extends Component {
             </InnerWrapper>
           )}
         </OuterWrapperSteps>
-      </div>
+      </CampaignSupportStepsWrapper>
     );
   }
 }
 CampaignSupportSteps.propTypes = {
-  classes: PropTypes.object,
   atStepNumber1: PropTypes.bool,
   atStepNumber2: PropTypes.bool,
   atPayToPromoteStep: PropTypes.bool,
   atSharingStep: PropTypes.bool,
   campaignBasePath: PropTypes.string,
   campaignXWeVoteId: PropTypes.string,
+  classes: PropTypes.object,
+  politicianBasePath: PropTypes.string,
 };
+
+const CampaignSupportStepsWrapper = styled('div')`
+`;
 
 export default withStyles(commonMuiStyles)(CampaignSupportSteps);

--- a/src/js/common/components/Navigation/CampaignTopNavigation.jsx
+++ b/src/js/common/components/Navigation/CampaignTopNavigation.jsx
@@ -58,7 +58,7 @@ export default function CampaignTopNavigation (incomingVariables) {
     },
   });
 
-  const { campaignSEOFriendlyPath, campaignXWeVoteId } = incomingVariables;
+  const { campaignSEOFriendlyPath, campaignXWeVoteId, politicianWeVoteId } = incomingVariables;
   // console.log('CampaignTopNavigation incomingVariables:', incomingVariables);
   // console.log('CampaignTopNavigation campaignSEOFriendlyPath:', campaignSEOFriendlyPath);
   const handleChange = (event, newValue) => {
@@ -89,6 +89,14 @@ export default function CampaignTopNavigation (incomingVariables) {
     commentsUrl = `/id/${campaignXWeVoteId}/comments`;
     updatesUrl = `/id/${campaignXWeVoteId}/updates`;
   }
+  // Overwrite detailsUrl if politicianWeVoteId is set
+  if (politicianWeVoteId) {
+    detailsUrl = `/${politicianWeVoteId}/p`;
+  }
+
+  // console.log('CampaignTopNavigation, detailsUrl:', detailsUrl);
+  // console.log('CampaignTopNavigation, commentsUrl:', commentsUrl);
+  // console.log('CampaignTopNavigation, updatesUrl:', updatesUrl);
 
   renderLog('CampaignTopNavigation functional component');
   return (

--- a/src/js/common/components/Settings/CompleteYourProfile.jsx
+++ b/src/js/common/components/Settings/CompleteYourProfile.jsx
@@ -167,9 +167,10 @@ class CompleteYourProfile extends Component {
     const voterPhotoQueuedToSave = VoterStore.getVoterPhotoQueuedToSave();
     const voterPhotoQueuedToSaveSet = VoterStore.getVoterPhotoQueuedToSaveSet();
     VoterActions.voterCompleteYourProfileSave(voterFirstNameQueuedToSave, voterFirstNameQueuedToSaveSet, voterLastNameQueuedToSave, voterLastNameQueuedToSaveSet, voterPhotoQueuedToSave, voterPhotoQueuedToSaveSet);
-    VoterActions.voterFirstNameQueuedToSave(undefined);
-    VoterActions.voterLastNameQueuedToSave(undefined);
-    VoterActions.voterPhotoQueuedToSave(undefined);
+    // 2023-05-06 When these are used, the values disappear while waiting for verify code modal to load
+    // VoterActions.voterFirstNameQueuedToSave(undefined);
+    // VoterActions.voterLastNameQueuedToSave(undefined);
+    // VoterActions.voterPhotoQueuedToSave(undefined);
     const voterIsSignedInWithEmail = VoterStore.getVoterIsSignedInWithEmail();
     const voterEmailQueuedToSave = VoterStore.getVoterEmailQueuedToSave();
     // const voterEmailQueuedToSaveSet = VoterStore.getVoterEmailQueuedToSaveSet();
@@ -259,14 +260,14 @@ class CompleteYourProfile extends Component {
       if (voterCanVoteForPoliticianInCampaign) {
         buttonText = 'Support with my vote';
       } else {
-        buttonText = 'Show your support';
+        buttonText = 'Help them win by endorsing';
       }
       introductionText = <span>Leading up to election day, WeVote.US will remind you to vote for all of the candidates you support. We keep your email secure and confidential.</span>;
     } else if (supportCampaignOnCampaignHome) {
       if (voterCanVoteForPoliticianInCampaign) {
         buttonText = 'Support with my vote';
       } else {
-        buttonText = 'Show your support';
+        buttonText = 'Help them win by endorsing';
       }
       outerMarginsOff = true;
     }
@@ -360,8 +361,6 @@ CompleteYourProfile.propTypes = {
   campaignXWeVoteId: PropTypes.string,
   classes: PropTypes.object,
   functionToUseWhenProfileComplete: PropTypes.func.isRequired,
-  politicianSEOFriendlyPath: PropTypes.string,
-  politicianWeVoteId: PropTypes.string,
   startCampaign: PropTypes.bool,
   supportCampaign: PropTypes.bool,
   supportCampaignOnCampaignHome: PropTypes.bool,

--- a/src/js/common/components/Settings/VoterPhotoUpload.jsx
+++ b/src/js/common/components/Settings/VoterPhotoUpload.jsx
@@ -57,7 +57,7 @@ class VoterPhotoUpload extends Component {
         VoterActions.voterPhotoQueuedToSave(photoFromFileReader);
       });
       fileReader.readAsDataURL(fileFromDropzone);
-      const dropzoneText = isMobileScreenSize() ? 'A small preview of your photo is shown below. You can: 1) Click \'Save photo\' below to continue, or 2) click here to upload different photo.' : 'A small preview of your photo is shown below. You can: 1) click \'Save photo\' below to continue, 2) delete it (hover over photo to see trash can), or 3) drag a NEW version here (or click here to find file).';
+      const dropzoneText = isMobileScreenSize() ? 'A small preview of your photo is shown below. You can: 1) Click button below to continue, or 2) click here to upload different photo.' : 'A small preview of your photo is shown below. You can: 1) click button below to continue, 2) delete it (hover over photo to see trash can), or 3) drag a NEW version here (or click here to find file).';
       this.setState({
         dropzoneText,
         showDropzoneIcon: false,

--- a/src/js/common/components/Style/CampaignCardStyles.jsx
+++ b/src/js/common/components/Style/CampaignCardStyles.jsx
@@ -4,6 +4,11 @@ export const BottomActionButtonWrapper = styled('div')`
   margin-top: 4px;
 `;
 
+export const BottomActionButtonEmptyWrapper = styled('div')`
+  height: 36px;
+  margin-top: 4px;
+`;
+
 export const CampaignActionButtonsWrapper = styled('div')`
   align-items: center;
   cursor: pointer;

--- a/src/js/common/components/Style/CampaignDetailsStyles.jsx
+++ b/src/js/common/components/Style/CampaignDetailsStyles.jsx
@@ -85,8 +85,18 @@ export const CampaignOwnersDesktopWrapper = styled('div')`
 export const CampaignOwnersWrapper = styled('div')`
 `;
 
+export const CampaignSubSectionSeeAll = styled('div')`
+  font-size: 16px;
+`;
+
 export const CampaignSubSectionTitle = styled('h2')`
   font-size: 22px;
+`;
+
+export const CampaignSubSectionTitleWrapper = styled('div')`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
   margin: 50px 0 10px 0;
 `;
 
@@ -192,6 +202,7 @@ export const DetailsSectionDesktopTablet = styled('div')`
 export const DetailsSectionMobile = styled('div')`
   display: flex;
   flex-flow: column;
+  margin-bottom: 60px;
 `;
 
 export const OneCampaignInnerWrapper = styled('div')(({ theme }) => (`
@@ -211,6 +222,12 @@ export const OneCampaignOuterWrapper = styled('div')(({ theme }) => (`
     border-radius: 5px;
   }
 `));
+
+export const OtherElectionsWrapper = styled('div')`
+  border-top: 1px solid #ddd;
+  margin-top: 25px;
+  padding-top: 25px;
+`;
 
 export const ReadMoreSpan = styled('div')`
   color: #4371cc;

--- a/src/js/common/components/Widgets/OfficeHeldNameText.jsx
+++ b/src/js/common/components/Widgets/OfficeHeldNameText.jsx
@@ -56,7 +56,7 @@ export default function OfficeHeldNameText (props) {
       );
     } else {
       nameHtml = (
-        <PartyAndOfficeWrapper>
+        <PartyAndOfficeHeldWrapper>
           <span className="u-gray-darker">
             {officeName}
             {' '}
@@ -70,7 +70,7 @@ export default function OfficeHeldNameText (props) {
           <YearStateWrapper inCard={inCard}>
             <YearState centeredText={centeredText} politicalParty={politicalParty} stateName={stateName} />
           </YearStateWrapper>
-        </PartyAndOfficeWrapper>
+        </PartyAndOfficeHeldWrapper>
       );
     }
   } else {
@@ -107,7 +107,7 @@ const DistrictAndPartySpan = styled('span')`
 const PartyAndYearWrapper = styled('div')`
 `;
 
-const PartyAndOfficeWrapper = styled('div')`
+const PartyAndOfficeHeldWrapper = styled('div')`
   line-height: 17px;
 `;
 

--- a/src/js/common/components/Widgets/OfficeNameText.jsx
+++ b/src/js/common/components/Widgets/OfficeNameText.jsx
@@ -38,7 +38,7 @@ export default function OfficeNameText (props) {
   // console.log('districtName: ', districtName, 'officeName: ', officeName);
   const officeLink = null;
   if (districtName) {
-    if (officeName === undefined) {
+    if (officeName === undefined || officeName === '') {
       officeAndDistrictHtml = (
         <NoPoliticalPartySpan>
           <span>Representative for </span>
@@ -54,7 +54,7 @@ export default function OfficeNameText (props) {
         <OfficeAndDistrictSpan>
           <span className="u-gray-darker">
             {officeName}
-            ,
+            {(officeName && districtName) ? ',' : ''}
             {' '}
           </span>
           {officeLink ? (

--- a/src/js/common/pages/Campaign/CampaignCommentsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignCommentsPage.jsx
@@ -27,6 +27,9 @@ class CampaignCommentsPage extends Component {
       campaignTitle: '',
       campaignXWeVoteId: '',
       chosenWebsiteName: '',
+      isBlockedByWeVote: false,
+      isBlockedByWeVoteReason: '',
+      linkedPoliticianWeVoteId: '',
     };
   }
 
@@ -79,6 +82,7 @@ class CampaignCommentsPage extends Component {
       campaignXWeVoteId,
       isBlockedByWeVote,
       isBlockedByWeVoteReason,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -96,6 +100,7 @@ class CampaignCommentsPage extends Component {
       campaignTitle,
       isBlockedByWeVote,
       isBlockedByWeVoteReason,
+      linkedPoliticianWeVoteId,
     });
   }
 
@@ -110,7 +115,7 @@ class CampaignCommentsPage extends Component {
     // const { classes } = this.props;
     const {
       campaignSEOFriendlyPath, campaignTitle, campaignXWeVoteId, chosenWebsiteName,
-      isBlockedByWeVote, isBlockedByWeVoteReason, voterCanEditThisCampaign,
+      isBlockedByWeVote, isBlockedByWeVoteReason, linkedPoliticianWeVoteId, voterCanEditThisCampaign,
     } = this.state;
     // console.log('render campaignSEOFriendlyPath: ', campaignSEOFriendlyPath, ', campaignXWeVoteId: ', campaignXWeVoteId);
     const htmlTitle = `Supporter Comments, ${campaignTitle} - ${chosenWebsiteName}`;
@@ -178,7 +183,11 @@ class CampaignCommentsPage extends Component {
               )}
             </BlockedReason>
           )}
-          <CampaignTopNavigation campaignSEOFriendlyPath={campaignSEOFriendlyPath} campaignXWeVoteId={campaignXWeVoteId} />
+          <CampaignTopNavigation
+            campaignSEOFriendlyPath={campaignSEOFriendlyPath}
+            campaignXWeVoteId={campaignXWeVoteId}
+            politicianWeVoteId={linkedPoliticianWeVoteId}
+          />
           <CommentsSectionOuterWrapper>
             <CommentsSectionInnerWrapper>
               <PageStatement>

--- a/src/js/common/pages/Campaign/CampaignDetailsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignDetailsPage.jsx
@@ -3,12 +3,13 @@ import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import Helmet from 'react-helmet';
+import { Link } from 'react-router-dom';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import {
   CampaignDescription, CampaignDescriptionDesktop, CampaignDescriptionWrapper,
   CampaignDescriptionDesktopWrapper, CampaignImagePlaceholder, CampaignImagePlaceholderText,
   CampaignImage, CampaignImageDesktop, CampaignImageDesktopWrapper, CampaignImageMobileWrapper,
-  CampaignOwnersDesktopWrapper, CampaignOwnersWrapper, CampaignSubSectionTitle,
+  CampaignOwnersDesktopWrapper, CampaignOwnersWrapper, CampaignSubSectionSeeAll, CampaignSubSectionTitle, CampaignSubSectionTitleWrapper,
   CampaignTitleAndScoreBar, CampaignTitleDesktop, CampaignTitleMobile,
   CommentsListWrapper, DetailsSectionDesktopTablet, DetailsSectionMobile,
   SupportButtonFooterWrapper, SupportButtonPanel,
@@ -50,6 +51,9 @@ class CampaignDetailsPage extends Component {
       chosenWebsiteName: '',
       finalElectionDateInPast: false,
       inPrivateLabelMode: false,
+      isBlockedByWeVote: false,
+      isBlockedByWeVoteReason: '',
+      linkedPoliticianWeVoteId: '',
       pathToUseWhenProfileComplete: '',
       payToPromoteStepCompleted: false,
       payToPromoteStepTurnedOn: false,
@@ -126,6 +130,7 @@ class CampaignDetailsPage extends Component {
       isBlockedByWeVote,
       isBlockedByWeVoteReason,
       isSupportersCountMinimumExceeded,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     let pathToUseWhenProfileComplete;
     if (campaignSEOFriendlyPath) {
@@ -155,6 +160,7 @@ class CampaignDetailsPage extends Component {
       isBlockedByWeVote,
       isBlockedByWeVoteReason,
       isSupportersCountMinimumExceeded,
+      linkedPoliticianWeVoteId,
       pathToUseWhenProfileComplete,
     });
   }
@@ -172,7 +178,7 @@ class CampaignDetailsPage extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -195,7 +201,7 @@ class CampaignDetailsPage extends Component {
     const { finalElectionDateInPast, payToPromoteStepCompleted, payToPromoteStepTurnedOn, sharingStepCompleted, step2Completed } = this.state;
     // console.log('functionToUseToKeepHelping sharingStepCompleted:', sharingStepCompleted, ', payToPromoteStepCompleted:', payToPromoteStepCompleted, ', step2Completed:', step2Completed);
     const keepHelpingDestinationString = keepHelpingDestination(step2Completed, payToPromoteStepCompleted, payToPromoteStepTurnedOn, sharingStepCompleted, finalElectionDateInPast);
-    historyPush(`${this.getCampaignBasePath()}/${keepHelpingDestinationString}`);
+    historyPush(`${this.getCampaignXBasePath()}/${keepHelpingDestinationString}`);
   }
 
   functionToUseWhenProfileComplete = () => {
@@ -246,7 +252,7 @@ class CampaignDetailsPage extends Component {
       campaignDescription, campaignDescriptionLimited, campaignPhotoLargeUrl,
       campaignSEOFriendlyPath, campaignTitle, campaignXWeVoteId,
       chosenWebsiteName, inPrivateLabelMode, isBlockedByWeVote, isBlockedByWeVoteReason,
-      finalElectionDateInPast, isSupportersCountMinimumExceeded,
+      finalElectionDateInPast, isSupportersCountMinimumExceeded, linkedPoliticianWeVoteId,
       voterCanEditThisCampaign, voterSupportsThisCampaign,
     } = this.state;
     // console.log('render isSupportersCountMinimumExceeded: ', isSupportersCountMinimumExceeded);
@@ -326,7 +332,11 @@ class CampaignDetailsPage extends Component {
               )}
             </BlockedReason>
           )}
-          <CampaignTopNavigation campaignSEOFriendlyPath={campaignSEOFriendlyPath} campaignXWeVoteId={campaignXWeVoteId} />
+          <CampaignTopNavigation
+            campaignSEOFriendlyPath={campaignSEOFriendlyPath}
+            campaignXWeVoteId={campaignXWeVoteId}
+            politicianWeVoteId={linkedPoliticianWeVoteId}
+          />
           <DetailsSectionMobile className="u-show-mobile">
             <CampaignImageMobileWrapper>
               {campaignPhotoLargeUrl ? (
@@ -401,9 +411,18 @@ class CampaignDetailsPage extends Component {
             <CommentsListWrapper>
               <DelayedLoad waitBeforeShow={1000}>
                 <Suspense fallback={<span>&nbsp;</span>}>
-                  <CampaignSubSectionTitle>
-                    Updates
-                  </CampaignSubSectionTitle>
+                  <CampaignSubSectionTitleWrapper>
+                    <CampaignSubSectionTitle>
+                      Updates
+                    </CampaignSubSectionTitle>
+                    {!!(this.getCampaignXBasePath()) && (
+                      <CampaignSubSectionSeeAll>
+                        <Link to={`${this.getCampaignXBasePath()}/updates`} className="u-link-color">
+                          See all
+                        </Link>
+                      </CampaignSubSectionSeeAll>
+                    )}
+                  </CampaignSubSectionTitleWrapper>
                   <CampaignNewsItemList
                     campaignXWeVoteId={campaignXWeVoteId}
                     campaignSEOFriendlyPath={campaignSEOFriendlyPath}
@@ -416,9 +435,18 @@ class CampaignDetailsPage extends Component {
             <CommentsListWrapper>
               <DelayedLoad waitBeforeShow={1000}>
                 <Suspense fallback={<span>&nbsp;</span>}>
-                  <CampaignSubSectionTitle>
-                    Reasons for supporting
-                  </CampaignSubSectionTitle>
+                  <CampaignSubSectionTitleWrapper>
+                    <CampaignSubSectionTitle>
+                      Reasons for supporting
+                    </CampaignSubSectionTitle>
+                    {!!(this.getCampaignXBasePath()) && (
+                      <CampaignSubSectionSeeAll>
+                        <Link to={`${this.getCampaignXBasePath()}/comments`} className="u-link-color">
+                          See all
+                        </Link>
+                      </CampaignSubSectionSeeAll>
+                    )}
+                  </CampaignSubSectionTitleWrapper>
                   <CampaignCommentsList campaignXWeVoteId={campaignXWeVoteId} startingNumberOfCommentsToDisplay={2} />
                 </Suspense>
               </DelayedLoad>
@@ -488,9 +516,18 @@ class CampaignDetailsPage extends Component {
                 <CommentsListWrapper>
                   <DelayedLoad waitBeforeShow={500}>
                     <Suspense fallback={<span>&nbsp;</span>}>
-                      <CampaignSubSectionTitle>
-                        Updates
-                      </CampaignSubSectionTitle>
+                      <CampaignSubSectionTitleWrapper>
+                        <CampaignSubSectionTitle>
+                          Updates
+                        </CampaignSubSectionTitle>
+                        {!!(this.getCampaignXBasePath()) && (
+                          <CampaignSubSectionSeeAll>
+                            <Link to={`${this.getCampaignXBasePath()}/updates`} className="u-link-color">
+                              See all
+                            </Link>
+                          </CampaignSubSectionSeeAll>
+                        )}
+                      </CampaignSubSectionTitleWrapper>
                       <CampaignNewsItemList
                         campaignXWeVoteId={campaignXWeVoteId}
                         campaignSEOFriendlyPath={campaignSEOFriendlyPath}
@@ -503,9 +540,18 @@ class CampaignDetailsPage extends Component {
                 <CommentsListWrapper>
                   <DelayedLoad waitBeforeShow={500}>
                     <Suspense fallback={<span>&nbsp;</span>}>
-                      <CampaignSubSectionTitle>
-                        Reasons for supporting
-                      </CampaignSubSectionTitle>
+                      <CampaignSubSectionTitleWrapper>
+                        <CampaignSubSectionTitle>
+                          Reasons for supporting
+                        </CampaignSubSectionTitle>
+                        {!!(this.getCampaignXBasePath()) && (
+                          <CampaignSubSectionSeeAll>
+                            <Link to={`${this.getCampaignXBasePath()}/comments`} className="u-link-color">
+                              See all
+                            </Link>
+                          </CampaignSubSectionSeeAll>
+                        )}
+                      </CampaignSubSectionTitleWrapper>
                       <CampaignCommentsList campaignXWeVoteId={campaignXWeVoteId} startingNumberOfCommentsToDisplay={2} />
                     </Suspense>
                   </DelayedLoad>
@@ -533,7 +579,6 @@ class CampaignDetailsPage extends Component {
             <SupportButtonPanel>
               <Suspense fallback={<span>&nbsp;</span>}>
                 <SupportButtonBeforeCompletionScreen
-                  campaignSEOFriendlyPath={campaignSEOFriendlyPath}
                   campaignXWeVoteId={campaignXWeVoteId}
                   functionToUseToKeepHelping={this.functionToUseToKeepHelping}
                   functionToUseWhenProfileComplete={this.functionToUseWhenProfileComplete}

--- a/src/js/common/pages/Campaign/CampaignNewsItemDetailsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignNewsItemDetailsPage.jsx
@@ -5,6 +5,7 @@ import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import Helmet from 'react-helmet';
+import { Link } from 'react-router-dom';
 import anonymous from '../../../../img/global/icons/avatar-generic.png';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import LazyImage from '../../components/LazyImage';
@@ -12,7 +13,7 @@ import {
   CampaignDescription, CampaignDescriptionDesktop, CampaignDescriptionWrapper,
   CampaignDescriptionDesktopWrapper, CampaignImagePlaceholder, CampaignImagePlaceholderText,
   CampaignImage, CampaignImageDesktop, CampaignImageDesktopWrapper, CampaignImageMobileWrapper,
-  CampaignSubSectionTitle,
+  CampaignSubSectionSeeAll, CampaignSubSectionTitle, CampaignSubSectionTitleWrapper,
   CampaignTitleAndScoreBar, CampaignTitleDesktop, CampaignTitleMobile,
   CommentsListWrapper, DetailsSectionDesktopTablet, DetailsSectionMobile,
   SpeakerAndPhotoOuterWrapper, SpeakerName, SpeakerVoterPhotoWrapper,
@@ -57,6 +58,8 @@ class CampaignNewsItemDetailsPage extends Component {
       finalElectionDateInPast: false,
       inDraftMode: false,
       inPrivateLabelMode: false,
+      isBlockedByWeVote: false,
+      isBlockedByWeVoteReason: '',
       pathToUseWhenProfileComplete: '',
       payToPromoteStepCompleted: false,
       payToPromoteStepTurnedOn: false,
@@ -227,7 +230,7 @@ class CampaignNewsItemDetailsPage extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -239,7 +242,7 @@ class CampaignNewsItemDetailsPage extends Component {
   }
 
   goToCampaignBasePath = () => {
-    historyPush(`${this.getCampaignBasePath()}`);
+    historyPush(`${this.getCampaignXBasePath()}`);
   }
 
   goToNextPage = () => {
@@ -253,7 +256,7 @@ class CampaignNewsItemDetailsPage extends Component {
     // console.log('functionToUseToKeepHelping');
     const { payToPromoteStepCompleted, payToPromoteStepTurnedOn, sharingStepCompleted, step2Completed } = this.state;
     const keepHelpingDestinationString = keepHelpingDestination(step2Completed, payToPromoteStepCompleted, payToPromoteStepTurnedOn, sharingStepCompleted);
-    historyPush(`${this.getCampaignBasePath()}/${keepHelpingDestinationString}`);
+    historyPush(`${this.getCampaignXBasePath()}/${keepHelpingDestinationString}`);
   }
 
   functionToUseWhenProfileComplete = () => {
@@ -279,31 +282,31 @@ class CampaignNewsItemDetailsPage extends Component {
   continueToNextStep = () => {
     const { match: { params } } = this.props;
     const { campaignXNewsItemWeVoteId } = params;
-    historyPush(`${this.getCampaignBasePath()}/send/${campaignXNewsItemWeVoteId}`);
+    historyPush(`${this.getCampaignXBasePath()}/send/${campaignXNewsItemWeVoteId}`);
     return null;
   }
 
   onCampaignEditClick = () => {
-    historyPush(`${this.getCampaignBasePath()}/edit`);
+    historyPush(`${this.getCampaignXBasePath()}/edit`);
     return null;
   }
 
   onCampaignNewsItemEditClick = () => {
     const { match: { params } } = this.props;
     const { campaignXNewsItemWeVoteId } = params;
-    historyPush(`${this.getCampaignBasePath()}/add-update/${campaignXNewsItemWeVoteId}`);
+    historyPush(`${this.getCampaignXBasePath()}/add-update/${campaignXNewsItemWeVoteId}`);
     return null;
   }
 
   onCampaignNewsItemShareClick = () => {
     const { match: { params } } = this.props;
     const { campaignXNewsItemWeVoteId } = params;
-    historyPush(`${this.getCampaignBasePath()}/share-it/${campaignXNewsItemWeVoteId}`);
+    historyPush(`${this.getCampaignXBasePath()}/share-it/${campaignXNewsItemWeVoteId}`);
     return null;
   }
 
   onCampaignGetMinimumSupportersClick = () => {
-    historyPush(`${this.getCampaignBasePath()}/share-campaign`);
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
     return null;
   }
 
@@ -420,7 +423,7 @@ class CampaignNewsItemDetailsPage extends Component {
           <UpdateSupportersHeader>
             <CampaignNewsItemPublishSteps
               atStepNumber2
-              campaignBasePath={this.getCampaignBasePath()}
+              campaignBasePath={this.getCampaignXBasePath()}
               campaignXNewsItemWeVoteId={campaignXNewsItemWeVoteId}
               campaignXWeVoteId={campaignXWeVoteId}
             />
@@ -579,9 +582,18 @@ class CampaignNewsItemDetailsPage extends Component {
               <CommentsListWrapper>
                 <DelayedLoad waitBeforeShow={1000}>
                   <Suspense fallback={<span>&nbsp;</span>}>
-                    <CampaignSubSectionTitle>
-                      Reasons for supporting
-                    </CampaignSubSectionTitle>
+                    <CampaignSubSectionTitleWrapper>
+                      <CampaignSubSectionTitle>
+                        Reasons for supporting
+                      </CampaignSubSectionTitle>
+                      {!!(this.getCampaignXBasePath()) && (
+                        <CampaignSubSectionSeeAll>
+                          <Link to={`${this.getCampaignXBasePath()}/comments`} className="u-link-color">
+                            See all
+                          </Link>
+                        </CampaignSubSectionSeeAll>
+                      )}
+                    </CampaignSubSectionTitleWrapper>
                     <CampaignCommentsList campaignXWeVoteId={campaignXWeVoteId} startingNumberOfCommentsToDisplay={2} />
                   </Suspense>
                 </DelayedLoad>
@@ -676,9 +688,18 @@ class CampaignNewsItemDetailsPage extends Component {
                   <CommentsListWrapper>
                     <DelayedLoad waitBeforeShow={500}>
                       <Suspense fallback={<span>&nbsp;</span>}>
-                        <CampaignSubSectionTitle>
-                          Reasons for supporting
-                        </CampaignSubSectionTitle>
+                        <CampaignSubSectionTitleWrapper>
+                          <CampaignSubSectionTitle>
+                            Reasons for supporting
+                          </CampaignSubSectionTitle>
+                          {!!(this.getCampaignXBasePath()) && (
+                            <CampaignSubSectionSeeAll>
+                              <Link to={`${this.getCampaignXBasePath()}/comments`} className="u-link-color">
+                                See all
+                              </Link>
+                            </CampaignSubSectionSeeAll>
+                          )}
+                        </CampaignSubSectionTitleWrapper>
                         <CampaignCommentsList campaignXWeVoteId={campaignXWeVoteId} startingNumberOfCommentsToDisplay={2} />
                       </Suspense>
                     </DelayedLoad>
@@ -709,7 +730,6 @@ class CampaignNewsItemDetailsPage extends Component {
               <SupportButtonPanel>
                 <Suspense fallback={<span>&nbsp;</span>}>
                   <SupportButtonBeforeCompletionScreen
-                    campaignSEOFriendlyPath={campaignSEOFriendlyPath}
                     campaignXWeVoteId={campaignXWeVoteId}
                     functionToUseToKeepHelping={this.functionToUseToKeepHelping}
                     functionToUseWhenProfileComplete={this.functionToUseWhenProfileComplete}

--- a/src/js/common/pages/Campaign/CampaignNewsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignNewsPage.jsx
@@ -27,6 +27,9 @@ class CampaignNewsPage extends Component {
       campaignTitle: '',
       campaignXWeVoteId: '',
       chosenWebsiteName: '',
+      isBlockedByWeVote: false,
+      isBlockedByWeVoteReason: '',
+      linkedPoliticianWeVoteId: '',
     };
   }
 
@@ -79,6 +82,7 @@ class CampaignNewsPage extends Component {
       campaignXWeVoteId,
       isBlockedByWeVote,
       isBlockedByWeVoteReason,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -98,6 +102,7 @@ class CampaignNewsPage extends Component {
       campaignTitle,
       isBlockedByWeVote,
       isBlockedByWeVoteReason,
+      linkedPoliticianWeVoteId,
     });
   }
 
@@ -112,8 +117,8 @@ class CampaignNewsPage extends Component {
     // const { classes } = this.props;
     const {
       campaignSEOFriendlyPath, campaignTitle, campaignXWeVoteId, chosenWebsiteName,
-      isBlockedByWeVote, isBlockedByWeVoteReason, voterCanEditThisCampaign,
-      voterCanSendUpdatesToThisCampaign,
+      isBlockedByWeVote, isBlockedByWeVoteReason, linkedPoliticianWeVoteId,
+      voterCanEditThisCampaign, voterCanSendUpdatesToThisCampaign,
     } = this.state;
     // console.log('render campaignSEOFriendlyPath: ', campaignSEOFriendlyPath, ', campaignXWeVoteId: ', campaignXWeVoteId);
     const htmlTitle = `Updates, ${campaignTitle} - ${chosenWebsiteName}`;
@@ -181,7 +186,11 @@ class CampaignNewsPage extends Component {
               )}
             </BlockedReason>
           )}
-          <CampaignTopNavigation campaignSEOFriendlyPath={campaignSEOFriendlyPath} campaignXWeVoteId={campaignXWeVoteId} />
+          <CampaignTopNavigation
+            campaignSEOFriendlyPath={campaignSEOFriendlyPath}
+            campaignXWeVoteId={campaignXWeVoteId}
+            politicianWeVoteId={linkedPoliticianWeVoteId}
+          />
           <CommentsSectionOuterWrapper>
             <CommentsSectionInnerWrapper>
               <PageStatementWrapper>

--- a/src/js/common/pages/CampaignSupport/CampaignRecommendedCampaigns.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignRecommendedCampaigns.jsx
@@ -34,6 +34,7 @@ class CampaignRecommendedCampaigns extends Component {
       campaignTitle: '',
       campaignXWeVoteId: '',
       chosenWebsiteName: '',
+      linkedPoliticianWeVoteId: '',
       maximumNumberOfCampaignsToSupport: 5,
       numberOfCampaignsLeftToSupport: 5,
       recommendedCampaignDescription: '',
@@ -61,7 +62,11 @@ class CampaignRecommendedCampaigns extends Component {
     const {
       campaignSEOFriendlyPath,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
+    this.setState({
+      linkedPoliticianWeVoteId,
+    });
     if (campaignSEOFriendlyPath) {
       this.setState({
         campaignSEOFriendlyPath,
@@ -110,9 +115,11 @@ class CampaignRecommendedCampaigns extends Component {
       campaignSEOFriendlyPath,
       campaignTitle,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignTitle,
+      linkedPoliticianWeVoteId,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -171,11 +178,16 @@ class CampaignRecommendedCampaigns extends Component {
     const voterSignedInWithEmail = VoterStore.getVoterIsSignedInWithEmail();
     if (voterFirstRetrieveCompleted && !voterSignedInWithEmail) {
       // Leave this component and go to news page if not signed in
-      historyPush(`${this.getCampaignBasePath()}/updates`);
+      const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
+      if (campaignSEOFriendlyPath || campaignXWeVoteId) {
+        historyPush(`${this.getCampaignXBasePath()}/updates`);
+      } else {
+        console.log('CampaignRecommendedCampaigns onVoterStoreChange cannot redirect. Missing campaignSEOFriendlyPath or campaignXWeVoteId');
+      }
     }
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -183,16 +195,29 @@ class CampaignRecommendedCampaigns extends Component {
     } else {
       campaignBasePath = `/id/${campaignXWeVoteId}`;
     }
-
     return campaignBasePath;
   }
 
+  getPoliticianBasePath = () => {
+    const { politicianSEOFriendlyPath, linkedPoliticianWeVoteId } = this.state;
+    let politicianBasePath;
+    if (politicianSEOFriendlyPath) {
+      politicianBasePath = `/${politicianSEOFriendlyPath}/-`;
+    } else if (linkedPoliticianWeVoteId) {
+      politicianBasePath = `/${linkedPoliticianWeVoteId}/p`;
+    } else {
+      // console.log('CampaignRecommendedCampaigns getPoliticianBasePath, failed to get politicianBasePath');
+      politicianBasePath = this.getCampaignXBasePath();
+    }
+    return politicianBasePath;
+  }
+
   goToDetailsPage = () => {
-    historyPush(`${this.getCampaignBasePath()}`);
+    historyPush(`${this.getPoliticianBasePath()}`);
   }
 
   goToUpdatesPage = () => {
-    historyPush(`${this.getCampaignBasePath()}/updates`);
+    historyPush(`${this.getCampaignXBasePath()}/updates`);
   }
 
   oneClickSupportActionComplete = (campaignXWeVoteId) => {
@@ -342,8 +367,9 @@ class CampaignRecommendedCampaigns extends Component {
               <ContentInnerWrapperDefault>
                 <CampaignSupportSteps
                   atSharingStep
-                  campaignBasePath={this.getCampaignBasePath()}
+                  campaignBasePath={this.getCampaignXBasePath()}
                   campaignXWeVoteId={campaignXWeVoteId}
+                  politicianBasePath={this.getPoliticianBasePath()}
                 />
                 <CampaignTitle>{campaignTitle}</CampaignTitle>
                 <RecommendedCampaignsIntroText>
@@ -402,8 +428,9 @@ class CampaignRecommendedCampaigns extends Component {
             <ContentInnerWrapperDefault>
               <CampaignSupportSteps
                 atSharingStep
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXWeVoteId={campaignXWeVoteId}
+                politicianBasePath={this.getPoliticianBasePath()}
               />
               <RecommendedCampaignsIntroText>
                 Support

--- a/src/js/common/pages/CampaignSupport/CampaignSupportEndorsement.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignSupportEndorsement.jsx
@@ -39,6 +39,7 @@ class CampaignSupportEndorsement extends Component {
       campaignTitle: '',
       campaignXWeVoteId: '',
       chosenWebsiteName: '',
+      linkedPoliticianWeVoteId: '',
       payToPromoteStepTurnedOn: true,
     };
   }
@@ -60,10 +61,12 @@ class CampaignSupportEndorsement extends Component {
       campaignSEOFriendlyPath,
       campaignXPoliticianList,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignXPoliticianList,
+      linkedPoliticianWeVoteId,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -116,11 +119,13 @@ class CampaignSupportEndorsement extends Component {
       campaignTitle,
       campaignXPoliticianList,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       campaignXPoliticianList,
+      linkedPoliticianWeVoteId,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -149,7 +154,7 @@ class CampaignSupportEndorsement extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -157,16 +162,29 @@ class CampaignSupportEndorsement extends Component {
     } else {
       campaignBasePath = `/id/${campaignXWeVoteId}`;
     }
-
     return campaignBasePath;
+  }
+
+  getPoliticianBasePath = () => {
+    const { politicianSEOFriendlyPath, linkedPoliticianWeVoteId } = this.state;
+    let politicianBasePath;
+    if (politicianSEOFriendlyPath) {
+      politicianBasePath = `/${politicianSEOFriendlyPath}/-`;
+    } else if (linkedPoliticianWeVoteId) {
+      politicianBasePath = `/${linkedPoliticianWeVoteId}/p`;
+    } else {
+      // console.log('CampaignRecommendedCampaigns getPoliticianBasePath, failed to get politicianBasePath');
+      politicianBasePath = this.getCampaignXBasePath();
+    }
+    return politicianBasePath;
   }
 
   goToNextStep = () => {
     const { payToPromoteStepTurnedOn } = this.state;
     if (payToPromoteStepTurnedOn) {
-      historyPush(`${this.getCampaignBasePath()}/pay-to-promote`);
+      historyPush(`${this.getCampaignXBasePath()}/pay-to-promote`);
     } else {
-      historyPush(`${this.getCampaignBasePath()}/share-campaign`);
+      historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
     }
   }
 
@@ -230,8 +248,9 @@ class CampaignSupportEndorsement extends Component {
             <ContentInnerWrapperDefault>
               <CampaignSupportSteps
                 atStepNumber2
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXWeVoteId={campaignXWeVoteId}
+                politicianBasePath={this.getPoliticianBasePath()}
               />
               <CampaignSupportImageWrapper>
                 {campaignPhotoLargeUrl ? (

--- a/src/js/common/pages/CampaignSupport/CampaignSupportPayToPromote.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignSupportPayToPromote.jsx
@@ -31,6 +31,7 @@ class CampaignSupportPayToPromote extends Component {
       campaignTitle: '',
       campaignXWeVoteId: '',
       chosenWebsiteName: '',
+      linkedPoliticianWeVoteId: '',
       voterFirstName: '',
     };
   }
@@ -50,9 +51,11 @@ class CampaignSupportPayToPromote extends Component {
       campaignPhotoLargeUrl,
       campaignSEOFriendlyPath,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
+      linkedPoliticianWeVoteId,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -100,10 +103,12 @@ class CampaignSupportPayToPromote extends Component {
       campaignSEOFriendlyPath,
       campaignTitle,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
+      linkedPoliticianWeVoteId,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -132,7 +137,7 @@ class CampaignSupportPayToPromote extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -143,18 +148,32 @@ class CampaignSupportPayToPromote extends Component {
     return campaignBasePath;
   }
 
+  getPoliticianBasePath = () => {
+    const { politicianSEOFriendlyPath, linkedPoliticianWeVoteId } = this.state;
+    let politicianBasePath;
+    if (politicianSEOFriendlyPath) {
+      politicianBasePath = `/${politicianSEOFriendlyPath}/-`;
+    } else if (linkedPoliticianWeVoteId) {
+      politicianBasePath = `/${linkedPoliticianWeVoteId}/p`;
+    } else {
+      // console.log('CampaignRecommendedCampaigns getPoliticianBasePath, failed to get politicianBasePath');
+      politicianBasePath = this.getCampaignXBasePath();
+    }
+    return politicianBasePath;
+  }
+
   goToIWillChipIn = () => {
-    const pathForNextStep = `${this.getCampaignBasePath()}/pay-to-promote-process`;
+    const pathForNextStep = `${this.getCampaignXBasePath()}/pay-to-promote-process`;
     historyPush(pathForNextStep);
   }
 
   goToIWillShare = () => {
-    const pathForNextStep = `${this.getCampaignBasePath()}/i-will-share-campaign`;
+    const pathForNextStep = `${this.getCampaignXBasePath()}/i-will-share-campaign`;
     historyPush(pathForNextStep);
   }
 
   submitSkipForNow = () => {
-    const pathForNextStep = `${this.getCampaignBasePath()}/share-campaign-with-one-friend`;
+    const pathForNextStep = `${this.getCampaignXBasePath()}/share-campaign-with-one-friend`;
     historyPush(pathForNextStep);
   }
 
@@ -201,8 +220,9 @@ class CampaignSupportPayToPromote extends Component {
             <ContentInnerWrapperDefault>
               <CampaignSupportSteps
                 atPayToPromoteStep
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXWeVoteId={campaignXWeVoteId}
+                politicianBasePath={this.getPoliticianBasePath()}
               />
               <CampaignSupportImageWrapper>
                 {campaignPhotoLargeUrl ? (

--- a/src/js/common/pages/CampaignSupport/CampaignSupportPayToPromoteProcess.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignSupportPayToPromoteProcess.jsx
@@ -193,11 +193,11 @@ class CampaignSupportPayToPromoteProcess extends Component {
   }
 
   goToIWillShare = () => {
-    const pathForNextStep = `${this.getCampaignBasePath()}/share-campaign`;
+    const pathForNextStep = `${this.getCampaignXBasePath()}/share-campaign`;
     historyPush(pathForNextStep);
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {

--- a/src/js/common/pages/CampaignSupport/CampaignSupportShare.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignSupportShare.jsx
@@ -35,6 +35,7 @@ class CampaignSupportShare extends Component {
       campaignTitle: '',
       campaignXWeVoteId: '',
       chosenWebsiteName: '',
+      linkedPoliticianWeVoteId: '',
       shareButtonClicked: false,
     };
   }
@@ -55,9 +56,11 @@ class CampaignSupportShare extends Component {
       campaignPhotoLargeUrl,
       campaignSEOFriendlyPath,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
+      linkedPoliticianWeVoteId,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -77,7 +80,7 @@ class CampaignSupportShare extends Component {
         campaignXWeVoteId: campaignXWeVoteIdFromParams,
       });
     }
-    // Take the "calculated" identifiers and retrieve so we have the voter's comment
+    // Take the "calculated" identifiers and retrieve, so we have the voter's comment
     retrieveCampaignXFromIdentifiers(campaignSEOFriendlyPath, campaignXWeVoteId);
     window.scrollTo(0, 0);
   }
@@ -121,10 +124,12 @@ class CampaignSupportShare extends Component {
       campaignSEOFriendlyPath,
       campaignTitle,
       campaignXWeVoteId,
+      linkedPoliticianWeVoteId,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
+      linkedPoliticianWeVoteId,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -135,6 +140,7 @@ class CampaignSupportShare extends Component {
         campaignSEOFriendlyPath: campaignSEOFriendlyPathFromParams,
       });
     }
+    // console.log('onCampaignStoreChange campaignSEOFriendlyPath: ', campaignSEOFriendlyPath, ', campaignXWeVoteId: ', campaignXWeVoteId);
     if (campaignXWeVoteId) {
       recommendedCampaignXListCount = CampaignStore.getRecommendedCampaignXListCount(campaignXWeVoteId);
       recommendedCampaignXListHasBeenRetrieved = CampaignStore.getRecommendedCampaignXListHasBeenRetrieved(campaignXWeVoteId);
@@ -161,7 +167,7 @@ class CampaignSupportShare extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -169,23 +175,38 @@ class CampaignSupportShare extends Component {
     } else {
       campaignBasePath = `/id/${campaignXWeVoteId}`;
     }
-
+    // console.log('getCampaignXBasePath campaignBasePath: ', campaignBasePath);
     return campaignBasePath;
+  }
+
+  getPoliticianBasePath = () => {
+    const { politicianSEOFriendlyPath, linkedPoliticianWeVoteId } = this.state;
+    let politicianBasePath;
+    if (politicianSEOFriendlyPath) {
+      politicianBasePath = `/${politicianSEOFriendlyPath}/-`;
+    } else if (linkedPoliticianWeVoteId) {
+      politicianBasePath = `/${linkedPoliticianWeVoteId}/p`;
+    } else {
+      // console.log('CampaignRecommendedCampaigns getPoliticianBasePath, failed to get politicianBasePath');
+      politicianBasePath = this.getCampaignXBasePath();
+    }
+    return politicianBasePath;
   }
 
   goToNextStep = () => {
     const { showShareCampaignWithOneFriend } = this.props;
     const { recommendedCampaignXListCount, recommendedCampaignXListHasBeenRetrieved, shareButtonClicked } = this.state;
+    // console.log('goToNextStep getCampaignXBasePath: ', this.getCampaignXBasePath())
     if (shareButtonClicked || showShareCampaignWithOneFriend) {
       // Since showing direct message choices is the final step,
       // link should take voter back to the campaign updates page or on to the  "recommended-campaigns"
       if (recommendedCampaignXListHasBeenRetrieved && recommendedCampaignXListCount > 0) {
-        historyPush(`${this.getCampaignBasePath()}/recommended-campaigns`);
+        historyPush(`${this.getCampaignXBasePath()}/recommended-campaigns`);
       } else {
-        historyPush(`${this.getCampaignBasePath()}/updates`);
+        historyPush(`${this.getCampaignXBasePath()}/updates`);
       }
     } else {
-      historyPush(`${this.getCampaignBasePath()}/share-campaign-with-one-friend`);
+      historyPush(`${this.getCampaignXBasePath()}/share-campaign-with-one-friend`);
     }
   }
 
@@ -234,8 +255,9 @@ class CampaignSupportShare extends Component {
             <ContentInnerWrapperDefault>
               <CampaignSupportSteps
                 atSharingStep
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXWeVoteId={campaignXWeVoteId}
+                politicianBasePath={this.getPoliticianBasePath()}
               />
               <CampaignSupportImageWrapper>
                 {campaignPhotoLargeUrl ? (

--- a/src/js/common/pages/Settings/CompleteYourProfileMobile.jsx
+++ b/src/js/common/pages/Settings/CompleteYourProfileMobile.jsx
@@ -1,0 +1,180 @@
+import { Close } from '@mui/icons-material';
+import { IconButton } from '@mui/material';
+import styled from 'styled-components';
+import withStyles from '@mui/styles/withStyles';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import Helmet from 'react-helmet';
+import { OuterWrapper } from '../../components/Style/stepDisplayStyles';
+import historyPush from '../../utils/historyPush';
+import { renderLog } from '../../utils/logging';
+import CompleteYourProfile from '../../components/Settings/CompleteYourProfile';
+import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
+
+
+class CompleteYourProfileMobile extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      campaignSEOFriendlyPath: '',
+      campaignXWeVoteId: '',
+      pathToUseWhenProfileComplete: '',
+    };
+  }
+
+  componentDidMount () {
+    // console.log('CampaignDetailsPage componentDidMount');
+    this.onAppObservableStoreChange();
+    this.appStateSubscription = messageService.getMessage().subscribe(() => this.onAppObservableStoreChange());
+    const { match: { params }, setShowHeaderFooter } = this.props;
+    const { campaignSEOFriendlyPath, campaignXWeVoteId } = params;
+    const { becomeMember, createNewsItem, startCampaign, supportCampaign } = this.props;
+    let pathToUseWhenProfileComplete = '';
+    if (becomeMember) {
+      pathToUseWhenProfileComplete = '/membership';
+    } else if (startCampaign) {
+      pathToUseWhenProfileComplete = '/profile/started';
+    } else if (createNewsItem && campaignSEOFriendlyPath) {
+      pathToUseWhenProfileComplete = `/c/${campaignSEOFriendlyPath}/add-update`;
+    } else if (createNewsItem && campaignXWeVoteId) {
+      pathToUseWhenProfileComplete = `/id/${campaignXWeVoteId}/add-update`;
+    } else if (supportCampaign && campaignSEOFriendlyPath) {
+      pathToUseWhenProfileComplete = `/c/${campaignSEOFriendlyPath}/why-do-you-support`;
+    } else if (supportCampaign && campaignXWeVoteId) {
+      pathToUseWhenProfileComplete = `/id/${campaignXWeVoteId}/why-do-you-support`;
+    }
+    // console.log('componentDidMount campaignSEOFriendlyPath: ', campaignSEOFriendlyPath, ', campaignXWeVoteId: ', campaignXWeVoteId);
+    this.setState({
+      campaignSEOFriendlyPath,
+      campaignXWeVoteId,
+      pathToUseWhenProfileComplete,
+    });
+    setShowHeaderFooter(false);
+    window.scrollTo(0, 0);
+  }
+
+  componentWillUnmount () {
+    const { setShowHeaderFooter } = this.props;
+    setShowHeaderFooter(true);
+    this.appStateSubscription.unsubscribe();
+  }
+
+  onAppObservableStoreChange () {
+    const chosenWebsiteName = AppObservableStore.getChosenWebsiteName();
+    this.setState({
+      chosenWebsiteName,
+    });
+  }
+
+  cancelFunction = () => {
+    // console.log('CompleteYourProfileMobile cancelFunction');
+    const { becomeMember, createNewsItem, startCampaign, supportCampaign } = this.props;
+    const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
+    if (becomeMember) {
+      historyPush('/start-a-campaign-preview');
+    } else if (startCampaign) {
+      historyPush('/start-a-campaign-preview');
+    } else if (createNewsItem && campaignSEOFriendlyPath) {
+      historyPush(`/c/${campaignSEOFriendlyPath}/updates`);
+    } else if (createNewsItem && campaignXWeVoteId) {
+      historyPush(`/id/${campaignXWeVoteId}/updates`);
+    } else if (supportCampaign && campaignSEOFriendlyPath) {
+      historyPush(`/c/${campaignSEOFriendlyPath}`);
+    } else if (supportCampaign && campaignXWeVoteId) {
+      historyPush(`/id/${campaignXWeVoteId}`);
+    }
+  };
+
+  functionToUseWhenProfileComplete = () => {
+    const { pathToUseWhenProfileComplete } = this.state;
+    historyPush(pathToUseWhenProfileComplete);
+  }
+
+  render () {
+    renderLog('CompleteYourProfileMobile');  // Set LOG_RENDER_EVENTS to log all renders
+    const { becomeMember, classes, createNewsItem, startCampaign, supportCampaign } = this.props;
+    const { campaignXWeVoteId, chosenWebsiteName } = this.state;
+    let completeProfileTitle = <span>&nbsp;</span>;
+    let htmlPageTitle = `Complete Your Profile - ${chosenWebsiteName}`;
+    if (becomeMember) {
+      completeProfileTitle = <span>becomeMember</span>;
+    } else if (createNewsItem) {
+      completeProfileTitle = <span>Complete your profile</span>;
+    } else if (startCampaign) {
+      completeProfileTitle = <span>Complete your profile</span>;
+    } else if (supportCampaign) {
+      completeProfileTitle = <span>Complete your support</span>;
+      htmlPageTitle = `Complete Your Support - ${chosenWebsiteName}`;
+    }
+    return (
+      <div>
+        <Helmet title={htmlPageTitle} />
+        <PageWrapperComplete>
+          <OuterWrapper>
+            <InnerWrapper>
+              <ContentTitle>
+                {completeProfileTitle}
+                <IconButton
+                  aria-label="Close"
+                  classes={{ root: classes.closeButton }}
+                  onClick={() => { this.cancelFunction(); }}
+                  id="completeYourProfileMobileClose"
+                  size="large"
+                >
+                  <Close />
+                </IconButton>
+              </ContentTitle>
+              <CompleteYourProfile
+                becomeMember={becomeMember}
+                campaignXWeVoteId={campaignXWeVoteId}
+                functionToUseWhenProfileComplete={this.functionToUseWhenProfileComplete}
+                createNewsItem={createNewsItem}
+                startCampaign={startCampaign}
+                supportCampaign={supportCampaign}
+              />
+            </InnerWrapper>
+          </OuterWrapper>
+        </PageWrapperComplete>
+      </div>
+    );
+  }
+}
+CompleteYourProfileMobile.propTypes = {
+  classes: PropTypes.object,
+  becomeMember: PropTypes.bool,
+  createNewsItem: PropTypes.bool,
+  match: PropTypes.object,
+  startCampaign: PropTypes.bool,
+  supportCampaign: PropTypes.bool,
+  setShowHeaderFooter: PropTypes.func,
+};
+
+const styles = () => ({
+  buttonRoot: {
+    width: 250,
+  },
+  closeButton: {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+});
+
+const ContentTitle = styled('h1')(({ theme }) => (`
+  font-size: 22px;
+  font-weight: 600;
+  margin: 20px 15px;
+  ${theme.breakpoints.down('sm')} {
+    font-size: 20px;
+  }
+`));
+
+const InnerWrapper = styled('div')`
+`;
+
+const PageWrapperComplete = styled('div')`
+  margin: 0 auto;
+  max-width: 480px;
+`;
+
+export default withStyles(styles)(CompleteYourProfileMobile);

--- a/src/js/common/pages/SuperSharing/SuperSharingAddContacts.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingAddContacts.jsx
@@ -183,7 +183,7 @@ class SuperSharingAddContacts extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -198,14 +198,14 @@ class SuperSharingAddContacts extends Component {
   goToNextStep = () => {
     const { campaignXNewsItemWeVoteId } = this.state;
     if (campaignXNewsItemWeVoteId) {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-choose-email-recipients/${campaignXNewsItemWeVoteId}`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-choose-email-recipients/${campaignXNewsItemWeVoteId}`);
     } else {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-choose-email-recipients`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-choose-email-recipients`);
     }
   }
 
   returnToOtherSharingOptions = () => {
-    historyPush(`${this.getCampaignBasePath()}/share-campaign`);
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
   }
 
   submitSkipForNow = () => {
@@ -235,7 +235,7 @@ class SuperSharingAddContacts extends Component {
             <ContentInnerWrapperDefault>
               <SuperSharingSteps
                 atStepNumber1
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXNewsItemWeVoteId={campaignXNewsItemWeVoteId}
                 campaignXWeVoteId={campaignXWeVoteId}
               />

--- a/src/js/common/pages/SuperSharing/SuperSharingChooseRecipients.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingChooseRecipients.jsx
@@ -210,7 +210,7 @@ class SuperSharingChooseRecipients extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -225,9 +225,9 @@ class SuperSharingChooseRecipients extends Component {
   goToNextStep = () => {
     const { campaignXNewsItemWeVoteId } = this.state;
     if (campaignXNewsItemWeVoteId) {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-compose-email/${campaignXNewsItemWeVoteId}`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-compose-email/${campaignXNewsItemWeVoteId}`);
     } else {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-compose-email`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-compose-email`);
     }
   }
 
@@ -242,9 +242,9 @@ class SuperSharingChooseRecipients extends Component {
   onClickAddContacts = () => {
     const { campaignXNewsItemWeVoteId } = this.state;
     if (campaignXNewsItemWeVoteId) {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-add-email-contacts/${campaignXNewsItemWeVoteId}`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-add-email-contacts/${campaignXNewsItemWeVoteId}`);
     } else {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-add-email-contacts`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-add-email-contacts`);
     }
   }
 
@@ -277,7 +277,7 @@ class SuperSharingChooseRecipients extends Component {
   }
 
   returnToOtherSharingOptions = () => {
-    historyPush(`${this.getCampaignBasePath()}/share-campaign`);
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
   }
 
   submitSkipForNow = () => {
@@ -326,7 +326,7 @@ class SuperSharingChooseRecipients extends Component {
             <ContentInnerWrapperDefault>
               <SuperSharingSteps
                 atStepNumber2
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXNewsItemWeVoteId={campaignXNewsItemWeVoteId}
                 campaignXWeVoteId={campaignXWeVoteId}
               />

--- a/src/js/common/pages/SuperSharing/SuperSharingComposeEmailMessage.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingComposeEmailMessage.jsx
@@ -195,7 +195,7 @@ class SuperSharingComposeEmailMessage extends Component {
     const { campaignXNewsItemWeVoteId } = this.state;
     const mostRecentlySavedCampaignXNewsItemWeVoteId = CampaignNewsItemStore.getMostRecentlySavedCampaignXNewsItemWeVoteId();
     if (mostRecentlySavedCampaignXNewsItemWeVoteId && mostRecentlySavedCampaignXNewsItemWeVoteId !== campaignXNewsItemWeVoteId) {
-      historyPush(`${this.getCampaignBasePath()}/u-preview/${mostRecentlySavedCampaignXNewsItemWeVoteId}`);
+      historyPush(`${this.getCampaignXBasePath()}/u-preview/${mostRecentlySavedCampaignXNewsItemWeVoteId}`);
     }
   }
 
@@ -216,7 +216,7 @@ class SuperSharingComposeEmailMessage extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -243,14 +243,14 @@ class SuperSharingComposeEmailMessage extends Component {
   goToNextStep = () => {
     const { campaignXNewsItemWeVoteId } = this.state;
     if (campaignXNewsItemWeVoteId) {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-send-email/${campaignXNewsItemWeVoteId}`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-send-email/${campaignXNewsItemWeVoteId}`);
     } else {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-send-email`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-send-email`);
     }
   }
 
   returnToOtherSharingOptions = () => {
-    historyPush(`${this.getCampaignBasePath()}/share-campaign`);
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
   }
 
   submitSkipForNow = () => {
@@ -283,7 +283,7 @@ class SuperSharingComposeEmailMessage extends Component {
         ShareActions.personalizedMessageQueuedToSave(undefined);
       });
     }
-    historyPush(`${this.getCampaignBasePath()}/super-sharing-send-email`);
+    historyPush(`${this.getCampaignXBasePath()}/super-sharing-send-email`);
   }
 
   render () {
@@ -309,7 +309,7 @@ class SuperSharingComposeEmailMessage extends Component {
             <ContentInnerWrapperDefault>
               <SuperSharingSteps
                 atStepNumber3
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXNewsItemWeVoteId={campaignXNewsItemWeVoteId}
                 campaignXWeVoteId={campaignXWeVoteId}
               />

--- a/src/js/common/pages/SuperSharing/SuperSharingIntro.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingIntro.jsx
@@ -62,7 +62,7 @@ class SuperSharingIntro extends Component {
     window.scrollTo(0, 0);
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { match: { params } } = this.props;
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = params;
     let campaignBasePath;
@@ -75,15 +75,15 @@ class SuperSharingIntro extends Component {
   }
 
   returnToOtherSharingOptions = () => {
-    historyPush(`${this.getCampaignBasePath()}/share-campaign`);
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
   }
 
   startSuperSharing = () => {
     const { sms } = this.props;
     if (sms) {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-add-sms-contacts`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-add-sms-contacts`);
     } else {
-      historyPush(`${this.getCampaignBasePath()}/super-sharing-add-email-contacts`);
+      historyPush(`${this.getCampaignXBasePath()}/super-sharing-add-email-contacts`);
     }
   }
 

--- a/src/js/common/pages/SuperSharing/SuperSharingSendEmail.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingSendEmail.jsx
@@ -197,7 +197,7 @@ class SuperSharingSendEmail extends Component {
     });
   }
 
-  getCampaignBasePath = () => {
+  getCampaignXBasePath = () => {
     const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
     let campaignBasePath;
     if (campaignSEOFriendlyPath) {
@@ -212,7 +212,7 @@ class SuperSharingSendEmail extends Component {
   onStep1Click = () => {
     const { campaignXNewsItemWeVoteId } = this.state;
     const sms = false;
-    const step1ClickPath = onStep1ClickPath(this.getCampaignBasePath(), campaignXNewsItemWeVoteId, sms);
+    const step1ClickPath = onStep1ClickPath(this.getCampaignXBasePath(), campaignXNewsItemWeVoteId, sms);
     if (step1ClickPath) {
       historyPush(step1ClickPath);
     }
@@ -221,7 +221,7 @@ class SuperSharingSendEmail extends Component {
   onStep2Click = () => {
     const { campaignXNewsItemWeVoteId } = this.state;
     const sms = false;
-    const step2ClickPath = onStep2ClickPath(this.getCampaignBasePath(), campaignXNewsItemWeVoteId, sms);
+    const step2ClickPath = onStep2ClickPath(this.getCampaignXBasePath(), campaignXNewsItemWeVoteId, sms);
     if (step2ClickPath) {
       historyPush(step2ClickPath);
     }
@@ -230,14 +230,14 @@ class SuperSharingSendEmail extends Component {
   onStep3Click = () => {
     const { campaignXNewsItemWeVoteId } = this.state;
     const sms = false;
-    const step3ClickPath = onStep3ClickPath(this.getCampaignBasePath(), campaignXNewsItemWeVoteId, sms);
+    const step3ClickPath = onStep3ClickPath(this.getCampaignXBasePath(), campaignXNewsItemWeVoteId, sms);
     if (step3ClickPath) {
       historyPush(step3ClickPath);
     }
   }
 
   returnToOtherSharingOptions = () => {
-    historyPush(`${this.getCampaignBasePath()}/share-campaign`);
+    historyPush(`${this.getCampaignXBasePath()}/share-campaign`);
   }
 
   submitSendEmail = () => {
@@ -248,7 +248,7 @@ class SuperSharingSendEmail extends Component {
         initializejQuery(() => {
           ShareActions.superSharingSendEmail(superShareItemId);
         });
-        historyPush(`${this.getCampaignBasePath()}/recommended-campaigns`);
+        historyPush(`${this.getCampaignXBasePath()}/recommended-campaigns`);
       }
     }
   }
@@ -278,7 +278,7 @@ class SuperSharingSendEmail extends Component {
             <ContentInnerWrapperDefault>
               <SuperSharingSteps
                 atStepNumber4
-                campaignBasePath={this.getCampaignBasePath()}
+                campaignBasePath={this.getCampaignXBasePath()}
                 campaignXNewsItemWeVoteId={campaignXNewsItemWeVoteId}
                 campaignXWeVoteId={campaignXWeVoteId}
               />

--- a/src/js/common/utils/campaignUtils.js
+++ b/src/js/common/utils/campaignUtils.js
@@ -18,6 +18,7 @@ export function getCampaignXValuesFromIdentifiers (campaignSEOFriendlyPath, camp
   let isBlockedByWeVote = false;
   let isBlockedByWeVoteReason = '';
   let isSupportersCountMinimumExceeded = false;
+  let linkedPoliticianWeVoteId = '';
   let voterIsCampaignXOwner = false;
   if (campaignSEOFriendlyPath) {
     campaignX = CampaignStore.getCampaignXBySEOFriendlyPath(campaignSEOFriendlyPath);
@@ -34,6 +35,7 @@ export function getCampaignXValuesFromIdentifiers (campaignSEOFriendlyPath, camp
       is_blocked_by_we_vote: isBlockedByWeVote,
       is_blocked_by_we_vote_reason: isBlockedByWeVoteReason,
       is_supporters_count_minimum_exceeded: isSupportersCountMinimumExceeded,
+      linked_politician_we_vote_id: linkedPoliticianWeVoteId,
       voter_is_campaignx_owner: voterIsCampaignXOwner,
       we_vote_hosted_campaign_photo_large_url: campaignPhotoLargeUrl,
       we_vote_hosted_campaign_photo_medium_url: campaignPhotoMediumUrl,
@@ -54,6 +56,7 @@ export function getCampaignXValuesFromIdentifiers (campaignSEOFriendlyPath, camp
     isBlockedByWeVote,
     isBlockedByWeVoteReason,
     isSupportersCountMinimumExceeded,
+    linkedPoliticianWeVoteId,
     voterIsCampaignXOwner,
   };
 }

--- a/src/js/common/utils/filterListToRemoveEntriesWithDuplicateValue.js
+++ b/src/js/common/utils/filterListToRemoveEntriesWithDuplicateValue.js
@@ -1,0 +1,22 @@
+import arrayContains from './arrayContains';
+
+export default function filterListToRemoveEntriesWithDuplicateValue (incomingList, fieldName, fieldRequired = false) {
+  let isUniqueEntry;
+  const valuesAlreadySeenList = [];
+  return incomingList.filter((oneEntry) => {
+    isUniqueEntry = true;
+    if (!oneEntry || !oneEntry[fieldName]) {
+      if (fieldRequired) {
+        // While we require a value in the field (in fieldName), we filter out all entries that don't have one
+        isUniqueEntry = false;
+      } else {
+        // When we don't require a value for the fieldName, we can pass -- entry can be considered unique
+      }
+    } else if (arrayContains(oneEntry[fieldName], valuesAlreadySeenList)) {
+      isUniqueEntry = false;
+    } else {
+      valuesAlreadySeenList.push(oneEntry[fieldName]);
+    }
+    return isUniqueEntry;
+  });
+}

--- a/src/js/common/utils/saveCampaignSupportAndGoToNextPage.js
+++ b/src/js/common/utils/saveCampaignSupportAndGoToNextPage.js
@@ -1,0 +1,34 @@
+import CampaignSupporterActions from '../actions/CampaignSupporterActions';
+import CampaignSupporterStore from '../stores/CampaignSupporterStore';
+import historyPush from './historyPush';
+import initializejQuery from './initializejQuery';
+
+function goToNextPage (campaignXBaseBath) {
+  const pathToUseWhenProfileComplete = `${campaignXBaseBath}/why-do-you-support`;
+  console.log('goToNextPage pathToUseWhenProfileComplete: ', pathToUseWhenProfileComplete);
+  setTimeout(() => {
+    historyPush(pathToUseWhenProfileComplete);
+  }, 500);
+  return null;
+}
+
+export default function saveCampaignSupportAndGoToNextPage (campaignXWeVoteId = '', campaignXBaseBath = '') {
+  if (!campaignXWeVoteId) {
+    console.log('saveCampaignSupportAndGoToNextPage MISSING campaignXWeVoteId');
+    return null;
+  }
+  let visibleToPublic = CampaignSupporterStore.getVisibleToPublic(campaignXWeVoteId);
+  const visibleToPublicChanged = CampaignSupporterStore.getVisibleToPublicQueuedToSaveSet();
+  if (visibleToPublicChanged) {
+    // If it has changed, use new value
+    visibleToPublic = CampaignSupporterStore.getVisibleToPublicQueuedToSave();
+  }
+  console.log('saveCampaignSupportAndGoToNextPage visibleToPublic: ', visibleToPublic);
+  const campaignSupported = true;
+  const campaignSupportedChanged = true;
+  const saveVisibleToPublic = true;
+  initializejQuery(() => {
+    CampaignSupporterActions.supportCampaignSave(campaignXWeVoteId, campaignSupported, campaignSupportedChanged, visibleToPublic, saveVisibleToPublic);
+  }, goToNextPage(campaignXBaseBath));
+  return null;
+}

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -345,7 +345,7 @@ class OfficeItemCompressed extends Component {
                   </Suspense>
                 </PositionRowListScoreSpacer>
               </PositionRowListScoreColumn>
-            )
+            );
             return (
               <BallotScrollingInnerWrapper key={uniqueKey}>
                 <BallotHorizontallyScrollingContainer>

--- a/src/js/components/CandidateListRoot/FirstCandidateListController.jsx
+++ b/src/js/components/CandidateListRoot/FirstCandidateListController.jsx
@@ -67,34 +67,41 @@ class FirstCandidateListController extends Component {
   }
 
   CandidatesForStateRetrieve = () => {
-    const { stateCode, year } = this.props;
+    const { stateCode } = this.props; // year
     initializejQuery(() => {
-      const yearsRetrieved = [];
-      // Retrieve all candidates for this state for last two years
+      // Retrieve all candidates for this state for this and next year (previously: last two years)
       const today = new Date();
       const thisYearInteger = today.getFullYear();
-      let electionDay = thisYearInteger;
-      // console.log(`candidatesQuery-${stateCode}-${electionDay}`);
+      // console.log(`candidatesQuery-${stateCode}-${thisYearInteger}`);
       let filteredStateCode = '';
       if (stateCode) {
         filteredStateCode = stateCode.toLowerCase().replace('all', '');
         filteredStateCode = filteredStateCode.toLowerCase().replace('na', '');
       }
-      if (apiCalming(`candidatesQuery-${stateCode}-${electionDay}`, 180000)) {
-        CandidateActions.candidatesQuery(electionDay, [], filteredStateCode);
+      if (apiCalming(`candidatesQuery-${stateCode}-${thisYearInteger}`, 180000)) {
+        CandidateActions.candidatesQuery(thisYearInteger, [], filteredStateCode);
       }
-      yearsRetrieved.push(electionDay);
-      electionDay = thisYearInteger - 1;
-      // console.log(`candidatesQuery-${stateCode}-${electionDay}`);
-      if (apiCalming(`candidatesQuery-${stateCode}-${electionDay}`, 180000)) {
-        CandidateActions.candidatesQuery(electionDay, [], filteredStateCode);
+      // Now retrieve national candidates (Presidential)
+      if (apiCalming(`candidatesQuery-na-${thisYearInteger}`, 180000)) {
+        CandidateActions.candidatesQuery(thisYearInteger, [], 'na');
       }
-      yearsRetrieved.push(electionDay);
-      if (!(year in yearsRetrieved)) {
-        if (apiCalming(`candidatesQuery-${stateCode}-${year}`, 180000)) {
-          CandidateActions.candidatesQuery(year, [], filteredStateCode);
-        }
+      // const yearsRetrieved = [];
+      // yearsRetrieved.push(thisYearInteger);
+      const nextYear = thisYearInteger + 1;
+      // console.log(`candidatesQuery-${stateCode}-${nextYear}`);
+      if (apiCalming(`candidatesQuery-${stateCode}-${nextYear}`, 180000)) {
+        CandidateActions.candidatesQuery(nextYear, [], filteredStateCode);
       }
+      // Now retrieve national candidates (Presidential)
+      if (apiCalming(`candidatesQuery-na-${nextYear}`, 180000)) {
+        CandidateActions.candidatesQuery(nextYear, [], 'na');
+      }
+      // yearsRetrieved.push(nextYear);
+      // if (!(year in yearsRetrieved)) {
+      //   if (apiCalming(`candidatesQuery-${stateCode}-${year}`, 180000)) {
+      //     CandidateActions.candidatesQuery(year, [], filteredStateCode);
+      //   }
+      // }
     });
   }
 

--- a/src/js/components/Navigation/FooterCandidateList.jsx
+++ b/src/js/components/Navigation/FooterCandidateList.jsx
@@ -34,9 +34,10 @@ export default function FooterCandidateList () {
 }
 
 const FooterCandidateListWrapper = styled('span')`
+  align-items: center;
   display: flex;
   flex-flow: column;
-  align-items: center;
+  margin-top: 10px; // To match BallotElectionListWithFilters
 `;
 
 const SimpleModeItemWrapper = styled('div')`

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -56,7 +56,7 @@ class ItemActionBar extends PureComponent {
     const { ballotItemWeVoteId } = this.props;
     if (ballotItemWeVoteId) {
       const isCandidate = stringContains('cand', ballotItemWeVoteId); // isCandidate = the default
-      const isMeasure = stringContains('meas', ballotItemWeVoteId); // isCandidate = the default
+      const isMeasure = stringContains('meas', ballotItemWeVoteId);
       const isPolitician = stringContains('pol', ballotItemWeVoteId);
       let ballotItemType;
       if (isCandidate) {
@@ -73,6 +73,7 @@ class ItemActionBar extends PureComponent {
       let numberOfOpposePositionsForScore = 0;
       let voterTextStatement = '';
       const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);
+      // console.log('ballotItemStatSheet', ballotItemStatSheet);
       if (ballotItemStatSheet) {
         const {
           voterOpposesBallotItem,

--- a/src/js/pages/Campaigns/CampaignsHome.jsx
+++ b/src/js/pages/Campaigns/CampaignsHome.jsx
@@ -69,7 +69,7 @@ class CampaignsHome extends Component {
   }
 
   componentDidMount () {
-    console.log('CampaignsHome componentDidMount');
+    // console.log('CampaignsHome componentDidMount');
     window.scrollTo(0, 0);
     const { match: { params: {
       state_candidates_phrase: stateCandidatesPhrase,
@@ -93,6 +93,7 @@ class CampaignsHome extends Component {
     // Pulled from onCandidateStoreChange and onBallotStoreChange
     // Note: sorting is being done in CandidateListRoot
     const candidateList = CandidateStore.getCandidateList();
+    // console.log('ComponentDidMount candidateList', candidateList);
     const { candidateListOnYourBallot, candidateListIsBattleground, candidateListOther } = this.splitUpCandidateList(candidateList);
     this.setState({
       candidateList,
@@ -305,8 +306,9 @@ class CampaignsHome extends Component {
 
   splitUpCandidateList = (candidateList) => {
     const { politicianWeVoteIdsAlreadyShown } = this.state;
-    // console.log('splitUpCandidateList, politicianWeVoteIdsAlreadyShown:', politicianWeVoteIdsAlreadyShown)
+    // console.log('splitUpCandidateList, politicianWeVoteIdsAlreadyShown:', politicianWeVoteIdsAlreadyShown);
     const candidateListOnYourBallot = BallotStore.getAllBallotItemsFlattened();
+    // console.log('splitUpCandidateList, candidateListOnYourBallot:', candidateListOnYourBallot);
     const weVoteIdsOnYourBallot = extractAttributeValueListFromObjectList('we_vote_id', candidateListOnYourBallot);
     const candidateListRemaining = candidateList.filter((oneCandidate) => !arrayContains(oneCandidate.we_vote_id, weVoteIdsOnYourBallot));
     const candidateListIsBattleground = candidateListRemaining.filter((oneCandidate) => oneCandidate.is_battleground_race);
@@ -337,12 +339,13 @@ class CampaignsHome extends Component {
   updateActiveFilters = (setDefaultListMode = false) => {
     const {
       campaignList, candidateList,
-      listOfYearsWhenCampaignExists, listOfYearsWhenCandidateExists, listOfYearsWhenRepresentativeExists,
+      // listOfYearsWhenCampaignExists, listOfYearsWhenCandidateExists,
+      listOfYearsWhenRepresentativeExists,
     } = this.state;
     let { listModeShown } = this.state;
-    const listOfYears = [...new Set([...listOfYearsWhenCampaignExists, ...listOfYearsWhenCandidateExists, ...listOfYearsWhenRepresentativeExists])];
+    // const listOfYears = [...new Set([...listOfYearsWhenCampaignExists, ...listOfYearsWhenCandidateExists, ...listOfYearsWhenRepresentativeExists])];
     // console.log('listOfYears:', listOfYears, ', setDefaultListMode:', setDefaultListMode);
-    let filterCount = 0;
+    // let filterCount = 0;
     let upcomingEndorsementsAvailable = false;
     const todayAsInteger = getTodayAsInteger();
     // console.log('thisYearInteger:', thisYearInteger);
@@ -375,21 +378,21 @@ class CampaignsHome extends Component {
     // const useDropdownWithThisNumberOfYears = 4;
     // const displayAsChip = numberOfYears < useDropdownWithThisNumberOfYears;
     const displayAsChip = true; // Explore converting this to a dropdown
-    listOfYears.forEach((oneYear) => {
-      filterCount += 1;
-      listModeFiltersAvailable.push({
-        displayAsChip,
-        filterDisplayName: `${oneYear}`,
-        filterName: `show${oneYear}`,
-        filterOrder: 5000 - oneYear,
-        filterSelected: listModeShown === `show${oneYear}`,
-        filterType: 'showYear',
-        filterYear: oneYear,
-      });
-    });
-    // if (upcomingEndorsementsAvailable) {
-    // We still want to show this filter option
-    filterCount += 1;
+    // listOfYears.forEach((oneYear) => {
+    //   filterCount += 1;
+    //   listModeFiltersAvailable.push({
+    //     displayAsChip,
+    //     filterDisplayName: `${oneYear}`,
+    //     filterName: `show${oneYear}`,
+    //     filterOrder: 5000 - oneYear,
+    //     filterSelected: listModeShown === `show${oneYear}`,
+    //     filterType: 'showYear',
+    //     filterYear: oneYear,
+    //   });
+    // });
+    // // if (upcomingEndorsementsAvailable) {
+    // // We still want to show this filter option
+    // filterCount += 1;
     listModeFiltersAvailable.push({
       displayAsChip: true,
       filterDisplayName: 'Upcoming',
@@ -398,8 +401,9 @@ class CampaignsHome extends Component {
       filterSelected: listModeShown === 'showUpcomingEndorsements',
       filterType: 'showUpcomingEndorsements',
     });
-    // }
-    if (filterCount > 1) {
+    // // }
+    // if (filterCount > 1) {
+    if (listModeShown === 'showAllEndorsements') {
       listModeFiltersAvailable.push({
         displayAsChip,
         filterDisplayName: 'All Years',
@@ -438,16 +442,20 @@ class CampaignsHome extends Component {
 
   getDefaultListModeShown = (incomingUpcomingEndorsementsAvailable = false) => {
     const { listOfYearsWhenCampaignExists, listOfYearsWhenCandidateExists, listOfYearsWhenRepresentativeExists, upcomingEndorsementsAvailable } = this.state;
+    // const { upcomingEndorsementsAvailable } = this.state;
     const listOfYears = [...new Set([...listOfYearsWhenCampaignExists, ...listOfYearsWhenCandidateExists, ...listOfYearsWhenRepresentativeExists])];
     // console.log('getDefaultListModeShown listOfYearsWhenCandidateExists:', listOfYearsWhenCandidateExists);
     if (upcomingEndorsementsAvailable || incomingUpcomingEndorsementsAvailable) {
       return 'showUpcomingEndorsements';
-    } else if (listOfYears && listOfYears.length > 0) {
-      const mostRecentYear = Math.max.apply(null, listOfYears);
-      // console.log('mostRecentYear:', mostRecentYear);
-      return `show${mostRecentYear}`;
+      // } else if (listOfYears && listOfYears.length > 0) {
+      //   const mostRecentYear = Math.max.apply(null, listOfYears);
+      //   // console.log('mostRecentYear:', mostRecentYear);
+      //   return `show${mostRecentYear}`;
+      // }
+    } else if (listOfYears && listOfYears.length > 1) {
+      return 'showAllEndorsements';
     }
-    return 'showAllEndorsements';
+    return 'showUpcomingEndorsements';
   }
 
   getListOfYearsWhenCampaignExists = (campaignList) => {
@@ -600,6 +608,7 @@ class CampaignsHome extends Component {
               <WhatIsHappeningSection>
                 <Suspense fallback={<span>&nbsp;</span>}>
                   <CampaignListRoot
+                    hideCampaignsLinkedToPoliticians
                     hideIfNoResults
                     incomingList={campaignList}
                     incomingListTimeStampOfChange={campaignListTimeStampOfChange}
@@ -696,6 +705,7 @@ class CampaignsHome extends Component {
             <WhatIsHappeningSection>
               <Suspense fallback={<span>&nbsp;</span>}>
                 <CampaignListRoot
+                  hideCampaignsLinkedToPoliticians
                   hideIfNoResults
                   incomingList={campaignList}
                   incomingListTimeStampOfChange={campaignListTimeStampOfChange}
@@ -703,7 +713,8 @@ class CampaignsHome extends Component {
                   listModeFiltersTimeStampOfChange={listModeFiltersTimeStampOfChange}
                   searchText={searchText}
                   stateCode={stateCode}
-                  titleTextForList="Upcoming Campaigns"
+                  // titleTextForList="Upcoming Campaigns" // TODO: Needs work
+                  titleTextForList="Campaigns"
                 />
               </Suspense>
             </WhatIsHappeningSection>

--- a/src/js/stores/CandidateStore.js
+++ b/src/js/stores/CandidateStore.js
@@ -89,6 +89,7 @@ class CandidateStore extends ReduceStore {
   //  support.
   getAllCachedPositionsByPoliticianWeVoteId (politicianWeVoteId) {
     const candidateList = this.getState().candidateListsByPoliticianWeVoteId[politicianWeVoteId] || [];
+    // console.log('candidateList', candidateList);
     let allCachedPositionsList = [];
     let allCachedPositionsListForThisCandidate;
     let allCachedPositionsForThisCandidateDict;
@@ -101,7 +102,7 @@ class CandidateStore extends ReduceStore {
       // console.log('222) allCachedPositionsListForThisCandidate', allCachedPositionsListForThisCandidate);
       allCachedPositionsList = allCachedPositionsList.concat(allCachedPositionsListForThisCandidate);
     });
-    // console.log('getAllCachedPositionsByPoliticianWeVoteId candidateList', candidateList, ', allCachedPositionsList:', allCachedPositionsList);
+    // console.log('getAllCachedPositionsByPoliticianWeVoteId ', politicianWeVoteId, ', candidateList:', candidateList, ', allCachedPositionsList:', allCachedPositionsList);
     return allCachedPositionsList;
   }
 
@@ -370,6 +371,29 @@ class CandidateStore extends ReduceStore {
           allCachedCandidates,
           candidateListsByPoliticianWeVoteId,
         };
+
+      case 'representativesQuery':
+        // incomingRepresentativeCount = 0;
+        // candidateList = action.res.candidates;
+        // // console.log('CandidateStore candidatesRetrieve contestOfficeWeVoteId:', contestOfficeWeVoteId, ', candidateList:', candidateList);
+        // candidateList.forEach((one) => {
+        //   // allCachedCandidates[one.we_vote_id] = one;
+        //   incomingRepresentativeCount += 1;
+        // });
+        // // console.log('localRepresentativeList:', localRepresentativeList);
+        // // console.log('candidateListsByOfficeWeVoteId:', candidateListsByOfficeWeVoteId);
+        // // console.log('candidateListsByOfficeWeVoteId[contestOfficeWeVoteId]:', candidateListsByOfficeWeVoteId[contestOfficeWeVoteId]);
+        // // candidateListsByOfficeWeVoteId[contestOfficeWeVoteId].forEach((two) => {
+        // //   console.log('two:', two);
+        // // });
+        //
+        // return {
+        //   ...state,
+        //   allCachedCandidates,
+        //   candidateListsByOfficeWeVoteId,
+        //   numberOfCandidatesRetrievedByOffice,
+        // };
+        return state;
 
       case 'voterAddressSave':
       case 'voterBallotItemsRetrieve':

--- a/src/js/stores/SupportStore.js
+++ b/src/js/stores/SupportStore.js
@@ -34,12 +34,17 @@ class SupportStore extends ReduceStore {
     }
     const isCandidate = stringContains('cand', ballotItemWeVoteId);
     const isMeasure = stringContains('meas', ballotItemWeVoteId);
+    // const isPolitician = stringContains('pol', ballotItemWeVoteId);
     let allCachedPositions = [];
     if (isCandidate) {
       allCachedPositions = CandidateStore.getAllCachedPositionsByCandidateWeVoteId(ballotItemWeVoteId);
     } else if (isMeasure) {
       allCachedPositions = MeasureStore.getAllCachedPositionsByMeasureWeVoteId(ballotItemWeVoteId);
     }
+    // TODO Reality check this
+    // else if (isPolitician) {
+    //   allCachedPositions = CandidateStore.getAllCachedPositionsByPoliticianWeVoteId(ballotItemWeVoteId);
+    // }
     // console.log('getBallotItemStatSheet allCachedPositions:', allCachedPositions);
     const results = extractScoreFromNetworkFromPositionList(allCachedPositions);
     const { numberOfSupportPositionsForScore, numberOfOpposePositionsForScore, numberOfInfoOnlyPositionsForScore } = results;


### PR DESCRIPTION
Updated 'Show your support' button language to 'Help them win by endorsing'. Added getPoliticianBasePath distinct from getCampaignBasePath. Did navigation (Campaign top nav) cleanup, including jumping back to Politician page from Campaign pages for linked campaigns. Refactored the CampaignListRoot, CandidateListRoot and RepresentativeListRoot to use more generic internal variables, so we can compare those files and more easily see the significant differences. Updated the CampaignsHome to remove filters by year.