### PR TITLE
[WV-1083] Mobile: Candidate photos get squashed if they have a long name or party name on the ballot page [Team Review]

### DIFF
--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -1477,7 +1477,7 @@ const MobileHeaderOuterContainer = styled('div', {
   position: fixed;
   z-index: 1;
   right: 0;
-  transform: translateY(${scrolledDown ? 0 : '-100%'});
+  transform: translateY(${scrolledDown ? 0 : '-120%'});
   transition: transform .3s ease-in-out;
   // visibility: ${scrolledDown ? 'visible' : 'hidden'};
   // opacity: ${scrolledDown ? 1 : 0};

--- a/src/js/common/utils/extractPoliticianDetailsFromUrl.js
+++ b/src/js/common/utils/extractPoliticianDetailsFromUrl.js
@@ -22,7 +22,8 @@ export default function extractPoliticianDetailsFromUrl (url) {
 
   if (fromIndex === -1) {
     const nameWithoutFrom = capitalizeWords.slice(0, words.length).join(' '); // Creates a name for urls without 'from'
-    return { state: null, name: nameWithoutFrom }; // If 'from' is not found, return null for both
+    const nameWithoutFromAndPolitician = nameWithoutFrom ? nameWithoutFrom.replace(/\bpolitician\b/i, '').trim() : null;
+    return { state: null, name: nameWithoutFromAndPolitician }; // If 'from' is not found, return null for both
   }
 
   // Extract state and name based on the position of 'from'

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -892,6 +892,7 @@ const HeaderBarWrapper = styled('div', {
   margin-top: ${hasNotch ? '9%' : ''};
   box-shadow: ${(!scrolledDown || !hasSubmenu)  ? '' : standardBoxShadow('wide')};
   border-bottom: ${(!scrolledDown || !hasSubmenu) ? '' : '1px solid #aaa'};
+  padding-left: calc(100vw - 100%);
 `));
 
 const StyledHeaderMenuTabs = styled(Tabs)`

--- a/src/js/components/Navigation/HeaderNotificationMenu.jsx
+++ b/src/js/components/Navigation/HeaderNotificationMenu.jsx
@@ -306,7 +306,7 @@ class HeaderNotificationMenu extends Component {
           open={menuOpen}
           onClose={this.handleClose}
           elevation={2}
-           anchorEl={anchorEl}
+          anchorEl={anchorEl}
           anchorOrigin={{
             vertical: 'bottom',
             horizontal: 'right',

--- a/src/js/components/Style/BallotStyles.jsx
+++ b/src/js/components/Style/BallotStyles.jsx
@@ -119,6 +119,11 @@ export const CandidateNameAndPartyWrapper = styled('div')`
   flex-flow: column nowrap;
   align-items: flex-start;
   justify-content: flex-start;
+  max-width: 225px;
+
+  @media (width < 450px) {
+    max-width: 150px;
+  }
 `;
 
 export const CandidateParty = styled('div')`

--- a/src/js/components/Style/pageLayoutStyles.js
+++ b/src/js/components/Style/pageLayoutStyles.js
@@ -105,6 +105,7 @@ export const HeaderContentOuterContainer = styled('div')`
   display: flex;
   justify-content: center;
   width: 100%;
+  padding-left: calc(-100% + 100vw);
 `;
 
 export const DualHeaderContainer = styled('div', {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

https://wevoteusa.atlassian.net/browse/WV-1027
https://wevoteusa.atlassian.net/browse/WV-962

### Changes included this pull request?
-Adds a max-width to CandidateNameAndPartyWrapper to stop squeezing the photo on longer names/party names
-Adds another check for edge cases of politican-name-national urls in extractPoliticianDetailsFromUrl.js 
-Adds another 20% to transform on the translateY for MobileHeaderOuterContainer

-Adds calc function to take into account size of scrollbar when visible and adds that amount to margin-left 