### PR TITLE
[WV-131]<fixes twitter login button unresponsive after hitting back button>TEAM REVIEW

### DIFF
--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -134,9 +134,12 @@ class TwitterSignIn extends Component {
   twitterSignInWebApp = () => {
     const brandingOff = Cookies.get('we_vote_branding_off') || 0;
     oAuthLog(`twitterSignInWebApp isWebApp(): ${isWebApp()},  returnURL: ${returnURL}`);
-    this.setState({
-      twitterSignInStartSubmitted: true,
-    });
+    // causing bug WV-131 in desktop version
+    if (isIOS()) {
+      this.setState({
+        twitterSignInStartSubmitted: true,
+      });
+    }
     $ajax({
       endpoint: 'twitterSignInStart',
       data: { return_url: returnURL },


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
After redirecting to Twitter login and then hitting back button, user is returned to sign in options panel with Twitter button disabled. This issue occurs consistently in Safari and only occasionally in Chrome when other factors are present.

### Changes included this pull request?
At line 138 set state twitterSigninStartSubmitted: true only if isIOS. This prevents disabled from being set to true in line 187