### PR TITLE
Updated the submit functions in HeartFavoriteToggleLive to update supportersCount and opposersCount. Includes local state update in the CampaignStore so we don't have to wait for API response.

### DIFF
--- a/src/js/common/actions/CampaignActions.js
+++ b/src/js/common/actions/CampaignActions.js
@@ -12,6 +12,22 @@ export default {
       });
   },
 
+  campaignLocalAttributesUpdate (campaignXWeVoteId, supportersCountLocal = false, opposersCountLocal = false) {
+    const payloadDict = {
+      campaignXWeVoteId,
+    };
+    if (supportersCountLocal !== false) {
+      payloadDict.supporters_count = supportersCountLocal;
+    }
+    if (opposersCountLocal !== false) {
+      payloadDict.opposers_count = opposersCountLocal;
+    }
+    Dispatcher.dispatch({
+      type: 'campaignLocalAttributesUpdate',
+      payload: payloadDict,
+    });
+  },
+
   campaignRetrieve (campaignWeVoteId) {
     let { hostname } = window.location;
     hostname = hostname || '';
@@ -61,5 +77,4 @@ export default {
         recommended_campaigns_for_campaignx_we_vote_id: campaignXWeVoteId,
       });
   },
-
 };

--- a/src/js/common/components/CampaignSupport/CampaignSupportThermometer.jsx
+++ b/src/js/common/components/CampaignSupport/CampaignSupportThermometer.jsx
@@ -14,6 +14,7 @@ class CampaignSupportThermometer extends React.Component {
     super(props);
     this.state = {
       finalElectionDateInPast: false,
+      opposersCount: 0,
       politicianWeVoteId: '',
       supportersCountNextGoal: CampaignStore.getCampaignXSupportersCountNextGoalDefault(),
       supportersCount: 0,
@@ -37,6 +38,7 @@ class CampaignSupportThermometer extends React.Component {
       campaignXWeVoteId,
     } = this.props;
     const {
+      opposersCount: opposersCountPrevious,
       supportersCount: supportersCountPrevious,
     } = prevState;
     // console.log('CampaignSupportThermometer componentDidUpdate campaignXWeVoteId:', campaignXWeVoteId);
@@ -49,13 +51,16 @@ class CampaignSupportThermometer extends React.Component {
       const campaignX = CampaignStore.getCampaignXByWeVoteId(campaignXWeVoteId);
       const {
         campaignx_we_vote_id: campaignXWeVoteIdFromDict,
+        opposers_count: opposersCount,
         supporters_count: supportersCount,
       } = campaignX;
+      let opposersCountChanged = false;
       let supportersCountChanged = false;
       if (campaignXWeVoteIdFromDict) {
+        opposersCountChanged = opposersCount !== opposersCountPrevious;
         supportersCountChanged = supportersCount !== supportersCountPrevious;
       }
-      if (campaignXWeVoteId !== previousCampaignXWeVoteId || supportersCountChanged) {
+      if (campaignXWeVoteId !== previousCampaignXWeVoteId || opposersCountChanged || supportersCountChanged) {
         this.onCampaignStoreChange();
       }
     }
@@ -81,6 +86,7 @@ class CampaignSupportThermometer extends React.Component {
         campaignx_we_vote_id: campaignXWeVoteIdFromDict,
         final_election_date_in_past: finalElectionDateInPast,
         linked_politician_we_vote_id: politicianWeVoteId,
+        opposers_count: opposersCount,
         supporters_count: supportersCount,
         supporters_count_next_goal: supportersCountNextGoal,
       } = campaignX;
@@ -89,10 +95,17 @@ class CampaignSupportThermometer extends React.Component {
         supportersCountNextGoalWithFloor += 20;
       }
       if (campaignXWeVoteIdFromDict && politicianWeVoteId) {
-        const { politicianWeVoteId: politicianWeVoteIdPrevious } = this.state;
-        if (politicianWeVoteId !== politicianWeVoteIdPrevious) {
+        const {
+          opposersCount: opposersCountPrevious,
+          politicianWeVoteId: politicianWeVoteIdPrevious,
+          supportersCount: supportersCountPrevious,
+        } = this.state;
+        if ((opposersCount !== opposersCountPrevious) ||
+            (politicianWeVoteId !== politicianWeVoteIdPrevious) ||
+            (supportersCount !== supportersCountPrevious)) {
           this.setState({
             finalElectionDateInPast,
+            opposersCount,
             politicianWeVoteId,
             supportersCount,
             supportersCountNextGoal: supportersCountNextGoalWithFloor,
@@ -101,6 +114,7 @@ class CampaignSupportThermometer extends React.Component {
       } else if (campaignXWeVoteIdFromDict && !politicianWeVoteId) {
         this.setState({
           finalElectionDateInPast,
+          opposersCount,
           supportersCount,
           supportersCountNextGoal: supportersCountNextGoalWithFloor,
         });
@@ -129,6 +143,7 @@ class CampaignSupportThermometer extends React.Component {
     // to arrive.
     this.setState({
       finalElectionDateInPast: false,
+      opposersCount: 0,
       supportersCount: 0,
       supportersCountNextGoal: 0,
     });

--- a/src/js/common/components/Widgets/HeartFavoriteToggle/HeartFavoriteToggleBase.jsx
+++ b/src/js/common/components/Widgets/HeartFavoriteToggle/HeartFavoriteToggleBase.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import CampaignActions from '../../../actions/CampaignActions';
 import DesignTokenColors from '../../Style/DesignTokenColors';
 import numberWithCommas from '../../../utils/numberWithCommas';
 import HeartFavoriteToggleIcon from './HeartFavoriteToggleIcon';
@@ -98,7 +99,7 @@ class HeartFavoriteToggleBase extends Component {
   }
 
   handleActionClick = (support = true, oppose = false, stopSupporting = false, stopOpposing = false) => {
-    const { voterSignedInWithEmail } = this.props;
+    const { campaignXWeVoteId, voterSignedInWithEmail } = this.props;
     const {
       campaignXOpposersCountLocal: campaignXOpposersCountLocalPrevious,
       campaignXSupportersCountLocal: campaignXSupportersCountLocalPrevious,
@@ -125,11 +126,19 @@ class HeartFavoriteToggleBase extends Component {
               if (this.props.submitSupport) {
                 this.props.submitSupport();
               }
+              // Local quick update of supporters_count in CampaignX object
+              const supportersCountLocal = this.state.campaignXSupportersCountLocal;
+              CampaignActions.campaignLocalAttributesUpdate(campaignXWeVoteId, supportersCountLocal);
             });
           }
           if (voterOpposesLocalPrevious) {
             this.setState({
               campaignXOpposersCountLocal: Math.max(0, campaignXOpposersCountLocalPrevious - 1),
+            }, () => {
+              // Local quick update of opposers_count in CampaignX object
+              const opposersCountLocal = this.state.campaignXOpposersCountLocal;
+              const supportersCountLocal = false;
+              CampaignActions.campaignLocalAttributesUpdate(campaignXWeVoteId, supportersCountLocal, opposersCountLocal);
             });
           }
         } else if (stopSupporting) {
@@ -140,6 +149,9 @@ class HeartFavoriteToggleBase extends Component {
               if (this.props.submitStopSupporting) {
                 this.props.submitStopSupporting();
               }
+              // Local quick update of supporters_count in CampaignX object
+              const supportersCountLocal = this.state.campaignXSupportersCountLocal;
+              CampaignActions.campaignLocalAttributesUpdate(campaignXWeVoteId, supportersCountLocal);
             });
           }
         } else if (oppose) {
@@ -150,11 +162,19 @@ class HeartFavoriteToggleBase extends Component {
               if (this.props.submitOppose) {
                 this.props.submitOppose();
               }
+              // Local quick update of opposers_count in CampaignX object
+              const opposersCountLocal = this.state.campaignXOpposersCountLocal;
+              const supportersCountLocal = false;
+              CampaignActions.campaignLocalAttributesUpdate(campaignXWeVoteId, supportersCountLocal, opposersCountLocal);
             });
           }
           if (voterSupportsLocalPrevious) {
             this.setState({
               campaignXSupportersCountLocal: Math.max(0, campaignXSupportersCountLocalPrevious - 1),
+            }, () => {
+              // Local quick update of supporters_count in CampaignX object
+              const supportersCountLocal = this.state.campaignXSupportersCountLocal;
+              CampaignActions.campaignLocalAttributesUpdate(campaignXWeVoteId, supportersCountLocal);
             });
           }
         } else if (stopOpposing) {
@@ -165,6 +185,10 @@ class HeartFavoriteToggleBase extends Component {
               if (this.props.submitStopOpposing) {
                 this.props.submitStopOpposing();
               }
+              // Local quick update of opposers_count in CampaignX object
+              const opposersCountLocal = this.state.campaignXOpposersCountLocal;
+              const supportersCountLocal = false;
+              CampaignActions.campaignLocalAttributesUpdate(campaignXWeVoteId, supportersCountLocal, opposersCountLocal);
             });
           }
         }
@@ -207,7 +231,7 @@ class HeartFavoriteToggleBase extends Component {
           )}
           {/* Add "like this politician?" popout */}
           {(!voterSignedInWithEmail && showSignInPromptSupports) && (
-            <span onClick={() => this.handleSignInClick()}> sign in</span>
+            <span onClick={() => this.handleSignInClick()}>&nbsp;sign in</span>
           )}
         </LikeContainer>
         <DislikeContainer onClick={() => {
@@ -229,7 +253,7 @@ class HeartFavoriteToggleBase extends Component {
           )}
           {/* Add "Don't like this politician?" popout */}
           {(!voterSignedInWithEmail && showSignInPromptOpposes) && (
-            <span onClick={() => this.handleSignInClick()}> sign in</span>
+            <span onClick={() => this.handleSignInClick()}>&nbsp;sign in</span>
           )}
         </DislikeContainer>
       </HeartFavoriteToggleContainer>

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -20,7 +20,7 @@ import {
   CampaignOwnersDesktopWrapper, CampaignSubSectionSeeAll, CampaignSubSectionTitle, CampaignSubSectionTitleWrapper, // CampaignTitleAndScoreBar,
   CommentsListWrapper, DetailsSectionDesktopTablet, DetailsSectionMobile, OtherElectionsWrapper, SupportButtonFooterWrapperAboveFooterButtons, SupportButtonPanel,
 } from '../../components/Style/CampaignDetailsStyles';
-import { EditIndicator, ElectionInPast, IndicatorButtonWrapper, IndicatorRow } from '../../components/Style/CampaignIndicatorStyles';
+import { EditIndicator, IndicatorButtonWrapper, IndicatorRow } from '../../components/Style/CampaignIndicatorStyles';
 import {
   CandidateCampaignListDesktop, CandidateCampaignListMobile, CandidateCampaignWrapper,
   // OfficeHeldNameDesktop, OfficeHeldNameMobile, PoliticianImageDesktop, PoliticianImageDesktopPlaceholder, PoliticianImageMobile, PoliticianImageMobilePlaceholder, PoliticianNameDesktop, PoliticianNameMobile, PoliticianNameOuterWrapperDesktop,
@@ -46,18 +46,19 @@ import returnFirstXWords from '../../utils/returnFirstXWords';
 import saveCampaignSupportAndGoToNextPage from '../../utils/saveCampaignSupportAndGoToNextPage';
 import DesignTokenColors from '../../components/Style/DesignTokenColors';
 import OrganizationActions from '../../../actions/OrganizationActions';
+import SupportActions from '../../../actions/SupportActions';
 
 // const CampaignCommentsList = React.lazy(() => import(/* webpackChunkName: 'CampaignCommentsList' */ '../../components/Campaign/CampaignCommentsList'));
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
 const CampaignNewsItemList = React.lazy(() => import(/* webpackChunkName: 'CampaignNewsItemList' */ '../../components/Campaign/CampaignNewsItemList'));
 const CampaignShareChunk = React.lazy(() => import(/* webpackChunkName: 'CampaignShareChunk' */ '../../components/Campaign/CampaignShareChunk'));
+const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ '../../../components/Widgets/ItemActionBar/ItemActionBar'));
 const OfficeNameText = React.lazy(() => import(/* webpackChunkName: 'OfficeNameText' */ '../../components/Widgets/OfficeNameText'));
 const PoliticianEndorsementsList = React.lazy(() => import(/* webpackChunkName: 'PoliticianEndorsementsList' */ '../../components/Politician/PoliticianEndorsementsList'));
 const PoliticianLinks = React.lazy(() => import(/* webpackChunkName: 'PolitianLinks' */ '../../components/Politician/PoliticianLinks'));
 const PoliticianRetrieveController = React.lazy(() => import(/* webpackChunkName: 'PoliticianRetrieveController' */ '../../components/Politician/PoliticianRetrieveController'));
 const PoliticianPositionRetrieveController = React.lazy(() => import(/* webpackChunkName: 'PoliticianPositionRetrieveController' */ '../../components/Position/PoliticianPositionRetrieveController'));
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../components/Widgets/ReadMore'));
-const SupportButtonBeforeCompletionScreen = React.lazy(() => import(/* webpackChunkName: 'SupportButtonBeforeCompletionScreen' */ '../../components/CampaignSupport/SupportButtonBeforeCompletionScreen'));
 const UpdatePoliticianInformation = React.lazy(() => import(/* webpackChunkName: 'UpdatePoliticianInformation' */ '../../components/Politician/UpdatePoliticianInformation'));
 
 const futureFeaturesDisabled = true;
@@ -143,6 +144,7 @@ class PoliticianDetailsPage extends Component {
     if (apiCalming('organizationsFollowedRetrieve', 60000)) {
       OrganizationActions.organizationsFollowedRetrieve();
     }
+    SupportActions.voterAllPositionsRetrieve();
 
     // console.log('componentDidMount triggerSEOPathRedirect: ', triggerSEOPathRedirect, ', politicianSEOFriendlyPathFromObject: ', politicianSEOFriendlyPathFromObject);
     if (triggerSEOPathRedirect && politicianSEOFriendlyPathFromObject) {
@@ -589,6 +591,7 @@ class PoliticianDetailsPage extends Component {
     }
 
     const campaignAdminEditUrl = `${webAppConfig.WE_VOTE_SERVER_ROOT_URL}campaign/${linkedCampaignXWeVoteId}/summary`;
+    const candidateWeVoteId = CandidateStore.getCandidateWeVoteIdRunningFromPoliticianWeVoteId(politicianWeVoteId);
 
     if (politicianDataNotFound) {
       return (
@@ -1065,11 +1068,31 @@ class PoliticianDetailsPage extends Component {
         <SupportButtonFooterWrapperAboveFooterButtons className="u-show-mobile">
           <SupportButtonPanel>
             <Suspense fallback={<span>&nbsp;</span>}>
-              <SupportButtonBeforeCompletionScreen
-                campaignXWeVoteId={linkedCampaignXWeVoteId}
-                functionToUseToKeepHelping={this.functionToUseToKeepHelping}
-                functionToUseWhenProfileComplete={this.functionToUseWhenProfileComplete}
-              />
+              {(finalElectionDateInPast) ? ( /*  || usePoliticianWeVoteIdForBallotItem */
+                <ItemActionBar
+                  ballotItemWeVoteId={politicianWeVoteId}
+                  ballotItemDisplayName={politicianName}
+                  commentButtonHide
+                  externalUniqueId={`PoliticianDetailsPage-ItemActionBar-${politicianWeVoteId}`}
+                  hidePositionPublicToggle
+                  // inCard
+                  positionPublicToggleWrapAllowed
+                  shareButtonHide
+                  useSupportWording
+                />
+              ) : (
+                <ItemActionBar
+                  ballotItemWeVoteId={candidateWeVoteId}
+                  ballotItemDisplayName={politicianName}
+                  commentButtonHide
+                  externalUniqueId={`PoliticianDetailsPage-ItemActionBar-${candidateWeVoteId}`}
+                  hidePositionPublicToggle
+                  // inCard
+                  positionPublicToggleWrapAllowed
+                  shareButtonHide
+                  // useSupportWording
+                />
+              )}
             </Suspense>
           </SupportButtonPanel>
         </SupportButtonFooterWrapperAboveFooterButtons>

--- a/src/js/common/stores/CampaignStore.js
+++ b/src/js/common/stores/CampaignStore.js
@@ -469,6 +469,30 @@ class CampaignStore extends ReduceStore {
         revisedState = { ...revisedState, voterOwnedCampaignXWeVoteIds };
         return revisedState;
 
+      case 'campaignLocalAttributesUpdate':
+        // console.log('CampaignStore campaignLocalAttributesUpdate: ', action.payload);
+        if (action.payload === undefined) {
+          return state;
+        } else {
+          const campaignXWeVoteId = action.payload.campaignXWeVoteId || '';
+          if (campaignXWeVoteId in allCachedCampaignXDicts) {
+            campaignX = this.getCampaignXByWeVoteId(campaignXWeVoteId);
+            if (action.payload.opposers_count) {
+              campaignX.opposers_count = action.payload.opposers_count;
+            }
+            if (action.payload.supporters_count) {
+              campaignX.supporters_count = action.payload.supporters_count;
+            }
+            allCachedCampaignXDicts[campaignXWeVoteId] = campaignX;
+            return {
+              ...state,
+              allCachedCampaignXDicts,
+            };
+          } else {
+            return state;
+          }
+        }
+
       case 'campaignNewsItemSave':
         // console.log('CampaignNewsItemStore campaignNewsItemSave');
         if (action.res.campaignx_we_vote_id && action.res.success) {

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -55,7 +55,7 @@ class ItemActionBar extends PureComponent {
   }
 
   componentDidMount () {
-    // console.log('itemActionBar, NEW componentDidMount');
+    // console.log('ItemActionBar, NEW componentDidMount');
     const { ballotItemWeVoteId } = this.props;
     if (ballotItemWeVoteId) {
       const isCandidate = stringContains('cand', ballotItemWeVoteId); // isCandidate = the default
@@ -76,7 +76,7 @@ class ItemActionBar extends PureComponent {
       let numberOfOpposePositionsForScore = 0;
       let voterTextStatement = '';
       const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);
-      // console.log('ballotItemStatSheet', ballotItemStatSheet);
+      // console.log('ballotItemType:', ballotItemType, ', ballotItemStatSheet:', ballotItemStatSheet);
       if (ballotItemStatSheet) {
         const {
           voterOpposesBallotItem,
@@ -108,11 +108,10 @@ class ItemActionBar extends PureComponent {
   }
 
   componentDidUpdate (prevProps) {
-    // console.log('itemActionBar, RELOAD componentWillReceiveProps');
+    // console.log('ItemActionBar, RELOAD componentWillReceiveProps');
     const { ballotItemWeVoteId: previousBallotItemWeVoteId } = prevProps;
     const { ballotItemWeVoteId } = this.props;
     if (ballotItemWeVoteId !== undefined && ballotItemWeVoteId && ballotItemWeVoteId !== previousBallotItemWeVoteId) {
-      console.log('itemActionBar, ballotItemWeVoteId setState');
       const isCandidate = stringContains('cand', ballotItemWeVoteId); // isCandidate = the default
       const isMeasure = stringContains('meas', ballotItemWeVoteId); // isCandidate = the default
       const isPolitician = stringContains('pol', ballotItemWeVoteId);
@@ -124,6 +123,7 @@ class ItemActionBar extends PureComponent {
       } else if (isPolitician) {
         ballotItemType = 'POLITICIAN';
       }
+      // console.log('ItemActionBar, ballotItemWeVoteId setState, ballotItemWeVoteId: ', ballotItemWeVoteId);
       this.setState({
         ballotItemType,
         ballotItemWeVoteId,
@@ -157,6 +157,7 @@ class ItemActionBar extends PureComponent {
     const { ballotItemWeVoteId, isOpposeAPIState, isSupportAPIState, isOpposeLocalState, isSupportLocalState } = this.state;
     if (ballotItemWeVoteId) {
       const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);
+      // console.log('ItemActionBar, onSupportStoreChange, ballotItemWeVoteId:', ballotItemWeVoteId, ', ballotItemStatSheet:', ballotItemStatSheet);
       if (ballotItemStatSheet) {
         const {
           numberOfOpposePositionsForScore,
@@ -168,13 +169,13 @@ class ItemActionBar extends PureComponent {
         } = ballotItemStatSheet;
 
         if (numberOfOpposePositionsForScore !== undefined && numberOfOpposePositionsForScore !== this.state.numberOfSupportPositionsForScore) {
-          // console.log('itemActionBar, support_count setState');
+          // console.log('ItemActionBar, support_count setState');
           this.setState({
             numberOfSupportPositionsForScore,
           });
         }
         if (numberOfOpposePositionsForScore !== undefined && numberOfOpposePositionsForScore !== this.state.numberOfOpposePositionsForScore) {
-          // console.log('itemActionBar, oppose_count setState');
+          // console.log('ItemActionBar, oppose_count setState');
           this.setState({
             numberOfOpposePositionsForScore,
           });
@@ -194,7 +195,7 @@ class ItemActionBar extends PureComponent {
         if (localOpposeStateLocked) {
           // Don't make a change until the API state matches the local state
           if (voterOpposesBallotItem !== undefined && voterOpposesBallotItem === isOpposeLocalState) {
-            // console.log('itemActionBar, isOpposeAPIState CATCHUP setState');
+            // console.log('ItemActionBar, isOpposeAPIState CATCHUP setState');
             this.setState({
               isOpposeAPIState: voterOpposesBallotItem,
               isOpposeLocalState: undefined,
@@ -203,7 +204,7 @@ class ItemActionBar extends PureComponent {
           }
         } else if (voterOpposesBallotItem !== undefined && voterOpposesBallotItem !== isOpposeAPIState) {
           // Don't make a change if the value from the API server already matches isOpposeAPIState
-          // console.log('itemActionBar, isOpposeAPIState FRESH setState');
+          // console.log('ItemActionBar, isOpposeAPIState FRESH setState');
           this.setState({
             isOpposeAPIState: voterOpposesBallotItem,
             isOpposeLocalState: undefined,
@@ -213,7 +214,7 @@ class ItemActionBar extends PureComponent {
         if (localSupportStateLocked) {
           // Don't make a change until the API state matches the local state
           if (voterSupportsBallotItem !== undefined && voterSupportsBallotItem === isSupportLocalState) {
-            // console.log('itemActionBar, isSupportLocalState CATCHUP setState');
+            // console.log('ItemActionBar, isSupportLocalState CATCHUP setState');
             this.setState({
               isSupportAPIState: voterSupportsBallotItem,
               isSupportLocalState: undefined,
@@ -222,7 +223,7 @@ class ItemActionBar extends PureComponent {
           }
         } else if (voterSupportsBallotItem !== undefined && voterSupportsBallotItem !== isSupportAPIState) {
           // Don't make a change if the value from the API server already matches isSupportAPIState
-          // console.log('itemActionBar, isSupportAPIState FRESH setState');
+          // console.log('ItemActionBar, isSupportAPIState FRESH setState');
           this.setState({
             isSupportAPIState: voterSupportsBallotItem,
             isSupportLocalState: undefined,

--- a/src/js/stores/CandidateStore.js
+++ b/src/js/stores/CandidateStore.js
@@ -99,6 +99,7 @@ class CandidateStore extends ReduceStore {
       allCachedPositionsAboutCandidates: explanationPositions, // Dictionary with candidate_we_vote_id as one key, organization_we_vote_id as the second key, and the position as value
       candidateListsByOfficeWeVoteId: {}, // Dictionary with office_we_vote_id as key and list of candidates in the office as value
       candidateListsByPoliticianWeVoteId: {}, // Dictionary with politician_we_vote_id as key and list of candidates linked to the politician as value
+      candidateWeVoteIdInFutureByPoliticianWeVoteId: {}, // Dictionary with politician_we_vote_id as key and the candidate_we_vote_id as value
       numberOfCandidatesRetrievedByOffice: {}, // Dictionary with office_we_vote_id as key and number of candidates as value
     };
   }
@@ -117,7 +118,7 @@ class CandidateStore extends ReduceStore {
   //  support.
   getAllCachedPositionsByPoliticianWeVoteId (politicianWeVoteId) {
     const candidateList = this.getState().candidateListsByPoliticianWeVoteId[politicianWeVoteId] || [];
-    // console.log('candidateList', candidateList);
+    // console.log('getAllCachedPositionsByPoliticianWeVoteId candidateList', candidateList);
     let allCachedPositionsList = [];
     let allCachedPositionsListForThisCandidate;
     let allCachedPositionsForThisCandidateDict;
@@ -177,6 +178,18 @@ class CandidateStore extends ReduceStore {
     const candidate = this.getState().allCachedCandidates[candidateWeVoteId] || {};
     if (candidate && candidate.ballot_item_display_name) {
       return candidate.ballot_item_display_name;
+    }
+    return '';
+  }
+
+  // getCandidateRunningFromPoliticianWeVoteId (politicianWeVoteId) {
+  //   return {};
+  // }
+
+  getCandidateWeVoteIdRunningFromPoliticianWeVoteId (politicianWeVoteId) {
+    const candidateWeVoteIdInFutureByPoliticianWeVoteId = this.getState().candidateWeVoteIdInFutureByPoliticianWeVoteId || {};
+    if (politicianWeVoteId && candidateWeVoteIdInFutureByPoliticianWeVoteId && candidateWeVoteIdInFutureByPoliticianWeVoteId[politicianWeVoteId]) {
+      return candidateWeVoteIdInFutureByPoliticianWeVoteId[politicianWeVoteId];
     }
     return '';
   }
@@ -291,7 +304,8 @@ class CandidateStore extends ReduceStore {
 
   reduce (state, action) {
     const {
-      allCachedCandidates, allCachedCandidateWeVoteIdsByCampaignXWeVoteId, allCachedPositionsAboutCandidates, numberOfCandidatesRetrievedByOffice,
+      allCachedCandidates, allCachedCandidateWeVoteIdsByCampaignXWeVoteId, allCachedPositionsAboutCandidates,
+      candidateWeVoteIdInFutureByPoliticianWeVoteId, numberOfCandidatesRetrievedByOffice,
     } = state;
     let {
       candidateListsByOfficeWeVoteId, candidateListsByPoliticianWeVoteId,
@@ -402,6 +416,9 @@ class CandidateStore extends ReduceStore {
         localCandidateList = [];
         candidateList.forEach((one) => {
           allCachedCandidates[one.we_vote_id] = one;
+          if (one.election_is_upcoming) {
+            candidateWeVoteIdInFutureByPoliticianWeVoteId[politicianWeVoteId] = one.we_vote_id;
+          }
           if (one.linked_campaignx_we_vote_id) {
             allCachedCandidateWeVoteIdsByCampaignXWeVoteId[one.linked_campaignx_we_vote_id] = one.we_vote_id;
           }
@@ -420,6 +437,7 @@ class CandidateStore extends ReduceStore {
           allCachedCandidates,
           allCachedCandidateWeVoteIdsByCampaignXWeVoteId,
           candidateListsByPoliticianWeVoteId,
+          candidateWeVoteIdInFutureByPoliticianWeVoteId,
         };
 
       case 'representativesQuery':

--- a/src/js/stores/OrganizationStore.js
+++ b/src/js/stores/OrganizationStore.js
@@ -380,7 +380,7 @@ class OrganizationStore extends ReduceStore {
   reduce (state, action) {
     // Note: We deal with errors (!action.res.success) on an API-by-API basis.
     if (!action.res) {
-      console.log('OrganizationStore ', action.type, ' FAILED, no action.res');
+      // console.log('OrganizationStore ', action.type, ' FAILED, no action.res');
       return state;
     }
     const {

--- a/src/js/stores/SupportStore.js
+++ b/src/js/stores/SupportStore.js
@@ -34,17 +34,16 @@ class SupportStore extends ReduceStore {
     }
     const isCandidate = stringContains('cand', ballotItemWeVoteId);
     const isMeasure = stringContains('meas', ballotItemWeVoteId);
-    // const isPolitician = stringContains('pol', ballotItemWeVoteId);
+    const isPolitician = stringContains('pol', ballotItemWeVoteId);
     let allCachedPositions = [];
     if (isCandidate) {
       allCachedPositions = CandidateStore.getAllCachedPositionsByCandidateWeVoteId(ballotItemWeVoteId);
     } else if (isMeasure) {
       allCachedPositions = MeasureStore.getAllCachedPositionsByMeasureWeVoteId(ballotItemWeVoteId);
+    } else if (isPolitician) {
+      // TODO Reality check this
+      allCachedPositions = CandidateStore.getAllCachedPositionsByPoliticianWeVoteId(ballotItemWeVoteId);
     }
-    // TODO Reality check this
-    // else if (isPolitician) {
-    //   allCachedPositions = CandidateStore.getAllCachedPositionsByPoliticianWeVoteId(ballotItemWeVoteId);
-    // }
     // console.log('getBallotItemStatSheet allCachedPositions:', allCachedPositions);
     const results = extractScoreFromNetworkFromPositionList(allCachedPositions);
     const { numberOfSupportPositionsForScore, numberOfOpposePositionsForScore, numberOfInfoOnlyPositionsForScore } = results;


### PR DESCRIPTION
Updated the submit functions in HeartFavoriteToggleLive to update supportersCount and opposersCount. Includes local state update in the CampaignStore so we don't have to wait for API response.