### PR TITLE
Removing fsevents because it isn't supported in Linux.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "d3-zoom": "^3.0.0",
         "flux": "~4.0.1",
         "fs-extra": "^10.0.0",
-        "fsevents": "^2.3.2",
         "gapi-script": "github:wevote/gapi-script",
         "glob": "^7.1.6",
         "iframe-resizer-react": "^1.1.0",
@@ -10483,7 +10482,9 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "os": [
         "darwin"
       ],
@@ -30166,7 +30167,9 @@
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "d3-zoom": "^3.0.0",
     "flux": "~4.0.1",
     "fs-extra": "^10.0.0",
-    "fsevents": "^2.3.2",
     "gapi-script": "github:wevote/gapi-script",
     "glob": "^7.1.6",
     "iframe-resizer-react": "^1.1.0",


### PR DESCRIPTION
Removing fsevents because it isn't supported in Linux.