### PR TITLE
WV-1204 Add datalayer for "Copy link" on Share Ballot [FEEDBACK PROVIDED]

### DIFF
--- a/src/js/common/components/CampaignShare/ShareByCopyLink.jsx
+++ b/src/js/common/components/CampaignShare/ShareByCopyLink.jsx
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import styled from 'styled-components';
-import TagManager from 'react-gtm-module';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import { renderLog } from '../../utils/logging';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
 import CampaignStore from '../../stores/CampaignStore';
 import { generateSharingLink } from './shareButtonCommon';
+import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
 
 class ShareByCopyLink extends Component {
   constructor (props) {
@@ -97,8 +97,10 @@ class ShareByCopyLink extends Component {
     if (this.props.onClickFunction) {
       this.props.onClickFunction();
     }
+
     // adding dataLayer for "Copy link" on Share Ballot
-    const currentPathname = window.location.pathname;
+    const { location: { pathname: currentPathname } } = window;
+    const page = lookupPageNameAndPageTypeDict(currentPathname);
 
     const dataLayerObject = {
       event: 'ShareBallotCopyLinkClick',
@@ -107,13 +109,15 @@ class ShareByCopyLink extends Component {
         campaignXWeVoteId: this.props.campaignXWeVoteId || null,
       },
       pageDetails: {
-        pageName: 'ShareBallotModal',
+        pageName: page.pageName,
+        pageType: page.pageType,
         pathname: currentPathname,
       },
       timestamp: new Date().toISOString(),
     };
     console.log('DataLayer for copy link:', dataLayerObject);
-    TagManager.dataLayer({ dataLayer: dataLayerObject });
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push(dataLayerObject);
   }
 
   render () {

--- a/src/js/common/components/CampaignShare/ShareByCopyLink.jsx
+++ b/src/js/common/components/CampaignShare/ShareByCopyLink.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import { renderLog } from '../../utils/logging';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
@@ -96,6 +97,23 @@ class ShareByCopyLink extends Component {
     if (this.props.onClickFunction) {
       this.props.onClickFunction();
     }
+    // adding dataLayer for "Copy link" on Share Ballot
+    const currentPathname = window.location.pathname;
+
+    const dataLayerObject = {
+      event: 'ShareBallotCopyLinkClick',
+      shareDetails: {
+        shareType: this.props.shareType || 'ballotWithChoices',
+        campaignXWeVoteId: this.props.campaignXWeVoteId || null,
+      },
+      pageDetails: {
+        pageName: 'ShareBallotModal',
+        pathname: currentPathname,
+      },
+      timestamp: new Date().toISOString(),
+    };
+    console.log('DataLayer for copy link:', dataLayerObject);
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
   }
 
   render () {
@@ -124,6 +142,7 @@ ShareByCopyLink.propTypes = {
   darkButton: PropTypes.bool,
   mobileMode: PropTypes.bool,
   onClickFunction: PropTypes.func,
+  shareType: PropTypes.string,
   uniqueExternalId: PropTypes.string,
 };
 

--- a/src/js/common/components/CampaignShare/ShareOnTwitterButton.jsx
+++ b/src/js/common/components/CampaignShare/ShareOnTwitterButton.jsx
@@ -84,6 +84,19 @@ class ShareOnTwitterButton extends Component {
 
   saveActionShareButton = () => {
     CampaignSupporterActions.shareButtonClicked(true);
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'ShareBallotTwitterClick',
+      shareDetails: {
+        platform: 'Twitter',
+        campaignXWeVoteId: this.props.campaignXWeVoteId || null,
+      },
+      pageDetails: {
+        pageName: 'ShareBallotModal',
+        pathname: window.location.pathname,
+      },
+      timestamp: new Date().toISOString(),
+    });
   }
 
   render () {

--- a/src/js/components/Share/ShareModalOption.jsx
+++ b/src/js/components/Share/ShareModalOption.jsx
@@ -68,6 +68,19 @@ class ShareModalOption extends Component {
     if (this.props.onClickFunction) {
       this.props.onClickFunction();
     }
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: 'ShareModalCopyLinkClick',
+      shareDetails: {
+        title: this.props.title || 'Copy link',
+        urlShared: this.props.urlToShare || '',
+      },
+      pageDetails: {
+        pageName: 'ShareModal',
+        pathname: window.location.pathname,
+      },
+      timestamp: new Date().toISOString(),
+    });
   }
 
   render () {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1102

### Changes included this pull request?
- Summary: Adds `dataLayer` to the "Copy link" action in the Share Ballot
- Testing: Clicked the "Copy link" button and `window.dataLayer` receives correct event