### PR TITLE
[Issue #51] Redirect user to home page after sign out in Security & Sign In tab

### DIFF
--- a/src/js/common/components/SignIn/SignInOptionsPanel.jsx
+++ b/src/js/common/components/SignIn/SignInOptionsPanel.jsx
@@ -384,7 +384,7 @@ export default class SignInOptionsPanel extends Component {
   signOut () {
     // console.log('SignInOptionsPanel.jsx signOut');
     VoterSessionActions.voterSignOut();
-    historyPush('/ballot');
+    historyPush('/');
   }
 
   render () {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
JIRA Issue #51

### Changes included this pull request?
Sign out in the Security and Sign In tab in user settings now redirects the user to the home page rather than to the ballot page.