### PR TITLE
Stopped the app from jumping horizontally 7 pixels when search box expands

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -60,7 +60,7 @@ body {
   font-weight:normal;
   letter-spacing:.15px;
   line-height: 1.4;
-  margin:0 auto;
+  /* margin:0 auto; Removed 3/19/25 https://wevoteusa.atlassian.net/issues/WV-1028 */
   text-align:left
 }
 

--- a/src/js/components/Share/ShareModal.jsx
+++ b/src/js/components/Share/ShareModal.jsx
@@ -189,6 +189,17 @@ class ShareModal extends Component {
   render () {
     renderLog('ShareModal');  // Set LOG_RENDER_EVENTS to log all renders
     // console.log('ShareModal render');
+
+    // 3/20/25 we need to upgrade from '@mui/material';
+    // "@mui/base has been deprecated and has been replaced by Base UI. We strongly recommend using the new package instead."
+    // import Dialog from '@base-ui-components/react/dialog' instead of '@mui/material';
+    // In the meantime, the following hack mostly undoes problem caused by
+    // node_modules/@mui/base/legacy/unstable_useModal/ModalManager.js handleContainer()
+    //    container.style.paddingRight = "".concat(getPaddingRight(container) + scrollbarSize, "px");
+    const bodyElement = document.querySelector('body');
+    bodyElement.style.removeProperty('overflow');       // 3/20/25 remove mysteriously added  'style="padding-right: 15px; overflow: hidden;"'
+    bodyElement.style.removeProperty('padding-right');
+
     const { location: { pathname } } = window;
     const { classes } = this.props;
     const {

--- a/src/js/startCordova.js
+++ b/src/js/startCordova.js
@@ -106,7 +106,7 @@ export function initializationForCordova (startReact) {
     //   window.pbakondyScreenSize = result;
     if (isIPad()) {
       document.querySelector('body').style.height = getCordovaScreenHeight();
-      console.log('Cordova: Initial "body" height for iPad = calcualation disabled '); // , result.height / result.scale);
+      console.log('Cordova: Initial "body" height for iPad = calculation disabled '); // , result.height / result.scale);
     }
     initializejQuery(() => {
       const { $ } = window;


### PR DESCRIPTION
Fix also stops the TopHeader from jumping horizontally when other tabs are selected.

We use a deprecated version of Dialog from '@mui/material', and should replace it with the new version in '@base-ui-components/react/dialog' Added some code to ShareModal, that mostly resolves the problem in the old version. From the doc: "@mui/base has been deprecated and has been replaced by Base UI. We strongly recommend using the new package instead." The change would be... import Dialog from '@base-ui-components/react/dialog' instead of '@mui/material';
Created issue https://wevoteusa.atlassian.net/browse/WV-1044 for this upgrade

Resolves https://wevoteusa.atlassian.net/issues/WV-1028
Resolves https://wevoteusa.atlassian.net/issues/WV-1019

