### PR TITLE
VW-933, VW-901 Change the Data Layer object properties using lookupPageNameAndPageTypeDict function [TEAM READY]

### DIFF
--- a/src/js/common/components/Challenge/JoinChallengeButton.jsx
+++ b/src/js/common/components/Challenge/JoinChallengeButton.jsx
@@ -12,6 +12,7 @@ import ChallengeParticipantActions from '../../actions/ChallengeParticipantActio
 import ReadyStore from '../../../stores/ReadyStore';
 import VoterStore from '../../../stores/VoterStore';
 import { getChallengeValuesFromIdentifiers } from '../../utils/challengeUtils';
+import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
 
 class JoinChallengeButton extends React.Component {
   constructor (props) {
@@ -127,6 +128,8 @@ class JoinChallengeButton extends React.Component {
     // console.log('goToInviteFriends currentPathname: ', currentPathname);
 
     // Adding event data to dataLayer for Google Tag Manager to fire the inviteFriendsToChallenge tag
+    const page = lookupPageNameAndPageTypeDict(currentPathname);
+    const destinationPage = lookupPageNameAndPageTypeDict(inviteFriendsPath);
     TagManager.dataLayer({
       dataLayer: {
         event: 'inviteFriendsToChallenge',
@@ -137,13 +140,13 @@ class JoinChallengeButton extends React.Component {
           challengeWeVoteId,
         },
         pageDetails: {
-          pageType: "challenge",
-          pageName: window.location.href,
+          pageType: page.pageType,
+          pageName: page.pageName,
           pathName: currentPathname,
         },
         destinationDetails: {
-          destinationPageType: "challenge",
-          destinationPageName: `${window.location.origin}${inviteFriendsPath}`,
+          destinationPageType: destinationPage.pageType,
+          destinationPageName: destinationPage.pageName,
           destinationPathName: inviteFriendsPath,
         },
       },
@@ -174,6 +177,8 @@ class JoinChallengeButton extends React.Component {
       AppObservableStore.setSetUpAccountEntryPath(joinChallengeNextStepPath);
       // console.log('goToJoinChallenge currentPathname: ', currentPathname);
       // Adding event data to dataLayer for Google Tag Manager to fire the inviteFriendsToChallenge tag
+      const page = lookupPageNameAndPageTypeDict(currentPathname);
+      const destinationPage = lookupPageNameAndPageTypeDict(joinChallengeNextStepPath);
       TagManager.dataLayer({
         dataLayer: {
           event: 'joinChallenge',
@@ -184,13 +189,13 @@ class JoinChallengeButton extends React.Component {
             challengeWeVoteId,
           },
           pageDetails: {
-            pageType: "challenge",
-            pageName: window.location.href,
+            pageType: page.pageType,
+            pageName: page.pageName,
             pathName: currentPathname,
           },
           destinationDetails: {
-            destinationPageType: 'challenge',
-            destinationPageName: `${window.location.origin}${joinChallengeNextStepPath}`,
+            destinationPageType: destinationPage.pageType,
+            destinationPageName: destinationPage.pageName,
             destinationPathName: joinChallengeNextStepPath,
           },
         },

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -16,6 +16,10 @@ const pageNameAndTypeSimpleDict = {
     pageName: 'Email',
     pageType: 'settings',
   },
+  '/challenges': {
+    pageName: 'ChallengesHomeLoader',
+    pageType: 'challenge',
+  },
 };
 
 function calculatePageNameAndPageTypeDict (path) {
@@ -25,7 +29,17 @@ function calculatePageNameAndPageTypeDict (path) {
   if (isChallengeSEOFriendlyURL(path)) {
     // We need to add more complex logic here because there are many paths in /src/App.jsx that use "/+/" in the path
     settingsPageType = 'challenge';
-    settingsPageName = 'ChallengeHomePage';
+    if (path.endsWith('join-challenge')) {
+      settingsPageName = 'ChallengeInviteFriendsJoin';
+    } else if (path.endsWith('customize-message')) {
+      settingsPageName = 'ChallengeInviteCustomizeMessage';
+    } else if (path.endsWith('invite-friends')) {
+      settingsPageName = 'ChallengeInviteFriends';
+    } else if (path.endsWith('edit')) {
+      settingsPageName = 'ChallengeStartEditAll';
+    } else {
+      settingsPageName = 'ChallengeHomePage';
+    }
   } else if (isPoliticianSEOFriendlyURL(path)) {
     // We need to add more complex logic here because there are many paths in /src/App.jsx that use "/-/" in the path
     settingsPageType = 'politician';


### PR DESCRIPTION
VW-933, VW-901 Change the Data Layer object properties using pageType and pageName from lookupPageNameAndPageTypeDict function

### What github.com/wevote/WebApp/issues does this fix?
It sets pageTypes and pageNames in date layer objects for 'inviteFriendsToChallenge' and 'joinChallenge' events using lookupPageNameAndPageTypeDict function. 

### Changes included this pull request?
- lookupPageNameAndPageTypeDict: Added all paths related to 'challenge' path type that are definded in App.jsx.
- JoinChallengeButton: Updated the Data Layer object properties using pageType and pageName from lookupPageNameAndPageTypeDict function.
