### PR TITLE
WV-316 After pressing cancel, redirects user to sign in options [TEAM REVIEW]

### DIFF
--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -302,12 +302,12 @@ class VoterPhoneVerificationEntry extends Component {
     // console.log('cancelShouldCloseModal:', cancelShouldCloseModal);
     if (cancelShouldCloseModal) {
       this.closeSignInModalLocal();
-    } else if (isMobileScreenSize()) {
-      if (this.props.showAllSignInOptions) {
-        this.props.showAllSignInOptions();
-      } 
     } else if (isCordova()) {
-      // WV-316: seperated Cordovoa and Mobile screen size logic, Mobile only shows all sign in options.
+      if (this.props.showAllSignInOptions) {
+        // WV-316: seperated Cordovoa and Mobile screen cancel logic, Mobile only shows all sign in options on cancel.
+      } 
+    } else if (isMobileScreenSize()) {
+     this.props.showAllSignInOptions(); 
     }
   };
 

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -303,9 +303,9 @@ class VoterPhoneVerificationEntry extends Component {
     if (cancelShouldCloseModal) {
       this.closeSignInModalLocal();
     } else if (isCordova() || isMobileScreenSize()) {
-      // if (this.props.showAllSignInOptions) {
-      //   this.props.showAllSignInOptions();
-      // }
+      if (this.props.showAllSignInOptions) {
+        this.props.showAllSignInOptions();
+      }
     }
   };
 

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -302,10 +302,12 @@ class VoterPhoneVerificationEntry extends Component {
     // console.log('cancelShouldCloseModal:', cancelShouldCloseModal);
     if (cancelShouldCloseModal) {
       this.closeSignInModalLocal();
-    } else if (isCordova() || isMobileScreenSize()) {
+    } else if (isMobileScreenSize()) {
       if (this.props.showAllSignInOptions) {
         this.props.showAllSignInOptions();
-      }
+      } 
+    } else if (isCordova()) {
+      // WV-316: seperated Cordovoa and Mobile screen size logic, Mobile only shows all sign in options.
     }
   };
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

WV-316 - 'We should aim to eliminate unnecessary steps and if a user opts to use the 'Cancel' button, they should be redirected back to one step.'

### Changes included this pull request?

Commented back in logic that pressing cancel redirects user sign in options rather than clearing the number form.
