### PR TITLE
WV-539 : Added Terms of Service and Privacy Policy text to Sign In Modal

### DIFF
--- a/src/js/common/components/SignIn/SignInOptionsPanel.jsx
+++ b/src/js/common/components/SignIn/SignInOptionsPanel.jsx
@@ -1,6 +1,6 @@
 import { Facebook, Twitter } from '@mui/icons-material';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Suspense } from 'react';
 import Button from 'react-bootstrap/Button';
 import styled from 'styled-components';
 import AnalyticsActions from '../../../actions/AnalyticsActions';
@@ -31,7 +31,7 @@ import LoadingWheel from '../Widgets/LoadingWheel';
 import signInModalGlobalState from '../Widgets/signInModalGlobalState';
 import SnackNotifier, { openSnackbar } from '../Widgets/SnackNotifier';
 
-
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../Widgets/OpenExternalWebSite'));
 /* global $ */
 
 const debugMode = false;
@@ -412,6 +412,9 @@ export default class SignInOptionsPanel extends Component {
     //   'hideFacebookSignInButton', hideFacebookSignInButton, 'hideDialogForCordova', hideDialogForCordova,
     //   '\nisOnFacebookSupportedDomainUrl', isOnFacebookSupportedDomainUrl, 'isOnWeVoteRootUrl', isOnWeVoteRootUrl);
 
+    const termsOfServiceURL = `${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/terms`;
+    const privacyPolicyURL = `${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/privacy`;
+
     return (
       <>
         <SnackNotifier />
@@ -620,6 +623,37 @@ export default class SignInOptionsPanel extends Component {
               <br />
             </div>
             )}
+            <TermsWrapper>
+              By continuing, you accept WeVote.US’s 
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="openTermsOfService"
+                  url={termsOfServiceURL}
+                  target="_blank"
+                  className="open-web-site"
+                  body={(
+                    <span>
+                      Terms of Service
+                    </span>
+                  )}
+                />
+              </Suspense> 
+              and 
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="openPrivacyPolicy"
+                  url={privacyPolicyURL}
+                  target="_blank"
+                  className="open-web-site open-web-site__no-right-padding"
+                  body={(
+                    <span>
+                      Privacy Policy
+                    </span>
+                  )}
+                />
+              </Suspense> 
+              .
+              </TermsWrapper>
           </Main>
         </SignInOptionsPanelWrapper>
       </>
@@ -643,6 +677,12 @@ const OrWrapper = styled('div')(({ theme }) => (`
   ${theme.breakpoints.down('sm')} {
     margin-bottom: -2px;
     margin-top: 0;
+  }
+`));
+
+const TermsWrapper = styled('div')(({ theme }) => (`
+  ${theme.breakpoints.down('sm')} {
+    padding-top: 30px;
   }
 `));
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
https://wevoteusa.atlassian.net/browse/WV-539

### Changes included this pull request?
- Adds text and links to the Privacy Policy and Terms and Conditions to the Login Modal
- Some styling to space the text in small windows

I encountered an existing error when going directly to the Privacy policy in a new tab. Screenshots below.

![Screenshot 2024-09-24 at 1 49 48 PM](https://github.com/user-attachments/assets/89fc829e-5990-4332-9d4a-0fd22383af1b)
![Screenshot 2024-09-24 at 1 49 34 PM](https://github.com/user-attachments/assets/66bd3010-7bbb-4bb9-9e58-7dfa685a1ea7)
