### PR TITLE
Comments out unused onBlur from propTypes for WV-241 [TEAM REVIEW]

### DIFF
--- a/src/js/components/Search/BaseSearchbox.jsx
+++ b/src/js/components/Search/BaseSearchbox.jsx
@@ -102,8 +102,8 @@ class BaseSearchbox extends React.Component {
             type="search"
             placeholder={this.props.placeholder}
             value={this.state.searchText}
+            onBlur={this.props.onBlur}
             onChange={this.handleInputChange}
-            // onClear={this.handleClear} // 2/26/23 temporarily removed, there is no onClear for an HTML input, but using a listener action is possible
             maxLength={50}
         />
         {this.state.searchText && <ClearButton onClick={this.handleClear} />}
@@ -117,7 +117,7 @@ BaseSearchbox.propTypes = {
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   onFocus: PropTypes.func,
-  // onBlur: PropTypes.func,
+  onBlur: PropTypes.func,
   onClear: PropTypes.func,
 };
 

--- a/src/js/components/Search/BaseSearchbox.jsx
+++ b/src/js/components/Search/BaseSearchbox.jsx
@@ -117,7 +117,7 @@ BaseSearchbox.propTypes = {
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   onFocus: PropTypes.func,
-  onBlur: PropTypes.func,
+  // onBlur: PropTypes.func,
   onClear: PropTypes.func,
 };
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-241 BaseSearchbox integration: Unknown event handler property onClear

### Changes included this pull request?
-Comments out unused onBlur in propTypes to remove Linter warning
-PRs purpose is to ask about removing commented code for propTypes and unused attribute, onClear on input tag
