### PR TITLE
Updated webpack to use wevotedeveloper.com SSL if configured

### DIFF
--- a/serverWevotedeveloper.js
+++ b/serverWevotedeveloper.js
@@ -1,0 +1,25 @@
+/* eslint-disable */
+// start the express server
+const express = require("express");
+const app = express();
+const fs = require("fs");
+const https = require("https");
+const path = require("path");
+const webAppConfig = require("./src/js/config");
+
+const port = 3000;
+const opts = { redirect: true };
+const hostname = "wevotedeveloper.com";
+
+app.use("/", express.static("build", opts));
+app.all("*", (req, res) => res.sendFile(__dirname + "/build/index.html"));
+
+const certOptions = {
+  key: fs.readFileSync(path.resolve(__dirname + "/src/cert/wevotedeveloper.com_key.txt")),
+  cert: fs.readFileSync(path.resolve(__dirname + "/src/cert/wevotedeveloper.com.crt")),
+};
+
+const server = https.createServer(certOptions, app).listen(port, function () {
+  console.log("INFO: https server started", new Date());
+  console.log(`INFO: Server is at https://${hostname}:${port}`);
+});

--- a/serverWevotedeveloper.js
+++ b/serverWevotedeveloper.js
@@ -1,5 +1,10 @@
 /* eslint-disable */
+
 // start the express server
+
+// invoke:
+//    node serverWevotedeveloper.js
+
 const express = require("express");
 const app = express();
 const fs = require("fs");

--- a/src/js/components/Widgets/StorybookRedirect.jsx
+++ b/src/js/components/Widgets/StorybookRedirect.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { renderLog } from '../../common/utils/logging';
+
+
+// React functional component example
+export default function StorybookRedirect () {
+  renderLog('StorybookRedirect functional component');
+
+  return (
+    <a href="/storybook?path=/docs/design-system--docs">Redirect to Html page</a>
+  );
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,8 @@ if (major < 13) {
 } else {
   console.log(`Node version is: ${process.version}`);
 }
+console.log('useRealCerts in webpack.config.js ', useRealCerts);
+console.log('key: ', fs.readFileSync(`./${source}/cert/wevotedeveloper.com.crt`).toString());
 
 module.exports = (env, argv) => ({
   entry: path.resolve(__dirname, `./${source}/index.jsx`),
@@ -166,7 +168,7 @@ module.exports = (env, argv) => ({
     static: {
       directory: path.join(__dirname, './build'),
     },
-    host: 'localhost',
+    host: (useRealCerts ? 'wevotedeveloper.com' : 'localhost'),
     port,
     historyApiFallback: true,
     // open: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ if (major < 13) {
   console.log(`Node version is: ${process.version}`);
 }
 console.log('useRealCerts in webpack.config.js ', useRealCerts);
-console.log('key: ', fs.readFileSync(`./${source}/cert/wevotedeveloper.com.crt`).toString());
+// console.log('key: ', fs.readFileSync(`./${source}/cert/wevotedeveloper.com.crt`).toString());
 
 module.exports = (env, argv) => ({
   entry: path.resolve(__dirname, `./${source}/index.jsx`),


### PR DESCRIPTION
Works on Safari and Firefox for webapp, but not on Chrome. 
Works on all three for local Python API server (which uses a different local http server program).
Works with Chrome and and the Express webserver ... `node serverWevotedeveloper.js`, but not with Chrome and the Webpack devServer.
Will keep working on chrome.


