### PR TITLE
[WV-1137] Implement dataLayer tracking for candidate card clicks [FEEDBACK PROVIDED]

### DIFF
--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -135,6 +135,7 @@ class PoliticianDetailsPage extends Component {
     // this.onScroll = this.onScroll.bind(this);
   }
 
+
   componentDidMount () {
     // console.log('PoliticianDetailsPage componentDidMount');
     const { match: { params } } = this.props;

--- a/src/js/components/Ballot/BallotScrollingContainer.jsx
+++ b/src/js/components/Ballot/BallotScrollingContainer.jsx
@@ -2,6 +2,7 @@ import { ArrowForwardIos, ArrowBackIos } from '@mui/icons-material';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import { BallotHorizontallyScrollingContainer, BallotScrollingInnerWrapper, LeftArrowInnerWrapper, LeftArrowOuterWrapper, RightArrowInnerWrapper, RightArrowOuterWrapper } from '../../common/components/Style/ScrollingStyles';
 import HeartFavoriteToggleLoader from '../../common/components/Widgets/HeartFavoriteToggle/HeartFavoriteToggleLoader';
 import { handleHorizontalScroll } from '../../common/utils/leftRightArrowCalculation';
@@ -141,6 +142,26 @@ class BallotScrollingContainer extends Component {
           <CandidateContainer
             data-modal-trigger
             className="u-cursor--pointer"
+            onClick={() => {
+              // DataLayer push
+              const dataLayerObject = {
+                event: 'relatedCandidateCardClick',
+                element_id: oneCandidate.we_vote_id,
+                candidateDetails: {
+                  name: oneCandidate.ballot_item_display_name,
+                  party: oneCandidate.party,
+                  office: oneCandidate.contest_office_name,
+                  state: oneCandidate.state_code,
+                },
+                pageDetails: {
+                  pageName: 'CandidatePage',
+                  section: 'CandidatesWhoRanForSameOffice',
+                  pathname: window.location.pathname,
+                }
+              };
+              console.log('Pushing to dataLayer:', dataLayerObject);
+              TagManager.dataLayer({ dataLayer: dataLayerObject });
+            }}
           >
             <CandidateWrapper>
               <CandidateInfo data-modal-trigger>


### PR DESCRIPTION
### WV-1137: Pull Request: Add dataLayer Tracking for Candidate Card Clicks
Summary
This pull request implements Google Tag Manager (GTM) dataLayer tracking for clicks on candidate cards in the "Candidates who ran for same office" section of the application.

Details of the Change
Added a dataLayer push to the onClick handler of the <CandidateContainer> in BallotScrollingContainer.jsx.
The dataLayer event includes:
Candidate ID, name, party, office, and state
Page name and section
Current pathname

