### PR TITLE
[WV-4] updates styling of voter email and phone entry lists TEAM REVIEW

### DIFF
--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -13,7 +13,7 @@ import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { renderLog } from '../../common/utils/logging';
 import VoterStore from '../../stores/VoterStore';
-import { FirstRowPhoneOrEmail, SecondRowPhoneOrEmail, TrashCan } from '../Style/pageLayoutStyles';
+import { FirstRowPhoneOrEmail, SecondRowPhoneOrEmail, SecondRowPhoneOrEmailDiv, AllPhoneOrEmailTypes } from '../Style/pageLayoutStyles';
 import { ButtonContainerHorizontal } from '../Welcome/sectionStyles';
 import SettingsVerifySecretCode from '../../common/components/Settings/SettingsVerifySecretCode';
 import { validateEmail } from '../../utils/regex-checks';
@@ -531,50 +531,50 @@ class VoterEmailAddressEntry extends Component {
             </FirstRowPhoneOrEmail>
             <SecondRowPhoneOrEmail>
               {isPrimaryEmailAddress ? (
-                <div key={`${voterEmailAddressFromList.email_we_vote_id}-internal`}>
+                <SecondRowPhoneOrEmailDiv>
                   <span>
                     Primary
-                    <span style={{ paddingRight: '112px' }}>&nbsp;</span>
                   </span>
-                  <OverlayTrigger
-                    placement="right"
-                    overlay={(
-                      <Tooltip id="tooltip-top">
-                        Cannot remove primary email. Please add another primary email before removing this one.
-                      </Tooltip>
-                    )}
-                  >
-                    <TrashCan>
-                      <span
-                        // className="u-gray-darker"
-                        style={{ color: '#757575' }}
-
-                      >
-                        <Delete />
-                      </span>
-                    </TrashCan>
-                  </OverlayTrigger>
-                </div>
+                  <span>
+                    <OverlayTrigger
+                      placement="right"
+                      overlay={(
+                        <Tooltip id="tooltip-top">
+                          You must add a new primary email before removing this one.
+                        </Tooltip>
+                      )}
+                    >
+                      <div>
+                        <span
+                          className="u-gray-border"
+                        >
+                          <Delete />
+                        </span>
+                      </div>
+                    </OverlayTrigger>
+                  </span>
+                </SecondRowPhoneOrEmailDiv>
               ) : (
-                <div key={`${voterEmailAddressFromList.email_we_vote_id}-internal`}>
+                <SecondRowPhoneOrEmailDiv key={`${voterEmailAddressFromList.email_we_vote_id}-internal`}>
                   <span
                     className="u-link-color u-cursor--pointer u-no-break"
                     onClick={() => this.setAsPrimaryEmailAddress(voterEmailAddressFromList.email_we_vote_id)}
                   >
                     Make Primary
-                    <span style={{ paddingRight: '65px' }}>&nbsp;</span>
                   </span>
                   {allowRemoveEmail && (
-                    <TrashCan>
-                      <span
-                        className="u-link-color u-cursor--pointer"
-                        onClick={() => this.removeVoterEmailAddress(voterEmailAddressFromList.email_we_vote_id)}
-                      >
-                        <Delete />
-                      </span>
-                    </TrashCan>
+                  <span>
+                    <div>
+                        <span
+                          className="u-link-color u-cursor--pointer"
+                          onClick={() => this.removeVoterEmailAddress(voterEmailAddressFromList.email_we_vote_id)}
+                        >
+                          <Delete />
+                        </span>
+                      </div>
+                  </span>
                   )}
-                </div>
+                </SecondRowPhoneOrEmailDiv>
               )}
             </SecondRowPhoneOrEmail>
           </div>
@@ -602,20 +602,24 @@ class VoterEmailAddressEntry extends Component {
               {voterEmailAddressFromList.email_ownership_is_verified ?
                 null : (
                   <SecondRowPhoneOrEmail>
-                    <span
-                      className="u-link-color u-cursor--pointer u-no-break"
-                      onClick={() => this.reSendSignInCodeEmail(voterEmailAddressFromList.normalized_email_address)}
-                    >
-                      Send verification again
-                    </span>
-                    {allowRemoveEmail && (
-                      <TrashCan
-                        className="u-link-color u-cursor--pointer"
-                        onClick={() => this.removeVoterEmailAddress(voterEmailAddressFromList.email_we_vote_id)}
+                    <SecondRowPhoneOrEmailDiv key={`${voterEmailAddressFromList.email_we_vote_id}-internal`}>
+                      <span
+                        className="u-link-color u-cursor--pointer u-no-break"
+                        onClick={() => this.reSendSignInCodeEmail(voterEmailAddressFromList.normalized_email_address)}
                       >
-                        <Delete />
-                      </TrashCan>
-                    )}
+                        Send verification again
+                      </span>
+                      {allowRemoveEmail && (
+                        <span>
+                          <div
+                            className="u-link-color u-cursor--pointer"
+                            onClick={() => this.removeVoterEmailAddress(voterEmailAddressFromList.email_we_vote_id)}
+                          >
+                            <Delete />
+                          </div>
+                        </span>
+                      )}
+                    </SecondRowPhoneOrEmailDiv>
                   </SecondRowPhoneOrEmail>
                 )}
             </div>
@@ -633,7 +637,7 @@ class VoterEmailAddressEntry extends Component {
             {emailAddressStatusHtml}
           </span>
         ) : (
-          <div>
+          <AllPhoneOrEmailTypes>
             {verifiedEmailsFound ? (
               <EmailSection isWeb={isWebApp()}>
                 <span className="h3">
@@ -654,7 +658,7 @@ class VoterEmailAddressEntry extends Component {
                 {toVerifyEmailListHtml}
               </EmailSection>
             )}
-          </div>
+          </AllPhoneOrEmailTypes>
         )}
         {!hideSignInWithEmailForm && (
           <EmailSection isWeb={isWebApp()}>

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -18,7 +18,7 @@ import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { renderLog } from '../../common/utils/logging';
 import VoterStore from '../../stores/VoterStore';
-import { FirstRowPhoneOrEmail, SecondRowPhoneOrEmail, TrashCan } from '../Style/pageLayoutStyles';
+import { FirstRowPhoneOrEmail, SecondRowPhoneOrEmail, SecondRowPhoneOrEmailDiv, AllPhoneOrEmailTypes } from '../Style/pageLayoutStyles';
 import { ButtonContainerHorizontal } from '../Welcome/sectionStyles';
 import SettingsVerifySecretCode from '../../common/components/Settings/SettingsVerifySecretCode';
 // import { validatePhoneOrEmail } from '../../utils/regex-checks';
@@ -580,49 +580,45 @@ class VoterPhoneVerificationEntry extends Component {
             </FirstRowPhoneOrEmail>
             <SecondRowPhoneOrEmail>
               {isPrimarySMSPhoneNumber ? (
-                <div key={`${voterSMSPhoneNumberFromList.sms_we_vote_id}-internal`}>
+                <SecondRowPhoneOrEmailDiv>
                   <span>
                     Primary
-                    <span style={{ paddingRight: '112px' }}>&nbsp;</span>
                   </span>
                   <OverlayTrigger
                     placement="right"
                     overlay={(
                       <Tooltip id="tooltip-top">
-                        Cannot remove primary phone number. Please add another primary number before removing this one.
+                        You must add a new primary number before removing this one.
                       </Tooltip>
                     )}
                   >
-                    <TrashCan>
+                    <div>
                       <span
-                        // className="u-gray-mid"
-                        style={{ color: '#757575' }}
-
+                        className="u-gray-border"
                       >
                         <Delete />
                       </span>
-                    </TrashCan>
+                    </div>
                   </OverlayTrigger>
 
-                </div>
+                </SecondRowPhoneOrEmailDiv>
               ) : (
-                <div key={`${voterSMSPhoneNumberFromList.sms_we_vote_id}-internal`}>
+                <SecondRowPhoneOrEmailDiv key={`${voterSMSPhoneNumberFromList.sms_we_vote_id}-internal`}>
                   <span
                      className="u-link-color u-cursor--pointer"
                      onClick={() => this.setAsPrimarySMSPhoneNumber.bind(this, voterSMSPhoneNumberFromList.sms_we_vote_id)}
                   >
                     Make Primary
-                    <span style={{ paddingRight: '65px' }}>&nbsp;</span>
                   </span>
                   {allowRemoveSMSPhoneNumber && (
-                    <TrashCan
+                    <div
                       className="u-link-color u-cursor--pointer"
                       onClick={() => this.removeVoterSMSPhoneNumber.bind(this, voterSMSPhoneNumberFromList.sms_we_vote_id)}
                     >
                       <Delete />
-                    </TrashCan>
+                    </div>
                   )}
-                </div>
+                </SecondRowPhoneOrEmailDiv>
               )}
             </SecondRowPhoneOrEmail>
           </div>
@@ -650,20 +646,22 @@ class VoterPhoneVerificationEntry extends Component {
               {voterSMSPhoneNumberFromList.sms_ownership_is_verified ?
                 null : (
                   <SecondRowPhoneOrEmail>
-                    <span
-                      className="u-link-color u-cursor--pointer u-no-break"
-                      onClick={() => this.reSendSignInCodeSMS(voterSMSPhoneNumberFromList.normalized_sms_phone_number)}
-                    >
-                      Send verification again
-                    </span>
-                    {allowRemoveSMSPhoneNumber && (
-                      <TrashCan
-                        className="u-link-color u-cursor--pointer"
-                        onClick={() => this.removeVoterSMSPhoneNumber.bind(this, voterSMSPhoneNumberFromList.sms_we_vote_id)}
+                    <SecondRowPhoneOrEmailDiv>
+                      <span
+                        className="u-link-color u-cursor--pointer u-no-break"
+                        onClick={() => this.reSendSignInCodeSMS(voterSMSPhoneNumberFromList.normalized_sms_phone_number)}
                       >
-                        <Delete />
-                      </TrashCan>
-                    )}
+                        Send verification again
+                      </span>
+                      {allowRemoveSMSPhoneNumber && (
+                        <div
+                          className="u-link-color u-cursor--pointer"
+                          onClick={() => this.removeVoterSMSPhoneNumber.bind(this, voterSMSPhoneNumberFromList.sms_we_vote_id)}
+                        >
+                          <Delete />
+                        </div>
+                      )}
+                    </SecondRowPhoneOrEmailDiv>
                   </SecondRowPhoneOrEmail>
                 )}
             </div>
@@ -681,7 +679,7 @@ class VoterPhoneVerificationEntry extends Component {
             {smsPhoneNumberStatusHtml}
           </span>
         ) : (
-          <div>
+          <AllPhoneOrEmailTypes>
             {verifiedSMSFound ? (
               <PhoneNumberSection isWeb={isWebApp()}>
                 <span className="h3">
@@ -702,7 +700,7 @@ class VoterPhoneVerificationEntry extends Component {
                 {toVerifySMSListHtml}
               </PhoneNumberSection>
             )}
-          </div>
+          </AllPhoneOrEmailTypes>
         )}
         {!hideSignInWithPhoneForm && (
           <PhoneNumberSection isWeb={isWebApp()}>

--- a/src/js/components/Style/pageLayoutStyles.js
+++ b/src/js/components/Style/pageLayoutStyles.js
@@ -290,17 +290,27 @@ export const OfficeShareWrapper = styled('div')`
 `;
 
 export const FirstRowPhoneOrEmail = styled('div')`
-  margin: 5px 5px 2px 36px;
-  text-align: left;
+  margin: 5px 0px 2px 0px;
+  text-align: center;
 `;
 
 export const SecondRowPhoneOrEmail = styled('div')`
-  margin: 0 0 4px 50px;
-  text-align: left;
+  margin-bottom: 4px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
-export const TrashCan = styled('span')`
-  margin-left: 30px;
+export const SecondRowPhoneOrEmailDiv = styled('div')`
+  width: 250px;
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const AllPhoneOrEmailTypes = styled('div')`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 export const TermsAndPrivacyText = styled('span')`


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Amends #3867 addressing stying of the VoterEmailAddressEntry and PhoneEmailAddressEntry components

### Changes included in this pull request?
- Create SecondRowPhoneOrEmailDiv and AllPhoneOrEmailTypes styled divs
- Label (primary, make primary, send verification again) and trash icon in set-width (250) flex-box container --(Will this be ok for Cordova?)
- Space-between and centered