### PR TITLE
[TEAM REVIEW] WV-505 On the Ready Page, Update Tab order (UI Accessibility) - John Mook

### DIFF
--- a/src/js/components/Ballot/BallotTitleHeader.jsx
+++ b/src/js/components/Ballot/BallotTitleHeader.jsx
@@ -201,13 +201,15 @@ class BallotTitleHeader extends Component {
                             >
                               Ballot for
                               {' '}
-                              <span
-                                className={linksOff ? '' : 'u-cursor--pointer u-link-color u-link-underline-on-hover'}
-                                onClick={this.showSelectBallotModalEditAddress}
-                              >
-                                {(textForMapSearch && textForMapSearch !== '') ? textForMapSearch : originalTextAddress}
-                              </span>
-                              {linksOff ? <></> : editIconStyled}
+                              <button style={{ backgroundColor: 'transparent', border: 'none', padding: '0' }} type="button">
+                                <span
+                                  className={linksOff ? '' : 'u-cursor--pointer u-link-color u-link-underline-on-hover'}
+                                  onClick={this.showSelectBallotModalEditAddress}
+                                >
+                                  {(textForMapSearch && textForMapSearch !== '') ? textForMapSearch : originalTextAddress}
+                                </span>
+                                {linksOff ? <></> : editIconStyled}
+                              </button>
                             </BallotAddress>
                           ) : (
                             <>

--- a/src/js/components/Ready/ReadyFinePrint.jsx
+++ b/src/js/components/Ready/ReadyFinePrint.jsx
@@ -28,7 +28,7 @@ class ReadyFinePrint extends Component {
     this.state = {
       contentUnfurled: false,
     };
-    this.firstListItemRef = React.createRef();
+    this.introHeaderRef = React.createRef();
   }
 
   componentDidMount () {
@@ -44,7 +44,7 @@ class ReadyFinePrint extends Component {
       contentUnfurled: !contentUnfurled,
     });
     if (!contentUnfurled) {
-      this.firstListItemRef.current.focus();
+      this.introHeaderRef.current.focus();
     }
   }
 
@@ -55,7 +55,7 @@ class ReadyFinePrint extends Component {
     return (
       <OuterWrapper>
         <InnerWrapper>
-          <IntroHeader titleCentered={titleCentered} titleLarge={titleLarge} tabIndex={0} ref={this.firstListItemRef}>
+          <IntroHeader titleCentered={titleCentered} titleLarge={titleLarge} tabIndex={0} ref={this.introHeaderRef}>
             The fine print:
           </IntroHeader>
           <ListWrapper>

--- a/src/js/components/Ready/ReadyIntroduction.jsx
+++ b/src/js/components/Ready/ReadyIntroduction.jsx
@@ -34,7 +34,7 @@ class ReadyIntroduction extends Component {
     this.state = {
       contentUnfurled: false,
     };
-    this.firstListItemRef = React.createRef();
+    this.introHeaderRef = React.createRef();
   }
 
   componentDidMount () {
@@ -67,7 +67,7 @@ class ReadyIntroduction extends Component {
       contentUnfurled: !contentUnfurled,
     });
     if (!contentUnfurled) {
-      this.firstListItemRef.current.focus();
+      this.introHeaderRef.current.focus();
     }
   }
 
@@ -95,7 +95,7 @@ class ReadyIntroduction extends Component {
     return (
       <OuterWrapper>
         <InnerWrapper>
-          <IntroHeader titleCentered={titleCentered} titleLarge={titleLarge} tabIndex={0} ref={this.firstListItemRef}>
+          <IntroHeader titleCentered={titleCentered} titleLarge={titleLarge} tabIndex={0} ref={this.introHeaderRef}>
             WeVote helps you:
           </IntroHeader>
           <ListWrapper>

--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -344,6 +344,7 @@ class IssueCard extends Component {
                       {includeLinkToIssue ? (
                         <Link to={this.getIssueLink}
                               className="u-no-underline"
+                              tabIndex={-1}
                         >
                           {issueImage}
                         </Link>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

https://wevoteusa.atlassian.net/browse/WV-505

### Changes included this pull request?
In BallotTitleHeader:
-add button to address span to include it in the tab order

In ReadyFinePrint and Ready Introduction:
-renames ref to introHeaderRef to be more descriptive

In Issue Card:
-removes issueImage from the tab order to reduce redundancy
