### PR TITLE
On the API server we are now storing the politician profile photo in CampaignX entries, and this update changes how we display these photos (if a campaign photo doesn't exist). On CampaignsHome, removed the display of Campaigns for prior elections outside of search.

### DIFF
--- a/src/js/common/components/Campaign/CampaignCardForList.jsx
+++ b/src/js/common/components/Campaign/CampaignCardForList.jsx
@@ -7,10 +7,25 @@ import styled from 'styled-components';
 // import { convertStateCodeToStateText } from '../../utils/addressFunctions';
 // import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import {
-  CampaignImageMobile, CampaignImagePlaceholderText, CampaignImageMobilePlaceholder, CampaignImageDesktopPlaceholder, CampaignImageDesktop,
-  CandidateCardForListWrapper, CampaignActionButtonsWrapper,
-  OneCampaignPhotoWrapperMobile, OneCampaignPhotoDesktopColumn, OneCampaignTitle, OneCampaignOuterWrapper, OneCampaignTextColumn, OneCampaignInnerWrapper, OneCampaignDescription,
-  SupportersWrapper, SupportersCount, SupportersActionLink,
+  CampaignImageMobile,
+  CampaignImagePlaceholderText,
+  CampaignImageMobilePlaceholder,
+  CampaignImageDesktopPlaceholder,
+  CampaignImageDesktop,
+  CampaignPoliticianImageMobile,
+  CandidateCardForListWrapper,
+  CampaignActionButtonsWrapper,
+  OneCampaignPhotoWrapperMobile,
+  OneCampaignPhotoDesktopColumn,
+  OneCampaignTitle,
+  OneCampaignOuterWrapper,
+  OneCampaignTextColumn,
+  OneCampaignInnerWrapper,
+  OneCampaignDescription,
+  SupportersWrapper,
+  SupportersCount,
+  SupportersActionLink,
+  CampaignPoliticianImageDesktop,
 } from '../Style/CampaignCardStyles';
 // import { getTodayAsInteger, getYearFromUltimateElectionDate } from '../../utils/dateFormat';
 import historyPush from '../../utils/historyPush';
@@ -261,8 +276,9 @@ class CampaignCardForList extends Component {
       supporters_count: supportersCount,
       supporters_count_next_goal: supportersCountNextGoal,
       // visible_on_this_site: visibleOnThisSite,
-      we_vote_hosted_campaign_photo_large_url: CampaignPhotoLargeUrl,
-      we_vote_hosted_campaign_photo_medium_url: CampaignPhotoMediumUrl,
+      we_vote_hosted_campaign_photo_large_url: campaignPhotoLargeUrl,
+      we_vote_hosted_campaign_photo_medium_url: campaignPhotoMediumUrl,
+      we_vote_hosted_profile_image_url_large: weVoteHostedProfileImageUrlLarge,
     } = campaignX;
     // const stateName = convertStateCodeToStateText(stateCode);
     const supportersCountNextGoalWithFloor = supportersCountNextGoal || CampaignStore.getCampaignXSupportersCountNextGoalDefault();
@@ -421,8 +437,14 @@ class CampaignCardForList extends Component {
               </CampaignActionButtonsWrapper>
             </OneCampaignTextColumn>
             <OneCampaignPhotoWrapperMobile className="u-cursor--pointer u-show-mobile" onClick={this.onCampaignClick}>
-              {CampaignPhotoLargeUrl ? (
-                <CampaignImageMobile src={CampaignPhotoLargeUrl} alt="Campaign" />
+              {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                <>
+                  {campaignPhotoLargeUrl ? (
+                    <CampaignImageMobile src={campaignPhotoLargeUrl} alt="Campaign" />
+                  ) : (
+                    <CampaignPoliticianImageMobile src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                  )}
+                </>
               ) : (
                 <CampaignImageMobilePlaceholder>
                   <CampaignImagePlaceholderText>
@@ -432,12 +454,24 @@ class CampaignCardForList extends Component {
               )}
             </OneCampaignPhotoWrapperMobile>
             <OneCampaignPhotoDesktopColumn className="u-cursor--pointer u-show-desktop-tablet" limitCardWidth={limitCardWidth} onClick={this.onCampaignClick}>
-              {CampaignPhotoMediumUrl ? (
+              {(campaignPhotoMediumUrl || weVoteHostedProfileImageUrlLarge) ? (
                 <>
-                  {limitCardWidth ? (
-                    <CampaignImageDesktop src={CampaignPhotoMediumUrl} alt="" width="300px" height="157px" />
+                  {campaignPhotoMediumUrl ? (
+                    <>
+                      {limitCardWidth ? (
+                        <CampaignImageDesktop src={campaignPhotoMediumUrl} alt="" width="300px" height="157px" />
+                      ) : (
+                        <CampaignImageDesktop src={campaignPhotoMediumUrl} alt="" width="224px" height="117px" />
+                      )}
+                    </>
                   ) : (
-                    <CampaignImageDesktop src={CampaignPhotoMediumUrl} alt="" width="224px" height="117px" />
+                    <>
+                      {limitCardWidth ? (
+                        <CampaignPoliticianImageDesktop src={weVoteHostedProfileImageUrlLarge} alt="" width="157px" height="157px" />
+                      ) : (
+                        <CampaignPoliticianImageDesktop src={weVoteHostedProfileImageUrlLarge} alt="" width="117px" height="117px" />
+                      )}
+                    </>
                   )}
                 </>
               ) : (

--- a/src/js/common/components/Campaign/CampaignListRoot.jsx
+++ b/src/js/common/components/Campaign/CampaignListRoot.jsx
@@ -141,7 +141,7 @@ class CampaignListRoot extends Component {
     });
     filteredList = filteredListModified;
     // //////////////////////
-    // Now filter candidates
+    // Now filter
     if (listModeFilters && listModeFilters.length > 0) {
       const todayAsInteger = getTodayAsInteger();
       listModeFilters.forEach((oneFilter) => {

--- a/src/js/common/components/Style/CampaignCardStyles.jsx
+++ b/src/js/common/components/Style/CampaignCardStyles.jsx
@@ -47,15 +47,14 @@ export const CampaignImageDesktopSharedStyles = css`
 export const CampaignImageDesktopPlaceholder = styled('div', {
   shouldForwardProp: (prop) => !['limitCardWidth'].includes(prop),
 })(({ limitCardWidth }) => (`
-  ${limitCardWidth ? 'height: 157px;' : 'height: 117px;'}
   align-items: center;
   background-color: #eee;
   display: flex;
+  ${limitCardWidth ? 'height: 157px;' : 'height: 117px;'}
   justify-content: center;
   ${limitCardWidth ? 'width: 300px;' : 'width: 224px;'}
   ${CampaignImageDesktopSharedStyles}
 `));
-
 
 export const CampaignImageDesktop = styled('img', {
   shouldForwardProp: (prop) => !['limitCardWidth'].includes(prop),
@@ -88,6 +87,20 @@ export const CampaignImagePlaceholderText = styled('div')`
 `;
 
 export const CampaignImageMobile = styled('img')`
+  max-height: 157px;
+  ${CampaignImageMobileSharedStyles}
+`;
+
+export const CampaignPoliticianImageDesktop = styled('img', {
+  shouldForwardProp: (prop) => !['limitCardWidth'].includes(prop),
+})(({ limitCardWidth }) => (`
+  // We don't want to set height/width here because this component is also used for very large versions of this image
+  // ${limitCardWidth ? 'height: 157px;' : 'height: 117px;'}
+  // ${limitCardWidth ? 'width: 300px;' : 'width: 224px;'}
+  ${CampaignImageDesktopSharedStyles}
+`));
+
+export const CampaignPoliticianImageMobile = styled('img')`
   max-height: 157px;
   ${CampaignImageMobileSharedStyles}
 `;
@@ -148,7 +161,11 @@ export const OneCampaignOuterWrapper = styled('div', {
 export const OneCampaignPhotoDesktopColumn = styled('div', {
   shouldForwardProp: (prop) => !['limitCardWidth'].includes(prop),
 })(({ limitCardWidth }) => (`
+  align-items: center;
+  background-color: #eee;
+  display: flex;
   ${limitCardWidth ? 'height: 157px;' : 'height: 117px;'}
+  justify-content: center;
   margin-bottom: 0;
   ${limitCardWidth ? '' : 'margin-left: 15px;'}
   margin-top: 0;

--- a/src/js/common/components/Style/CampaignDetailsStyles.jsx
+++ b/src/js/common/components/Style/CampaignDetailsStyles.jsx
@@ -36,11 +36,11 @@ export const CampaignImageDesktop = styled('img')`
 `;
 
 export const CampaignImagePlaceholder = styled('div')(({ theme }) => (`
+  align-items: center;
   background-color: #eee;
   border-radius: 5px;
   display: flex;
   justify-content: center;
-  align-items: center;
   min-height: 183px;
   ${theme.breakpoints.up('sm')} {
     min-height: 174px;
@@ -58,6 +58,11 @@ export const CampaignImagePlaceholderText = styled('div')`
 `;
 
 export const CampaignImageDesktopWrapper = styled('div')(({ theme }) => (`
+  align-items: center;
+  background-color: #eee;
+  border-radius: 5px;
+  display: flex;
+  justify-content: center;
   margin-bottom: 10px;
   min-height: 180px;
   ${theme.breakpoints.up('sm')} {
@@ -83,6 +88,11 @@ export const CampaignOwnersDesktopWrapper = styled('div')`
 `;
 
 export const CampaignOwnersWrapper = styled('div')`
+`;
+
+export const CampaignPoliticianImageDesktop = styled('img')`
+  border-radius: 5px;
+  height: 100%;
 `;
 
 export const CampaignSubSectionSeeAll = styled('div')`

--- a/src/js/common/components/Style/CampaignProcessStyles.jsx
+++ b/src/js/common/components/Style/CampaignProcessStyles.jsx
@@ -13,6 +13,7 @@ export const CampaignImage = styled('img', {
 export const CampaignProcessStepIntroductionText = styled('div')(({ theme }) => (`
   color: #555;
   font-size: 16px;
+  max-height: 324px; // Added to deal with 200x200 images
   max-width: 620px;
   text-align: left;
   ${theme.breakpoints.down('sm')} {
@@ -24,6 +25,7 @@ export const CampaignProcessStepTitle = styled('div')(({ theme }) => (`
   font-size: 32px;
   font-weight: 600;
   margin: 20px 0 10px 0;
+  max-height: 324px; // Added to deal with 200x200 images
   max-width: 620px;
   ${theme.breakpoints.down('sm')} {
     font-size: 22px;

--- a/src/js/common/components/Style/CampaignSupportStyles.jsx
+++ b/src/js/common/components/Style/CampaignSupportStyles.jsx
@@ -55,6 +55,7 @@ export const CampaignSupportSectionWrapper = styled('div', {
   display: flex;
   justify-content: center;
   ${marginTopOff ? '' : 'margin-top: 20px;'}
+  max-height: 324px; // Added to deal with 200x200 images
   max-width: 620px;
 `));
 

--- a/src/js/common/pages/Campaign/CampaignDetailsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignDetailsPage.jsx
@@ -6,13 +6,30 @@ import Helmet from 'react-helmet';
 import { Link } from 'react-router-dom';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import {
-  CampaignDescription, CampaignDescriptionDesktop, CampaignDescriptionWrapper,
-  CampaignDescriptionDesktopWrapper, CampaignImagePlaceholder, CampaignImagePlaceholderText,
-  CampaignImage, CampaignImageDesktop, CampaignImageDesktopWrapper, CampaignImageMobileWrapper,
-  CampaignOwnersDesktopWrapper, CampaignOwnersWrapper, CampaignSubSectionSeeAll, CampaignSubSectionTitle, CampaignSubSectionTitleWrapper,
-  CampaignTitleAndScoreBar, CampaignTitleDesktop, CampaignTitleMobile,
-  CommentsListWrapper, DetailsSectionDesktopTablet, DetailsSectionMobile,
-  SupportButtonFooterWrapper, SupportButtonPanel,
+  CampaignDescription,
+  CampaignDescriptionDesktop,
+  CampaignDescriptionWrapper,
+  CampaignDescriptionDesktopWrapper,
+  CampaignImagePlaceholder,
+  CampaignImagePlaceholderText,
+  CampaignImage,
+  CampaignImageDesktop,
+  CampaignImageDesktopWrapper,
+  CampaignImageMobileWrapper,
+  CampaignOwnersDesktopWrapper,
+  CampaignOwnersWrapper,
+  CampaignSubSectionSeeAll,
+  CampaignSubSectionTitle,
+  CampaignSubSectionTitleWrapper,
+  CampaignTitleAndScoreBar,
+  CampaignTitleDesktop,
+  CampaignTitleMobile,
+  CommentsListWrapper,
+  DetailsSectionDesktopTablet,
+  DetailsSectionMobile,
+  SupportButtonFooterWrapper,
+  SupportButtonPanel,
+  CampaignPoliticianImageDesktop,
 } from '../../components/Style/CampaignDetailsStyles';
 import { PageWrapper } from '../../components/Style/stepDisplayStyles';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
@@ -60,6 +77,7 @@ class CampaignDetailsPage extends Component {
       sharingStepCompleted: false,
       step2Completed: false,
       voterCanEditThisCampaign: false,
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -131,6 +149,7 @@ class CampaignDetailsPage extends Component {
       isBlockedByWeVoteReason,
       isSupportersCountMinimumExceeded,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     let pathToUseWhenProfileComplete;
     if (campaignSEOFriendlyPath) {
@@ -162,6 +181,7 @@ class CampaignDetailsPage extends Component {
       isSupportersCountMinimumExceeded,
       linkedPoliticianWeVoteId,
       pathToUseWhenProfileComplete,
+      weVoteHostedProfileImageUrlLarge,
     });
   }
 
@@ -186,7 +206,6 @@ class CampaignDetailsPage extends Component {
     } else {
       campaignBasePath = `/id/${campaignXWeVoteId}`;
     }
-
     return campaignBasePath;
   }
 
@@ -225,13 +244,7 @@ class CampaignDetailsPage extends Component {
   }
 
   onCampaignEditClick = () => {
-    const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
-    // console.log('campaignX:', campaignX);
-    if (campaignSEOFriendlyPath) {
-      historyPush(`/c/${campaignSEOFriendlyPath}/edit`);
-    } else {
-      historyPush(`/id/${campaignXWeVoteId}/edit`);
-    }
+    historyPush(`${this.getCampaignXBasePath()}/edit`);
     return null;
   }
 
@@ -253,9 +266,9 @@ class CampaignDetailsPage extends Component {
       campaignSEOFriendlyPath, campaignTitle, campaignXWeVoteId,
       chosenWebsiteName, inPrivateLabelMode, isBlockedByWeVote, isBlockedByWeVoteReason,
       finalElectionDateInPast, isSupportersCountMinimumExceeded, linkedPoliticianWeVoteId,
-      voterCanEditThisCampaign, voterSupportsThisCampaign,
+      voterCanEditThisCampaign, voterSupportsThisCampaign, weVoteHostedProfileImageUrlLarge,
     } = this.state;
-    // console.log('render isSupportersCountMinimumExceeded: ', isSupportersCountMinimumExceeded);
+    // console.log('render campaignPhotoLargeUrl: ', campaignPhotoLargeUrl, ', weVoteHostedProfileImageUrlLarge: ', weVoteHostedProfileImageUrlLarge);
     const htmlTitle = `${campaignTitle} - ${chosenWebsiteName}`;
     if (isBlockedByWeVote && !voterCanEditThisCampaign) {
       return (
@@ -339,8 +352,14 @@ class CampaignDetailsPage extends Component {
           />
           <DetailsSectionMobile className="u-show-mobile">
             <CampaignImageMobileWrapper>
-              {campaignPhotoLargeUrl ? (
-                <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+              {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                <>
+                  {campaignPhotoLargeUrl ? (
+                    <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                  ) : (
+                    <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                  )}
+                </>
               ) : (
                 <DelayedLoad waitBeforeShow={1000}>
                   <CampaignImagePlaceholder>
@@ -457,8 +476,14 @@ class CampaignDetailsPage extends Component {
             <ColumnsWrapper>
               <ColumnTwoThirds>
                 <CampaignImageDesktopWrapper>
-                  {campaignPhotoLargeUrl ? (
-                    <CampaignImageDesktop src={campaignPhotoLargeUrl} alt="Campaign" />
+                  {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                    <>
+                      {campaignPhotoLargeUrl ? (
+                        <CampaignImageDesktop src={campaignPhotoLargeUrl} alt="Campaign" />
+                      ) : (
+                        <CampaignPoliticianImageDesktop src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                      )}
+                    </>
                   ) : (
                     <DelayedLoad waitBeforeShow={1000}>
                       <CampaignImagePlaceholder>

--- a/src/js/common/pages/Campaign/CampaignNewsItemDetailsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignNewsItemDetailsPage.jsx
@@ -10,14 +10,31 @@ import anonymous from '../../../../img/global/icons/avatar-generic.png';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import LazyImage from '../../components/LazyImage';
 import {
-  CampaignDescription, CampaignDescriptionDesktop, CampaignDescriptionWrapper,
-  CampaignDescriptionDesktopWrapper, CampaignImagePlaceholder, CampaignImagePlaceholderText,
-  CampaignImage, CampaignImageDesktop, CampaignImageDesktopWrapper, CampaignImageMobileWrapper,
-  CampaignSubSectionSeeAll, CampaignSubSectionTitle, CampaignSubSectionTitleWrapper,
-  CampaignTitleAndScoreBar, CampaignTitleDesktop, CampaignTitleMobile,
-  CommentsListWrapper, DetailsSectionDesktopTablet, DetailsSectionMobile,
-  SpeakerAndPhotoOuterWrapper, SpeakerName, SpeakerVoterPhotoWrapper,
-  SupportButtonFooterWrapper, SupportButtonPanel,
+  CampaignDescription,
+  CampaignDescriptionDesktop,
+  CampaignDescriptionWrapper,
+  CampaignDescriptionDesktopWrapper,
+  CampaignImagePlaceholder,
+  CampaignImagePlaceholderText,
+  CampaignImage,
+  CampaignImageDesktop,
+  CampaignImageDesktopWrapper,
+  CampaignImageMobileWrapper,
+  CampaignSubSectionSeeAll,
+  CampaignSubSectionTitle,
+  CampaignSubSectionTitleWrapper,
+  CampaignTitleAndScoreBar,
+  CampaignTitleDesktop,
+  CampaignTitleMobile,
+  CommentsListWrapper,
+  DetailsSectionDesktopTablet,
+  DetailsSectionMobile,
+  SpeakerAndPhotoOuterWrapper,
+  SpeakerName,
+  SpeakerVoterPhotoWrapper,
+  SupportButtonFooterWrapper,
+  SupportButtonPanel,
+  CampaignPoliticianImageDesktop,
 } from '../../components/Style/CampaignDetailsStyles';
 import { PageWrapper } from '../../components/Style/stepDisplayStyles';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
@@ -66,6 +83,7 @@ class CampaignNewsItemDetailsPage extends Component {
       sharingStepCompleted: false,
       step2Completed: false,
       voterCanEditThisCampaign: false,
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -159,6 +177,7 @@ class CampaignNewsItemDetailsPage extends Component {
       isBlockedByWeVote,
       isBlockedByWeVoteReason,
       isSupportersCountMinimumExceeded,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     let pathToUseWhenProfileComplete;
     if (campaignSEOFriendlyPath) {
@@ -186,6 +205,7 @@ class CampaignNewsItemDetailsPage extends Component {
       isBlockedByWeVoteReason,
       isSupportersCountMinimumExceeded,
       pathToUseWhenProfileComplete,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignXNewsItemWeVoteId) {
       const campaignXNewsItem = CampaignStore.getCampaignXNewsItemByWeVoteId(campaignXNewsItemWeVoteId);
@@ -320,7 +340,7 @@ class CampaignNewsItemDetailsPage extends Component {
       chosenWebsiteName, datePosted, inDraftMode, isBlockedByWeVote, isBlockedByWeVoteReason,
       inPrivateLabelMode, finalElectionDateInPast, isSupportersCountMinimumExceeded,
       speakerName, speakerProfileImageUrlTiny,
-      voterCanEditThisCampaign,
+      voterCanEditThisCampaign, weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const htmlTitle = `${campaignTitle} - ${chosenWebsiteName}`;
     if (isBlockedByWeVote && !voterCanEditThisCampaign) {
@@ -497,8 +517,14 @@ class CampaignNewsItemDetailsPage extends Component {
             </NewsItemSubjectMobile>
             {speakerHTML}
             <CampaignImageMobileWrapper>
-              {campaignPhotoLargeUrl ? (
-                <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+              {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                <>
+                  {campaignPhotoLargeUrl ? (
+                    <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                  ) : (
+                    <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                  )}
+                </>
               ) : (
                 <DelayedLoad waitBeforeShow={1000}>
                   <CampaignImagePlaceholder>
@@ -608,8 +634,14 @@ class CampaignNewsItemDetailsPage extends Component {
                 </NewsItemSubjectDesktop>
                 {speakerHTML}
                 <CampaignImageDesktopWrapper>
-                  {campaignPhotoLargeUrl ? (
-                    <CampaignImageDesktop src={campaignPhotoLargeUrl} alt="Campaign" />
+                  {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                    <>
+                      {campaignPhotoLargeUrl ? (
+                        <CampaignImageDesktop src={campaignPhotoLargeUrl} alt="Campaign" />
+                      ) : (
+                        <CampaignPoliticianImageDesktop src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                      )}
+                    </>
                   ) : (
                     <DelayedLoad waitBeforeShow={1000}>
                       <CampaignImagePlaceholder>

--- a/src/js/common/pages/CampaignSupport/CampaignRecommendedCampaigns.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignRecommendedCampaigns.jsx
@@ -305,6 +305,7 @@ class CampaignRecommendedCampaigns extends Component {
             campaignx_we_vote_id: recommendedCampaignXWeVoteId,
             // seo_friendly_path: recommendedCampaignSEOFriendlyPath,
             we_vote_hosted_campaign_photo_large_url: recommendedCampaignPhotoLargeUrl,
+            we_vote_hosted_profile_image_url_large: weVoteHostedProfileImageUrlLarge,
           } = nextCampaignX;
           this.setState({
             recommendedCampaignDescription,
@@ -312,6 +313,7 @@ class CampaignRecommendedCampaigns extends Component {
             recommendedCampaignTitle,
             recommendedCampaignXWeVoteId,
             recommendedCampaignPhotoLargeUrl,
+            weVoteHostedProfileImageUrlLarge,
           });
           keepLooking = false;
         }
@@ -351,7 +353,7 @@ class CampaignRecommendedCampaigns extends Component {
       campaignXNewsItemsExist, campaignXWeVoteId, chosenWebsiteName,
       descriptionUnfurledMode, numberOfCampaignsLeftToSupport,
       recommendedCampaignDescription, recommendedCampaignTitle, recommendedCampaignXListHasBeenRetrieved,
-      recommendedCampaignXWeVoteId, recommendedCampaignPhotoLargeUrl,
+      recommendedCampaignXWeVoteId, recommendedCampaignPhotoLargeUrl, weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const htmlTitle = `${campaignTitle} - ${chosenWebsiteName}`;
     const supportButtonClasses = classes.buttonDefault; // isWebApp() ? classes.buttonDefault : classes.buttonDefaultCordova;
@@ -449,8 +451,14 @@ class CampaignRecommendedCampaigns extends Component {
               </RecommendedCampaignsIntroText>
               <RecommendedCampaignWrapper>
                 <CampaignSupportImageWrapper borderRadiusOnTop="10px">
-                  {recommendedCampaignPhotoLargeUrl ? (
-                    <CampaignImage src={recommendedCampaignPhotoLargeUrl} alt="Campaign" noBorderRadius />
+                  {(recommendedCampaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                    <>
+                      {recommendedCampaignPhotoLargeUrl ? (
+                        <CampaignImage src={recommendedCampaignPhotoLargeUrl} alt="Campaign" noBorderRadius />
+                      ) : (
+                        <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" noBorderRadius />
+                      )}
+                    </>
                   ) : (
                     <CampaignSupportImageWrapperText>
                       {recommendedCampaignTitle}
@@ -570,6 +578,7 @@ const CampaignDescription = styled('div')`
 
 const CampaignImage = styled('img')`
   border-radius: 8px 8px 0 0;
+  max-height: 324px; // Added to deal with 200x200 images
   max-width: 620px;
   min-height: 117px;
   width: 100%;
@@ -586,6 +595,7 @@ const RecommendedCampaignsIntroText = styled('div')(({ theme }) => (`
   font-size: 20px;
   font-weight: 400;
   margin: 18px 0 20px 0;
+  max-height: 324px; // Added to deal with 200x200 images
   max-width: 620px;
   text-align: center;
   ${theme.breakpoints.down('sm')} {
@@ -597,6 +607,7 @@ const RecommendedCampaignWrapper = styled('div')`
   border: 1px solid #ddd;
   border-radius: 10px;
   box-shadow: 0 20px 40px -25px #999;
+  max-height: 324px; // Added to deal with 200x200 images
   max-width: 620px;
 `;
 

--- a/src/js/common/pages/CampaignSupport/CampaignSupportEndorsement.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignSupportEndorsement.jsx
@@ -41,6 +41,7 @@ class CampaignSupportEndorsement extends Component {
       chosenWebsiteName: '',
       linkedPoliticianWeVoteId: '',
       payToPromoteStepTurnedOn: true,
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -62,11 +63,13 @@ class CampaignSupportEndorsement extends Component {
       campaignXPoliticianList,
       campaignXWeVoteId,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignXPoliticianList,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -120,12 +123,14 @@ class CampaignSupportEndorsement extends Component {
       campaignXPoliticianList,
       campaignXWeVoteId,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       campaignXPoliticianList,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -232,7 +237,7 @@ class CampaignSupportEndorsement extends Component {
     const {
       campaignPhotoLargeUrl, campaignSEOFriendlyPath, campaignTitle,
       campaignXPoliticianList, campaignXWeVoteId, chosenWebsiteName,
-      voterPhotoUrlLarge,
+      voterPhotoUrlLarge, weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const htmlTitle = `Why do you support ${campaignTitle}? - ${chosenWebsiteName}`;
     let numberOfPoliticians = 0;
@@ -253,8 +258,14 @@ class CampaignSupportEndorsement extends Component {
                 politicianBasePath={this.getPoliticianBasePath()}
               />
               <CampaignSupportImageWrapper>
-                {campaignPhotoLargeUrl ? (
-                  <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                  <>
+                    {campaignPhotoLargeUrl ? (
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    ) : (
+                      <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                    )}
+                  </>
                 ) : (
                   <CampaignSupportImageWrapperText>
                     {campaignTitle}

--- a/src/js/common/pages/CampaignSupport/CampaignSupportPayToPromote.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignSupportPayToPromote.jsx
@@ -33,6 +33,7 @@ class CampaignSupportPayToPromote extends Component {
       chosenWebsiteName: '',
       linkedPoliticianWeVoteId: '',
       voterFirstName: '',
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -52,10 +53,12 @@ class CampaignSupportPayToPromote extends Component {
       campaignSEOFriendlyPath,
       campaignXWeVoteId,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -104,11 +107,13 @@ class CampaignSupportPayToPromote extends Component {
       campaignTitle,
       campaignXWeVoteId,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -182,7 +187,7 @@ class CampaignSupportPayToPromote extends Component {
     const { classes } = this.props;
     const {
       campaignPhotoLargeUrl, campaignSEOFriendlyPath, campaignTitle, campaignXWeVoteId,
-      chosenWebsiteName, voterFirstName,
+      chosenWebsiteName, voterFirstName, weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const htmlTitle = `Chip in to support ${campaignTitle} - ${chosenWebsiteName}`;
     let chipInDescriptionText1 = '';
@@ -225,8 +230,14 @@ class CampaignSupportPayToPromote extends Component {
                 politicianBasePath={this.getPoliticianBasePath()}
               />
               <CampaignSupportImageWrapper>
-                {campaignPhotoLargeUrl ? (
-                  <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                  <>
+                    {campaignPhotoLargeUrl ? (
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    ) : (
+                      <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                    )}
+                  </>
                 ) : (
                   <CampaignSupportImageWrapperText>
                     {campaignTitle}

--- a/src/js/common/pages/CampaignSupport/CampaignSupportShare.jsx
+++ b/src/js/common/pages/CampaignSupport/CampaignSupportShare.jsx
@@ -37,6 +37,7 @@ class CampaignSupportShare extends Component {
       chosenWebsiteName: '',
       linkedPoliticianWeVoteId: '',
       shareButtonClicked: false,
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -57,10 +58,12 @@ class CampaignSupportShare extends Component {
       campaignSEOFriendlyPath,
       campaignXWeVoteId,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -125,11 +128,13 @@ class CampaignSupportShare extends Component {
       campaignTitle,
       campaignXWeVoteId,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       linkedPoliticianWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -221,7 +226,7 @@ class CampaignSupportShare extends Component {
       campaignPhotoLargeUrl, campaignSEOFriendlyPath, campaignTitle,
       campaignXWeVoteId, chosenWebsiteName,
       recommendedCampaignXListCount, recommendedCampaignXListHasBeenRetrieved,
-      shareButtonClicked,
+      shareButtonClicked, weVoteHostedProfileImageUrlLarge,
     } = this.state;
     let campaignProcessStepIntroductionText = 'Voters joined this campaign thanks to the people who shared it. Join them and help this campaign grow!';
     let campaignProcessStepTitle = 'Sharing leads to way more votes.';
@@ -260,8 +265,14 @@ class CampaignSupportShare extends Component {
                 politicianBasePath={this.getPoliticianBasePath()}
               />
               <CampaignSupportImageWrapper>
-                {campaignPhotoLargeUrl ? (
-                  <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                  <>
+                    {campaignPhotoLargeUrl ? (
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    ) : (
+                      <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                    )}
+                  </>
                 ) : (
                   <CampaignSupportImageWrapperText>
                     {campaignTitle}

--- a/src/js/common/pages/SuperSharing/SuperSharingAddContacts.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingAddContacts.jsx
@@ -39,6 +39,7 @@ class SuperSharingAddContacts extends Component {
       campaignXNewsItemWeVoteId: '',
       campaignXWeVoteId: '',
       chosenWebsiteName: '',
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -63,11 +64,13 @@ class SuperSharingAddContacts extends Component {
       campaignSEOFriendlyPath,
       campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignXNewsItemWeVoteId,
       campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -140,11 +143,13 @@ class SuperSharingAddContacts extends Component {
       campaignTitle,
       campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -220,6 +225,7 @@ class SuperSharingAddContacts extends Component {
       campaignXNewsItemWeVoteId,
       campaignXPoliticianList, campaignXWeVoteId, chosenWebsiteName,
       voterContactEmailListCount, voterContactEmailGoogleCount,
+      weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const htmlTitle = `Import your address book - ${chosenWebsiteName}`;
     // let numberOfPoliticians = 0;
@@ -240,8 +246,14 @@ class SuperSharingAddContacts extends Component {
                 campaignXWeVoteId={campaignXWeVoteId}
               />
               <CampaignSupportImageWrapper>
-                {campaignPhotoLargeUrl ? (
-                  <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                  <>
+                    {campaignPhotoLargeUrl ? (
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    ) : (
+                      <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                    )}
+                  </>
                 ) : (
                   <CampaignSupportImageWrapperText>
                     {campaignTitle}

--- a/src/js/common/pages/SuperSharing/SuperSharingChooseRecipients.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingChooseRecipients.jsx
@@ -48,6 +48,7 @@ class SuperSharingChooseRecipients extends Component {
       chosenWebsiteName: '',
       numberOfRecipientsToDisplay: STARTING_NUMBER_OF_RECIPIENTS_TO_DISPLAY,
       recipientEmailsChosen: [], // List of recipient email addresses lower case
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -74,11 +75,13 @@ class SuperSharingChooseRecipients extends Component {
       campaignSEOFriendlyPath,
       // campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignXNewsItemWeVoteId,
       // campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -153,11 +156,13 @@ class SuperSharingChooseRecipients extends Component {
       campaignTitle,
       // campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       // campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -311,6 +316,7 @@ class SuperSharingChooseRecipients extends Component {
       campaignXWeVoteId, chosenWebsiteName,
       numberOfRecipientsToDisplay, recipientEmailsChosen,
       voterContactEmailListFiltered, voterContactEmailListCount,
+      weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const htmlTitle = `Choose Recipients for ${campaignTitle}? - ${chosenWebsiteName}`;
     // let numberOfPoliticians = 0;
@@ -331,8 +337,14 @@ class SuperSharingChooseRecipients extends Component {
                 campaignXWeVoteId={campaignXWeVoteId}
               />
               <CampaignSupportImageWrapper>
-                {campaignPhotoLargeUrl ? (
-                  <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                  <>
+                    {campaignPhotoLargeUrl ? (
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    ) : (
+                      <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                    )}
+                  </>
                 ) : (
                   <CampaignSupportImageWrapperText>
                     {campaignTitle}

--- a/src/js/common/pages/SuperSharing/SuperSharingComposeEmailMessage.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingComposeEmailMessage.jsx
@@ -45,6 +45,7 @@ class SuperSharingComposeEmailMessage extends Component {
       suggestedMessage: '',
       suggestedSubject: '',
       voterPhotoUrlLarge: '',
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -72,11 +73,13 @@ class SuperSharingComposeEmailMessage extends Component {
       campaignSEOFriendlyPath,
       campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignXNewsItemWeVoteId,
       campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -160,12 +163,14 @@ class SuperSharingComposeEmailMessage extends Component {
       campaignTitle,
       campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       campaignXNewsItemWeVoteId,
       campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -293,6 +298,7 @@ class SuperSharingComposeEmailMessage extends Component {
       campaignPhotoLargeUrl, campaignSEOFriendlyPath, campaignTitle,
       campaignXNewsItemWeVoteId, campaignXPoliticianList, campaignXWeVoteId, chosenWebsiteName,
       emailRecipientList, suggestedMessage, suggestedSubject, voterPhotoUrlLarge,
+      weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const emailRecipientListCount = emailRecipientList.length;
     const htmlTitle = `Send personalized message regarding ${campaignTitle}? - ${chosenWebsiteName}`;
@@ -314,8 +320,14 @@ class SuperSharingComposeEmailMessage extends Component {
                 campaignXWeVoteId={campaignXWeVoteId}
               />
               <CampaignSupportImageWrapper>
-                {campaignPhotoLargeUrl ? (
-                  <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                  <>
+                    {campaignPhotoLargeUrl ? (
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    ) : (
+                      <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                    )}
+                  </>
                 ) : (
                   <CampaignSupportImageWrapperText>
                     {campaignTitle}

--- a/src/js/common/pages/SuperSharing/SuperSharingSendEmail.jsx
+++ b/src/js/common/pages/SuperSharing/SuperSharingSendEmail.jsx
@@ -40,6 +40,7 @@ class SuperSharingSendEmail extends Component {
       chosenWebsiteName: '',
       emailRecipientList: [],
       voterContactEmailListCount: 0,
+      weVoteHostedProfileImageUrlLarge: '',
     };
   }
 
@@ -66,11 +67,13 @@ class SuperSharingSendEmail extends Component {
       campaignSEOFriendlyPath,
       // campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignXNewsItemWeVoteId,
       // campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -144,11 +147,13 @@ class SuperSharingSendEmail extends Component {
       campaignTitle,
       // campaignXPoliticianList,
       campaignXWeVoteId,
+      weVoteHostedProfileImageUrlLarge,
     } = getCampaignXValuesFromIdentifiers(campaignSEOFriendlyPathFromParams, campaignXWeVoteIdFromParams);
     this.setState({
       campaignPhotoLargeUrl,
       campaignTitle,
       // campaignXPoliticianList,
+      weVoteHostedProfileImageUrlLarge,
     });
     if (campaignSEOFriendlyPath) {
       this.setState({
@@ -261,7 +266,7 @@ class SuperSharingSendEmail extends Component {
       campaignXNewsItemWeVoteId,
       campaignXWeVoteId, chosenWebsiteName, emailRecipientList,
       personalizedMessage, personalizedSubject,
-      voterContactEmailListCount,
+      voterContactEmailListCount, weVoteHostedProfileImageUrlLarge,
     } = this.state;
     const emailRecipientListCount = emailRecipientList.length;
     const htmlTitle = `Review and send email - ${chosenWebsiteName}`;
@@ -283,8 +288,14 @@ class SuperSharingSendEmail extends Component {
                 campaignXWeVoteId={campaignXWeVoteId}
               />
               <CampaignSupportImageWrapper>
-                {campaignPhotoLargeUrl ? (
-                  <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                {(campaignPhotoLargeUrl || weVoteHostedProfileImageUrlLarge) ? (
+                  <>
+                    {campaignPhotoLargeUrl ? (
+                      <CampaignImage src={campaignPhotoLargeUrl} alt="Campaign" />
+                    ) : (
+                      <CampaignImage src={weVoteHostedProfileImageUrlLarge} alt="Campaign" />
+                    )}
+                  </>
                 ) : (
                   <CampaignSupportImageWrapperText>
                     {campaignTitle}

--- a/src/js/common/utils/campaignUtils.js
+++ b/src/js/common/utils/campaignUtils.js
@@ -20,6 +20,7 @@ export function getCampaignXValuesFromIdentifiers (campaignSEOFriendlyPath, camp
   let isSupportersCountMinimumExceeded = false;
   let linkedPoliticianWeVoteId = '';
   let voterIsCampaignXOwner = false;
+  let weVoteHostedProfileImageUrlLarge = '';
   if (campaignSEOFriendlyPath) {
     campaignX = CampaignStore.getCampaignXBySEOFriendlyPath(campaignSEOFriendlyPath);
   } else if (campaignXWeVoteId) {
@@ -40,6 +41,7 @@ export function getCampaignXValuesFromIdentifiers (campaignSEOFriendlyPath, camp
       we_vote_hosted_campaign_photo_large_url: campaignPhotoLargeUrl,
       we_vote_hosted_campaign_photo_medium_url: campaignPhotoMediumUrl,
       we_vote_hosted_campaign_photo_small_url: campaignPhotoSmallUrl,
+      we_vote_hosted_profile_image_url_large: weVoteHostedProfileImageUrlLarge,
     } = campaignX);
     campaignXPoliticianList = CampaignStore.getCampaignXPoliticianList(campaignXWeVoteIdFromObject);
   }
@@ -58,6 +60,7 @@ export function getCampaignXValuesFromIdentifiers (campaignSEOFriendlyPath, camp
     isSupportersCountMinimumExceeded,
     linkedPoliticianWeVoteId,
     voterIsCampaignXOwner,
+    weVoteHostedProfileImageUrlLarge,
   };
 }
 

--- a/src/js/pages/Campaigns/CampaignsHome.jsx
+++ b/src/js/pages/Campaigns/CampaignsHome.jsx
@@ -57,8 +57,8 @@ class CampaignsHome extends Component {
       listModeShown: 'showUpcomingEndorsements',
       listModeFiltersAvailable: [],
       listModeFiltersTimeStampOfChange: 0,
-      listOfYearsWhenCampaignExists: [],
-      listOfYearsWhenCandidateExists: [],
+      // listOfYearsWhenCampaignExists: [],
+      // listOfYearsWhenCandidateExists: [],
       listOfYearsWhenRepresentativeExists: [],
       politicianWeVoteIdsAlreadyShown: [],
       representativeListOnYourBallot: [],
@@ -282,15 +282,15 @@ class CampaignsHome extends Component {
     }
     this.setState({
       campaignsShowing,
-      listOfYearsWhenCampaignExists: this.getListOfYearsWhenCampaignExists(campaignList),
+      // listOfYearsWhenCampaignExists: this.getListOfYearsWhenCampaignExists(campaignList),
     }, () => this.updateActiveFilters(setDefaultListMode));
   }
 
   onIncomingCandidateListChange (setDefaultListMode = false) {
-    const { candidateList } = this.state;
+    // const { candidateList } = this.state;
     // console.log('CampaignsHome onIncomingCandidateListChange, candidateList:', candidateList);
     this.setState({
-      listOfYearsWhenCandidateExists: this.getListOfYearsWhenCandidateExists(candidateList),
+      // listOfYearsWhenCandidateExists: this.getListOfYearsWhenCandidateExists(candidateList),
     }, () => this.updateActiveFilters(setDefaultListMode));
   }
 
@@ -441,9 +441,9 @@ class CampaignsHome extends Component {
   }
 
   getDefaultListModeShown = (incomingUpcomingEndorsementsAvailable = false) => {
-    const { listOfYearsWhenCampaignExists, listOfYearsWhenCandidateExists, listOfYearsWhenRepresentativeExists, upcomingEndorsementsAvailable } = this.state;
-    // const { upcomingEndorsementsAvailable } = this.state;
-    const listOfYears = [...new Set([...listOfYearsWhenCampaignExists, ...listOfYearsWhenCandidateExists, ...listOfYearsWhenRepresentativeExists])];
+    // const { listOfYearsWhenCampaignExists, listOfYearsWhenCandidateExists, listOfYearsWhenRepresentativeExists, upcomingEndorsementsAvailable } = this.state;
+    const { upcomingEndorsementsAvailable } = this.state;
+    // const listOfYears = [...new Set([...listOfYearsWhenCampaignExists, ...listOfYearsWhenCandidateExists, ...listOfYearsWhenRepresentativeExists])];
     // console.log('getDefaultListModeShown listOfYearsWhenCandidateExists:', listOfYearsWhenCandidateExists);
     if (upcomingEndorsementsAvailable || incomingUpcomingEndorsementsAvailable) {
       return 'showUpcomingEndorsements';
@@ -452,9 +452,11 @@ class CampaignsHome extends Component {
       //   // console.log('mostRecentYear:', mostRecentYear);
       //   return `show${mostRecentYear}`;
       // }
-    } else if (listOfYears && listOfYears.length > 1) {
-      return 'showAllEndorsements';
     }
+    // 2023-05-15 Turned off for now
+    // else if (listOfYears && listOfYears.length > 1) {
+    //   return 'showAllEndorsements';
+    // }
     return 'showUpcomingEndorsements';
   }
 
@@ -531,6 +533,7 @@ class CampaignsHome extends Component {
   clearSearchFunction = () => {
     this.setState({
       isSearching: false,
+      listModeShown: 'showUpcomingEndorsements',
       searchText: '',
     }, () => this.updateActiveFilters());
   }


### PR DESCRIPTION
On the API server we are now storing the politician profile photo in CampaignX entries, and this update changes how we display these photos (if a campaign photo doesn't exist). On CampaignsHome, removed the display of Campaigns for prior elections outside of search.