### PR TITLE
replace '.replace' with '.replaceAll' for WV-129

### DIFF
--- a/src/js/pages/Campaigns/CampaignsHome.jsx
+++ b/src/js/pages/Campaigns/CampaignsHome.jsx
@@ -129,7 +129,7 @@ class CampaignsHome extends Component {
       }
     }
     if (stateName) {
-      stateName = stateName.replace('-', ' ');
+      stateName = stateName.replaceAll('-', ' ');
       let newStateCode = convertStateTextToStateCode(stateName);
       if (newStateCode.toLowerCase() === 'na') {
         newStateCode = 'all';
@@ -183,7 +183,7 @@ class CampaignsHome extends Component {
       }
 
       if (stateName) {
-        stateName = stateName.replace('-', ' ');
+        stateName = stateName.replaceAll('-', ' ');
         const { stateCode } = this.state;
         let newStateCode = convertStateTextToStateCode(stateName);
         // console.log('stateCode:', stateCode, ', newStateCode:', newStateCode);
@@ -561,7 +561,7 @@ class CampaignsHome extends Component {
   getStateNamePathnameFromStateCode = (stateCode) => {
     const stateName = convertStateCodeToStateText(stateCode);
     const stateNamePhrase = `${stateName}-candidates`;
-    const stateNamePhraseLowerCase = stateNamePhrase.replace(/\s+/g, '-').toLowerCase();
+    const stateNamePhraseLowerCase = stateNamePhrase.replaceAll(/\s+/g, '-').toLowerCase();
     return `/${stateNamePhraseLowerCase}/cs/`;
   }
 

--- a/src/js/pages/Campaigns/CampaignsHomeLoader.jsx
+++ b/src/js/pages/Campaigns/CampaignsHomeLoader.jsx
@@ -45,7 +45,7 @@ class CampaignsHomeLoader extends Component {
       // }
     }
     if (stateName) {
-      stateName = stateName.replace('-', ' ');
+      stateName = stateName.replaceAll('-', ' ');
       let newStateCode = convertStateTextToStateCode(stateName);
       if (newStateCode.toLowerCase() === 'na') {
         newStateCode = 'all';
@@ -85,7 +85,7 @@ class CampaignsHomeLoader extends Component {
       // }
 
       if (stateName) {
-        stateName = stateName.replace('-', ' ');
+        stateName = stateName.replaceAll('-', ' ');
         const { stateCode } = this.state;
         let newStateCode = convertStateTextToStateCode(stateName);
         // console.log('stateCode:', stateCode, ', newStateCode:', newStateCode);
@@ -119,7 +119,7 @@ class CampaignsHomeLoader extends Component {
   getStateNamePathnameFromStateCode = (stateCode) => {
     const stateName = convertStateCodeToStateText(stateCode);
     const stateNamePhrase = `${stateName}-candidates`;
-    const stateNamePhraseLowerCase = stateNamePhrase.replace(/\s+/g, '-').toLowerCase();
+    const stateNamePhraseLowerCase = stateNamePhrase.replaceAll(/\s+/g, '-').toLowerCase();
     return `/${stateNamePhraseLowerCase}/cs/`;
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

- WV-129

### Changes included this pull request?

- changed 4 occurrences of replace with replaceAll. 
- WebApp\src\js\pages\Campaigns\CampaignHomeLoader.jsx 
- WebApp\src\js\pages\Campaigns\CampaignHome.jsx.

These changes allows District of Columbia to load on the first click.