### PR TITLE
[Wv-581] implement learn more modal challenge invite friends

### DIFF
--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -8,7 +8,6 @@ import stringContains from '../../utils/stringContains';
 import CandidateStore from '../../../stores/CandidateStore';
 import MeasureStore from '../../../stores/MeasureStore';
 import SupportStore from '../../../stores/SupportStore';
-import PayToPromoteProcess from '../CampaignSupport/PayToPromoteProcess';
 
 // const PayToPromoteProcess = React.lazy(() => import(/* webpackChunkName: 'PayToPromoteProcess' */ './PayToPromoteProcess')); // eslint-disable-line import/no-cycle
 
@@ -190,10 +189,8 @@ class BoostLearnMoreModal extends Component {
 
     return (
       <ModalDisplayTemplateA
-       // dialogTitleJSX={<>{dialogTitleText}</>} commented because it is not working but can restore if needed
+        dialogTitleJSX={<>{dialogTitleText}</>}
         show={show}
-        dialogTitleJSX={<div>Learn More</div>}
-        //textFieldJSX={<div>Learn more content here</div>}
         // tallMode commented because it is not working but can restore if needed
         textFieldJSX={textFieldJSX}
         toggleModal={this.props.toggleModal}

--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -8,7 +8,6 @@ import stringContains from '../../utils/stringContains';
 import CandidateStore from '../../../stores/CandidateStore';
 import MeasureStore from '../../../stores/MeasureStore';
 import SupportStore from '../../../stores/SupportStore';
-import PayToPromoteProcess from '../CampaignSupport/PayToPromoteProcess';
 
 // const PayToPromoteProcess = React.lazy(() => import(/* webpackChunkName: 'PayToPromoteProcess' */ './PayToPromoteProcess')); // eslint-disable-line import/no-cycle
 
@@ -183,11 +182,8 @@ class BoostLearnMoreModal extends Component {
     // console.log('BoostLearnMoreModal render, voter_address_object: ', voter_address_object);
     const textFieldJSX = (
       <TextFieldWrapper>
-        <PayToPromoteProcess
-          campaignXWeVoteId={campaignXWeVoteId}
-          chipInPaymentValueDefault="1.00"
-          lowerDonations
-        />
+        
+        <div>Learn more content here</div>
       </TextFieldWrapper>
     );
 
@@ -196,9 +192,9 @@ class BoostLearnMoreModal extends Component {
        // dialogTitleJSX={<>{dialogTitleText}</>} commented because it is not working but can restore if needed
         show={show}
         dialogTitleJSX={<div>Learn More</div>}
-        textFieldJSX={<div>Learn more content here</div>}
+        //textFieldJSX={<div>Learn more content here</div>}
         // tallMode commented because it is not working but can restore if needed
-       // textFieldJSX={textFieldJSX} commented because it is not working but can restore if needed
+        textFieldJSX={textFieldJSX}
         toggleModal={this.props.toggleModal}
       />
     );

--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -1,0 +1,211 @@
+import withStyles from '@mui/styles/withStyles';
+import withTheme from '@mui/styles/withTheme';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import ModalDisplayTemplateA, { templateAStyles, TextFieldWrapper } from '../../../components/Widgets/ModalDisplayTemplateA';
+import { renderLog } from '../../utils/logging';
+import stringContains from '../../utils/stringContains';
+import CandidateStore from '../../../stores/CandidateStore';
+import MeasureStore from '../../../stores/MeasureStore';
+import SupportStore from '../../../stores/SupportStore';
+import PayToPromoteProcess from '../CampaignSupport/PayToPromoteProcess';
+
+// const PayToPromoteProcess = React.lazy(() => import(/* webpackChunkName: 'PayToPromoteProcess' */ './PayToPromoteProcess')); // eslint-disable-line import/no-cycle
+
+class BoostLearnMoreModal extends Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+  componentDidMount () {
+    this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
+    // this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
+    this.candidateStoreListener = CandidateStore.addListener(this.onCandidateStoreChange.bind(this));
+    this.measureStoreListener = MeasureStore.addListener(this.onMeasureStoreChange.bind(this));
+    const { ballotItemWeVoteId } = this.props;
+    const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);
+    if (ballotItemStatSheet) {
+      const { voterOpposesBallotItem, voterSupportsBallotItem } = ballotItemStatSheet;
+      this.setState({
+        voterOpposesBallotItem,
+        voterSupportsBallotItem,
+      });
+    }
+
+    // const voter = VoterStore.getVoter();
+    // const voterIsSignedIn = VoterStore.getVoterIsSignedIn();
+    // const { voter_photo_url_medium: voterPhotoUrlMedium } = voter;
+
+    let ballotItemDisplayName = '';
+    // let ballotItemType;
+    let campaignXWeVoteId;
+    let isCandidate = false;
+    let isMeasure = false;
+    if (stringContains('cand', this.props.ballotItemWeVoteId)) {
+      const candidate = CandidateStore.getCandidateByWeVoteId(this.props.ballotItemWeVoteId);
+      ballotItemDisplayName = candidate.ballot_item_display_name || '';
+      // ballotItemType = 'CANDIDATE';
+      campaignXWeVoteId = candidate.linked_campaignx_we_vote_id || '';
+      isCandidate = true;
+    } else if (stringContains('meas', this.props.ballotItemWeVoteId)) {
+      const measure = MeasureStore.getMeasure(this.props.ballotItemWeVoteId);
+      ballotItemDisplayName = measure.ballot_item_display_name || '';
+      // ballotItemType = 'MEASURE';
+      isMeasure = true;
+    }
+    this.setState({
+      ballotItemDisplayName,
+      // ballotItemType,
+      campaignXWeVoteId,
+      isCandidate,
+      isMeasure,
+      // voterIsSignedIn,
+      // voterPhotoUrlMedium,
+    });
+  }
+
+  componentDidUpdate () {
+    const { initialFocusSet } = this.state;
+    if (this.positionInput) {
+      // Set the initial focus at the end of any existing text
+      if (!initialFocusSet) {
+        const { positionInput } = this;
+        const { length } = positionInput.value;
+        positionInput.focus();
+        positionInput.setSelectionRange(length, length);
+        this.setState({
+          initialFocusSet: true,
+        });
+      }
+    }
+  }
+
+  componentWillUnmount () {
+    this.candidateStoreListener.remove();
+    this.measureStoreListener.remove();
+    this.supportStoreListener.remove();
+    // this.voterStoreListener.remove();
+  }
+
+  onCandidateStoreChange () {
+    if (this.state.isCandidate) {
+      const { ballotItemWeVoteId } = this.props;
+      const candidate = CandidateStore.getCandidateByWeVoteId(ballotItemWeVoteId);
+      const ballotItemDisplayName = candidate.ballot_item_display_name || '';
+      const campaignXWeVoteId = candidate.linked_campaignx_we_vote_id || '';
+      this.setState({
+        ballotItemDisplayName,
+        campaignXWeVoteId,
+      });
+    }
+  }
+
+  onMeasureStoreChange () {
+    if (this.state.isMeasure) {
+      const { ballotItemWeVoteId } = this.props;
+      const measure = MeasureStore.getMeasure(ballotItemWeVoteId);
+      const ballotItemDisplayName = measure.ballot_item_display_name || '';
+      this.setState({
+        ballotItemDisplayName,
+      });
+    }
+  }
+
+  onSupportStoreChange () {
+    const { ballotItemWeVoteId } = this.props;
+    const ballotItemStatSheet = SupportStore.getBallotItemStatSheet(ballotItemWeVoteId);
+    let voterOpposesBallotItem = '';
+    let voterSupportsBallotItem = '';
+    // let voterTextStatement = '';
+    // let voterPositionIsPublic = '';
+    if (ballotItemStatSheet) {
+      ({ voterOpposesBallotItem, voterSupportsBallotItem } = ballotItemStatSheet);
+    }
+    this.setState({
+      voterOpposesBallotItem,
+      voterSupportsBallotItem,
+    });
+
+    // if (ballotItemStatSheet) {
+    //   ({ voterPositionIsPublic, voterTextStatement } = ballotItemStatSheet);
+    // }
+    // this.setState({
+    //   voterTextStatement,
+    //   voterPositionIsPublic,
+    // });
+  }
+
+  // onVoterStoreChange () {
+  //   const voter = VoterStore.getVoter();
+  //   const voterIsSignedIn = VoterStore.getVoterIsSignedIn();
+  //   const { voter_photo_url_medium: voterPhotoUrlMedium } = voter;
+  //   this.setState({
+  //     voterIsSignedIn,
+  //     voterPhotoUrlMedium,
+  //   });
+  // }
+
+  render () {
+    renderLog('BoostLearnMoreModal');  // Set LOG_RENDER_EVENTS to log all renders
+    // const { ballotItemWeVoteId } = this.props;
+    const { show } = this.props;
+    // console.log('BoostLearnMoreModal render, ballotItemWeVoteId: ', ballotItemWeVoteId, ', show: ', show);
+    const {
+      // ballotItemDisplayName,
+      campaignXWeVoteId,
+      // voterOpposesBallotItem, voterSupportsBallotItem,
+    } = this.state;
+
+    // const horizontalEllipsis = '\u2026';
+    let dialogTitleText = '';
+
+    // if (voterSupportsBallotItem) {
+    //   if (ballotItemDisplayName) {
+    //     dialogTitleText = `Why you chose ${ballotItemDisplayName}${horizontalEllipsis}`;
+    //   } else {
+    //     dialogTitleText = `Why you support${horizontalEllipsis}`;
+    //   }
+    // } else if (voterOpposesBallotItem) {
+    //   if (ballotItemDisplayName) {
+    //     dialogTitleText = `Why you oppose ${ballotItemDisplayName}${horizontalEllipsis}`;
+    //   } else {
+    //     dialogTitleText = `Why you oppose${horizontalEllipsis}`;
+    //   }
+    // } else if (ballotItemDisplayName) {
+    //   dialogTitleText = `Your thoughts about ${ballotItemDisplayName}${horizontalEllipsis}`;
+    // } else {
+    //   dialogTitleText = `Your thoughts${horizontalEllipsis}`;
+    // }
+    dialogTitleText = ''; // Overwrite until we can adjust
+
+    // console.log('BoostLearnMoreModal render, voter_address_object: ', voter_address_object);
+    const textFieldJSX = (
+      <TextFieldWrapper>
+        <PayToPromoteProcess
+          campaignXWeVoteId={campaignXWeVoteId}
+          chipInPaymentValueDefault="1.00"
+          lowerDonations
+        />
+      </TextFieldWrapper>
+    );
+
+    return (
+      <ModalDisplayTemplateA
+        dialogTitleJSX={<>{dialogTitleText}</>}
+        show={show}
+        tallMode
+        textFieldJSX={textFieldJSX}
+        toggleModal={this.props.toggleModal}
+      />
+    );
+  }
+}
+BoostLearnMoreModal.propTypes = {
+  ballotItemWeVoteId: PropTypes.string.isRequired,
+  show: PropTypes.bool,
+  toggleModal: PropTypes.func.isRequired,
+};
+
+export default withTheme(withStyles(templateAStyles)(BoostLearnMoreModal));

--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -193,10 +193,12 @@ class BoostLearnMoreModal extends Component {
 
     return (
       <ModalDisplayTemplateA
-        dialogTitleJSX={<>{dialogTitleText}</>}
+       // dialogTitleJSX={<>{dialogTitleText}</>} commented because it is not working but can restore if needed
         show={show}
-        tallMode
-        textFieldJSX={textFieldJSX}
+        dialogTitleJSX={<div>Learn More</div>}
+        textFieldJSX={<div>Your content here</div>}
+        // tallMode commented because it is not working but can restore if needed
+       // textFieldJSX={textFieldJSX} commented because it is not working but can restore if needed
         toggleModal={this.props.toggleModal}
       />
     );

--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -180,7 +180,6 @@ class BoostLearnMoreModal extends Component {
     // console.log('BoostLearnMoreModal render, voter_address_object: ', voter_address_object);
     const textFieldJSX = (
       <TextFieldWrapper>
-        
         <div>Learn more content here</div>
       </TextFieldWrapper>
     );

--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -9,8 +9,6 @@ import CandidateStore from '../../../stores/CandidateStore';
 import MeasureStore from '../../../stores/MeasureStore';
 import SupportStore from '../../../stores/SupportStore';
 
-// const PayToPromoteProcess = React.lazy(() => import(/* webpackChunkName: 'PayToPromoteProcess' */ './PayToPromoteProcess')); // eslint-disable-line import/no-cycle
-
 class BoostLearnMoreModal extends Component {
   constructor (props) {
     super(props);

--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -196,7 +196,7 @@ class BoostLearnMoreModal extends Component {
        // dialogTitleJSX={<>{dialogTitleText}</>} commented because it is not working but can restore if needed
         show={show}
         dialogTitleJSX={<div>Learn More</div>}
-        textFieldJSX={<div>Your content here</div>}
+        textFieldJSX={<div>Learn more content here</div>}
         // tallMode commented because it is not working but can restore if needed
        // textFieldJSX={textFieldJSX} commented because it is not working but can restore if needed
         toggleModal={this.props.toggleModal}

--- a/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
+++ b/src/js/common/components/ChallengeInviteFriends/BoostLearnMoreModal.jsx
@@ -8,6 +8,7 @@ import stringContains from '../../utils/stringContains';
 import CandidateStore from '../../../stores/CandidateStore';
 import MeasureStore from '../../../stores/MeasureStore';
 import SupportStore from '../../../stores/SupportStore';
+import PayToPromoteProcess from '../CampaignSupport/PayToPromoteProcess';
 
 // const PayToPromoteProcess = React.lazy(() => import(/* webpackChunkName: 'PayToPromoteProcess' */ './PayToPromoteProcess')); // eslint-disable-line import/no-cycle
 

--- a/src/js/common/components/Navigation/ChallengeInviteSteps.jsx
+++ b/src/js/common/components/Navigation/ChallengeInviteSteps.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Link, withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { withStyles } from '@mui/styles';
@@ -12,6 +12,8 @@ import StepOneIcon from '../../../../img/global/svg-icons/issues/material-symbol
 import StepOneActiveIcon from '../../../../img/global/svg-icons/issues/material-symbols-counter-1-active.svg';
 import StepTwoIcon from '../../../../img/global/svg-icons/issues/material-symbols-counter-2.svg';
 import StepTwoActiveIcon from '../../../../img/global/svg-icons/issues/material-symbols-counter-2-active.svg';
+
+const BoostLearnMoreModal = React.lazy(() => import(/* webpackChunkName: 'BoostLearnMoreModal' */ '../ChallengeInviteFriends/BoostLearnMoreModal'));
 
 // Color and font variables
 const commonTextStyle = {
@@ -29,8 +31,10 @@ class ChallengeInviteSteps extends React.Component {
     super(props);
     this.state = {
       activeStep: this.getActiveStepFromPath(),
+      showBoostLearnMoreModal: false,
     };
   }
+
   // Get the current step based on the URL to determine which step is active by default when the page loads
   getActiveStepFromPath = () => {
     const { location } = this.props;
@@ -65,6 +69,13 @@ class ChallengeInviteSteps extends React.Component {
     this.setState({ activeStep: stepNumber });
   };
 
+  // Function to toggle modal visibility
+  toggleBoostLearnMoreModal = () => {
+    this.setState((prevState) => ({
+      showBoostLearnMoreModal: !prevState.showBoostLearnMoreModal,
+    }));
+  };
+
   render() {
     return (
       <ChallengeInviteStepsContainer>
@@ -80,7 +91,7 @@ class ChallengeInviteSteps extends React.Component {
           </h2>
           <Wrapper>
             <LearnMoreTextBlock />
-            <button type="button">
+            <button type="button" onClick={this.toggleBoostLearnMoreModal}>
               Learn more
             </button>
           </Wrapper>
@@ -128,6 +139,16 @@ class ChallengeInviteSteps extends React.Component {
             </Link>
           </StepTwoIconAndText>
         </StepsContainer>
+        {/* Render BoostLearnMoreModal */}
+        <Suspense fallback={<></>}>
+          {this.state.showBoostLearnMoreModal && (
+            <BoostLearnMoreModal
+              show={this.state.showBoostLearnMoreModal}
+              toggleModal={this.toggleBoostLearnMoreModal}
+              ballotItemWeVoteId={this.props.challengeWeVoteId}
+            />
+          )}
+        </Suspense>
       </ChallengeInviteStepsContainer>
     );
   }


### PR DESCRIPTION
1) Created a new component BoostLearnMoreModal.jsx from HelpWinOrDefeatModal.jsx. 
Added import to ChallengeInviteSteps.jsx

2) ChallengeInviteSteps.jsx 
- Render BoostLearnMoreModal component within a Suspense wrapper to optimize loading 
- Added conditional rendering for BoostLearnMoreModal, ensuring it only shows when the showBoostLearnMoreModal state is true.
-Added the toggleBoostLearnMoreModal function to manage modal visibility by toggling showBoostLearnMoreModal state.
- Added an onClick handler to trigger the modal visibility toggle when needed.

                  *************************IMPORTANT*****************************
The original modal was not working to me -  the modal remained constantly loaded.
 After reviewing, I simplified the code by commenting a few lines and using basic divs. Now, the modal works, though there could be other underlying issues in the original code. 
   Here screenshots about it. 
<img width="1710" alt="223" src="https://github.com/user-attachments/assets/ba96a9bd-9fe3-4d5a-9f5b-07de966cb61c">
<img width="1710" alt="Screenshot 2024-10-07 at 1 17 42 PM" src="https://github.com/user-attachments/assets/3cdd67ff-185c-473d-a537-df9dd482be02">

