### PR TITLE
[Resolved WV-1006] Added margin in the bottom, allowing 'join challenge' and 'learn more' buttons to be visible.

### DIFF
--- a/src/js/common/components/ChallengeListRoot/ChallengeCardList.jsx
+++ b/src/js/common/components/ChallengeListRoot/ChallengeCardList.jsx
@@ -271,6 +271,9 @@ const ChallengeCardForListVerticalWrapper = styled('div')`
   max-width: 250px;
   margin-right: 5px;
   margin-bottom: 20px;
+  @media (max-width: 600px) {
+    margin-bottom: 80px;
+  }
 `;
 
 const JoinedButtonsInnerWrapper = styled('div')`


### PR DESCRIPTION

### What github.com/wevote/WebApp/issues does this fix?
WV-1006

### Changes included this pull request?
Changed margin for screen sizes less than 600px.