### PR TITLE
Made the Twitter Account Links clickable on the Supporters' Slide-out drawer

### DIFF
--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -353,14 +353,23 @@ class PositionItem extends Component {
                       <DesktopItemTwitterContainer>
                         { !!(position.twitter_followers_count && String(position.twitter_followers_count) !== '0') && (
                           <DesktopItemTwitter>
-                            <Twitter classes={{ root: classes.twitterLogo }} />
-                            <TwitterHandleWrapper>
-                              @
-                              {position.speaker_twitter_handle}
-                            </TwitterHandleWrapper>
-                            <TwitterFollowersWrapper>
-                              {abbreviateNumber(position.twitter_followers_count)}
-                            </TwitterFollowersWrapper>
+                            <OpenExternalWebSite
+                              body={(
+                                <div style={{ marginTop: '-24px' }}>
+                                  <Twitter classes={{ root: classes.twitterLogo }} />
+                                  <TwitterHandleWrapper>
+                                    @
+                                    {position.speaker_twitter_handle}
+                                  </TwitterHandleWrapper>
+                                  <TwitterFollowersWrapper>
+                                    {abbreviateNumber(position.twitter_followers_count)}
+                                  </TwitterFollowersWrapper>
+                                </div>
+                              )}
+                              linkIdAttribute="candidateTwitterDesktop"
+                              url={`https://twitter.com/${position.speaker_twitter_handle}`}
+                              target="_blank"
+                            />
                           </DesktopItemTwitter>
                         )}
                       </DesktopItemTwitterContainer>

--- a/src/js/components/Ballot/PositionItem.jsx
+++ b/src/js/components/Ballot/PositionItem.jsx
@@ -366,7 +366,7 @@ class PositionItem extends Component {
                                   </TwitterFollowersWrapper>
                                 </div>
                               )}
-                              linkIdAttribute="candidateTwitterDesktop"
+                              linkIdAttribute="positionItemTwitterDesktop"
                               url={`https://twitter.com/${position.speaker_twitter_handle}`}
                               target="_blank"
                             />


### PR DESCRIPTION
Slide out drawer link is now clickable for some responsive size, plus desktop.  These links are not displayed in Cordova.

Whoops thought this was a Cordova issue, but fixed it in WebApp.

Resolves https://wevoteusa.atlassian.net/browse/WV-102
