### PR TITLE
WV-706 Ballot search fixes, updated/refactored search function [Team Review]

### DIFF
--- a/src/js/components/Ballot/BallotItemCompressed.jsx
+++ b/src/js/components/Ballot/BallotItemCompressed.jsx
@@ -9,6 +9,7 @@ export default class BallotItemCompressed extends PureComponent {
     renderLog('BallotItemCompressed');  // Set LOG_RENDER_EVENTS to log all renders
     const {
       ballotItemDisplayName, candidateList, candidatesToShowForSearchResults,
+      foundInSearchWords,
       isFirstBallotItem, isMeasure, primaryParty,
       weVoteId,
     } = this.props;
@@ -26,6 +27,7 @@ export default class BallotItemCompressed extends PureComponent {
             candidateList={candidateList}
             candidatesToShowForSearchResults={candidatesToShowForSearchResults}
             disableAutoRollUp
+            foundInSearchWords={foundInSearchWords}
             isFirstBallotItem={isFirstBallotItem}
             primaryParty={primaryParty}
           />
@@ -38,6 +40,7 @@ BallotItemCompressed.propTypes = {
   ballotItemDisplayName: PropTypes.string.isRequired,
   candidateList: PropTypes.array,
   candidatesToShowForSearchResults: PropTypes.array,
+  foundInSearchWords: PropTypes.bool,
   isFirstBallotItem: PropTypes.bool,
   isMeasure: PropTypes.bool,
   primaryParty: PropTypes.string,

--- a/src/js/components/Ballot/OfficeItemCompressed.jsx
+++ b/src/js/components/Ballot/OfficeItemCompressed.jsx
@@ -240,7 +240,7 @@ class OfficeItemCompressed extends Component {
 
   // eslint-disable-next-line no-unused-vars
   generateCandidates = (officeWeVoteId) => {
-    const { candidateList, disableAutoRollUp, externalUniqueId, isFirstBallotItem } = this.props;
+    const { candidateList, disableAutoRollUp, externalUniqueId, foundInSearchWords, isFirstBallotItem } = this.props;
     if (!candidateList || candidateList.length === 0) {
       // console.log('OfficeItemCompressed generateCandidates candidateList is empty');
       return (
@@ -259,7 +259,7 @@ class OfficeItemCompressed extends Component {
     // If there are supported candidates, then limit what we show to supported and opposed candidates
     let candidatesToRender;
     let limitNumberOfCandidatesShownToThisNumber;
-    if (showAllCandidates) {
+    if (showAllCandidates || foundInSearchWords) {
       candidatesToRender = candidateList;
       limitNumberOfCandidatesShownToThisNumber = candidatesToRender.length;
     } else if (disableAutoRollUp) {
@@ -415,6 +415,7 @@ OfficeItemCompressed.propTypes = {
   // classes: PropTypes.object,
   disableAutoRollUp: PropTypes.bool,
   externalUniqueId: PropTypes.string,
+  foundInSearchWords: PropTypes.bool,
   isFirstBallotItem: PropTypes.bool,
   organization: PropTypes.object,
   organizationWeVoteId: PropTypes.string,

--- a/src/js/pages/Ballot/Ballot.jsx
+++ b/src/js/pages/Ballot/Ballot.jsx
@@ -1639,6 +1639,7 @@ class Ballot extends Component {
                                         ballotItemDisplayName={item.ballot_item_display_name}
                                         candidateList={item.candidate_list}
                                         candidatesToShowForSearchResults={item.candidatesToShowForSearchResults}
+                                        foundInSearchWords={item.foundInSearchWords}
                                         id={chipLabelText(item.ballot_item_display_name)}
                                         isFirstBallotItem={isFirstBallotItem}
                                         isMeasure={item.kind_of_ballot_item === TYPES.MEASURE}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-706 Ballot search function 
### Changes included this pull request?
- FilterBaseSearch: Refactored filter function to check for search value and filter out candidates that did not match, similar functionality to /CampaignListRoot `onFilterOrListChange` search matching. 
- Ballot/BallotItemCompressed/OfficeItemCompressed: Passed `foundInSearchWords` prop to ensure when item is found the component will properly rerender the new item. Was running into an issue where the initial search candidate would work but when searching for another candidate in the same category (ie. presidential candidate) the second search would not update. 