### PR TITLE
WV-546 SignIn Page - Misaligned SignIn with Twitter and SignIn with Apple buttons, misaligned logo icons, and incorrect text for 'Sign In with Twitter'

### DIFF
--- a/src/js/common/components/SignIn/SignInOptionsPanel.jsx
+++ b/src/js/common/components/SignIn/SignInOptionsPanel.jsx
@@ -1,4 +1,4 @@
-import { Facebook, Twitter } from '@mui/icons-material';
+import { Facebook, X as Twitter } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import Button from 'react-bootstrap/Button';

--- a/src/js/components/Apple/AppleSignIn.jsx
+++ b/src/js/components/Apple/AppleSignIn.jsx
@@ -236,9 +236,9 @@ const AppleLogoSvg = styled('svg', {
   shouldForwardProp: (prop) => !['signedIn', 'enabled'].includes(prop),
 })(({ signedIn, enabled }) => (`
   position: absolute;
-  left: ${signedIn ? '29%' : '5%'};
+  left: ${signedIn ? '29%' : '13.3px'};
   top: 11px;
-  height: 20px;
+  width: 24px;
   color: ${enabled ? '#fff' : 'grey'};
 `));
 
@@ -262,9 +262,10 @@ https://developer.apple.com/design/resources/ or we risk getting rejected by App
 const AppleSignInButton = styled('button', {
   shouldForwardProp: (prop) => !['isWeb', 'tinyScreen'].includes(prop),
 })(({ isWeb, tinyScreen }) => (`
-  margin-top: ${isWeb ? '8px' : '10px'};
+  margin-top: ${isWeb ? '11px' : '13px'};
   border: none;
-  padding-left: ${tinyScreen ? '20px' : '40px'};
+  margin-left: ${tinyScreen ? '20px' : '0px'};
+  text-align: center;
   background-color: #000;
   color: #fff;
 `));
@@ -275,22 +276,27 @@ https://developer.apple.com/design/resources/ or we risk getting rejected by App
 */
 const AppleSignInContainer  = styled('div', {
   shouldForwardProp: (prop) => !['enabled'].includes(prop),
-})(({ enabled }) => (`
+})(({ enabled, theme }) => (`
   font-family: -apple-system, BlinkMacSystemFont, sans-serif;
   background-color: #000;
   border-color: #000;
   color: ${enabled ? '#fff' : 'grey'};
   display: block;
-  margin: 0 auto 11px;
+  margin: 0 auto 0;
   ${isCordova() ? 'margin-bottom: 8px' : ''};
-  height: 46px;
-  border-radius: 4px;
+  height: 49.5px;
+  border-radius: 8px;
   overflow: hidden;
-  padding: 0 40px;
+  padding-left: 0px;
   position: relative;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
+  ${theme.breakpoints.up('md')} {
+    width: 80%;
+  }
+  ${theme.breakpoints.down('md')} {
+    width: 100%;
+  }
 `));
 
 /*

--- a/src/js/components/Twitter/TwitterSignIn.jsx
+++ b/src/js/components/Twitter/TwitterSignIn.jsx
@@ -1,6 +1,7 @@
-import { Twitter } from '@mui/icons-material';
+import { X as Twitter } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import { withStyles } from '@mui/styles'; // Import withStyles
 import TwitterActions from '../../actions/TwitterActions';
 import SplitIconButton from '../../common/components/Widgets/SplitIconButton';
 import { cordovaOpenSafariView, isIOS } from '../../common/utils/cordovaUtils';
@@ -13,6 +14,19 @@ import webAppConfig from '../../config';
 import $ajax from '../../utils/service';
 
 const returnURL = `${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/twitter_sign_in`;
+const styles = (theme) => ({
+  splitButton: {
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+    },
+    [theme.breakpoints.up('md')]: {
+      width: '80%',
+    },
+  },
+  centeredSplitButtonText: {
+    paddingRight: '53px',
+  },
+});
 
 class TwitterSignIn extends Component {
   static handleTwitterOpenURL (url) {
@@ -193,6 +207,7 @@ class TwitterSignIn extends Component {
 
   render () {
     let { buttonText } = this.props;
+    const { classes } = this.props;
     const { buttonSubmittedText, twitterSignInCrash, twitterSignInStartSubmitted } = this.state;
     // fixed for WV-131 disables button for iOS but not for webApp browser
     let twitterSignInButtonDisabled = (isIOS() && twitterSignInStartSubmitted) || twitterSignInCrash;
@@ -212,15 +227,22 @@ class TwitterSignIn extends Component {
     return (
       <>
         <SplitIconButton
-          backgroundColor="#55acee"
-          fontColor={twitterSignInButtonDisabled ? 'gray' : 'white'}
-          buttonText={twitterSignInButtonDisabled ? shortenText(buttonSubmittedText, 32) : shortenText(buttonText, 32)}
+          backgroundColor="#FFFFFF"
+          fontColor={twitterSignInButtonDisabled ? 'gray' : 'black'}
+          buttonText={(
+            <span className={classes.centeredSplitButtonText}>
+              {twitterSignInButtonDisabled ?
+                shortenText(buttonSubmittedText, 32) :
+                shortenText(buttonText, 32)}
+            </span>
+          )}
+          classes={{ splitButton: classes.splitButton }} // Pass custom classes
           disabled={twitterSignInButtonDisabled}
           externalUniqueId="twitterSignIn"
           icon={<Twitter />}
           id="twitterSignIn"
           onClick={isWebApp() ? this.twitterSignInWebApp : this.twitterSignInWebAppCordova}
-          separatorColor="rgba(250, 250, 250, .6)"
+          separatorColor="rgba(255, 255, 255, 1)"
           title="Sign in to find voter guides"
         />
         {twitterSignInCrash && (
@@ -241,7 +263,8 @@ TwitterSignIn.propTypes = {
   buttonSubmittedText: PropTypes.string,
   closeSignInModal: PropTypes.func,
   inModal: PropTypes.bool,
+  classes: PropTypes.object.isRequired, // Add classes to propTypes
 };
 
-export default TwitterSignIn;
+export default withStyles(styles)(TwitterSignIn);
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-546 SignIn Page - Misaligned SignIn with Twitter and SignIn with Apple buttons, misaligned logo icons, and incorrect text for 'Sign In with Twitter'
### Changes included this pull request?
1. Apple and Twitter buttons were aligned and are more uniform.
2. The text in the buttons and heading text are aligned.
3. Logos for both buttons are same size and also aligned
4. Twitter button was updated to use X terminology and match the new X platform style more
5. Button are full length and cover end-to-end on mobile and are only 80% on desktop for better aesthetics.