### PR TITLE
add optional chaining operator to organization and guide information …

### DIFF
--- a/src/js/pages/Values/OneValue.jsx
+++ b/src/js/pages/Values/OneValue.jsx
@@ -211,18 +211,18 @@ class OneValue extends Component {
         });
         organizationsForValue = filter(organizationsForValueModified,
           (organization) => (
-            organization.organization_name.toLowerCase().includes(searchTextLowercase) ||
-            organization.twitter_description.toLowerCase().includes(searchTextLowercase) ||
-            organization.organization_twitter_handle.toLowerCase().includes(searchTextLowercase)
+            organization.organization_name?.toLowerCase().includes(searchTextLowercase) ||
+            organization.twitter_description?.toLowerCase().includes(searchTextLowercase) ||
+            organization.organization_twitter_handle?.toLowerCase().includes(searchTextLowercase)
           ));
         organizationsForValueLength = organizationsForValue.length;
         organizationListIdentifier = `${valueSlug}${organizationsForValueLength}`;
       }
       if (showEndorsersForThisElection) {
         voterGuidesForValue = filter(voterGuidesForValue,
-          (guide) => guide.voter_guide_display_name.toLowerCase().includes(searchTextLowercase) ||
-              guide.twitter_description.toLowerCase().includes(searchTextLowercase) ||
-              guide.twitter_handle.toLowerCase().includes(searchTextLowercase));
+          (guide) => guide.voter_guide_display_name?.toLowerCase().includes(searchTextLowercase) ||
+              guide.twitter_description?.toLowerCase().includes(searchTextLowercase) ||
+              guide.twitter_handle?.toLowerCase().includes(searchTextLowercase));
       }
     }
 


### PR DESCRIPTION
…to prevent string  methods from trying to execute with a null value

### What github.com/wevote/WebApp/issues does this fix?
This is fixing issue WV-158 "The Search bar on "All Endorses" for any Topic rejects user queries"

### Changes included this pull request?
The only change was including the optional chaining operator to lines 214-216 and 223-225. The toLowerCase() string method was trying to operate on the details for 'organization' and 'guide' before that data was available. The optional chaining operator prevented it from running before there was a value present. 

### Additional Notes
I would also add that in my local environment, not "every" topic created this bug behavior. The only two I could find at a quick glance that did it for me were the "Pro Choice" topic and "2nd Amendment Gun Rights" topics. Many other topics did not display the error behavior for me/ 