### PR TITLE
Performance improvements for the new candidate page   @SailingSteve

### DIFF
--- a/src/js/common/components/Campaign/CampaignCardForList.jsx
+++ b/src/js/common/components/Campaign/CampaignCardForList.jsx
@@ -94,9 +94,6 @@ class CampaignCardForList extends Component {
     this.appStateSubscription.unsubscribe();
     this.campaignStoreListener.remove();
     this.campaignSupporterStoreListener.remove();
-    if (this.timer) {
-      clearTimeout(this.timer);
-    }
   }
 
   onAppObservableStoreChange () {

--- a/src/js/common/components/CampaignSupport/MostRecentCampaignSupport.jsx
+++ b/src/js/common/components/CampaignSupport/MostRecentCampaignSupport.jsx
@@ -60,7 +60,10 @@ class MostRecentCampaignSupport extends React.Component {
     }
     this.timeInterval = null;
     // this.timeInterval = setInterval(() => this.setCommentsToDisplay(), 30000);
-    this.timeInterval = setInterval(() => this.moveSupportersOnStage(), 3000);
+    // Aug 4, 2023 There was nothing happening in "Performance" in the browser for most of these three seconds,
+    // and it made the page load look slow and the slow load was distracting
+    // this.timeInterval = setInterval(() => this.moveSupportersOnStage(), 3000);
+    this.timeInterval = setInterval(() => this.moveSupportersOnStage(), 100);
   }
 
   componentDidUpdate (prevProps, prevState) {

--- a/src/js/common/components/Style/PoliticianDetailsStyles.jsx
+++ b/src/js/common/components/Style/PoliticianDetailsStyles.jsx
@@ -2,7 +2,7 @@ import styled, { css } from 'styled-components';
 
 export const CandidateCampaignListDesktop = styled('div')`
   font-size: 18px;
-  margin-bottom: 20x;
+  margin-bottom: 20px;
   min-height: 34px;
 `;
 

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -78,6 +78,7 @@ class PoliticianDetailsPage extends Component {
       chosenWebsiteName: '',
       finalElectionDateInPast: false,
       // inPrivateLabelMode: false,
+      loadSlow: false,
       officeHeldList: [],
       opponentCandidateList: [],
       payToPromoteStepCompleted: false,
@@ -455,7 +456,7 @@ class PoliticianDetailsPage extends Component {
     // console.log('componentDidMount politicianSEOFriendlyPathFromUrl: ', politicianSEOFriendlyPathFromUrl);
     const {
       allCachedPositionsForThisPolitician, ballotpediaPoliticianUrl, candidateCampaignList, chosenWebsiteName,
-      supporterEndorsementsWithText, finalElectionDateInPast, linkedCampaignXWeVoteId,
+      supporterEndorsementsWithText, finalElectionDateInPast, linkedCampaignXWeVoteId, loadSlow,
       officeHeldList, officeHeldNameForSearch, opponentCandidateList,
       politicalParty, politicianDataNotFound,
       politicianDescription, politicianDescriptionLimited, politicianImageUrlLarge,
@@ -645,7 +646,7 @@ class PoliticianDetailsPage extends Component {
     if (allCachedPositionsForThisPolitician && allCachedPositionsForThisPolitician.length > 0) {
       positionListTeaserHtml = (
         <CommentsListWrapper>
-          <DelayedLoad waitBeforeShow={1000}>
+          <DelayedLoad waitBeforeShow={loadSlow ? 1000 : 0}>
             <Suspense fallback={<span>&nbsp;</span>}>
               <CampaignSubSectionTitleWrapper>
                 <CampaignSubSectionTitle>
@@ -681,7 +682,7 @@ class PoliticianDetailsPage extends Component {
     if (supporterEndorsementsWithText && supporterEndorsementsWithText.length > 0) {
       commentListTeaserHtml = (
         <CommentsListWrapper>
-          <DelayedLoad waitBeforeShow={1500}>
+          <DelayedLoad waitBeforeShow={loadSlow ? 1500 : 0}>
             <Suspense fallback={<span>&nbsp;</span>}>
               <CampaignSubSectionTitleWrapper>
                 <CampaignSubSectionTitle>
@@ -743,7 +744,7 @@ class PoliticianDetailsPage extends Component {
                   <PoliticianImageMobile src={politicianImageUrlLarge} alt="Politician" />
                 </PoliticianImageMobilePlaceholder>
               ) : (
-                <DelayedLoad waitBeforeShow={1000}>
+                <DelayedLoad waitBeforeShow={loadSlow ? 1000 : 0}>
                   <CampaignImagePlaceholder>
                     <CampaignImagePlaceholderText>
                       No image provided
@@ -835,7 +836,7 @@ class PoliticianDetailsPage extends Component {
             </Suspense>
             {(!futureFeaturesDisabled && nextReleaseFeaturesEnabled) && (
               <CommentsListWrapper>
-                <DelayedLoad waitBeforeShow={1000}>
+                <DelayedLoad waitBeforeShow={loadSlow ? 1000 : 0}>
                   <Suspense fallback={<span>&nbsp;</span>}>
                     <CampaignSubSectionTitleWrapper>
                       <CampaignSubSectionTitle>
@@ -915,7 +916,7 @@ class PoliticianDetailsPage extends Component {
                       <PoliticianImageDesktop src={politicianImageUrlLarge} alt="Politician" />
                     </PoliticianImageDesktopPlaceholder>
                   ) : (
-                    <DelayedLoad waitBeforeShow={1000}>
+                    <DelayedLoad waitBeforeShow={loadSlow ? 1000 : 0}>
                       <CampaignImagePlaceholder>
                         <CampaignImagePlaceholderText>
                           No image provided
@@ -970,7 +971,7 @@ class PoliticianDetailsPage extends Component {
                 </Suspense>
                 {(!futureFeaturesDisabled && nextReleaseFeaturesEnabled) && (
                   <CommentsListWrapper>
-                    <DelayedLoad waitBeforeShow={500}>
+                    <DelayedLoad waitBeforeShow={loadSlow ? 500 : 0}>
                       <Suspense fallback={<span>&nbsp;</span>}>
                         <CampaignSubSectionTitleWrapper>
                           <CampaignSubSectionTitle>

--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -63,9 +63,16 @@ export default class Header extends Component {
       dumpCssFromId('header-container');
     }
     if (VoterStore.getVoterWeVoteId() === '' && apiCalming('voterRetrieve', 500)) {
-      setTimeout(() => {
-        VoterActions.voterRetrieve();
-      }, 1000);
+      // Aug 3, 2023: Removed the 1-second delay, and the result is visibly faster.
+      // Not sure why we had a delay here, or if it is still needed somewhere, but it is removed for now.
+      // Adding a big delay here fools lighthouse into reporting a faster speed index, performance, and LCP,
+      // but when you look at that delay in "Performance", nothing is happening in the browser -- it is just dead time.
+      // I believe that the delay was fooling Lighthouse into thinking the page had loaded, and the stuff after the
+      // delay was some sort of continuously loading real time data like a stock ticker update.
+      // setTimeout(() => {
+      //  VoterActions.voterRetrieve();
+      // }, 5000);
+      VoterActions.voterRetrieve();
     }
   }
 

--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -67,8 +67,8 @@ export default class Header extends Component {
       // Not sure why we had a delay here, or if it is still needed somewhere, but it is removed for now.
       // Adding a big delay here fools lighthouse into reporting a faster speed index, performance, and LCP,
       // but when you look at that delay in "Performance", nothing is happening in the browser -- it is just dead time.
-      // I believe that the delay was fooling Lighthouse into thinking the page had loaded, and the stuff after the
-      // delay was some sort of continuously loading real time data like a stock ticker update.
+      // I believe that the delay was fooling Lighthouse into thinking the page had loaded, and that the activity
+      // after the delay was some sort of continuously updating real time data (like a stock ticker update).
       // setTimeout(() => {
       //  VoterActions.voterRetrieve();
       // }, 5000);


### PR DESCRIPTION
For candidate Adam Schiff, Nancy Pelosi's endorsement on the right was the last visible element to be rendered and was appearing at about 4.5 seconds
After these changes the page is fully rendered and Nancy appears (to the right and below) at about 1.1 seconds.  In the more typical situation where you don't start the app on this page, it loads in about 950ms.
The https://github.com/wevote/WeVoteServer/pull/2191 siteConfigurationRetrieve improvement knocks about a half second off the page load time.
Separately we were calling retrievePositionListsForOneCandidate for six elections for Adam Schiff (a waste of time) now we load one... either a future election, or the most recent one in the past.
Did not remove all the `<DelayedLoad />` in PoliticsDetailsPage.jsx, just set them conditionally to zero.  This knocked at least a second off the load, and since the rest of the page was loading so quickly, these delays seemed to have little value.
Unfortunately Lighthouse does not give reliable results for this page.  The "Performance" and LDP/FCP numbers are wrong probably due to the facebook graph API at 2.4 seconds and the activityNoticeListRetrieve activityNoticeListRetrieve at 4 seconds.  Other timers expiring later (without doing anything) might also be confusing Lighthouse.
Without Facebook and activityNotice, and monitoring the "Performance" tab, the screen is completely rendered at 950ms and no frame updates occur beyond 950ms.