### PR TITLE
[WV-166] Fix

### DIFF
--- a/src/js/common/utils/addressFunctions.js
+++ b/src/js/common/utils/addressFunctions.js
@@ -88,6 +88,18 @@ export function convertStateCodeFilterToStateCode (stateCodeFilter) {
   return '';
 }
 
+export function isValidStateCode (incomingStateCode) {
+  if (incomingStateCode) {
+    // Log incoming State Code
+    console.log('incomingStateCode:', incomingStateCode);
+    const incomingStateCodeUpper = incomingStateCode.toUpperCase();
+    const existingStateCodes = Object.keys(stateCodeMap);
+    return existingStateCodes.indexOf(incomingStateCodeUpper) > -1;
+  } else {
+    return false;
+  }
+}
+
 export function getAllStateCodeFilters () {
   return Object.keys(stateCodeMap).map((stateCode) => `stateCode${stateCode}`);
 }

--- a/src/js/pages/Campaigns/CampaignsHomeLoader.jsx
+++ b/src/js/pages/Campaigns/CampaignsHomeLoader.jsx
@@ -11,7 +11,6 @@ import CampaignsHomeFilterPlaceholder from '../../components/CampaignsHome/Campa
 import CandidateListRootPlaceholder from '../../components/CampaignsHome/CandidateListRootPlaceholder';
 import VoterStore from '../../stores/VoterStore';
 import { cordovaSimplePageContainerTopOffset } from '../../utils/cordovaCalculatedOffsets';
-import Header from '../../components/Navigation/Header.jsx'
 
 const CampaignsHome = React.lazy(() => import(/* webpackChunkName: 'CampaignsHome' */ './CampaignsHome'));
 
@@ -118,10 +117,6 @@ class CampaignsHomeLoader extends Component {
   }
 
   getStateNamePathnameFromStateCode = (stateCode) => {
-    // Logging to see what StateCode it says I'm in
-    console.log('getStateNamePathnameFromStateCode:', stateCode);
-    // Trying to find where Ontario is coming from 'ON'
-    console.log('convertStateCodeToStateText of stateCode:', convertStateCodeToStateText(stateCode));
     if (isValidStateCode(stateCode)) {
       const stateName = convertStateCodeToStateText(stateCode);
       if (stateName) {

--- a/src/js/pages/Campaigns/CampaignsHomeLoader.jsx
+++ b/src/js/pages/Campaigns/CampaignsHomeLoader.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import styled from 'styled-components';
-import { convertStateCodeToStateText, convertStateTextToStateCode } from '../../common/utils/addressFunctions';
+import { convertStateCodeToStateText, convertStateTextToStateCode, isValidStateCode } from '../../common/utils/addressFunctions';
 import historyPush from '../../common/utils/historyPush';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
@@ -11,6 +11,7 @@ import CampaignsHomeFilterPlaceholder from '../../components/CampaignsHome/Campa
 import CandidateListRootPlaceholder from '../../components/CampaignsHome/CandidateListRootPlaceholder';
 import VoterStore from '../../stores/VoterStore';
 import { cordovaSimplePageContainerTopOffset } from '../../utils/cordovaCalculatedOffsets';
+import Header from '../../components/Navigation/Header.jsx'
 
 const CampaignsHome = React.lazy(() => import(/* webpackChunkName: 'CampaignsHome' */ './CampaignsHome'));
 
@@ -117,10 +118,22 @@ class CampaignsHomeLoader extends Component {
   }
 
   getStateNamePathnameFromStateCode = (stateCode) => {
-    const stateName = convertStateCodeToStateText(stateCode);
-    const stateNamePhrase = `${stateName}-candidates`;
-    const stateNamePhraseLowerCase = stateNamePhrase.replaceAll(/\s+/g, '-').toLowerCase();
-    return `/${stateNamePhraseLowerCase}/cs/`;
+    // Logging to see what StateCode it says I'm in
+    console.log('getStateNamePathnameFromStateCode:', stateCode);
+    // Trying to find where Ontario is coming from 'ON'
+    console.log('convertStateCodeToStateText of stateCode:', convertStateCodeToStateText(stateCode));
+    if (isValidStateCode(stateCode)) {
+      const stateName = convertStateCodeToStateText(stateCode);
+      if (stateName) {
+        const stateNamePhrase = `${stateName}-candidates`;
+        const stateNamePhraseLowerCase = stateNamePhrase.replaceAll(/\s+/g, '-').toLowerCase();
+        return `/${stateNamePhraseLowerCase}/cs/`;
+      } else {
+        return '/cs';
+      }
+    } else {
+      return '/cs';
+    }
   }
 
   getTopPadding = () => {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-166]

### Changes included this pull request?
A new function is added to addressFunctions.js made in collaboration with Dale. A new set of conditional operations was added to CampaignsHomeLoader.jsx. With each of these in conjunction, if a stateCode isn't recognized (for example, someone is out of the country) they will then be routed to /cs instead of -candidates/cs. There is not longer an issue with the header not appearing and the expected behavior is happening. 