### PR TITLE
[WV-523] Push voter_we_vote_id to GA4 from within WebApp user data [TEAM REVIEW]

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -234,16 +234,13 @@ class App extends Component {
       AppObservableStore.setGoogleAnalyticsPending(true);
       setTimeout(() => {
         const chosenTrackingId = AppObservableStore.getChosenGoogleAnalyticsTrackingID();
-        const weVoteTrackingId = webAppConfig.GOOGLE_ANALYTICS_TRACKING_ID === undefined ? '' : webAppConfig.GOOGLE_ANALYTICS_TRACKING_ID;
+        const weVoteTrackingId = webAppConfig.GOOGLE_ANALYTICS_TRACKING_ID || '';
+
         if (chosenTrackingId && weVoteTrackingId) {
           console.log('Google Analytics (2) ENABLED');
           ReactGA.initialize([
-            {
-              trackingId: chosenTrackingId,
-            },
-            {
-              trackingId: weVoteTrackingId,
-            },
+            { trackingId: chosenTrackingId },
+            { trackingId: weVoteTrackingId },
           ]);
         } else if (chosenTrackingId) {
           console.log('Google Analytics Chosen ENABLED');
@@ -258,16 +255,22 @@ class App extends Component {
         } else {
           console.log('Google Analytics did not receive a trackingID, NOT ENABLED');
         }
+
         const voterWeVoteId = VoterStore.getVoterWeVoteId();
-        const weVoteGTMId = webAppConfig.GOOGLE_ADS_TRACKING_ID === undefined ? '' : webAppConfig.GOOGLE_ADS_TRACKING_ID;
+        const weVoteGTMId = webAppConfig.GOOGLE_TAG_MANAGER_ID || '';
+
         if (weVoteGTMId) {
           const tagManagerArgs = {
-            gtmId: webAppConfig.GOOGLE_TAG_MANAGER_ID,
+            gtmId: weVoteGTMId,
             dataLayer: {
               weVoteId: voterWeVoteId,
             },
           };
+
+          console.log('Initializing Google Tag Manager with GTM ID:', weVoteGTMId);
           TagManager.initialize(tagManagerArgs);
+        } else {
+          console.log('Google Tag Manager did not receive a valid GTM ID, NOT ENABLED');
         }
       }, 3000);
     }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -259,13 +259,13 @@ class App extends Component {
           console.log('Google Analytics did not receive a trackingID, NOT ENABLED');
         }
         const voterWeVoteId = VoterStore.getVoterWeVoteId();
-        ReactGA.gtag('set', 'voter', {
-          weVoteId: voterWeVoteId,
-        });
         const weVoteGTMId = webAppConfig.GOOGLE_ADS_TRACKING_ID === undefined ? '' : webAppConfig.GOOGLE_ADS_TRACKING_ID;
         if (weVoteGTMId) {
           const tagManagerArgs = {
-            gtmId: weVoteGTMId,
+            gtmId: webAppConfig.GOOGLE_TAG_MANAGER_ID,
+            dataLayer: {
+              weVoteId: voterWeVoteId,
+            },
           };
           TagManager.initialize(tagManagerArgs);
         }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -239,8 +239,12 @@ class App extends Component {
         if (chosenTrackingId && weVoteTrackingId) {
           console.log('Google Analytics (2) ENABLED');
           ReactGA.initialize([
-            { trackingId: chosenTrackingId },
-            { trackingId: weVoteTrackingId },
+            {
+              trackingId: chosenTrackingId,
+            },
+            {
+              trackingId: weVoteTrackingId,
+            },
           ]);
         } else if (chosenTrackingId) {
           console.log('Google Analytics Chosen ENABLED');


### PR DESCRIPTION
It now attaches the wevoterid to the datalayer using the TagManager datalayer. Did you mean for the GTMId to be the GOOGLE_ADS_TRACKING_ID @DaleMcGrew I made a seperate key value pair in the config but can adjust that if you prefer the former.