### PR TITLE
[WV-547] Fixed Tab Key navigation for the sign-in page [Team Review]

### DIFF
--- a/src/js/common/components/SignIn/SignInOptionsPanel.jsx
+++ b/src/js/common/components/SignIn/SignInOptionsPanel.jsx
@@ -552,6 +552,7 @@ export default class SignInOptionsPanel extends Component {
               // hideSignInWithPhoneForm={isCordova()}
               showAllSignInOptions={this.showAllSignInOptions}
               showPhoneOnlySignIn={this.showPhoneOnlySignIn}
+              showEmailOnlySignIn={this.showEmailOnlySignIn}
             />
             {/* {isCordova() && ( */}
             {/*  <VoterPhoneEmailCordovaEntryModal */}

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -242,8 +242,12 @@ class VoterEmailAddressEntry extends Component {
       this.setState({
         displayEmailVerificationButton: false,
       });
+      const TermsOfServiceLink = document.getElementById("openTermsOfService");
+      if (TermsOfServiceLink) {
+        TermsOfServiceLink.focus(); 
+      }
       blurTextFieldAndroid();
-    }
+    } 
   };
 
   onCancel = () => {
@@ -266,6 +270,10 @@ class VoterEmailAddressEntry extends Component {
       if (this.props.showAllSignInOptions) {
         this.props.showAllSignInOptions();
       }
+    }
+    const TermsOfServiceLink = document.getElementById("openTermsOfService");
+    if (TermsOfServiceLink) {
+      TermsOfServiceLink.focus(); 
     }
   };
 

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -280,6 +280,10 @@ class VoterPhoneVerificationEntry extends Component {
       this.setState({
         displayPhoneVerificationButton: false,
       });
+      const nextField = document.getElementById("enterVoterEmailAddress") || document.getElementById("openTermsOfService");    
+      if (nextField) {
+        nextField.focus();
+      }
     }
     blurTextFieldAndroid();
   };
@@ -306,12 +310,18 @@ class VoterPhoneVerificationEntry extends Component {
       // WV-316: seperated Cordovoa and Mobile screen cancel logic, Mobile only shows all sign in options on cancel.
       // if (this.props.showAllSignInOptions) {
       //   this.props.showAllSignInOptions();
-      // }
+      // }  
     } else if (isMobileScreenSize()) {
-      if (this.props.showAllSignInOptions) {
-        this.props.showAllSignInOptions();
+      if (this.props.showEmailOnlySignIn) {
+        this.props.showEmailOnlySignIn();
+      }
+    } else {
+      const nextField = document.getElementById("enterVoterEmailAddress") || document.getElementById("openTermsOfService");    
+      if (nextField) {
+        nextField.focus();
       }
     }
+
   };
 
   onFocus = () => {
@@ -738,6 +748,7 @@ VoterPhoneVerificationEntry.propTypes = {
   lockOpenPhoneVerificationButton: PropTypes.bool,
   showAllSignInOptions: PropTypes.func,
   showPhoneOnlySignIn: PropTypes.func,
+  showEmailOnlySignIn: PropTypes.func
 };
 
 const styles = {


### PR DESCRIPTION
SignInOptionsPanel.js - added showEmailOnlysignIn() to VoterPhoneVerificationEntry.js as prop

VoterPhoneVerificationEntry.jsx - In OnBlur() and OnCancel() functions added code to set the focus back on the correct field.

VoterEmailAddressEntry.jsx -  In OnBlur() and OnCancel() functions added code to set the focus back on the correct field.
