### PR TITLE
WV-937 [TEAM REVIEW] Keyboard accessibility issues: Ballot Page #4,5.

### DIFF
--- a/src/js/components/Navigation/BallotDecisionsTabs.jsx
+++ b/src/js/components/Navigation/BallotDecisionsTabs.jsx
@@ -84,6 +84,7 @@ class BallotDecisionsTabs extends Component {
           classes={{ root: classes.tabRootAllChoice }}
           id="allItemsCompletionLevelTab"
           onClick={() => this.goToDifferentCompletionLevelTab('filterAllBallotItems')}
+          tabIndex={0}
           label={(
             <Badge
               classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 0 ? null : classes.badgeColorPrimary }}
@@ -107,6 +108,7 @@ class BallotDecisionsTabs extends Component {
             classes={{ root: classes.tabRoot }}
             id="remainingChoicesCompletionLevelTab"
             onClick={() => this.goToDifferentCompletionLevelTab('filterRemaining')}
+            tabIndex={0}
             style={{ paddingRight: '26px' }}
             label={(
               <Badge
@@ -131,7 +133,8 @@ class BallotDecisionsTabs extends Component {
           <Tab
             classes={{ root: classes.tabRoot }}
             id="decidedItemsCompletionLevelTab"
-            onClick={() => this.goToDifferentCompletionLevelTab('filterDecided')}
+            onClick={() =>this.goToDifferentCompletionLevelTab('filterDecided')}
+            tabIndex={0}
             label={(
               <Badge
                 classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 2 ? null : classes.badgeColorPrimary }}


### PR DESCRIPTION
Keyboard accessibility issues: Ballot Page
Issue 4: Make sure you can reach “Remaining Choices” and “Chosen” (you must choose one candidate on your ballot to see those options)
Issue 5: Click on the election name to find a prior election that has State & Local ballot items. With only “All” and “Federal” you have to tab twice after “All” to get to “Federal” and that may be because those elements are on the page but not visible?