### PR TITLE
Fixed color (WV-854) and commented the corresponding TC SignIn_009

### DIFF
--- a/tests/browserstack_automation/specs/SignInPage.js
+++ b/tests/browserstack_automation/specs/SignInPage.js
@@ -103,19 +103,19 @@ describe('SignIn', () => {
   });
 
   // SignIn_009
-  it('verifyColorForContents', async () => {
+  /* it('verifyColorForContents', async () => {
     const xbackgroundColor = await (SignIn.xBttnElement).getCSSProperty('background-color');
     const applebackgroundColor = await (SignIn.appleBttnElement).getCSSProperty('background-color');
     const xTextColor = await (SignIn.signInWithXTextElement).getCSSProperty('color');
     const appleTextColor = await (SignIn.signInWithAppleTextElement).getCSSProperty('color');
     // Convert 'rgba' to 'rgb' by removing the alpha value if present
-    await expect(await xbackgroundColor.value.replace('rgba', 'rgb').replace(/,\s*1\)$/, ')')).toBe('rgb(85,172,238)');
+    await expect(await xbackgroundColor.value.replace('rgba', 'rgb').replace(/,\s*1\)$/, ')')).toBe('rgb(255,255,255)');
 
     await expect(await applebackgroundColor.value.replace('rgba', 'rgb').replace(/,\s*1\)$/, ')')).toBe('rgb(0,0,0)');
 
-    await expect(await xTextColor.value.replace('rgba', 'rgb').replace(/,\s*1\)$/, ')')).toBe('rgb(255,255,255)');
+    await expect(await xTextColor.value.replace('rgba', 'rgb').replace(/,\s*1\)$/, ')')).toBe('rgb(0,0,0)');
     await expect(await appleTextColor.value.replace('rgba', 'rgb').replace(/,\s*1\)$/, ')')).toBe('rgb(255,255,255)');
-  });
+  }); */
 
 
   // SignIn_010


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-854](https://wevoteusa.atlassian.net/browse/WV-854)

### Changes included this pull request?
1) Fixed the expected colors in automation test script 'verifyColorForContents' as the per the latest design. It was failing earlier due to design change.
BrowserStack run with updated color: https://observability.browserstack.com/projects/Default+Project/builds/Nadia+Vaida_readyForTestWV/28?tab=tests

2) Commented this test case as was suggested by Dale since the design might change in future. 
BrowserStack run for SignInPage with the above test case commented (regression for other test cases):
https://observability.browserstack.com/projects/Default+Project/builds/Nadia+Vaida_readyForTestWV/29?tab=tests

[WV-854]: https://wevoteusa.atlassian.net/browse/WV-854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ