### PR TITLE
[wv-758]Mobile Footer in middle of page in certain situations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -752,8 +752,8 @@ const WeVoteBody = styled('div')`
   //font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
   //line-height: 1.4;
   // margin: 0 auto;
-
   display: block;
+  min-height: 100vh;
   position: relative;
   z-index: 0;
   // this debug technique works!  ${() => console.log('-----------------------------')}

--- a/src/js/components/Share/ShareButtonFooter.jsx
+++ b/src/js/components/Share/ShareButtonFooter.jsx
@@ -560,7 +560,7 @@ const ShareButtonFooterWrapper = styled('div', {
 })(({ shareBottomValue }) => (`
   position: fixed;
   width: 100%;
-  ${shareBottomValue ? `bottom: ${shareBottomValue}` : ''};
+  bottom: ${shareBottomValue || '57px'};
   display: block;
   background-color: white;
   @media (min-width: 576px) {


### PR DESCRIPTION
[wv-758 ]Set min-height: 100vh to ensure full viewport height for the WeVoteBody styled component Defaulted bottom to '57px' for consistent appearance when no prop is provided.
