### PR TITLE
chore(config): update WebdriverIO local and browserstack configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "wdio:setup": "node tests/browserstack_automation/buildMobileCapabilities.js",
     "wdio": "wdio ./tests/browserstack_automation/config/wdio.config.js",
-    "wdio-local": "wdio ./tests/browserstack_automation/config/wdio.config.local.js",
+    "wdio-local-bs": "wdio ./tests/browserstack_automation/config/wdio.config.local.js",
+    "wdio-local": "wdio ./tests/browserstack_automation/config/wdio.local.config.js",
     "build": "node node/buildDateFile.js && npm run build-storybook && PRODUCTION=1 && MINIMIZED=1 webpack --mode production",
     "buildCordova": "node node/buildDateFile.js && node node/buildSrcCordova && CORDOVA=1 && webpack --mode development && node node/logCompileDate.js",
     "buildCordovaAndLinks": "node node/buildDateFile.js && node node/buildSrcCordova && CORDOVA=1 && webpack --mode development && node node/buildSymLinksRemote.js && bash ./node/unSymLinkIOS.sh && node node/logCompileDate.js",

--- a/tests/browserstack_automation/config/wdio.local.config.js
+++ b/tests/browserstack_automation/config/wdio.local.config.js
@@ -1,0 +1,17 @@
+const { config } = require('./wdio.config.js'); 
+
+config.capabilities = [{
+  maxInstances: 5,
+  browserName: 'chrome',
+  acceptInsecureCerts: true,
+  'goog:chromeOptions': {
+    args: ['--start-maximized']
+  }
+}];
+
+delete config.user;
+delete config.key;
+config.services = [];
+
+module.exports = { config };
+


### PR DESCRIPTION
Updated WebdriverIO configuration to run test between local browser and BrowserStack.

Test should be executed on local browser (chrome) instead of BrowserStack WHEN we run test(s) locally using 
`(WebAppEnv) $ npm run wdio-local -- --spec [specs_dir_path]/[spec].js` which make it easier for debugging during creating automated test script.

To run test locally on Browserstack, just run command: `(WebAppEnv) $ npm run wdio-local-bs -- --spec [specs_dir_path]/[spec].js`
