### PR TITLE
WV-194 increased image resolution on candidate supporters

### DIFF
--- a/src/js/common/components/CampaignSupport/MostRecentCampaignSupport.jsx
+++ b/src/js/common/components/CampaignSupport/MostRecentCampaignSupport.jsx
@@ -270,9 +270,9 @@ class MostRecentCampaignSupport extends React.Component {
             {supportersOnStageNow.map((comment) => (
               <CommentWrapper className="comment" key={comment.id}>
                 <CommentVoterPhotoWrapper>
-                  {comment.we_vote_hosted_profile_image_url_tiny ? (
+                  {comment.we_vote_hosted_profile_image_url_medium ? (
                     <LazyImage
-                      src={comment.we_vote_hosted_profile_image_url_tiny}
+                      src={comment.we_vote_hosted_profile_image_url_medium}
                       placeholder={avatarGeneric()}
                       className="profile-photo"
                       height={48}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-194](https://wevoteusa.atlassian.net/jira/software/projects/WV/issues/WV-194)

### Changes included this pull request?
Updated the image used to be the "mediium" instead of "tiny" version.

The image used is now 48x48 instead of 32x32.

![image](https://github.com/wevote/WebApp/assets/89757407/d6a54e38-58a9-4318-81bb-acf9f19458f2)


[WV-194]: https://wevoteusa.atlassian.net/browse/WV-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ