### PR TITLE
WV-175/updated OpenReplay privacy policy link

### DIFF
--- a/src/js/common/components/PrivacyBody.jsx
+++ b/src/js/common/components/PrivacyBody.jsx
@@ -284,9 +284,9 @@ export default class PrivacyBody extends Component {
             <Suspense fallback={<></>}>
               <OpenExternalWebSite
                 linkIdAttribute="openReplayPrivacy"
-                url="https://openreplay.com/privacy.html"
+                url="https://openreplay.com/legal/privacy.html"
                 target="_blank"
-                body={<span>https://openreplay.com/privacy.html</span>}
+                body={<span>https://openreplay.com/legal/privacy.html</span>}
               />
             </Suspense>
             ).


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
The user will be redirected to the Open Replay privacy page, allowing them to access the relevant information about privacy.

### Changes included this pull request?
The link on We Vote privacy page has been updated to reflect the fixed issue of taking the user to Open Replay's privacy information.
