### PR TITLE
Added "Help Win with $1" buttons, and many more changes [MERGE READY]

### DIFF
--- a/src/js/common/components/CampaignSupport/HelpWinOrDefeatModal.jsx
+++ b/src/js/common/components/CampaignSupport/HelpWinOrDefeatModal.jsx
@@ -28,12 +28,10 @@ class HelpWinOrDefeatModal extends Component {
     const { ballotItemWeVoteId } = this.props;
     const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);
     if (ballotItemStatSheet) {
-      const { voterOpposesBallotItem, voterPositionIsPublic, voterSupportsBallotItem, voterTextStatement } = ballotItemStatSheet;
+      const { voterOpposesBallotItem, voterSupportsBallotItem } = ballotItemStatSheet;
       this.setState({
         voterOpposesBallotItem,
-        voterPositionIsPublic,
         voterSupportsBallotItem,
-        voterTextStatement,
       });
     }
 
@@ -158,28 +156,27 @@ class HelpWinOrDefeatModal extends Component {
       voterOpposesBallotItem, voterSupportsBallotItem,
     } = this.state;
 
-    const dialogTitleText = '';
-
     const horizontalEllipsis = '\u2026';
-    let statementPlaceholderText = `Your thoughts${horizontalEllipsis}`;
+    let dialogTitleText = '';
 
     if (voterSupportsBallotItem) {
       if (ballotItemDisplayName) {
-        statementPlaceholderText = `Why you chose ${ballotItemDisplayName}${horizontalEllipsis}`;
+        dialogTitleText = `Why you chose ${ballotItemDisplayName}${horizontalEllipsis}`;
       } else {
-        statementPlaceholderText = `Why you support${horizontalEllipsis}`;
+        dialogTitleText = `Why you support${horizontalEllipsis}`;
       }
     } else if (voterOpposesBallotItem) {
       if (ballotItemDisplayName) {
-        statementPlaceholderText = `Why you oppose ${ballotItemDisplayName}${horizontalEllipsis}`;
+        dialogTitleText = `Why you oppose ${ballotItemDisplayName}${horizontalEllipsis}`;
       } else {
-        statementPlaceholderText = `Why you oppose${horizontalEllipsis}`;
+        dialogTitleText = `Why you oppose${horizontalEllipsis}`;
       }
     } else if (ballotItemDisplayName) {
-      statementPlaceholderText = `Your thoughts about ${ballotItemDisplayName}${horizontalEllipsis}`;
+      dialogTitleText = `Your thoughts about ${ballotItemDisplayName}${horizontalEllipsis}`;
     } else {
-      statementPlaceholderText = `Your thoughts${horizontalEllipsis}`;
+      dialogTitleText = `Your thoughts${horizontalEllipsis}`;
     }
+    dialogTitleText = ''; // Overwrite until we can adjust
 
     // console.log('HelpWinOrDefeatModal render, voter_address_object: ', voter_address_object);
     const textFieldJSX = (

--- a/src/js/common/components/CampaignSupport/PayToPromoteProcess.jsx
+++ b/src/js/common/components/CampaignSupport/PayToPromoteProcess.jsx
@@ -1,0 +1,509 @@
+import { LockOutlined } from '@mui/icons-material';
+import { Button, InputAdornment, TextField } from '@mui/material';
+import { styled as muiStyled } from '@mui/styles';
+import withStyles from '@mui/styles/withStyles';
+import { Elements } from '@stripe/react-stripe-js';
+import { loadStripe } from '@stripe/stripe-js';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import DonationListForm from '../Donation/DonationListForm';
+import InjectedCheckoutForm from '../Donation/InjectedCheckoutForm';
+import standardBoxShadow from '../Style/standardBoxShadow';
+import { OuterWrapper } from '../Style/stepDisplayStyles';
+import LoadingWheelComp from '../Widgets/LoadingWheelComp';
+import DonateStore from '../../stores/DonateStore';
+import historyPush from '../../utils/historyPush';
+import { renderLog } from '../../utils/logging';
+import { payToPromoteProcessStyles } from '../Style/CampaignSupportStyles';
+import webAppConfig from '../../../config';
+import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
+import CampaignStore from '../../stores/CampaignStore';
+import VoterStore from '../../../stores/VoterStore';
+import { getCampaignXValuesFromIdentifiers, retrieveCampaignXFromIdentifiersIfNeeded } from '../../utils/campaignUtils';
+import initializejQuery from '../../utils/initializejQuery';
+import SplitIconButton from '../Widgets/SplitIconButton';
+
+const stripePromise = loadStripe(webAppConfig.STRIPE_API_KEY);
+
+const futureFeaturesDisabled = true;
+const iconButtonStyles = {
+  width: window.innerWidth < 1280 ? 250 : 300,
+  margin: '16px',
+};
+
+class PayToPromoteProcess extends Component {
+  constructor (props) {
+    super(props);
+
+    this.state = {
+      campaignSEOFriendlyPath: '',
+      campaignTitle: '',
+      campaignXWeVoteId: '',
+      loaded: false,
+      chipInPaymentValue: '3.00',
+      chipInPaymentOtherValue: '',
+      preDonation: true,
+      showWaiting: false,
+      voterFirstName: '',
+    };
+    this.onOtherAmountFieldChange = this.onOtherAmountFieldChange.bind(this);
+    this.onChipIn = this.onChipIn.bind(this);
+    this.stopShowWaiting = this.stopShowWaiting.bind(this);
+  }
+
+  componentDidMount () {
+    initializejQuery(() => {
+      // console.log('PayToPromoteProcess, componentDidMount after init jQuery');
+      const { campaignXWeVoteId, chipInPaymentValueDefault } = this.props;
+      this.setState({ loaded: true });
+      this.onAppObservableStoreChange();
+      this.appStateSubscription = messageService.getMessage().subscribe(() => this.onAppObservableStoreChange());
+      this.campaignStoreListener = CampaignStore.addListener(this.onCampaignStoreChange.bind(this));
+      this.donateStoreListener = DonateStore.addListener(this.onDonateStoreChange.bind(this));
+      // dumpCookies();
+      this.onVoterStoreChange();
+      this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
+      if (chipInPaymentValueDefault) {
+        this.setState({ chipInPaymentValue: chipInPaymentValueDefault });
+      }
+      const {
+        campaignSEOFriendlyPath,
+        campaignTitle,
+      } = getCampaignXValuesFromIdentifiers('', campaignXWeVoteId);
+      if (campaignXWeVoteId) {
+        this.setState({
+          campaignTitle,
+        });
+        if (campaignSEOFriendlyPath) {
+          this.setState({
+            campaignSEOFriendlyPath,
+          });
+        }
+        if (campaignXWeVoteId) {
+          this.setState({
+            campaignXWeVoteId,
+          });
+        }
+        // Take the "calculated" identifiers and retrieve if missing
+        retrieveCampaignXFromIdentifiersIfNeeded('', campaignXWeVoteId);
+        DonateStore.noDispatchClearStripeErrorState();
+      }
+    });
+    window.scrollTo(0, 0);
+  }
+
+  componentWillUnmount () {
+    this.appStateSubscription.unsubscribe();
+    this.campaignStoreListener.remove();
+    this.donateStoreListener.remove();
+    this.voterStoreListener.remove();
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+  }
+
+  onAppObservableStoreChange () {
+    const chosenWebsiteName = AppObservableStore.getChosenWebsiteName();
+    this.setState({
+      chosenWebsiteName,
+    });
+  }
+
+  onCampaignStoreChange () {
+    const { campaignXWeVoteId } = this.props;
+    const {
+      campaignSEOFriendlyPath,
+      campaignTitle,
+    } = getCampaignXValuesFromIdentifiers('', campaignXWeVoteId);
+    this.setState({
+      campaignTitle,
+    });
+    if (campaignSEOFriendlyPath) {
+      this.setState({
+        campaignSEOFriendlyPath,
+      });
+    }
+    if (campaignXWeVoteId) {
+      this.setState({
+        campaignXWeVoteId,
+      });
+    }
+  }
+
+  onDonateStoreChange () {
+    // console.log('onDonateStore DonateStore:', DonateStore.getAll());
+    if (DonateStore.donationSuccess()  && DonateStore.donationResponseReceived()) {
+      console.log('onDonateStoreChange successful donation detected');
+      this.setState({
+        preDonation: false,
+      });
+    }
+  }
+
+  static getProps () {
+    return {};
+  }
+
+  onVoterStoreChange () {
+    const voterFirstName = VoterStore.getVoterFirstName();
+    this.setState({
+      voterFirstName,
+    });
+  }
+
+  onOtherAmountFieldChange (event) {
+    if (event && event.target) {
+      this.setState({
+        chipInPaymentValue: '',
+        chipInPaymentOtherValue: event.target.value.length > 0 ? event.target.value : '',
+      });
+    }
+  }
+
+  onChipIn () {
+    // return Promise.then(() => {
+    console.log('onChipIn in PayToPromoteProcess ------------------------------');
+    console.log('Donation store changed in PayToPromoteProcess, Checkout form removed');
+    this.setState({
+      showWaiting: true,
+    });
+  }
+
+  onDonationTempSubmit = () => {
+    this.setState({
+      preDonation: false,
+    });
+  }
+
+  goToIWillShare = () => {
+    const pathForNextStep = `${this.getCampaignXBasePath()}share-campaign`;
+    historyPush(pathForNextStep);
+  }
+
+  getCampaignXBasePath = () => {
+    const { campaignSEOFriendlyPath, campaignXWeVoteId } = this.state;
+    let campaignBasePath;
+    if (campaignSEOFriendlyPath) {
+      campaignBasePath = `/c/${campaignSEOFriendlyPath}/`;
+    } else {
+      campaignBasePath = `/id/${campaignXWeVoteId}/`;
+    }
+    return campaignBasePath;
+  }
+
+  changeValueFromButton (newValue) {
+    this.setState({
+      chipInPaymentValue: newValue,
+      chipInPaymentOtherValue: '',
+    });
+  }
+
+  stopShowWaiting () {
+    this.setState({
+      showWaiting: false,
+    });
+  }
+
+  render () {
+    renderLog('PayToPromoteProcess');  // Set LOG_RENDER_EVENTS to log all renders
+    const { classes, lowerDonations } = this.props;
+    const {
+      campaignTitle, chipInPaymentValue, chipInPaymentOtherValue,
+      loaded, showWaiting, campaignXWeVoteId, preDonation,
+    } = this.state;
+    if (campaignXWeVoteId === undefined || campaignXWeVoteId === '') {
+      // console.error('Must have a campaignXWeVoteId defined in PayToPromoteProcess to make a "chip in"');
+      return (
+        <LoadingWheelComp />
+      );
+    }
+    if (!loaded) {
+      return (
+        <LoadingWheelComp message="Waiting..." />
+      );
+    }
+
+    const { location: { pathname } } = window;
+    const pieces = pathname.split('/');
+    const returnPath = pieces && pieces.length > 3 ? `/${pieces[1]}/${pieces[2]}` : '/start-a-campaign';
+
+    return (
+      <PaymentToPromoteWrapper>
+        <OuterWrapper>
+          <InnerWrapper>
+            <ContributeGridWrapper show={preDonation}>
+              <ContributeMonthlyText>
+                Please chip in what you can:
+              </ContributeMonthlyText>
+              <ContributeGridSection>
+                {lowerDonations && (
+                  <ContributeGridItem>
+                    <Button
+                      classes={(chipInPaymentValue === '1' || chipInPaymentValue === '1.00') ? { root: classes.buttonRootSelected } : { root: classes.buttonRoot }}
+                      variant="contained"
+                      onClick={() => this.changeValueFromButton('1.00')}
+                    >
+                      <ButtonInsideWrapper>
+                        <PaymentAmount>
+                          $1
+                        </PaymentAmount>
+                        <WhatYouGet>
+                          <span className="u-show-mobile">5 views</span>
+                          <span className="u-show-desktop-tablet">5 views of campaign</span>
+                        </WhatYouGet>
+                      </ButtonInsideWrapper>
+                    </Button>
+                  </ContributeGridItem>
+                )}
+                <ContributeGridItem>
+                  <Button
+                    classes={(chipInPaymentValue === '3' || chipInPaymentValue === '3.00') ? { root: classes.buttonRootSelected } : { root: classes.buttonRoot }}
+                    variant="contained"
+                    onClick={() => this.changeValueFromButton('3.00')}
+                  >
+                    <ButtonInsideWrapper>
+                      <PaymentAmount>
+                        $3
+                      </PaymentAmount>
+                      <WhatYouGet>
+                        <span className="u-show-mobile">25 views</span>
+                        <span className="u-show-desktop-tablet">25 views of campaign</span>
+                      </WhatYouGet>
+                    </ButtonInsideWrapper>
+                  </Button>
+                </ContributeGridItem>
+                <ContributeGridItem>
+                  <Button
+                    classes={(chipInPaymentValue === '15' || chipInPaymentValue === '15.00') ? { root: classes.buttonRootSelected } : { root: classes.buttonRoot }}
+                    variant="contained"
+                    onClick={() => this.changeValueFromButton('15.00')}
+                  >
+                    <ButtonInsideWrapper>
+                      <PaymentAmount>
+                        $15
+                      </PaymentAmount>
+                      <WhatYouGet>
+                        <span className="u-show-mobile">200 views</span>
+                        <span className="u-show-desktop-tablet">200 views of campaign</span>
+                      </WhatYouGet>
+                    </ButtonInsideWrapper>
+                  </Button>
+                </ContributeGridItem>
+                <ContributeGridItem>
+                  <Button
+                    classes={(chipInPaymentValue === '35' || chipInPaymentValue === '35.00') ? { root: classes.buttonRootSelected } : { root: classes.buttonRoot }}
+                    variant="contained"
+                    onClick={() => this.changeValueFromButton('35.00')}
+                  >
+                    <ButtonInsideWrapper>
+                      <PaymentAmount>
+                        $35
+                      </PaymentAmount>
+                      <WhatYouGet>
+                        <span className="u-show-mobile">750 views</span>
+                        <span className="u-show-desktop-tablet">750 views of campaign</span>
+                      </WhatYouGet>
+                    </ButtonInsideWrapper>
+                  </Button>
+                </ContributeGridItem>
+                {!lowerDonations && (
+                  <ContributeGridItem>
+                    <Button
+                      classes={(chipInPaymentValue === '50' || chipInPaymentValue === '50.00') ? { root: classes.buttonRootSelected } : { root: classes.buttonRoot }}
+                      variant="contained"
+                      onClick={() => this.changeValueFromButton('50.00')}
+                    >
+                      <ButtonInsideWrapper>
+                        <PaymentAmount>
+                          $50
+                        </PaymentAmount>
+                        <WhatYouGet>
+                          <span className="u-show-mobile">1,250 views</span>
+                          <span className="u-show-desktop-tablet">1,250 views of campaign</span>
+                        </WhatYouGet>
+                      </ButtonInsideWrapper>
+                    </Button>
+                  </ContributeGridItem>
+                )}
+                <ContributeGridItemOtherItem>
+                  <TextField
+                    id="currency-input"
+                    label="Other Amount"
+                    variant="outlined"
+                    value={chipInPaymentOtherValue}
+                    onChange={this.onOtherAmountFieldChange}
+                    InputLabelProps={{
+                      classes: {
+                        root: classes.textFieldInputRoot,
+                        focused: classes.textFieldInputRoot,
+                      },
+                      shrink: true,
+                    }}
+                    InputProps={{
+                      classes: {
+                        root: classes.textFieldInputRoot,
+                        focused: classes.textFieldInputRoot,
+                      },
+                      startAdornment: <InputAdornment position="start">$</InputAdornment>,
+                    }}
+                    style={{ marginTop: 6, textAlign: 'center', width: '100%' }}
+                  />
+                </ContributeGridItemOtherItem>
+              </ContributeGridSection>
+            </ContributeGridWrapper>
+          </InnerWrapper>
+        </OuterWrapper>
+        <PaymentWrapper>
+          {futureFeaturesDisabled ? (
+            <PaymentCenteredWrapper show>
+              <ButtonContainer>
+                {preDonation ? (
+                  <SplitIconButton
+                    buttonText="Submit my choice"
+                    backgroundColor="#0834CD"
+                    separatorColor="#0834CD"
+                    styles={iconButtonStyles}
+                    adjustedIconWidth={40}
+                    externalUniqueId="becomeAMember"
+                    icon={<LockStyled />}
+                    id="stripeCheckOutForm"
+                    onClick={this.onDonationTempSubmit}
+                  />
+                ) : (
+                  <div>
+                    Thank you for your choice!
+                    We are still building our payment processing system.
+                  </div>
+                )}
+              </ButtonContainer>
+            </PaymentCenteredWrapper>
+          ) : (
+            <PaymentCenteredWrapper show={preDonation}>
+              {preDonation ? (
+                <Elements stripe={stripePromise}>
+                  <InjectedCheckoutForm
+                    value={chipInPaymentOtherValue || chipInPaymentValue}
+                    classes={{}}
+                    stopShowWaiting={this.stopShowWaiting}
+                    onDonation={this.onChipIn}
+                    showWaiting={showWaiting}
+                    isChipIn
+                    campaignXWeVoteId={campaignXWeVoteId}
+                  />
+                </Elements>
+              ) : (
+                <Button
+                  id="buttonReturn"
+                  classes={{ root: classes.buttonDefault }}
+                  color="primary"
+                  variant="contained"
+                  onClick={() => historyPush(returnPath)}
+                >
+                  {`Return to the "${campaignTitle}" Campaign`}
+                </Button>
+              )}
+            </PaymentCenteredWrapper>
+          )}
+        </PaymentWrapper>
+        <DonationListForm isCampaign leftTabIsMembership={false} />
+      </PaymentToPromoteWrapper>
+    );
+  }
+}
+PayToPromoteProcess.propTypes = {
+  campaignXWeVoteId: PropTypes.string,
+  chipInPaymentValueDefault: PropTypes.string,
+  classes: PropTypes.object,
+  lowerDonations: PropTypes.bool,
+};
+
+const ButtonContainer = styled('div')`
+  margin-top: 10px;
+`;
+
+const ButtonInsideWrapper = styled('div')`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+`;
+
+const ContributeGridWrapper = styled('div', {
+  shouldForwardProp: (prop) => !['show'].includes(prop),
+})(({ show, theme }) => (`
+  background-color: #ebebeb;
+  padding: 10px;
+  border: 1px solid darkgrey;
+  margin: auto auto 20px auto;
+  visibility: ${show ? 'visible' : 'hidden'};
+  height: ${show ? 'inherit' : '5px'};
+  width: 500px;
+  ${theme.breakpoints.down('sm')} {
+    width: 300px;
+`));
+
+const ContributeGridSection = styled('div')`
+  background-color: #ebebeb;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 10px 2px 10px;
+`;
+
+const ContributeMonthlyText = styled('div')`
+  font-weight: 600;
+  padding: 0 0 2px 18px;
+`;
+
+const ContributeGridItem = styled('div')`
+  background-color: #ebebeb;
+  padding: 5px 10px;
+  font-size: 30px;
+  text-align: center;
+`;
+
+const ContributeGridItemOtherItem = styled('div')`
+  background-color: #ebebeb;
+  padding: 5px 10px;
+  font-size: 30px;
+  text-align: center;
+  grid-column: auto / span 2;
+`;
+
+const InnerWrapper = styled('div')`
+`;
+
+const LockStyled = muiStyled(LockOutlined)({ color: 'white' });
+
+const PaymentAmount = styled('div')`
+  font-size: 1.1rem;
+`;
+
+const PaymentCenteredWrapper = styled('div', {
+  shouldForwardProp: (prop) => !['show'].includes(prop),
+})(({ show, theme }) => (`
+  width: 500px;
+  ${theme.breakpoints.down('sm')} {
+    width: 300px;
+  }
+  display: inline-block;
+  background-color: ${show ? 'rgb(246, 244,246)' : 'inherit'};
+  // box-shadow: ${show ? standardBoxShadow() : 'none'};
+  border: ${show ? '1px solid darkgrey' : 'none'};
+  border-radius: 3px;
+  padding: 8px;
+`));
+
+const PaymentToPromoteWrapper  = styled('div')`
+  margin-bottom: 15px;
+`;
+
+const PaymentWrapper  = styled('div')`
+  text-align: center;
+`;
+
+const WhatYouGet = styled('div')`
+  font-size: 1.3rem;
+`;
+
+export default withStyles(payToPromoteProcessStyles)(PayToPromoteProcess);

--- a/src/js/common/components/CampaignSupport/PayToPromoteProcess.jsx
+++ b/src/js/common/components/CampaignSupport/PayToPromoteProcess.jsx
@@ -17,9 +17,9 @@ import historyPush from '../../utils/historyPush';
 import { renderLog } from '../../utils/logging';
 import { payToPromoteProcessStyles } from '../Style/CampaignSupportStyles';
 import webAppConfig from '../../../config';
-import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
+// import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
 import CampaignStore from '../../stores/CampaignStore';
-import VoterStore from '../../../stores/VoterStore';
+// import VoterStore from '../../../stores/VoterStore';
 import { getCampaignXValuesFromIdentifiers, retrieveCampaignXFromIdentifiersIfNeeded } from '../../utils/campaignUtils';
 import initializejQuery from '../../utils/initializejQuery';
 import SplitIconButton from '../Widgets/SplitIconButton';
@@ -45,7 +45,7 @@ class PayToPromoteProcess extends Component {
       chipInPaymentOtherValue: '',
       preDonation: true,
       showWaiting: false,
-      voterFirstName: '',
+      // voterFirstName: '',
     };
     this.onOtherAmountFieldChange = this.onOtherAmountFieldChange.bind(this);
     this.onChipIn = this.onChipIn.bind(this);
@@ -57,13 +57,13 @@ class PayToPromoteProcess extends Component {
       // console.log('PayToPromoteProcess, componentDidMount after init jQuery');
       const { campaignXWeVoteId, chipInPaymentValueDefault } = this.props;
       this.setState({ loaded: true });
-      this.onAppObservableStoreChange();
-      this.appStateSubscription = messageService.getMessage().subscribe(() => this.onAppObservableStoreChange());
+      // this.onAppObservableStoreChange();
+      // this.appStateSubscription = messageService.getMessage().subscribe(() => this.onAppObservableStoreChange());
       this.campaignStoreListener = CampaignStore.addListener(this.onCampaignStoreChange.bind(this));
       this.donateStoreListener = DonateStore.addListener(this.onDonateStoreChange.bind(this));
       // dumpCookies();
-      this.onVoterStoreChange();
-      this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
+      // this.onVoterStoreChange();
+      // this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
       if (chipInPaymentValueDefault) {
         this.setState({ chipInPaymentValue: chipInPaymentValueDefault });
       }
@@ -94,21 +94,21 @@ class PayToPromoteProcess extends Component {
   }
 
   componentWillUnmount () {
-    this.appStateSubscription.unsubscribe();
+    // this.appStateSubscription.unsubscribe();
     this.campaignStoreListener.remove();
     this.donateStoreListener.remove();
-    this.voterStoreListener.remove();
+    // this.voterStoreListener.remove();
     if (this.timer) {
       clearTimeout(this.timer);
     }
   }
 
-  onAppObservableStoreChange () {
-    const chosenWebsiteName = AppObservableStore.getChosenWebsiteName();
-    this.setState({
-      chosenWebsiteName,
-    });
-  }
+  // onAppObservableStoreChange () {
+  //   const chosenWebsiteName = AppObservableStore.getChosenWebsiteName();
+  //   this.setState({
+  //     chosenWebsiteName,
+  //   });
+  // }
 
   onCampaignStoreChange () {
     const { campaignXWeVoteId } = this.props;
@@ -145,12 +145,12 @@ class PayToPromoteProcess extends Component {
     return {};
   }
 
-  onVoterStoreChange () {
-    const voterFirstName = VoterStore.getVoterFirstName();
-    this.setState({
-      voterFirstName,
-    });
-  }
+  // onVoterStoreChange () {
+  //   const voterFirstName = VoterStore.getVoterFirstName();
+  //   this.setState({
+  //     voterFirstName,
+  //   });
+  // }
 
   onOtherAmountFieldChange (event) {
     if (event && event.target) {
@@ -234,7 +234,7 @@ class PayToPromoteProcess extends Component {
           <InnerWrapper>
             <ContributeGridWrapper show={preDonation}>
               <ContributeMonthlyText>
-                Please chip in what you can:
+                Chip in to reach more voters:
               </ContributeMonthlyText>
               <ContributeGridSection>
                 {lowerDonations && (
@@ -249,8 +249,8 @@ class PayToPromoteProcess extends Component {
                           $1
                         </PaymentAmount>
                         <WhatYouGet>
-                          <span className="u-show-mobile">5 views</span>
-                          <span className="u-show-desktop-tablet">5 views of campaign</span>
+                          <span className="u-show-mobile">5 voters</span>
+                          <span className="u-show-desktop-tablet">5 voters reached</span>
                         </WhatYouGet>
                       </ButtonInsideWrapper>
                     </Button>
@@ -267,8 +267,8 @@ class PayToPromoteProcess extends Component {
                         $3
                       </PaymentAmount>
                       <WhatYouGet>
-                        <span className="u-show-mobile">25 views</span>
-                        <span className="u-show-desktop-tablet">25 views of campaign</span>
+                        <span className="u-show-mobile">15 voters</span>
+                        <span className="u-show-desktop-tablet">15 voters reached</span>
                       </WhatYouGet>
                     </ButtonInsideWrapper>
                   </Button>
@@ -284,8 +284,8 @@ class PayToPromoteProcess extends Component {
                         $15
                       </PaymentAmount>
                       <WhatYouGet>
-                        <span className="u-show-mobile">200 views</span>
-                        <span className="u-show-desktop-tablet">200 views of campaign</span>
+                        <span className="u-show-mobile">75 voters</span>
+                        <span className="u-show-desktop-tablet">75 voters reached</span>
                       </WhatYouGet>
                     </ButtonInsideWrapper>
                   </Button>
@@ -301,8 +301,8 @@ class PayToPromoteProcess extends Component {
                         $35
                       </PaymentAmount>
                       <WhatYouGet>
-                        <span className="u-show-mobile">750 views</span>
-                        <span className="u-show-desktop-tablet">750 views of campaign</span>
+                        <span className="u-show-mobile">175 voters</span>
+                        <span className="u-show-desktop-tablet">175 voters reached</span>
                       </WhatYouGet>
                     </ButtonInsideWrapper>
                   </Button>
@@ -319,8 +319,8 @@ class PayToPromoteProcess extends Component {
                           $50
                         </PaymentAmount>
                         <WhatYouGet>
-                          <span className="u-show-mobile">1,250 views</span>
-                          <span className="u-show-desktop-tablet">1,250 views of campaign</span>
+                          <span className="u-show-mobile">250 voters</span>
+                          <span className="u-show-desktop-tablet">250 voters reached</span>
                         </WhatYouGet>
                       </ButtonInsideWrapper>
                     </Button>
@@ -373,7 +373,7 @@ class PayToPromoteProcess extends Component {
                 ) : (
                   <div>
                     Thank you for your choice!
-                    We are still building our payment processing system.
+                    We are still building our payment processing system, but have recorded your choice.
                   </div>
                 )}
               </ButtonContainer>

--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -40,7 +40,7 @@ import isMobileScreenSize from '../utils/isMobileScreenSize';
 import DesignTokenColors from './Style/DesignTokenColors';
 import HeartFavoriteToggleLoader from './Widgets/HeartFavoriteToggle/HeartFavoriteToggleLoader';
 import SvgImage from './Widgets/SvgImage';
-import webAppConfig from "../../config";
+import webAppConfig from '../../config';
 
 const CampaignSupportThermometer = React.lazy(() => import(/* webpackChunkName: 'CampaignSupportThermometer' */ './CampaignSupport/CampaignSupportThermometer'));
 const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ '../../components/Widgets/ItemActionBar/ItemActionBar'));

--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -1,5 +1,5 @@
 import withStyles from '@mui/styles/withStyles';
-import { HowToVote } from '@mui/icons-material';
+import { HowToVote, Launch } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import React, { Suspense } from 'react';
 import { Link } from 'react-router-dom';
@@ -40,11 +40,13 @@ import isMobileScreenSize from '../utils/isMobileScreenSize';
 import DesignTokenColors from './Style/DesignTokenColors';
 import HeartFavoriteToggleLoader from './Widgets/HeartFavoriteToggle/HeartFavoriteToggleLoader';
 import SvgImage from './Widgets/SvgImage';
+import webAppConfig from "../../config";
 
 const CampaignSupportThermometer = React.lazy(() => import(/* webpackChunkName: 'CampaignSupportThermometer' */ './CampaignSupport/CampaignSupportThermometer'));
 const ItemActionBar = React.lazy(() => import(/* webpackChunkName: 'ItemActionBar' */ '../../components/Widgets/ItemActionBar/ItemActionBar'));
 const OfficeHeldNameText = React.lazy(() => import(/* webpackChunkName: 'OfficeHeldNameText' */ './Widgets/OfficeHeldNameText'));
 const OfficeNameText = React.lazy(() => import(/* webpackChunkName: 'OfficeNameText' */ './Widgets/OfficeNameText'));
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ './Widgets/OpenExternalWebSite'));
 
 // React functional component example
 function CardForListBody (props) {
@@ -55,7 +57,7 @@ function CardForListBody (props) {
     hideItemActionBar, limitCardWidth, linkedCampaignXWeVoteId, officeName,
     photoLargeUrl, politicalParty, politicianBaseBath,  // pathToUseToKeepHelping
     politicianDescription, politicianWeVoteId, profileImageBackgroundColor,
-    stateCode, tagIdBaseName, // supportersCount, supportersCountNextGoalRaw,
+    showPoliticianOpenInNewWindow, stateCode, tagIdBaseName, // supportersCount, supportersCountNextGoalRaw,
     ultimateElectionDate,
     useCampaignSupportThermometer, useOfficeHeld,
     usePoliticianWeVoteIdForBallotItem, useVerticalCard,
@@ -81,6 +83,7 @@ function CardForListBody (props) {
   } else if (['Working Families', 'Working Families Party'].includes(politicalParty)) {
     politicalPartySvgNameWithPath = '../../img/global/svg-icons/political-party-working-families.svg';
   }
+  const politicianDetailsURL = `${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}${politicianBaseBath}`;
 
   // /////////////////////// START OF DISPLAY
   return (
@@ -100,6 +103,30 @@ function CardForListBody (props) {
               {hideCardMargins ? (
                 <OneCampaignTitle>
                   {ballotItemDisplayName}
+                  {showPoliticianOpenInNewWindow && (
+                    <LaunchIconWrapper>
+                      <Suspense fallback={<></>}>
+                        <OpenExternalWebSite
+                          linkIdAttribute="openPoliticianPage"
+                          url={politicianDetailsURL}
+                          target="_blank"
+                          className="open-web-site open-web-site__no-right-padding"
+                          body={(
+                            <span>
+                              <Launch
+                                style={{
+                                  height: 14,
+                                  marginLeft: 2,
+                                  marginTop: '-3px',
+                                  width: 14,
+                                }}
+                              />
+                            </span>
+                          )}
+                        />
+                      </Suspense>
+                    </LaunchIconWrapper>
+                  )}
                 </OneCampaignTitle>
               ) : (
                 <OneCampaignTitleLink>
@@ -408,6 +435,7 @@ CardForListBody.propTypes = {
   politicianDescription: PropTypes.string,
   politicianWeVoteId: PropTypes.string,
   profileImageBackgroundColor: PropTypes.string,
+  showPoliticianOpenInNewWindow: PropTypes.bool,
   stateCode: PropTypes.string,
   // supportersCount: PropTypes.number.isRequired,
   // supportersCountNextGoalRaw: PropTypes.number,
@@ -432,6 +460,9 @@ export const FlexDivLeft = styled('div')`
   align-items: center;
   display: flex;
   justify-content: start;
+`;
+
+const LaunchIconWrapper = styled('span')`
 `;
 
 export const OfficeNameWrapper = styled('div')`

--- a/src/js/common/components/Style/CampaignSupportStyles.jsx
+++ b/src/js/common/components/Style/CampaignSupportStyles.jsx
@@ -1,5 +1,87 @@
 import styled from 'styled-components';
 import { isCordova, isWebApp } from '../../utils/isCordovaOrWebApp';
+import standardBoxShadow from './standardBoxShadow';
+
+
+export const payToPromoteProcessStyles = () => ({
+  buttonDefault: {
+    boxShadow: 'none !important',
+    fontSize: '14px',
+    height: '45px !important',
+    padding: '0 12px',
+    textTransform: 'none',
+    width: '100%',
+  },
+  buttonRoot: {
+    border: '1px solid #2e3c5d',
+    fontSize: 18,
+    textTransform: 'none',
+    width: '100%',
+    color: 'black',
+    backgroundColor: 'white',
+    '&:hover': {
+      backgroundColor: '#0834CD',
+      color: '#fff',
+    },
+  },
+  buttonRootSelected: {
+    border: '1px solid #236AC7',  // as in the Material UI example
+    fontSize: 18,
+    fontWeight: 600,
+    textTransform: 'none',
+    width: '100%',
+    color: '#236AC7',
+    backgroundColor: 'white',
+    '&:hover': {
+      backgroundColor: '#0834CD',
+      color: '#fff',
+    },
+  },
+  buttonSimpleLink: {
+    boxShadow: 'none !important',
+    fontSize: '18px',
+    height: '45px !important',
+    padding: '0 12px',
+    textDecoration: 'underline',
+    textTransform: 'none',
+    minWidth: 250,
+    '&:hover': {
+      color: '#4371cc',
+      textDecoration: 'underline',
+    },
+  },
+  textFieldRoot: {
+    fontSize: 18,
+    color: 'black',
+    backgroundColor: 'white',
+    boxShadow: standardBoxShadow(),
+  },
+  textFieldInputRoot: {
+    fontSize: 18,
+    color: 'black',
+    backgroundColor: 'white',
+  },
+  stripeAlertError: {
+    background: 'rgb(255, 177, 160)',
+    color: 'rgb(163, 40, 38)',
+    boxShadow: 'none',
+    pointerEvents: 'none',
+    fontWeight: 'bold',
+    marginBottom: 8,
+    // height: 40,
+    fontSize: 14,
+    width: '100%',
+    padding: '8px 16px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '4px',
+    '@media (max-width: 569px)': {
+      // height: 35,
+      fontSize: 14,
+    },
+  },
+});
 
 export const CampaignSupportDesktopButtonPanel = styled('div')`
   background-color: #fff;

--- a/src/js/common/components/Style/muiTheme.js
+++ b/src/js/common/components/Style/muiTheme.js
@@ -10,6 +10,7 @@ const muiTheme = createTheme({
   palette: {
     primary: {
       main: `${DesignTokenColors.primary600}`, // Former brandBlue #2E3C5D
+      dark: `${DesignTokenColors.primary700}`,
     },
     secondary: {
       main: `${DesignTokenColors.primary700}`,

--- a/src/js/common/components/Widgets/HeartFavoriteToggle/HeartFavoriteToggleLive.jsx
+++ b/src/js/common/components/Widgets/HeartFavoriteToggle/HeartFavoriteToggleLive.jsx
@@ -1,17 +1,17 @@
 import React, { Suspense } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import CampaignActions from '../../../actions/CampaignActions';
+// import CampaignActions from '../../../actions/CampaignActions';
 import CampaignStore from '../../../stores/CampaignStore';
 import OrganizationStore from '../../../../stores/OrganizationStore';
 import VoterStore from '../../../../stores/VoterStore';
 import AppObservableStore from '../../../stores/AppObservableStore';
 import CampaignSupporterStore from '../../../stores/CampaignSupporterStore';
-import apiCalming from '../../../utils/apiCalming';
+// import apiCalming from '../../../utils/apiCalming';
 import initializejQuery from '../../../utils/initializejQuery';
 import CampaignSupporterActions from '../../../actions/CampaignSupporterActions';
 import OrganizationActions from '../../../../actions/OrganizationActions';
-import PoliticianActions from '../../../actions/PoliticianActions';
+// import PoliticianActions from '../../../actions/PoliticianActions';
 import { renderLog } from '../../../utils/logging';
 
 const HeartFavoriteToggleBase = React.lazy(() => import(/* webpackChunkName: 'HeartFavoriteToggleBase' */ './HeartFavoriteToggleBase'));
@@ -46,12 +46,12 @@ class HeartFavoriteToggleLive extends React.Component {
     this.onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     // Not the most efficient, but allows us to put this component anywhere
-    const { campaignXWeVoteId } = this.props;
-    if (campaignXWeVoteId) {
-      if (apiCalming(`campaignRetrieve-${campaignXWeVoteId}`, 300000)) {
-        CampaignActions.campaignRetrieve(campaignXWeVoteId);
-      }
-    }
+    // const { campaignXWeVoteId } = this.props;
+    // if (campaignXWeVoteId) {
+    //   if (apiCalming(`campaignRetrieve-${campaignXWeVoteId}`, 300000)) {
+    //     CampaignActions.campaignRetrieve(campaignXWeVoteId);
+    //   }
+    // }
   }
 
   componentDidUpdate (prevProps) {
@@ -127,11 +127,11 @@ class HeartFavoriteToggleLive extends React.Component {
           voterCanVoteForPoliticianInCampaign,
         });
       }
-      if (politicianWeVoteId) {
-        if (apiCalming(`politicianRetrieve-${politicianWeVoteId}`, 300000)) {
-          PoliticianActions.politicianRetrieve(politicianWeVoteId);
-        }
-      }
+      // if (politicianWeVoteId) {
+      //   if (apiCalming(`politicianRetrieve-${politicianWeVoteId}`, 300000)) {
+      //     PoliticianActions.politicianRetrieve(politicianWeVoteId);
+      //   }
+      // }
     }
   }
 

--- a/src/js/components/Activity/ActivityPostAdd.jsx
+++ b/src/js/components/Activity/ActivityPostAdd.jsx
@@ -149,7 +149,7 @@ class ActivityPostAdd extends Component {
                 activityPostWeVoteId=""
                 externalUniqueId={externalUniqueId}
                 show={showActivityPostModal}
-                toggleActivityPostModal={this.toggleActivityPostModal}
+                toggleModal={this.toggleActivityPostModal}
               />
             </Suspense>
           )}

--- a/src/js/components/Activity/ActivityPostModal.jsx
+++ b/src/js/components/Activity/ActivityPostModal.jsx
@@ -134,7 +134,7 @@ class ActivityPostModal extends Component {
           className={classes.formStyles}
           onBlur={this.onBlurInput}
           onFocus={this.onFocusInput}
-          onSubmit={this.saveActivityPost.bind(this)}
+          onSubmit={this.saveActivityPost}
         >
           <TextFieldDiv>
             <VoterAvatarImg

--- a/src/js/components/Activity/ActivityTidbitItem.jsx
+++ b/src/js/components/Activity/ActivityTidbitItem.jsx
@@ -184,7 +184,7 @@ class ActivityTidbitItem extends Component {
               activityTidbitWeVoteId={activityTidbitWeVoteId}
               externalUniqueId={externalUniqueId}
               show={showActivityPostModal}
-              toggleActivityPostModal={this.toggleActivityPostModal}
+              toggleModal={this.toggleActivityPostModal}
             />
           </Suspense>
         )}

--- a/src/js/components/CandidateListRoot/CandidateCardForList.jsx
+++ b/src/js/components/CandidateListRoot/CandidateCardForList.jsx
@@ -191,11 +191,11 @@ class CandidateCardForList extends Component {
     if (!candidateWeVoteId) {
       return null;
     }
-    let candidateDescription;
+    // let candidateDescription;
     if (ballotGuideOfficialStatement) {
-      candidateDescription = ballotGuideOfficialStatement;
+      // candidateDescription = ballotGuideOfficialStatement;
     } else if (twitterDescription) {
-      candidateDescription = twitterDescription;
+      // candidateDescription = twitterDescription;
     }
     let districtName;
     if (contestOfficeList) {

--- a/src/js/components/CandidateListRoot/CandidateCardForList.jsx
+++ b/src/js/components/CandidateListRoot/CandidateCardForList.jsx
@@ -161,7 +161,7 @@ class CandidateCardForList extends Component {
 
   render () {
     renderLog('CandidateCardForList');  // Set LOG_RENDER_EVENTS to log all renders
-    const { limitCardWidth, useVerticalCard } = this.props;
+    const { limitCardWidth, showPoliticianOpenInNewWindow, useVerticalCard } = this.props;
     const { campaignSupported, candidate, linkedCampaignXWeVoteId } = this.state;
     if (!candidate) {
       return null;
@@ -223,6 +223,7 @@ class CandidateCardForList extends Component {
         // politicianDescription={candidateDescription}
         politicianWeVoteId={politicianWeVoteId}
         profileImageBackgroundColor={profileImageBackgroundColor}
+        showPoliticianOpenInNewWindow={showPoliticianOpenInNewWindow}
         stateCode={stateCode}
         supportersCount={supportersCount}
         supportersCountNextGoalRaw={supportersCountNextGoalRaw}
@@ -236,6 +237,7 @@ class CandidateCardForList extends Component {
 CandidateCardForList.propTypes = {
   candidateWeVoteId: PropTypes.string,
   limitCardWidth: PropTypes.bool,
+  showPoliticianOpenInNewWindow: PropTypes.bool,
   useVerticalCard: PropTypes.bool,
 };
 

--- a/src/js/components/CompleteYourProfile/CompleteYourProfile2024b.jsx
+++ b/src/js/components/CompleteYourProfile/CompleteYourProfile2024b.jsx
@@ -305,7 +305,7 @@ class CompleteYourProfile extends Component {
   }
 }
 CompleteYourProfile.propTypes = {
-  classes: PropTypes.object,
+  // classes: PropTypes.object,
 };
 const styles = () => ({
   navigationButton: {

--- a/src/js/components/PoliticianListRoot/PoliticianCardForList.jsx
+++ b/src/js/components/PoliticianListRoot/PoliticianCardForList.jsx
@@ -148,7 +148,7 @@ class PoliticianCardForList extends Component {
 
   render () {
     renderLog('PoliticianCardForList');  // Set LOG_RENDER_EVENTS to log all renders
-    const { limitCardWidth, politicianWeVoteId, useCampaignSupportThermometer, useVerticalCard } = this.props;
+    const { limitCardWidth, politicianWeVoteId, showPoliticianOpenInNewWindow, useCampaignSupportThermometer, useVerticalCard } = this.props;
     const { campaignSupported, candidate, candidateWeVoteId, linkedCampaignXWeVoteId, politician } = this.state;
     if (!politician) {
       return null;
@@ -236,6 +236,7 @@ class PoliticianCardForList extends Component {
         // politicianDescription={politicianDescriptionToDisplay}
         politicianWeVoteId={politicianWeVoteId}
         profileImageBackgroundColor={profileImageBackgroundColor}
+        showPoliticianOpenInNewWindow={showPoliticianOpenInNewWindow}
         stateCode={stateCode}
         supportersCount={supportersCount}
         supportersCountNextGoalRaw={supportersCountNextGoalRaw}
@@ -251,6 +252,7 @@ class PoliticianCardForList extends Component {
 PoliticianCardForList.propTypes = {
   politicianWeVoteId: PropTypes.string,
   limitCardWidth: PropTypes.bool,
+  showPoliticianOpenInNewWindow: PropTypes.bool,
   useCampaignSupportThermometer: PropTypes.bool,
   useVerticalCard: PropTypes.bool,
 };

--- a/src/js/components/PoliticianListRoot/PoliticianCardForList.jsx
+++ b/src/js/components/PoliticianListRoot/PoliticianCardForList.jsx
@@ -200,13 +200,13 @@ class PoliticianCardForList extends Component {
     if (!politicianWeVoteId) {
       return null;
     }
-    let politicianDescriptionToDisplay;
+    // let politicianDescriptionToDisplay;
     if (ballotGuideOfficialStatement) {
-      politicianDescriptionToDisplay = ballotGuideOfficialStatement;
+      // politicianDescriptionToDisplay = ballotGuideOfficialStatement;
     } else if (politicianDescription) {
-      politicianDescriptionToDisplay = politicianDescription;
+      // politicianDescriptionToDisplay = politicianDescription;
     } else if (twitterDescription) {
-      politicianDescriptionToDisplay = twitterDescription;
+      // politicianDescriptionToDisplay = twitterDescription;
     }
     let districtName;
     if (contestOfficeList) {

--- a/src/js/components/RepresentativeListRoot/RepresentativeCardForList.jsx
+++ b/src/js/components/RepresentativeListRoot/RepresentativeCardForList.jsx
@@ -144,7 +144,7 @@ class RepresentativeCardForList extends Component {
 
   render () {
     renderLog('RepresentativeCardForList');  // Set LOG_RENDER_EVENTS to log all renders
-    const { limitCardWidth, useVerticalCard } = this.props;
+    const { limitCardWidth, showPoliticianOpenInNewWindow, useVerticalCard } = this.props;
     const { campaignSupported, representative } = this.state;
     if (!representative) {
       return null;
@@ -197,6 +197,7 @@ class RepresentativeCardForList extends Component {
         // politicianDescription={twitterDescription}
         politicianWeVoteId={politicianWeVoteId}
         profileImageBackgroundColor={profileImageBackgroundColor}
+        showPoliticianOpenInNewWindow={showPoliticianOpenInNewWindow}
         stateCode={stateCode}
         supportersCount={supportersCount}
         supportersCountNextGoalRaw={supportersCountNextGoalRaw}
@@ -211,6 +212,7 @@ class RepresentativeCardForList extends Component {
 RepresentativeCardForList.propTypes = {
   limitCardWidth: PropTypes.bool,
   representativeWeVoteId: PropTypes.string,
+  showPoliticianOpenInNewWindow: PropTypes.bool,
   useVerticalCard: PropTypes.bool,
 };
 

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -68,7 +68,7 @@ class VoterEmailAddressEntry extends Component {
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     VoterActions.voterEmailAddressRetrieve();
     const inputFld = $('#enterVoterEmailAddress');
-    console.log('enterVoterEmailAddress ', $(inputFld));
+    // console.log('enterVoterEmailAddress ', $(inputFld));
     $(inputFld).blur();
     this._isMounted = true;
   }

--- a/src/js/components/VoterGuide/OrganizationModal.jsx
+++ b/src/js/components/VoterGuide/OrganizationModal.jsx
@@ -353,19 +353,8 @@ class OrganizationModal extends Component {
         onClose={this.closeOrganizationModal}
         open={modalOpen}
       >
-        <IconButton
-          aria-label="Close"
-          className={classes.closeButton}
-          id="closeOrganizationModal"
-          onClick={this.closeOrganizationModal}
-          size="large"
-        >
-          <span className="u-cursor--pointer">
-            <Close classes={{ root: classes.closeIcon }} />
-          </span>
-        </IconButton>
-        <DrawerHeaderOuterContainer id="politicianHeaderContainer" scrolledDown={scrolledDown}>
-          <DrawerHeaderInnerContainer>
+        <CloseDrawerIconWrapper>
+          <div>
             <IconButton
               aria-label="Close"
               className={classes.closeButton}
@@ -377,6 +366,25 @@ class OrganizationModal extends Component {
                 <Close classes={{ root: classes.closeIcon }} />
               </span>
             </IconButton>
+          </div>
+        </CloseDrawerIconWrapper>
+        <DrawerHeaderOuterContainer id="politicianHeaderContainer" scrolledDown={scrolledDown}>
+          <DrawerHeaderInnerContainer>
+            <CloseDrawerIconWrapper>
+              <div>
+                <IconButton
+                  aria-label="Close"
+                  className={classes.closeButton}
+                  id="closeOrganizationModal"
+                  onClick={this.closeOrganizationModal}
+                  size="large"
+                >
+                  <span className="u-cursor--pointer">
+                    <Close classes={{ root: classes.closeIcon }} />
+                  </span>
+                </IconButton>
+              </div>
+            </CloseDrawerIconWrapper>
             <DrawerHeaderContentContainer>
               {ballotItemDisplayName}
             </DrawerHeaderContentContainer>
@@ -386,6 +394,7 @@ class OrganizationModal extends Component {
           <PoliticianCardForListWrapper>
             <PoliticianCardForList
               politicianWeVoteId={politicianWeVoteId}
+              showPoliticianOpenInNewWindow
               useCampaignSupportThermometer
               useVerticalCard
             />
@@ -559,6 +568,12 @@ const styles = () => ({
 
 const BallotItemBottomSpacer = styled('div')`
   margin-bottom: 32px;
+`;
+
+const CloseDrawerIconWrapper = styled('div')`
+  display: flex;
+  justify-content: flex-end;
+  width: 100%;
 `;
 
 const PoliticianCardForListWrapper = styled('div')`

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -23,6 +23,7 @@ import PositionPublicToggle from '../PositionPublicToggle';
 import ShareButtonDropDown from '../ShareButtonDropdown';
 import { openSnackbar } from '../../../common/components/Widgets/SnackNotifier';
 import DesignTokenColors from '../../../common/components/Style/DesignTokenColors';
+import HelpWinOrDefeatModal from '../../../common/components/CampaignSupport/HelpWinOrDefeatModal'; // eslint-disable-line import/no-cycle
 import PositionStatementModal from '../PositionStatementModal'; // eslint-disable-line import/no-cycle
 
 const NUMBER_OF_BALLOT_CHOICES_ALLOWED_BEFORE_SHOW_MODAL = 3;
@@ -44,6 +45,7 @@ class ItemActionBar extends PureComponent {
       transitioning: false,
       voterTextStatement: undefined,
       voterTextStatementOpened: false,
+      helpWinOrDefeatModalOpen: false,
     };
     this.helpDefeatThemButton = this.helpDefeatThemButton.bind(this);
     this.helpThemWinButton = this.helpThemWinButton.bind(this);
@@ -245,9 +247,22 @@ class ItemActionBar extends PureComponent {
     }
   }
 
+  openHelpWinOrDefeatModal = () => {
+    this.setState({
+      helpWinOrDefeatModalOpen: true,
+    });
+  };
+
   openPositionStatement = () => {
     this.setState({
       voterTextStatementOpened: true,
+    });
+  };
+
+  toggleHelpWinOrDefeatFunction = () => {
+    const { helpWinOrDefeatModalOpen } = this.state;
+    this.setState({
+      helpWinOrDefeatModalOpen: !helpWinOrDefeatModalOpen,
     });
   };
 
@@ -262,37 +277,39 @@ class ItemActionBar extends PureComponent {
   };
 
   helpThemWinButton = (localUniqueId) => {
-    const { classes, externalUniqueId, inCard } = this.props;
-    const buttonRootClass = inCard ? classes.buttonRootForCard : classes.buttonRoot;
+    const { classes, externalUniqueId } = this.props;
+    // const buttonRootClass = inCard ? classes.buttonRootForCard : classes.buttonRoot;
+    const buttonRootClass = classes.buttonHelpRoot;
     return (
       <Button
         classes={{ root: buttonRootClass, outlinedPrimary: classes.buttonOutlinedPrimary }}
         color="primary"
         id={`itemActionBarHelpThemWinButton-${externalUniqueId}-${localUniqueId}`}
-        onClick={() => this.openPositionStatement()}
+        onClick={() => this.openHelpWinOrDefeatModal()}
         variant="contained"
       >
         <HelpButtonLabel>
-          Help Win
+          &nbsp;Help Win with $1&nbsp;
         </HelpButtonLabel>
       </Button>
     );
   };
 
   helpDefeatThemButton = (localUniqueId) => {
-    const { classes, externalUniqueId, inCard, opposeHideInMobile } = this.props;
-    const buttonRootClass = inCard ? classes.buttonRootForCard : classes.buttonRoot;
+    const { classes, externalUniqueId, opposeHideInMobile } = this.props;
+    // const buttonRootClass = inCard ? classes.buttonRootForCard : classes.buttonRoot;
+    const buttonRootClass = classes.buttonHelpRoot;
     return (
       <Button
         classes={{ root: buttonRootClass, outlinedPrimary: classes.buttonOutlinedPrimary }}
         className={`${opposeHideInMobile ? 'd-none d-sm-block ' : ''}`}
         color="primary"
         id={`itemActionBarHelpDefeatButton-${externalUniqueId}-${localUniqueId}`}
-        onClick={() => this.openPositionStatement()}
+        onClick={() => this.openHelpWinOrDefeatModal()}
         variant="contained"
       >
         <HelpButtonLabel>
-          Help Defeat
+          $1 to Help Defeat
         </HelpButtonLabel>
       </Button>
     );
@@ -300,7 +317,12 @@ class ItemActionBar extends PureComponent {
 
   opposeButton = (localUniqueId) => {
     const { classes, externalUniqueId, inCard, opposeHideInMobile } = this.props;
-    const buttonRootClass = inCard ? classes.buttonRootForCard : classes.buttonRoot;
+    let buttonRootClass = null;
+    if (inCard) {
+      buttonRootClass = this.isOpposeCalculated() ? classes.buttonRootForCardAfterChoice : classes.buttonRootForCard;
+    } else {
+      buttonRootClass = classes.buttonRoot;
+    }
     return (
       <Button
         classes={{ root: buttonRootClass, outlinedPrimary: classes.buttonOutlinedPrimary }}
@@ -343,7 +365,12 @@ class ItemActionBar extends PureComponent {
 
   supportButton = (localUniqueId) => {
     const { classes, externalUniqueId, inCard, shareButtonHide, useSupportWording } = this.props;
-    const buttonRootClass = inCard ? classes.buttonRootForCard : classes.buttonRoot;
+    let buttonRootClass = null;
+    if (inCard) {
+      buttonRootClass = this.isSupportCalculated() ? classes.buttonRootForCardAfterChoice : classes.buttonRootForCard;
+    } else {
+      buttonRootClass = classes.buttonRoot;
+    }
     return (
       <Button
         classes={{ root: buttonRootClass, outlinedPrimary: classes.buttonOutlinedPrimary }}
@@ -647,7 +674,8 @@ class ItemActionBar extends PureComponent {
       hideSupportYes, hideOpposeNo, useHelpDefeatOrHelpWin, useSupportWording,
     } = this.props;
     const {
-      ballotItemType, ballotItemWeVoteId, isOpposeAPIState, isSupportAPIState,
+      ballotItemType, ballotItemWeVoteId, helpWinOrDefeatModalOpen,
+      isOpposeAPIState, isSupportAPIState,
       numberOfOpposePositionsForScore, numberOfSupportPositionsForScore,
       voterPositionIsPublic, voterTextStatementOpened,
     } = this.state;
@@ -707,7 +735,7 @@ class ItemActionBar extends PureComponent {
 
     const ballotItemDisplayName = this.props.ballotItemDisplayName || '';
 
-    let helpDefeatButtonPopOverText = 'Share your opinion to help defeat';
+    let helpDefeatButtonPopOverText = 'Chip in $1 to help defeat';
     if (ballotItemDisplayName.length > 0) {
       helpDefeatButtonPopOverText += ` ${ballotItemDisplayName}`;
     }
@@ -717,7 +745,7 @@ class ItemActionBar extends PureComponent {
     if (ballotItemDisplayName.length > 0) {
       helpWinButtonPopOverText += ` ${ballotItemDisplayName}`;
     }
-    helpWinButtonPopOverText += ' win by making your opinions visible to other voters.';
+    helpWinButtonPopOverText += ' win by chipping in $1.';
 
     let supportButtonSelectedPopOverText = 'Click to choose';
     if (useSupportWording) {
@@ -828,7 +856,7 @@ class ItemActionBar extends PureComponent {
                       rootClose
                     >
                       <div>
-                        {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && ((useHelpDefeatOrHelpWin && this.isOpposeCalculated()) ? this.helpDefeatThemButton(`desktopVersion-${ballotItemWeVoteId}`) : this.supportButton(`desktopVersion-${ballotItemWeVoteId}`))}
+                        {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && ((useHelpDefeatOrHelpWin && this.isOpposeCalculated()) ? <></> : this.supportButton(`desktopVersion-${ballotItemWeVoteId}`))}
                         {(ballotItemType === 'MEASURE') && this.measureYesButton(`desktopVersion-${ballotItemWeVoteId}`)}
                       </div>
                     </OverlayTrigger>
@@ -842,7 +870,7 @@ class ItemActionBar extends PureComponent {
                   </StackedButton>
                 ) : (
                   <ButtonWrapper className="u-push--xs u-push--xs d-lg-none">
-                    {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && ((useHelpDefeatOrHelpWin && this.isOpposeCalculated()) ? this.helpDefeatThemButton(`desktopVersion-${ballotItemWeVoteId}`) : this.supportButton(`mobileVersion-${ballotItemWeVoteId}`))}
+                    {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && ((useHelpDefeatOrHelpWin && this.isOpposeCalculated()) ? <></> : this.supportButton(`mobileVersion-${ballotItemWeVoteId}`))}
                     {ballotItemType === 'MEASURE' && this.measureYesButton(`mobileVersion-${ballotItemWeVoteId}`)}
                   </ButtonWrapper>
                 )}
@@ -880,9 +908,45 @@ class ItemActionBar extends PureComponent {
                   </StackedButton>
                 ) : (
                   <ButtonWrapperRight className="d-lg-none">
-                    {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && ((useHelpDefeatOrHelpWin && this.isSupportCalculated()) ? this.helpThemWinButton(`desktopVersion-${ballotItemWeVoteId}`) : this.opposeButton(`mobileVersion-${ballotItemWeVoteId}`))}
+                    {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && ((useHelpDefeatOrHelpWin && this.isSupportCalculated()) ? this.helpThemWinButton(`mobileVersion-${ballotItemWeVoteId}`) : this.opposeButton(`mobileVersion-${ballotItemWeVoteId}`))}
                     {ballotItemType === 'MEASURE' && this.measureNoButton(`mobileVersion-${ballotItemWeVoteId}`)}
                   </ButtonWrapperRight>
+                )}
+              </>
+            )}
+
+            {/* Start of Help Defeat Them Button */}
+            {((ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && (useHelpDefeatOrHelpWin && this.isOpposeCalculated())) && (
+              <>
+                {/* Visible on desktop screens */}
+                {buttonsOnly ? (
+                  <StackedButton className="d-none d-lg-block" onlyTwoButtons={commentButtonHide}>
+                    {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && this.opposeButtonNoText(`desktopVersion-${ballotItemWeVoteId}`)}
+                    {ballotItemType === 'MEASURE' && this.measureNoButtonNoText(`desktopVersion-${ballotItemWeVoteId}`)}
+                  </StackedButton>
+                ) : (
+                  <ButtonWrapperFarRight className="d-none d-lg-block">
+                    <OverlayTrigger
+                      overlay={helpDefeatButtonPopoverTooltip}
+                      placement="top"
+                      rootClose
+                    >
+                      <div>
+                        {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && (useHelpDefeatOrHelpWin && this.isOpposeCalculated()) && this.helpDefeatThemButton(`desktopVersion-${ballotItemWeVoteId}`)}
+                      </div>
+                    </OverlayTrigger>
+                  </ButtonWrapperFarRight>
+                )}
+                {/* Visible on mobile devices and tablets */}
+                {buttonsOnly ? (
+                  <StackedButton className="d-lg-none d-xl-none" onlyTwoButtons={commentButtonHideInMobile}>
+                    {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && this.opposeButtonNoText(`mobileVersion-${ballotItemWeVoteId}`)}
+                    {ballotItemType === 'MEASURE' && this.measureNoButtonNoText(`mobileVersion-${ballotItemWeVoteId}`)}
+                  </StackedButton>
+                ) : (
+                  <ButtonWrapperFarRight className="d-lg-none">
+                    {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && (useHelpDefeatOrHelpWin && this.isOpposeCalculated()) && this.helpDefeatThemButton(`mobileVersion-${ballotItemWeVoteId}`)}
+                  </ButtonWrapperFarRight>
                 )}
               </>
             )}
@@ -913,12 +977,20 @@ class ItemActionBar extends PureComponent {
               ballotItemType={ballotItemType}
             />
           )}
+          {helpWinOrDefeatModalOpen && (
+            <HelpWinOrDefeatModal
+              ballotItemWeVoteId={ballotItemWeVoteId}
+              // externalUniqueId={externalUniqueId}
+              show={helpWinOrDefeatModalOpen}
+              toggleModal={this.toggleHelpWinOrDefeatFunction}
+            />
+          )}
           {voterTextStatementOpened && (
             <PositionStatementModal
               ballotItemWeVoteId={ballotItemWeVoteId}
               // externalUniqueId={externalUniqueId}
               show={voterTextStatementOpened}
-              togglePositionStatementModal={this.togglePositionStatementFunction}
+              toggleModal={this.togglePositionStatementFunction}
             />
           )}
         </ItemActionBarWrapper>
@@ -953,6 +1025,22 @@ ItemActionBar.propTypes = {
 };
 
 const styles = (theme) => ({
+  buttonHelpRoot: {
+    borderRadius: '15px',
+    padding: 4,
+    width: 'fit-content',
+    height: 32,
+    [theme.breakpoints.down('md')]: {
+      width: 'fit-content',
+      height: 30,
+    },
+    [theme.breakpoints.down('sm')]: {
+      width: 'fit-content',
+      minWidth: 80,
+      height: 28,
+      padding: '0 8px',
+    },
+  },
   buttonIcon: {
     fontSize: 18,
     marginRight: '.3rem',
@@ -1030,6 +1118,12 @@ const styles = (theme) => ({
     width: 138,
     height: 32,
   },
+  buttonRootForCardAfterChoice: {
+    borderRadius: '15px',
+    padding: 4,
+    width: 110,
+    height: 32,
+  },
   buttonNoTextRoot: {
     padding: 4,
     fontSize: 12,
@@ -1105,6 +1199,12 @@ const ButtonWrapper = styled('div')`
   display: flex;
   align-items: center;
   // {({ onlyTwoButtons }) => (onlyTwoButtons ? 'width: 50% !important;' : '')}
+`;
+
+const ButtonWrapperFarRight = styled('div')`
+  margin-left: 4px;
+  display: flex;
+  align-items: center;
 `;
 
 const ButtonWrapperRight = styled('div')`

--- a/src/js/components/Widgets/ItemPositionStatementActionBar2020.jsx
+++ b/src/js/components/Widgets/ItemPositionStatementActionBar2020.jsx
@@ -278,7 +278,7 @@ class ItemPositionStatementActionBar2020 extends Component {
             ballotItemWeVoteId={ballotItemWeVoteId}
             externalUniqueId={externalUniqueId}
             show={showPositionStatementModal}
-            togglePositionStatementModal={this.togglePositionStatementModal}
+            toggleModal={this.togglePositionStatementModal}
           />
         )}
       </Wrapper>

--- a/src/js/components/Widgets/ModalDisplayTemplateA.jsx
+++ b/src/js/components/Widgets/ModalDisplayTemplateA.jsx
@@ -37,18 +37,20 @@ class ModalDisplayTemplateA extends Component {
         style={{ paddingTop: `${isCordova() ? '75px' : 'undefined'}` }}
       >
         <DialogTitle classes={{ root: classes.dialogTitle }}>
-          <Title>
-            {dialogTitleJSX}
-          </Title>
-          <IconButton
-            aria-label="Close"
-            classes={{ root: classes.closeButton }}
-            onClick={() => { this.props.toggleModal(); }}
-            id={`closeModalDisplayTemplateA${externalUniqueId}`}
-            size="large"
-          >
-            <Close />
-          </IconButton>
+          <DialogTitleInnerWrapper>
+            <Title>
+              {dialogTitleJSX || <>&nbsp;</>}
+            </Title>
+            <IconButton
+              aria-label="Close"
+              classes={{ root: classes.closeButton }}
+              onClick={() => { this.props.toggleModal(); }}
+              id={`closeModalDisplayTemplateA${externalUniqueId}`}
+              size="large"
+            >
+              <Close />
+            </IconButton>
+          </DialogTitleInnerWrapper>
         </DialogTitle>
         <DialogContent classes={{ root: classes.dialogContent }}>
           <DialogContentInnerWrapper>
@@ -150,6 +152,12 @@ const DialogContentInnerWrapper = styled('div')`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+`;
+
+const DialogTitleInnerWrapper = styled('div')`
+  display: flex;
+  justify-content: space-between;
+  min-height: 28px;
 `;
 
 export const horizontalEllipsis = '\u2026';

--- a/src/js/components/Widgets/ModalDisplayTemplateA.jsx
+++ b/src/js/components/Widgets/ModalDisplayTemplateA.jsx
@@ -1,0 +1,200 @@
+import { Close } from '@mui/icons-material';
+import { Dialog, DialogContent, DialogTitle, IconButton } from '@mui/material';
+import withStyles from '@mui/styles/withStyles';
+import withTheme from '@mui/styles/withTheme';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import styled from 'styled-components';
+import { hasIPhoneNotch, isAndroidSizeWide } from '../../common/utils/cordovaUtils';
+import { isAndroid, isCordova } from '../../common/utils/isCordovaOrWebApp';
+import { renderLog } from '../../common/utils/logging';
+
+
+class ModalDisplayTemplateA extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+  render () {
+    renderLog('ModalDisplayTemplateA');  // Set LOG_RENDER_EVENTS to log all renders
+    const {
+      classes, dialogTitleJSX, externalUniqueId, tallMode, textFieldJSX,
+    } = this.props;
+    let dialogPaperCombined;
+    if (tallMode) {
+      dialogPaperCombined = { ...classes.dialogPaper, ...classes.dialogPaperAdditionTall };
+    } else {
+      dialogPaperCombined = classes.dialogPaper;
+    }
+    // This template is used by other components like ActivityPostModal, and PositionStatementModal
+    return (
+      <Dialog
+        classes={{ paper: dialogPaperCombined }}
+        onClose={() => { this.props.toggleModal(); }}
+        open={this.props.show}
+        style={{ paddingTop: `${isCordova() ? '75px' : 'undefined'}` }}
+      >
+        <DialogTitle classes={{ root: classes.dialogTitle }}>
+          <Title>
+            {dialogTitleJSX}
+          </Title>
+          <IconButton
+            aria-label="Close"
+            classes={{ root: classes.closeButton }}
+            onClick={() => { this.props.toggleModal(); }}
+            id={`closeModalDisplayTemplateA${externalUniqueId}`}
+            size="large"
+          >
+            <Close />
+          </IconButton>
+        </DialogTitle>
+        <DialogContent classes={{ root: classes.dialogContent }}>
+          <DialogContentInnerWrapper>
+            {textFieldJSX}
+          </DialogContentInnerWrapper>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+}
+ModalDisplayTemplateA.propTypes = {
+  classes: PropTypes.object,
+  dialogTitleJSX: PropTypes.object,
+  externalUniqueId: PropTypes.string,
+  show: PropTypes.bool,
+  tallMode: PropTypes.bool,
+  textFieldJSX: PropTypes.object,
+  toggleModal: PropTypes.func.isRequired,
+};
+
+export const templateAStyles = (theme) => ({
+  dialogTitle: {
+    padding: isAndroid() ? 8 : 'inherit',
+    paddingTop: !isAndroid() ? 16 : 'inherit',
+  },
+  dialogPaper: {
+    marginTop: hasIPhoneNotch() ? 68 : 48,
+    minHeight: isAndroid() ? '257px' : '200px',
+    maxHeight: '350px',
+    height: '80%',
+    width: '90%',
+    maxWidth: '600px',
+    top: '0',
+    transform: isAndroid() ? 'translate(0%, -18%)' : 'translate(0%, -20%)',
+    [theme.breakpoints.down('xs')]: {
+      minWidth: '95%',
+      maxWidth: '95%',
+      width: '95%',
+      minHeight: isAndroid() ? '237px' : '200px',
+      maxHeight: '330px',
+      height: '70%',
+      margin: '0 auto',
+      transform: 'translate(0%, -30%)',
+    },
+  },
+  dialogPaperAdditionTall: {
+    maxHeight: '550px',
+    [theme.breakpoints.down('xs')]: {
+      maxHeight: '530px',
+    },
+  },
+  dialogContent: {
+    padding: '0 16px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    height: '100%',
+  },
+  closeButton: {
+    position: 'absolute',
+    right: theme.spacing(1),
+    top: isAndroid() ? '-4px' : theme.spacing(1),
+  },
+  saveButtonRoot: {
+    width: '100%',
+  },
+  formStyles: {
+    width: '100%',
+  },
+  formControl: {
+    width: '100%',
+    marginTop: 16,
+  },
+  inputMultiline: {
+    fontSize: 20,
+    height: '100%',
+    width: '100%',
+    [theme.breakpoints.down('sm')]: {
+      fontSize: 18,
+    },
+  },
+  inputStyles: {
+    flex: '1 1 0',
+    fontSize: 18,
+    height: '100%',
+    width: '100%',
+    [theme.breakpoints.down('sm')]: {
+      fontSize: 16,
+    },
+  },
+  select: {
+    padding: '12px 12px',
+    margin: '0 1px',
+  },
+});
+
+const DialogContentInnerWrapper = styled('div')`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const horizontalEllipsis = '\u2026';
+
+export const PostSaveButton = styled('div')`
+  width: 100%;
+`;
+
+export const TextFieldDiv = styled('div')`
+  align-items: flex-start;
+  border: 1px solid #e8e8e8;
+  border-radius: 3px;
+  display: flex;
+  margin-bottom: 0;
+  padding: ${isAndroidSizeWide() ? '12px 12px 0 12px' : '12px'};
+`;
+
+export const TextFieldForm = styled('form')`
+  height: 95%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+export const TextFieldWrapper = styled('div')`
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const Title = styled('div')`
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+  margin-top: 2px;
+  text-align: left;
+  padding-left: 16px;
+`;
+
+export const VoterAvatarImg = styled('img')`
+  border-radius: 6px;
+  display: block;
+  margin-right: 12px;
+  width: 50px;
+`;
+
+export default withTheme(withStyles(templateAStyles)(ModalDisplayTemplateA));

--- a/src/js/components/Widgets/PositionStatementModal.jsx
+++ b/src/js/components/Widgets/PositionStatementModal.jsx
@@ -238,7 +238,7 @@ class PositionStatementModal extends Component {
           className={classes.formStyles}
           onBlur={this.onBlurInput}
           onFocus={this.onFocusInput}
-          onSubmit={this.savePositionStatement.bind(this)}
+          onSubmit={this.savePositionStatement}
         >
           <TextFieldDiv>
             <VoterAvatarImg

--- a/src/js/pages/Ballot/Ballot.jsx
+++ b/src/js/pages/Ballot/Ballot.jsx
@@ -34,6 +34,7 @@ import BallotShowAllItemsFooter from '../../components/Navigation/BallotShowAllI
 import { DualHeaderContainer, HeaderContentContainer, HeaderContentOuterContainer, PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import webAppConfig from '../../config';
 import BallotStore from '../../stores/BallotStore';
+import CampaignStore from '../../common/stores/CampaignStore';
 import ElectionStore from '../../stores/ElectionStore';
 import IssueStore from '../../stores/IssueStore';
 import SupportStore from '../../stores/SupportStore';
@@ -127,6 +128,7 @@ class Ballot extends Component {
     this.appStateSubscription = messageService.getMessage().subscribe(() => this.onAppObservableStoreChange());
     // We need a ballotStoreListener here because we want the ballot to display before positions are received
     this.ballotStoreListener = BallotStore.addListener(this.onBallotStoreChange.bind(this));
+    this.campaignStoreListener = CampaignStore.addListener(this.onCampaignStoreChange.bind(this));
     this.electionStoreListener = ElectionStore.addListener(this.onElectionStoreChange.bind(this));
     this.issueStoreListener = IssueStore.addListener(this.onIssueStoreChange.bind(this));
     this.supportStoreListener = SupportStore.addListener(this.onBallotStoreChange.bind(this));
@@ -761,6 +763,10 @@ class Ballot extends Component {
         ballotItemUnfurledTracker: BallotStore.currentBallotItemUnfurledTracker,
       });
     }
+  }
+
+  onCampaignStoreChange () {
+    // We want the CampaignStore active so it can take in the response data from voterBallotItemsRetrieve
   }
 
   onElectionStoreChange () {


### PR DESCRIPTION
Refactored PositionStatementModal and ActivityPostModal to use new ModalDisplayTemplateA. Then built HelpWinOrDefeatModal to also use ModalDisplayTemplateA. Broke out CampaignSupportPayToPromoteProcess, so we can put the heart of that page into HelpWinOrDefeatModal (as well as using it on the CampaignSupportPayToPromoteProcess page. Optimized HeartFavoriteToggleLive data loading to NOT retrieve the CampaignX or Politician record, but instead use transformed candidate data as a pseudo CampaignX object. Added ability to open Politician page in a new tab. Shifted "X" close icon in OrganizationModal to the right side. Added "Help Win with $1" buttons.

