### PR TITLE
[WV-941] Fix comments display: trigger activityListRetrieve, call saved…

### DIFF
--- a/src/js/components/Activity/ActivityCommentAdd.jsx
+++ b/src/js/components/Activity/ActivityCommentAdd.jsx
@@ -72,6 +72,14 @@ class ActivityCommentAdd extends Component {
     this.setState({
       statementText: '',
     });
+    ActivityActions.activityListRetrieve(activityTidbitWeVoteId);
+
+    if (this.props.addChildSavedFunction && parentCommentWeVoteId) {
+      this.props.addChildSavedFunction(parentCommentWeVoteId);
+    }
+    if (this.props.commentEditSavedFunction) {
+      this.props.commentEditSavedFunction();
+    }
     if (this.props.addChildSavedFunction && parentCommentWeVoteId) {
       this.props.addChildSavedFunction(parentCommentWeVoteId);
     }

--- a/src/js/stores/ActivityStore.js
+++ b/src/js/stores/ActivityStore.js
@@ -74,7 +74,7 @@ class ActivityStore extends ReduceStore {
     let oneActivityCommentModified = {};
     let parentComments = [];
     let parentCommentsWithChildren = [];
-    let parentCommentsUpdated = [];
+    const parentCommentsUpdated = [];
     let priorPostFound = false;
     let results = {};
     switch (action.type) {
@@ -90,8 +90,7 @@ class ActivityStore extends ReduceStore {
         // console.log('allCachedActivityCommentsInTreeByTidbitWeVoteId:', allCachedActivityCommentsInTreeByTidbitWeVoteId);
         // Traverse the tree and add it
         commentListUpdated = [];
-        parentComments = allCachedActivityCommentsInTreeByTidbitWeVoteId[activityComment.parent_we_vote_id];
-        parentCommentsUpdated = [];
+        parentComments = allCachedActivityCommentsInTreeByTidbitWeVoteId[activityComment.parent_we_vote_id] || [];
         if (activityComment.activity_comment_created) {
           // Add it to the tree
           if (activityComment.parent_comment_we_vote_id) {


### PR DESCRIPTION
[WV-941] Fix comments display:
1) Added logic to trigger ActivityActions.activityListRetrieve(activityTidbitWeVoteId)
2) Called addChildSavedFunction and commentEditSavedFunction after saving comment
3) Fixed loading of parentComments from allCachedActivityCommentsInTreeByTidbitWeVoteId
4) Checked nested comments render correctly in the tree structure do git add and git commit 


[WV-941]: https://wevoteusa.atlassian.net/browse/WV-941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ