### PR TITLE
[MERGE READY] - WV-616 - Ballot Page: ADA - Not tabbing through 'Edit Address'

### DIFF
--- a/src/js/components/Ballot/BallotTitleHeader.jsx
+++ b/src/js/components/Ballot/BallotTitleHeader.jsx
@@ -186,8 +186,8 @@ class BallotTitleHeader extends Component {
                           className={linksOff ? '' : 'u-cursor--pointer'}
                           id="ballotTitleBallotAddress"
                           onClick={this.showSelectBallotModalEditAddress}
-                          onKeyDown={(event) => {
-                            if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
+//                           onKeyDown={(event) => {
+//                             if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                         >
                           {ballotCaveat && (
                             <div>{ballotCaveat}</div>
@@ -202,8 +202,8 @@ class BallotTitleHeader extends Component {
                               className={linksOff ? '' : 'u-cursor--pointer'}
                               id="ballotTitleBallotAddress"
                               onClick={this.showSelectBallotModalEditAddress}
-                              onKeyDown={(event) => {
-                                if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
+//                               onKeyDown={(event) => {
+//                                 if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                             >
                               Ballot for
                               {' '}
@@ -225,8 +225,8 @@ class BallotTitleHeader extends Component {
                                   className={linksOff ? '' : 'u-cursor--pointer'}
                                   id="ballotTitleBallotAddressSubstituted"
                                   onClick={this.showSelectBallotModalEditAddress}
-                                  onKeyDown={(event) => {
-                                    if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
+//                                   onKeyDown={(event) => {
+//                                     if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                                 >
                                   Ballot for
                                   {' '}
@@ -242,8 +242,8 @@ class BallotTitleHeader extends Component {
                                   className={linksOff ? '' : 'u-cursor--pointer'}
                                   id="ballotTitleBallotAddress"
                                   onClick={this.showSelectBallotModalEditAddress}
-                                  onKeyDown={(event) => {
-                                    if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
+//                                   onKeyDown={(event) => {
+//                                     if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                                 >
                                   <span tabIndex={0} className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}>
                                     Click to enter your address

--- a/src/js/components/Ballot/BallotTitleHeader.jsx
+++ b/src/js/components/Ballot/BallotTitleHeader.jsx
@@ -186,6 +186,8 @@ class BallotTitleHeader extends Component {
                           className={linksOff ? '' : 'u-cursor--pointer'}
                           id="ballotTitleBallotAddress"
                           onClick={this.showSelectBallotModalEditAddress}
+                          onKeyDown={(event) => {
+                            if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                         >
                           {ballotCaveat && (
                             <div>{ballotCaveat}</div>
@@ -200,10 +202,12 @@ class BallotTitleHeader extends Component {
                               className={linksOff ? '' : 'u-cursor--pointer'}
                               id="ballotTitleBallotAddress"
                               onClick={this.showSelectBallotModalEditAddress}
+                              onKeyDown={(event) => {
+                                if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                             >
                               Ballot for
                               {' '}
-                              <span
+                              <span tabIndex={0}
                                 className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}
                               >
                                 <span>
@@ -221,10 +225,12 @@ class BallotTitleHeader extends Component {
                                   className={linksOff ? '' : 'u-cursor--pointer'}
                                   id="ballotTitleBallotAddressSubstituted"
                                   onClick={this.showSelectBallotModalEditAddress}
+                                  onKeyDown={(event) => {
+                                    if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                                 >
                                   Ballot for
                                   {' '}
-                                  <span className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}>
+                                  <span tabIndex={0} className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}>
                                     {substitutedAddress}
                                   </span>
                                   {linksOff ? <></> : editIconStyled}
@@ -236,8 +242,10 @@ class BallotTitleHeader extends Component {
                                   className={linksOff ? '' : 'u-cursor--pointer'}
                                   id="ballotTitleBallotAddress"
                                   onClick={this.showSelectBallotModalEditAddress}
+                                  onKeyDown={(event) => {
+                                    if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                                 >
-                                  <span className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}>
+                                  <span tabIndex={0} className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}>
                                     Click to enter your address
                                   </span>
                                   {linksOff ? <></> : editIconStyled}

--- a/src/js/components/Ballot/BallotTitleHeader.jsx
+++ b/src/js/components/Ballot/BallotTitleHeader.jsx
@@ -186,8 +186,6 @@ class BallotTitleHeader extends Component {
                           className={linksOff ? '' : 'u-cursor--pointer'}
                           id="ballotTitleBallotAddress"
                           onClick={this.showSelectBallotModalEditAddress}
-//                           onKeyDown={(event) => {
-//                             if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                         >
                           {ballotCaveat && (
                             <div>{ballotCaveat}</div>
@@ -202,8 +200,6 @@ class BallotTitleHeader extends Component {
                               className={linksOff ? '' : 'u-cursor--pointer'}
                               id="ballotTitleBallotAddress"
                               onClick={this.showSelectBallotModalEditAddress}
-//                               onKeyDown={(event) => {
-//                                 if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                             >
                               Ballot for
                               {' '}
@@ -225,8 +221,6 @@ class BallotTitleHeader extends Component {
                                   className={linksOff ? '' : 'u-cursor--pointer'}
                                   id="ballotTitleBallotAddressSubstituted"
                                   onClick={this.showSelectBallotModalEditAddress}
-//                                   onKeyDown={(event) => {
-//                                     if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                                 >
                                   Ballot for
                                   {' '}
@@ -242,8 +236,6 @@ class BallotTitleHeader extends Component {
                                   className={linksOff ? '' : 'u-cursor--pointer'}
                                   id="ballotTitleBallotAddress"
                                   onClick={this.showSelectBallotModalEditAddress}
-//                                   onKeyDown={(event) => {
-//                                     if (event.key === 'Enter') this.showSelectBallotModalEditAddress()}}
                                 >
                                   <span tabIndex={0} className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}>
                                     Click to enter your address

--- a/src/js/components/Style/BallotTitleHeaderStyles.jsx
+++ b/src/js/components/Style/BallotTitleHeaderStyles.jsx
@@ -4,9 +4,10 @@ import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import isMobileScreenSize from '../../common/utils/isMobileScreenSize'; // 2024-04-16 Upgrade to using this
 
-export const BallotAddress = styled('div', {
+export const BallotAddress = styled('button', {
   shouldForwardProp: (prop) => !['centerText', 'allowTextWrap'].includes(prop),
 })(({ allowTextWrap, centerText }) => (`
+  all: unset;
   margin-left: 2px;
   ${isMobileScreenSize() || isCordova() ? '' : 'font-size: 18px;'}
   ${allowTextWrap || isMobileScreenSize() || isCordova() ? '' : 'overflow: hidden;'}


### PR DESCRIPTION
I found a couple of options for tabbing over BallotAddress and opening the modal:
1) Change BallotAddress in BallotTitleHeaderStyles.jsx to a 'button'
2) Leave BallotAddress in BallotTitleHeaderStyles.jsx as a 'div' and include the onKeyDown in each BallotAddress div (more repetitive). I commented this one out in the pull request.  