### PR TITLE
[WV-131]  Sign In with Twitter button becomes unresponsive after navigating back MERGE READY

### DIFF
--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -134,9 +134,12 @@ class TwitterSignIn extends Component {
   twitterSignInWebApp = () => {
     const brandingOff = Cookies.get('we_vote_branding_off') || 0;
     oAuthLog(`twitterSignInWebApp isWebApp(): ${isWebApp()},  returnURL: ${returnURL}`);
-    this.setState({
-      twitterSignInStartSubmitted: true,
-    });
+    // causing bug WV-131 in desktop version
+    if (isIOS()) {
+      this.setState({
+        twitterSignInStartSubmitted: true,
+      });
+    }
     $ajax({
       endpoint: 'twitterSignInStart',
       data: { return_url: returnURL },

--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -81,7 +81,6 @@ class TwitterSignIn extends Component {
     this.state = {
       buttonSubmittedText: '',
       twitterSignInCrash: false,
-      twitterSignInDisabled: false,
       twitterSignInStartSubmitted: false,
     };
   }
@@ -134,17 +133,15 @@ class TwitterSignIn extends Component {
   twitterSignInWebApp = () => {
     const brandingOff = Cookies.get('we_vote_branding_off') || 0;
     oAuthLog(`twitterSignInWebApp isWebApp(): ${isWebApp()},  returnURL: ${returnURL}`);
-    // causing bug WV-131 in desktop version
-    if (isIOS()) {
-      this.setState({
-        twitterSignInStartSubmitted: true,
-      });
-    }
+    this.setState({
+      twitterSignInStartSubmitted: true,
+    });
     $ajax({
       endpoint: 'twitterSignInStart',
       data: { return_url: returnURL },
       success: (res) => {
         // console.log('twitterSignInWebApp success, res:', res);
+
         if (res.twitter_redirect_url) {
           if (brandingOff) {
             window.open(res.twitter_redirect_url);
@@ -160,7 +157,6 @@ class TwitterSignIn extends Component {
           // window.location.assign('');
           this.setState({
             twitterSignInCrash: true,
-            twitterSignInDisabled: true,
             twitterSignInStartSubmitted: false,
           });
         }
@@ -170,7 +166,7 @@ class TwitterSignIn extends Component {
         console.log('twitterSignInWebApp error: ', res);
 
         // Try reloading the page
-        window.location.assign('');
+        this.reloadApp();
       },
     });
   }
@@ -183,15 +179,16 @@ class TwitterSignIn extends Component {
 
   render () {
     let { buttonText } = this.props;
-    const { buttonSubmittedText, twitterSignInCrash, twitterSignInDisabled, twitterSignInStartSubmitted } = this.state;
-    let disabled = twitterSignInStartSubmitted;
+    const { buttonSubmittedText, twitterSignInCrash, twitterSignInStartSubmitted } = this.state;
+    // fixed for WV-131 disables button for iOS but not for webApp browser
+    let twitterSignInButtonDisabled = (isIOS() && twitterSignInStartSubmitted) || twitterSignInCrash;
     if (isIOS()) {
       const { device: { version } } = window;
       if (version) {
         const floatVersion = parseFloat(version);
         if (floatVersion < 13.0) {
           console.log('Sign in with Twitter is not available on iOS < 13, this phone is running: ', floatVersion);
-          disabled = true;
+          twitterSignInButtonDisabled = true;
           buttonText = '(Requires iOS 13)';
         }
       }
@@ -202,9 +199,9 @@ class TwitterSignIn extends Component {
       <>
         <SplitIconButton
           backgroundColor="#55acee"
-          fontColor={disabled || twitterSignInDisabled ? 'gray' : 'white'}
-          buttonText={twitterSignInStartSubmitted ? shortenText(buttonSubmittedText, 32) : shortenText(buttonText, 32)}
-          disabled={disabled || twitterSignInDisabled}
+          fontColor={twitterSignInButtonDisabled ? 'gray' : 'white'}
+          buttonText={twitterSignInButtonDisabled ? shortenText(buttonSubmittedText, 32) : shortenText(buttonText, 32)}
+          disabled={twitterSignInButtonDisabled}
           externalUniqueId="twitterSignIn"
           icon={<Twitter />}
           id="twitterSignIn"


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-131 Twitter login button disabled when using back button after redirect in Safari

### Changes included this pull request?
Simplified variables used when determining styling of button and when it is disabled.
Changed to only disable button in iOS due to issue in Safari browser.
Use reloadApp function to reload page instead of repeating code.