### PR TITLE
[WV-783] Fix negative days display in ChallengeAbout component

### DIFF
--- a/src/js/common/components/Challenge/ChallengeAbout.jsx
+++ b/src/js/common/components/Challenge/ChallengeAbout.jsx
@@ -69,9 +69,7 @@ function ChallengeAbout ({ challengeWeVoteId, showDaysLeft }) {
             {' '}
             ·
             {' '}
-            {daysLeft}
-            {' '}
-            days left
+            {daysLeft > 0 ? `${daysLeft} days left` : 'Challenge Ended'}
           </ShowDaysLeftText>
         </>
       )}

--- a/src/js/common/components/Challenge/JoinedAndDaysLeft.jsx
+++ b/src/js/common/components/Challenge/JoinedAndDaysLeft.jsx
@@ -16,7 +16,7 @@ function JoinedAndDaysLeft ({ challengeWeVoteId, borderSwitcher, padding }) {
   const onChallengeStoreChange = () => {
     const daysToChallengeEnds = ChallengeStore.getDaysUntilChallengeEnds(challengeWeVoteId);
     // console.log('Days to challenge ends:', daysToChallengeEnds);
-    setDaysLeft(daysToChallengeEnds);
+    setDaysLeft(Math.max(daysToChallengeEnds, 0));
     setVoterIsChallengeParticipant(ChallengeStore.getVoterIsChallengeParticipant(challengeWeVoteId));
   };
 
@@ -42,9 +42,7 @@ function JoinedAndDaysLeft ({ challengeWeVoteId, borderSwitcher, padding }) {
           <InfoIcon src={InfoOutlineIcon} alt="Info" />
         )}
         <DaysLeftText>
-          {daysLeft}
-          {' '}
-          Days Left
+          {daysLeft === 0 ? 'Challenge Ended' : `${daysLeft} Days Left`}
         </DaysLeftText>
       </JoinedInfoWrapper>
       <Suspense fallback={<span>&nbsp;</span>}>


### PR DESCRIPTION
- Updated onChallengeStoreChange to prevent negative values for daysLeft by using Math.max(daysToChallengeEnds, 0).
- Added conditional rendering in challengeDates to display 'Challenge Ended' when daysLeft is 0 or negative.
- Ensures a clear message when the challenge has ended, improving user experience and preventing confusing negative countdowns.
<img width="1710" alt="Screenshot 2024-11-08 at 10 19 45 PM" src="https://github.com/user-attachments/assets/ef5c3ecd-f4cb-43f9-9842-648d924c1c1c">
