### PR TITLE
[wv-518] Refactored component styles, remove timer from YourRank sinc…

### DIFF
--- a/src/js/common/components/Challenge/YourRank.jsx
+++ b/src/js/common/components/Challenge/YourRank.jsx
@@ -76,13 +76,10 @@ const YourRank = ({ classes, challengeWeVoteId }) => {
     };
   }, [challengeWeVoteId]);
 
+  // Show confetti when the component mounts
   useEffect(() => {
-    // Show confetti when the component mounts
     triggerConfetti();
-    // Hide confetti after a short duration
-    const timer = setTimeout(() => {
-    }, 5000);
-    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -97,14 +94,15 @@ const YourRank = ({ classes, challengeWeVoteId }) => {
             onClick={handleClick}
             classes={{ root: classes.buttonDesktop }}
             style={{
-              backgroundColor: clicked ? '#AC5204' : 'white',
-              color: clicked ? '#FFFFFF' : '#AC5204'}}
+              backgroundColor: clicked ? DesignTokenColors.accent500 : DesignTokenColors.whiteUI,
+              color: clicked ? DesignTokenColors.whiteUI : DesignTokenColors.accent500,
+            }}
           >
             #
             {rankOfVoter}
             {' '}
             <StyledArrowContainer>
-              <ArrowImg src={arrowImage} alt="arrow"/>
+              <ArrowImg src={arrowImage} alt="arrow" />
             </StyledArrowContainer>
           </Button>
         </YourRankButtonWrapper>
@@ -125,34 +123,34 @@ const YourRank = ({ classes, challengeWeVoteId }) => {
 const styles = (theme) => ({
   buttonDesktop: {
     boxShadow: 'none !important',
-    color: '#AC5204',
-    height: '34px',
-    border: '1px solid #AC5204',
+    border: `1px solid ${DesignTokenColors.accent500}`,
     borderRadius: '20px 20px 20px 20px',
+    color: DesignTokenColors.accent500,
+    height: '34px',
     transition: 'color 0.3s ease',
     textTransform: 'none',
     width: '105px',
   },
   desktopSimpleLink: {
-    border: '2px solid #AC5204',
+    border: `2px solid ${DesignTokenColors.accent500}`,
     boxShadow: 'none !important',
-    color: '#999',
+    color: DesignTokenColors.neutral500,
     marginTop: 10,
     padding: '0 20px',
     textTransform: 'none',
     width: 250,
   },
   mobileSimpleLink: {
+    '&:hover': {
+      color: DesignTokenColors.primary500,
+      textDecoration: 'underline',
+    },
     boxShadow: 'none !important',
-    color: '#999',
+    color: DesignTokenColors.neutral500,
     marginTop: 10,
     padding: '0 20px',
     textTransform: 'none',
     width: '100%',
-    '&:hover': {
-      color: '#4371cc',
-      textDecoration: 'underline',
-    },
   },
 });
 
@@ -171,18 +169,16 @@ const YourRankOuterWrapper = styled('div')`
 const YourRankButtonWrapper = styled('div', {
   shouldForwardProp: (prop) => !['clicked'].includes(prop),
 })(({ clicked }) => `
-  background-color: ${clicked ? DesignTokenColors.orange500 : DesignTokenColors.white};
-  width: 105px;
-  height: 34px;
-  // top: 443px;
-  // left: 234px;
-  gap: 0;
-  border-radius: 20px;
-  border: 1px solid #AC5204;
-  display: flex;
   align-items: center;
+  background-color: ${clicked ? DesignTokenColors.accent500 : DesignTokenColors.whiteUI};
+  border: 1px solid ${DesignTokenColors.accent500};
+  border-radius: 20px;
+  display: flex;
+  gap: 0;
+  height: 34px;
   justify-content: center;
   transition: background-color 0.3s ease, color 0.3s ease;
+  width: 105px;
 `);
 
 const YourRankText = styled('div')`
@@ -190,18 +186,18 @@ const YourRankText = styled('div')`
 `;
 
 const StyledArrowContainer = styled('div')`
-  width: '10.5px',
-  height: '12.5px',
-  top: '2.75px',
-  left: '14.25px',
+  angle: -90deg,
   gap: 0,
+  height: 12.5px,
+  left: 14.25px,
   opacity: 0,
-  angle: '-90 deg',
+  top: 2.75px,
+  width: 10.5px,
 `;
 
 const ArrowImg = styled('img')`
-  width: 10.5px;
   height: 12.5px;
+  width: 10.5px;
 `;
 
 export default withStyles(styles)(YourRank);


### PR DESCRIPTION
…e we use react confetti. Alphabetized CSS properties

[wv-518] Refactored component styles to ensure consistent color usage, primarily using DesignTokenColors.accent500 and DesignTokenColors.neutral500 for color styling. Alphabetized CSS properties in YourRankButtonWrapper, buttonDesktop, desktopSimpleLink, and mobileSimpleLink for better readability and maintainability.

add styles

add styles

add styles

Refactored YourRank component: replaced hardcoded colors with DesignTokenColors, fixed template literal usage, and cleaned up CSS syntax in styled components.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
