### PR TITLE
[WV-943] Candidates Page - Candidates under current representatives header is not loading

### DIFF
--- a/src/js/pages/Campaigns/CampaignsHome.jsx
+++ b/src/js/pages/Campaigns/CampaignsHome.jsx
@@ -721,6 +721,8 @@ class CampaignsHome extends Component {
     // console.log('CampaignsHomeLoader.jsx render campaignList:', campaignList);
     const pigsCanFly = false;
 
+    // console.log("Actual list: ", representativeListShownAsRepresentatives.length, "number of results: ", numberOfRepresentativeResults)
+
     if (detailsListMode) {
       // console.log('detailsListMode TRUE');
       return (
@@ -822,7 +824,7 @@ class CampaignsHome extends Component {
             {displayBattlegroundPlaceholder && <CandidateListRootPlaceholder titleTextForList="Candidates in Close Races" />}
           </>
         )}
-        {(representativeListShownAsRepresentatives && representativeListShownAsRepresentatives.length > 0) ? (
+        {(representativeListShownAsRepresentatives && representativeListShownAsRepresentatives.length > 0) && (
           <WhatIsHappeningSection useMinimumHeight={!isSearching && numberOfRepresentativeResults > 0}>
             <Suspense fallback={<span><CandidateListRootPlaceholder titleTextForList="Current Representatives" /></span>}>
               <RepresentativeListRoot
@@ -838,14 +840,6 @@ class CampaignsHome extends Component {
               />
             </Suspense>
           </WhatIsHappeningSection>
-        ) : (
-          <>
-            {numberOfRepresentativeResults > 0 && (
-              <>
-                <CandidateListRootPlaceholder titleTextForList="Current Representatives" />
-              </>
-            )}
-          </>
         )}
         {(candidateListOnYourBallot && candidateListOnYourBallot.length > 0) ? (
           <WhatIsHappeningSection useMinimumHeight={!isSearching && numberOfCandidatesOnBallotResults > 0}>


### PR DESCRIPTION
Previously, the code checked numberOfRepresentativeResults > 0 and displayed a CandidateListRootPlaceholder, even when representativeListShownAsRepresentatives was empty. This could mislead users by suggesting there were representatives when none were actually rendered.

Now, the UI only shows the section if representativeListShownAsRepresentatives has items. This avoids confusing UX and unnecessary rendering.

I added a console.log to compare the actual list length with numberOfRepresentativeResults to help catch any future data mismatches.

Tested with the state of Hawaii, which does have representatives, to confirm the updated logic works as intended.


<img width="1710" alt="Screenshot 2025-05-17 at 6 24 58 PM" src="https://github.com/user-attachments/assets/b550901a-a4c0-4051-a350-2b3de5097573" />


