### PR TITLE
[WV-321] TEAM REVIEW: styling for notifications with designtokencolors

### DIFF
--- a/src/js/common/components/Style/DesignTokenColors.js
+++ b/src/js/common/components/Style/DesignTokenColors.js
@@ -1,9 +1,13 @@
 const primitiveColorNames = {
   blue50: '#E6F3FF',
+  blueUI50: '#E2F2FD',
+  blueUI900: '0943A3',
   steel200: '#C8D4DF',
 };
 
 const DesignTokenColors = {
+  info50: primitiveColorNames.blueUI50,
+  info900: primitiveColorNames.blueUI900,
   primary50: primitiveColorNames.blue50,
   secondary200: primitiveColorNames.steel200,
 };

--- a/src/js/components/Navigation/HeaderNotificationMenu.jsx
+++ b/src/js/components/Navigation/HeaderNotificationMenu.jsx
@@ -16,6 +16,7 @@ import returnFirstXWords from '../../common/utils/returnFirstXWords';
 import ActivityStore from '../../stores/ActivityStore';
 import VoterStore from '../../stores/VoterStore';
 import { createDescriptionOfFriendPosts } from '../../utils/activityUtils';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
 
@@ -57,7 +58,8 @@ class HeaderNotificationMenu extends Component {
   }
 
   onActivityStoreChange () {
-    const allActivityNotices = ActivityStore.allActivityNotices();
+    const allActivityNotices = ActivityStore.allActivityNotices(); // this has no notification content from API
+    // const allActivityNotices = ActivityStore.allActivity(); // this has notification data for me, but missing some things. seed
     // console.log('allActivityNotices:', allActivityNotices);
     const activityNoticeIdListNotSeen = allActivityNotices
       .filter((activityNotice) => activityNotice.activity_notice_seen === false)
@@ -221,7 +223,7 @@ class HeaderNotificationMenu extends Component {
               <MenuItemText>
                 <div>
                   <strong>
-                    {activityNotice.speaker_voter_we_vote_id === voterWeVoteId ? 'You' : activityNotice.speaker_name}
+                    {activityNotice.speaker_voter_we_vote_id === voterWeVoteId ? 'YOU' : activityNotice.speaker_name.toUpperCase()}
                   </strong>
                   {' '}
                   {activityDescription}
@@ -368,20 +370,23 @@ const styles = (theme) => ({
     borderRight: '1px solid #ddd',
     borderBottom: '.5px solid #ddd',
     borderLeft: '1px solid #ddd',
+    color: 'grey', // not sure this is the grey we want, but I don't have any clicked items to check
     display: 'flex',
     fontSize: '14px !important',
+    fontWeight: '300',
     padding: '8px 6px !important',
     textAlign: 'left',
     whiteSpace: 'normal',
     width: '100%',
   },
   menuItemNotClicked: {
-    backgroundColor: '#e6ecfc',
+    backgroundColor: `${DesignTokenColors.info50}`,
     borderRight: '1px solid #ddd',
     borderBottom: '.5px solid #ddd',
-    borderLeft: '1px solid #ddd',
+    borderLeft: `5px solid ${DesignTokenColors.info900}`,
     display: 'flex',
     fontSize: '14px !important',
+    fontWeight: 'bold',
     padding: '8px 6px !important',
     textAlign: 'left',
     whiteSpace: 'normal',


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
This adds styling to notifications for when clicked vs not clicked and used some DesignTokenColors

### Potential Issues - 
Marked with comments, line 61 and 62, I get no notification data from ".allActivityNotices" but partial data from "allActivity". Dale took screenshots of the server code to mark what might be going on. 
