### PR TITLE
WV-985/WV-986 Data Capture "Fine Print" and "We Vote Helps you" "show more" click [TEAM REVIEW]

### DIFF
--- a/src/js/components/Widgets/ShowMoreButtons.jsx
+++ b/src/js/components/Widgets/ShowMoreButtons.jsx
@@ -10,6 +10,7 @@ import TagManager from 'react-gtm-module';
 import VoterStore from '../../stores/VoterStore';
 
 class ShowMoreButtons extends React.Component {
+  
   constructor(props) {
     super(props);
     this.handleShowMoreClick = this.handleShowMoreClick.bind(this);
@@ -17,10 +18,8 @@ class ShowMoreButtons extends React.Component {
   }
 
   handleShowMoreClick = () => {
-
     const { showMoreId, showMoreButtonWasClicked, trackInGTM, showMoreButtonsLink } = this.props;
     const { location: { pathname: currentPathname } } = window; // Get path here
-
     //if (trackInGTM) {
       //console.log('click');
       const eventName = showMoreButtonWasClicked ? 'showLessButtonClick' : 'showMoreButtonClick';
@@ -45,7 +44,7 @@ class ShowMoreButtons extends React.Component {
         weVoteVoterId: VoterStore.getVoterWeVoteId(),
       },
     };
-    console.log(currentPathname);
+    //console.log(currentPathname);
     TagManager.dataLayer({ dataLayer: dataLayerObject });
   };
 

--- a/src/js/components/Widgets/ShowMoreButtons.jsx
+++ b/src/js/components/Widgets/ShowMoreButtons.jsx
@@ -5,12 +5,53 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-
+import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import TagManager from 'react-gtm-module';
+import VoterStore from '../../stores/VoterStore';
 
 class ShowMoreButtons extends React.Component {
-  render () {
-    renderLog('ShowMoreButtons');  // Set LOG_RENDER_EVENTS to log all renders
-    const { classes, showLessCustomText, showMoreButtonsLink, showMoreButtonWasClicked, showMoreCustomText, showMoreId } = this.props;
+  constructor(props) {
+    super(props);
+    this.handleShowMoreClick = this.handleShowMoreClick.bind(this);
+    this.pushDataLayer = this.pushDataLayer.bind(this);
+  }
+
+  handleShowMoreClick = () => {
+
+    const { showMoreId, showMoreButtonWasClicked, trackInGTM, showMoreButtonsLink } = this.props;
+    const { location: { pathname: currentPathname } } = window; // Get path here
+
+    //if (trackInGTM) {
+      //console.log('click');
+      const eventName = showMoreButtonWasClicked ? 'showLessButtonClick' : 'showMoreButtonClick';
+      this.pushDataLayer(eventName, showMoreId, currentPathname); // Use currentPathname
+    //} else {
+      //console.log('Show More/Less clicked (not tracked):', showMoreId);
+    //}
+    showMoreButtonsLink();
+  };
+
+  pushDataLayer = (eventName, showMoreId, currentPathname) => { 
+    const currentPage = lookupPageNameAndPageTypeDict(currentPathname); 
+    const dataLayerObject = {
+      event: eventName,
+      element_id: showMoreId,
+      pageDetails: {
+        pageName: currentPage.pageName,
+        pageType: currentPage.pageType,
+        pathName: currentPathname, 
+      },
+      userDetails: {
+        weVoteVoterId: VoterStore.getVoterWeVoteId(),
+      },
+    };
+    console.log(currentPathname);
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+  };
+
+  render() {
+    renderLog('ShowMoreButtons');
+    const { classes, showLessCustomText, showMoreButtonWasClicked, showMoreCustomText, showMoreId } = this.props;
     let showMoreText;
 
     if (showMoreButtonWasClicked) {
@@ -20,24 +61,21 @@ class ShowMoreButtons extends React.Component {
     }
 
     return (
-      <ShowMoreButtonsStyled className="card-child" id={`toggleContentButton-${showMoreId}`} onClick={showMoreButtonsLink}>
+      <ShowMoreButtonsStyled className="card-child" id={`toggleContentButton-${showMoreId}`} onClick={this.handleShowMoreClick}>
         <ShowMoreButtonsText id="showMoreLink">
-          { showMoreText }
+          {showMoreText}
           {' '}
           {showMoreButtonWasClicked ? (
-            <ArrowDropUp
-              classes={{ root: classes.cardFooterIconRoot }}
-            />
+            <ArrowDropUp classes={{ root: classes.cardFooterIconRoot }} />
           ) : (
-            <ArrowDropDown
-              classes={{ root: classes.cardFooterIconRoot }}
-            />
+            <ArrowDropDown classes={{ root: classes.cardFooterIconRoot }} />
           )}
         </ShowMoreButtonsText>
       </ShowMoreButtonsStyled>
     );
   }
 }
+
 ShowMoreButtons.propTypes = {
   classes: PropTypes.object,
   showLessCustomText: PropTypes.string,
@@ -63,7 +101,6 @@ const ShowMoreButtonsStyled = styled('button')(({ theme }) => (`
   cursor: pointer;
   display: block !important;
   background: #fff !important;
-  // font-size: 18px;
   margin-bottom: 0 !important;
   margin-top: 0 !important;
   padding: 0 !important;
@@ -92,6 +129,3 @@ const ShowMoreButtonsText = styled('div')`
 `;
 
 export default withTheme(withStyles(styles)(ShowMoreButtons));
-
-
-

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -20,6 +20,10 @@ const pageNameAndTypeSimpleDict = {
     pageName: 'ChallengesHomeLoader',
     pageType: 'challenge',
   },
+  '/': {
+    pageName: 'Ready',
+    pageType: 'homepage',
+  },
 };
 
 function calculatePageNameAndPageTypeDict (path) {
@@ -52,8 +56,18 @@ function calculatePageNameAndPageTypeDict (path) {
 }
 
 export default function lookupPageNameAndPageTypeDict (path) {
-  if (path in pageNameAndTypeSimpleDict) {
+  if (pageNameAndTypeSimpleDict[path]) {
     return pageNameAndTypeSimpleDict[path];
+  } else if (path.includes('/ballot')) {
+    return {
+      pageName: 'Ballot',
+      pageType: 'ballot',
+    };
+  } else if (path.includes('/about')) {
+    return {
+      pageName: 'About',
+      pageType: 'about',
+    };
   } else {
     return calculatePageNameAndPageTypeDict(path);
   }


### PR DESCRIPTION
Add data capture to "Show More" clicks.  Incorporate new routes for lookupPageNameAndPageTypeDict.js to include '/ballot' and '/about' as well as '/' for ready/homepage. 
**Remove props to conditionally fire GTM, allowing for data capture on ALL ShowMoreButtons.  Please advise if this is incorrect.  We had discussed not using the props for this button, so if i need to edit and return to conditional rendering, please let know.