### PR TITLE
Wv 583 place joined and days left over challenge images on challenge home page

### DIFF
--- a/src/js/common/components/ChallengeListRoot/ChallengeCardList.jsx
+++ b/src/js/common/components/ChallengeListRoot/ChallengeCardList.jsx
@@ -13,6 +13,7 @@ import { isWebApp } from '../../utils/isCordovaOrWebApp';
 import ChallengeStore from '../../stores/ChallengeStore';
 import JoinChallengeAndLearnMoreButtons from '../Challenge/JoinChallengeAndLearnMoreButtons';
 import JoinedAndDaysLeft from '../Challenge/JoinedAndDaysLeft';
+import DesignTokenColors from '../Style/DesignTokenColors';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../Widgets/DelayedLoad'));
 
@@ -184,9 +185,9 @@ class ChallengeCardList extends Component {
                     useVerticalCard={useVerticalCard}
                   />
                   {/* JoinedAndDaysLeft component positioned absolutely */}
-                  <StyledJoinedAndDaysLeft>
+                  <JoinedAndDaysForChallengePage>
                     <JoinedAndDaysLeft challengeWeVoteId={oneChallenge.challenge_we_vote_id} />
-                  </StyledJoinedAndDaysLeft>
+                  </JoinedAndDaysForChallengePage>
                 </CardContainer>
                 <Link
                   id="challengeCardAbout"
@@ -220,16 +221,16 @@ class ChallengeCardList extends Component {
           )}
           */}
           {!!(challengeList &&
-              challengeList.length > 1 &&
-              numberToDisplay < challengeList.length) &&
-          (
-            <LoadMoreItemsManuallyWrapper>
-              <LoadMoreItemsManually
-                loadMoreFunction={this.loadMoreHasBeenClicked}
-                uniqueExternalId="ChallengeCardList"
-              />
-            </LoadMoreItemsManuallyWrapper>
-          )}
+            challengeList.length > 1 &&
+            numberToDisplay < challengeList.length) &&
+            (
+              <LoadMoreItemsManuallyWrapper>
+                <LoadMoreItemsManually
+                  loadMoreFunction={this.loadMoreHasBeenClicked}
+                  uniqueExternalId="ChallengeCardList"
+                />
+              </LoadMoreItemsManuallyWrapper>
+            )}
         </ListWrapper>
         <Suspense fallback={<></>}>
           <DelayedLoad loadingTextLeftAlign showLoadingText waitBeforeShow={2000}>
@@ -293,7 +294,7 @@ const CardContainer = styled('div')`
 const ChallengeCardForListVerticalWrapper = styled('div')`
   display: flex;
   flex-direction: column;
-  // height: ${isWebApp() ?  '100%' : 'unset'};
+  // height: ${isWebApp() ? '100%' : 'unset'};
   width: 80%;
   max-width: 300px;
 `;
@@ -301,10 +302,11 @@ const ChallengeCardForListVerticalWrapper = styled('div')`
 const Wrapper = styled('div')`
   min-height: 30px;
 `;
-const StyledJoinedAndDaysLeft = styled('div')`
+
+const JoinedAndDaysForChallengePage = styled('div')`
 align-items: center;
 border-radius: 20px;
-color: #000;
+color: ${DesignTokenColors.gray900};
 display: flex;
 font-size: 12px;
 left: 10px;

--- a/src/js/common/components/ChallengeListRoot/ChallengeCardList.jsx
+++ b/src/js/common/components/ChallengeListRoot/ChallengeCardList.jsx
@@ -12,6 +12,7 @@ import ChallengeAbout from '../Challenge/ChallengeAbout';
 import { isWebApp } from '../../utils/isCordovaOrWebApp';
 import ChallengeStore from '../../stores/ChallengeStore';
 import JoinChallengeAndLearnMoreButtons from '../Challenge/JoinChallengeAndLearnMoreButtons';
+import JoinedAndDaysLeft from '../Challenge/JoinedAndDaysLeft';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../Widgets/DelayedLoad'));
 
@@ -175,12 +176,18 @@ class ChallengeCardList extends Component {
             numberDisplayed += 1;
             return (
               <ChallengeCardForListVerticalWrapper key={`oneChallengeItem-${oneChallenge.challenge_we_vote_id}`}>
-                <ChallengeCardForList
-                  challengeWeVoteId={oneChallenge.challenge_we_vote_id}
-                  joinedAndDaysLeftOff
-                  limitCardWidth={useVerticalCard}
-                  useVerticalCard={useVerticalCard}
-                />
+                <CardContainer>
+                  <ChallengeCardForList
+                    challengeWeVoteId={oneChallenge.challenge_we_vote_id}
+                    joinedAndDaysLeftOff
+                    limitCardWidth={useVerticalCard}
+                    useVerticalCard={useVerticalCard}
+                  />
+                  {/* JoinedAndDaysLeft component positioned absolutely */}
+                  <StyledJoinedAndDaysLeft>
+                    <JoinedAndDaysLeft challengeWeVoteId={oneChallenge.challenge_we_vote_id} />
+                  </StyledJoinedAndDaysLeft>
+                </CardContainer>
                 <Link
                   id="challengeCardAbout"
                   to={this.onChallengeClickLink(oneChallenge.challenge_we_vote_id)}
@@ -279,6 +286,10 @@ const styles = () => ({
   },
 });
 
+const CardContainer = styled('div')`
+  position: relative;
+`;
+
 const ChallengeCardForListVerticalWrapper = styled('div')`
   display: flex;
   flex-direction: column;
@@ -289,6 +300,17 @@ const ChallengeCardForListVerticalWrapper = styled('div')`
 
 const Wrapper = styled('div')`
   min-height: 30px;
+`;
+const StyledJoinedAndDaysLeft = styled('div')`
+align-items: center;
+border-radius: 20px;
+color: #000;
+display: flex;
+font-size: 12px;
+left: 10px;
+padding: 5px 10px;
+position: absolute;
+top: 125px;
 `;
 
 export default withStyles(styles)(ChallengeCardList);


### PR DESCRIPTION
Fixed  'Joined and Days Left' over challenge images on the Challenge home page. 
**IMPORTANT**
**After facing limitations adding this functionality through `src/js/common/components/ChallengeListRoot/ChallengeCardForListBody.jsx`, I integrated the feature directly into `src/js/common/components/ChallengeListRoot/ChallengeCardList.jsx`.**

1) Created a custom-styled component `JoinAndDaysForChallengePage` specifically for the `ChallengeCardList.jsx` page, allowing absolute positioning and unique styles without affecting other components using `JoinedAndDaysLeft`.
2) Added `DesignTokenColors` in `JoinedAndDaysLeft` for consistent styles usage across the application.
3) Updated `ChallengeCardList.jsx` to import and use the `JoinAndDaysForChallengePage` styled component, positioning it correctly over the challenge card image.
