### PR TITLE
updated 'whatIsHappeningTitle' id to camel case in CandidatesPage tes…

### DIFF
--- a/tests/browserstack_automation/page_objects/candidates.page.js
+++ b/tests/browserstack_automation/page_objects/candidates.page.js
@@ -17,7 +17,7 @@ class CandidatesPage extends Page {
   }
 
   get pageHeaders () {
-    return $$('h2#WhatIsHappeningTitle');
+    return $$('h2#whatIsHappeningTitle');
   }
 
   get CandidateCardList () {


### PR DESCRIPTION
…tscript

### What github.com/wevote/WebApp/issues does this fix?
updated 'whatIsHappeningTitle' id to camel case in Candidates Page test script. The test case was failing due to mismatch in id name on webApp and the one used in test script.


### Changes included this pull request?
