### PR TITLE
 WV-41 [TEAM REVIEW] Set open state on Unfollow menu 

### DIFF
--- a/src/js/components/Values/IssueFollowToggleButton.jsx
+++ b/src/js/components/Values/IssueFollowToggleButton.jsx
@@ -141,6 +141,8 @@ class IssueFollowToggleButton extends Component {
     this.setState({
       isFollowing: false,
       isFollowingLocalValue: false,
+      open: false,
+      anchorEl: null
     });
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[Unfollow dropdown option shifted to top of screen on Web and Mobile devices. ](https://wevoteusa.atlassian.net/browse/WV-41)

### Changes included this pull request?
Added open state change when Unfollowing to keep the menu from appearing in the upper right hand corner when re-following.