### PR TITLE
Issue WV_987 Analytics Data Capture: 'Sign In or Sign Up' click - Push keyword/text

### DIFF
--- a/src/js/components/Widgets/SignInButton.jsx
+++ b/src/js/components/Widgets/SignInButton.jsx
@@ -23,7 +23,7 @@ const { pageName, pageType } = lookupPageNameAndPageTypeDict(window.location.pat
           voterWeVoteId: VoterStore.getVoterWeVoteId(),
         },
         destinationDetails: {
-          destinationPageName: 'SignInModel',
+          destinationPageName: 'SignInModal',
           destinationPathName: window.location.href,
           destinationPageType: 'auth',
         },

--- a/src/js/components/Widgets/SignInButton.jsx
+++ b/src/js/components/Widgets/SignInButton.jsx
@@ -1,7 +1,7 @@
-import TagManager from 'react-gtm-module';
 import { Button } from '@mui/material';
 import PropTypes from 'prop-types';
 import React from 'react';
+import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
@@ -13,8 +13,8 @@ import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageType
 export default function SignInButton (props) {
   renderLog('SignInButton');  // Set LOG_RENDER_EVENTS to log all renders
 
-// GTM Data Layer push for SignIn button on HomePage by AnujaLawankar-March24th,2025
-const { pageName, pageType } = lookupPageNameAndPageTypeDict(window.location.pathname);
+  // GTM Data Layer push for SignIn button on HomePage by AnujaLawankar-March24th,2025
+  const { pageName, pageType } = lookupPageNameAndPageTypeDict(window.location.pathname);
   const handleClick = () => {
     TagManager.dataLayer({
       dataLayer: {
@@ -24,17 +24,17 @@ const { pageName, pageType } = lookupPageNameAndPageTypeDict(window.location.pat
         },
         destinationDetails: {
           destinationPageName: 'SignInModal',
-          destinationPathName: window.location.href,
           destinationPageType: 'auth',
+          destinationPathname: window.location.pathname,
         },
         pageDetails: {
           pageName,
           pageType,
-          pathName: window.location.href,
+          pathname: window.location.pathname,
         },
       },
     });
-  // Trigger the actual sign-in modal
+    // Trigger the actual sign-in modal
     if (props.toggleSignInModal) {
       props.toggleSignInModal();
     }

--- a/src/js/components/Widgets/SignInButton.jsx
+++ b/src/js/components/Widgets/SignInButton.jsx
@@ -34,9 +34,10 @@ const { pageName, pageType } = lookupPageNameAndPageTypeDict(window.location.pat
         },
       },
     });
-
-    // Trigger the actual sign-in modal
-    props.toggleSignInModal();
+  // Trigger the actual sign-in modal
+    if (props.toggleSignInModal) {
+      props.toggleSignInModal();
+    }
   };
 
   return (


### PR DESCRIPTION
Issue WV_987 Analytics Data Capture: 'Sign In or Sign Up' click - Push keyword/text- Added the destinationPageName as SignInModal[MERGE READY]

### What github.com/wevote/WebApp/issues does this fix?

Added destinationPageName as SignInModal

### Changes included this pull request?
Added destinationPageName as SignInModal
