### PR TITLE
WV-986/WBV-987 Add Data Layer To "Show More" buttons on '"Fine Print" and "We Vote helps you" [CHANGES NEEDED]

### DIFF
--- a/src/js/components/Ready/ReadyFinePrint.jsx
+++ b/src/js/components/Ready/ReadyFinePrint.jsx
@@ -133,6 +133,7 @@ class ReadyFinePrint extends Component {
                     showMoreId="showMoreReadyFinePrintCompressed"
                     showMoreButtonWasClicked={contentUnfurled}
                     showMoreButtonsLink={this.contentUnfurledLink}
+                    trackInGTM={true}
                   />
                 </ShowMoreWrapper>
               )}

--- a/src/js/components/Ready/ReadyIntroduction.jsx
+++ b/src/js/components/Ready/ReadyIntroduction.jsx
@@ -194,6 +194,7 @@ class ReadyIntroduction extends Component {
                     showMoreId="showMoreReadyIntroductionCompressed"
                     showMoreButtonWasClicked={contentUnfurled}
                     showMoreButtonsLink={this.contentUnfurledLink}
+                    trackInGTM={true}
                   />
                 </ShowMoreWrapper>
               )}

--- a/src/js/components/Widgets/ShowMoreButtons.jsx
+++ b/src/js/components/Widgets/ShowMoreButtons.jsx
@@ -5,9 +5,45 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
+import TagManager from 'react-gtm-module';
+import VoterStore from '../../stores/VoterStore';
 
 
 class ShowMoreButtons extends React.Component {
+  handleClick=()=>{
+    //console.log('click')
+    const { showMoreId, showMoreButtonWasClicked, showMoreCustomText, trackInGTM } = this.props;
+
+    if (trackInGTM && !showMoreButtonWasClicked) {  
+      // console.log("Show More clicked (tracked):", showMoreId);
+      // const eventName = showMoreCustomText || 'show more';
+      const dataLayerObject = {
+        event: 'Show More Button Clicked',
+        element_id: showMoreId,
+        source:{
+          pageName: window.location.href,
+          pageType: "homepage",
+          pathName: window.location.pathname,
+        },
+        user:{
+          weVoteVoterId: VoterStore.getVoterWeVoteId(),
+          userStatus:"",
+          method:""
+        },
+        // button_text: eventName,
+      };
+    //  console.log("dataLayerObject:", dataLayerObject)
+      TagManager.dataLayer({ dataLayer: dataLayerObject });
+    } else if (trackInGTM && showMoreButtonWasClicked){
+       console.log("Show Less clicked (not tracked):", showMoreId);
+    }
+    else {
+      console.log("Show More/Less clicked (not tracked):", showMoreId);
+    }
+
+    this.props.showMoreButtonsLink(); 
+  };
+
   render () {
     renderLog('ShowMoreButtons');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes, showLessCustomText, showMoreButtonsLink, showMoreButtonWasClicked, showMoreCustomText, showMoreId } = this.props;
@@ -18,9 +54,9 @@ class ShowMoreButtons extends React.Component {
     } else {
       showMoreText = showMoreCustomText || 'show more';
     }
-
+    // onClick={showMoreButtonsLink}
     return (
-      <ShowMoreButtonsStyled className="card-child" id={`toggleContentButton-${showMoreId}`} onClick={showMoreButtonsLink}>
+      <ShowMoreButtonsStyled className="card-child" id={`toggleContentButton-${showMoreId}`} onClick={this.handleClick} >
         <ShowMoreButtonsText id="showMoreLink">
           { showMoreText }
           {' '}


### PR DESCRIPTION
Add Google Tag Manager data layer to two "Show More" instances: "fine print" and "we vote helps you.  
Specific logic changes include passing props from ReadyIntroduction.jsx and ReadyFinePrint.jsx components to create the instances where GTM fires.  Adding "trackInGTM={true}" down to other Show more instances will create data layers in those as well if future needs require.  

