### PR TITLE
added Missing , after ../specs/BallotPage.js' in wdio.confg.js and ad…

### DIFF
--- a/tests/browserstack_automation/config/wdio.config.js
+++ b/tests/browserstack_automation/config/wdio.config.js
@@ -48,7 +48,8 @@ module.exports.config = {
     '../specs/FooterLinks.js',
     '../specs/SignInPage.js',
 
-    '../specs/BallotPage.js'
+    '../specs/BallotPage.js',
+    '../specs/CandidatesPage.js',
 
     '../specs/WhosRunningForOffice.js',
 


### PR DESCRIPTION
…ded ../specs/CandidatesPage.js in the same file

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?

The automated test run was failing due to missing ',' in wdio.config.js file. Added the missing ',' after ../specs/BallotPage.js'.
Also added '../specs/CandidatesPage.js', in the same file for recently added test scripts for CandidatesPage.

error from test run:
ERROR @wdio/config:ConfigParser: Failed loading configuration file: file:///Users/nadia/MyProjects/WebApp/tests/browserstack_automation/config/wdio.config.js: /Users/nadia/MyProjects/WebApp/tests/browserstack_automation/config/wdio.config.js: Unexpected token, expected "," (53:4)

  51 |     '../specs/BallotPage.js'
  52 |
> 53 |     '../specs/WhosRunningForOffice.js',
     |     ^
  54 |
  55 |   ],

