### PR TITLE
Fixed HowItWorksModal slide change isssue for new viewers

### DIFF
--- a/src/js/pages/HowItWorks.jsx
+++ b/src/js/pages/HowItWorks.jsx
@@ -207,7 +207,7 @@ class HowItWorks extends Component {
         getStartedMode: 'getStartedForVoters',
         // getStartedUrl: '/ballot',
         selectedCategoryIndex: 0,
-        selectedStepIndex: 0,
+        // selectedStepIndex: 0,
       });
     }
     const howItWorksWatched = VoterStore.getInterfaceFlagState(VoterConstants.HOW_IT_WORKS_WATCHED);

--- a/src/js/pages/HowItWorks.jsx
+++ b/src/js/pages/HowItWorks.jsx
@@ -207,6 +207,7 @@ class HowItWorks extends Component {
         getStartedMode: 'getStartedForVoters',
         // getStartedUrl: '/ballot',
         selectedCategoryIndex: 0,
+        // Commented line 211 which seems to be causing users who visit the How It Works modal for the first time to experience a glitch when moving from the first slide to the second slide.
         // selectedStepIndex: 0,
       });
     }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
JIRA Issue #115

### Changes included this pull request?
Commented line 211 in WebApp/src/js/pages/HowItWorks.jsx which seems to be causing users who visit the How It Works modal for the first time to experience a glitch when moving from the first slide to the second slide.