### PR TITLE
[WV-1138] Add dataLayer to "Open in new tab symbol" on Candidate side panel [MERGED]

### DIFF
--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -90,7 +90,7 @@ function CardForListBody (props) {
                     <LaunchIconWrapper>
                       <Suspense fallback={<></>}>
                         <OpenExternalWebSite
-                          linkIdAttribute="openPoliticianPage"
+                          linkIdAttribute="openCandidateInNewTab"
                           url={politicianDetailsURL}
                           target="_blank"
                           className="open-web-site open-web-site__no-right-padding"
@@ -109,6 +109,14 @@ function CardForListBody (props) {
                           destinationPageName={destinationPage.pageName}
                           destinationPageType={destinationPage.pageType}
                           trackingOn
+                          candidateDetails={{
+                            candidateWeVoteId: candidateWeVoteId || politicianWeVoteId,
+                            candidateName: ballotItemDisplayName,
+                            officeName,
+                            politicianWeVoteId,
+                            politicalParty,
+                            stateCode,
+                          }}
                         />
                       </Suspense>
                     </LaunchIconWrapper>

--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -62,7 +62,7 @@ function CardForListBody (props) {
     politicalPartySvgNameWithPath = '../../img/global/svg-icons/political-party-working-families.svg';
   }
   const politicianDetailsURL = `${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}${politicianBasePath}`;
-  const destinationPage = lookupPageNameAndPageTypeDict(politicianDetailsURL);
+  const destinationPage = lookupPageNameAndPageTypeDict(politicianBasePath);
   // console.log('politicianBasePath:', politicianBasePath);
   // console.log('CardForListBody politicianDetailsURL:', politicianDetailsURL, ', destinationPage: ', destinationPage);
   const location = useLocation();

--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -62,7 +62,7 @@ function CardForListBody (props) {
     politicalPartySvgNameWithPath = '../../img/global/svg-icons/political-party-working-families.svg';
   }
   const politicianDetailsURL = `${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}${politicianBasePath}`;
-  const destinationPage = lookupPageNameAndPageTypeDict(politicianBasePath);
+  const destinationPage = lookupPageNameAndPageTypeDict(politicianDetailsURL);
   // console.log('politicianBasePath:', politicianBasePath);
   // console.log('CardForListBody politicianDetailsURL:', politicianDetailsURL, ', destinationPage: ', destinationPage);
   const location = useLocation();
@@ -109,8 +109,6 @@ function CardForListBody (props) {
                           destinationPageName={destinationPage.pageName}
                           destinationPageType={destinationPage.pageType}
                           trackingOn
-                          candidateWeVoteId={candidateWeVoteId}
-                          politicianWeVoteId={politicianWeVoteId}
                         />
                       </Suspense>
                     </LaunchIconWrapper>

--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -90,7 +90,7 @@ function CardForListBody (props) {
                     <LaunchIconWrapper>
                       <Suspense fallback={<></>}>
                         <OpenExternalWebSite
-                          linkIdAttribute="openCandidateInNewTab"
+                          linkIdAttribute="openPoliticianPage"
                           url={politicianDetailsURL}
                           target="_blank"
                           className="open-web-site open-web-site__no-right-padding"
@@ -109,14 +109,8 @@ function CardForListBody (props) {
                           destinationPageName={destinationPage.pageName}
                           destinationPageType={destinationPage.pageType}
                           trackingOn
-                          candidateDetails={{
-                            candidateWeVoteId: candidateWeVoteId || politicianWeVoteId,
-                            candidateName: ballotItemDisplayName,
-                            officeName,
-                            politicianWeVoteId,
-                            politicalParty,
-                            stateCode,
-                          }}
+                          candidateWeVoteId={candidateWeVoteId}
+                          politicianWeVoteId={politicianWeVoteId}
                         />
                       </Suspense>
                     </LaunchIconWrapper>

--- a/src/js/common/components/Widgets/OpenExternalWebSite.jsx
+++ b/src/js/common/components/Widgets/OpenExternalWebSite.jsx
@@ -11,7 +11,7 @@ import stringContains from '../../utils/stringContains';
 
 export default class OpenExternalWebSite extends Component {
   sendExternalLinkInfoToGTM = () => {
-    const { destinationPageName, destinationPageType, linkIdAttribute, pageName, pageType, trackingOn, url } = this.props;
+    const { candidateDetails, destinationPageName, destinationPageType, linkIdAttribute, pageName, pageType, trackingOn, url } = this.props;
     if (trackingOn) {
       const { location: { pathname: currentPathname } } = window;
       const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
@@ -23,9 +23,11 @@ export default class OpenExternalWebSite extends Component {
       // console.log('External link clicked:', this.props.url);
       const dataLayerObj = {
         actionDetails: {
+          actionType: 'navigate',
           buttonId: linkIdAttribute,
+          ...(candidateDetails && { candidateDetails }),
         },
-        event: 'click',
+        event: 'action',
         destinationDetails: {
           destinationPageName: destinationPageName || destinationPageNameLocalBackup,
           destinationPageType: destinationPageType || destinationPageTypeLocalBackup,
@@ -34,7 +36,7 @@ export default class OpenExternalWebSite extends Component {
         pageDetails: {
           pageName: pageName || pageNameLocalBackup,
           pageType: pageType || pageTypeLocalBackup,
-          pathname: window.location.pathname,
+          pathname: currentPathname,
         },
         userDetails: {
           stateCode: VoterStore.getVoterStateCode(),
@@ -114,4 +116,12 @@ OpenExternalWebSite.propTypes = {
   title: PropTypes.string,
   trackingOn: PropTypes.bool,
   url: PropTypes.string.isRequired,
+  candidateDetails: PropTypes.shape({
+    candidateWeVoteId: PropTypes.string,
+    candidateName: PropTypes.string,
+    officeName: PropTypes.string,
+    politicianWeVoteId: PropTypes.string,
+    politicalParty: PropTypes.string,
+    stateCode: PropTypes.string,
+  }),
 };

--- a/src/js/common/components/Widgets/OpenExternalWebSite.jsx
+++ b/src/js/common/components/Widgets/OpenExternalWebSite.jsx
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import TagManager from 'react-gtm-module';
-import CandidateStore from "../../../stores/CandidateStore";
-import PoliticianStore from "../../../common/stores/PoliticianStore";
+import CandidateStore from '../../../stores/CandidateStore';
+import PoliticianStore from '../../stores/PoliticianStore';
 import VoterStore from '../../../stores/VoterStore';
 import { cordovaOpenSafariView } from '../../utils/cordovaUtils';
 import { isAndroid, isWebApp } from '../../utils/isCordovaOrWebApp';
@@ -141,9 +141,5 @@ OpenExternalWebSite.propTypes = {
   trackingOn: PropTypes.bool,
   url: PropTypes.string.isRequired,
   candidateWeVoteId: PropTypes.string,
-  candidateName: PropTypes.string,
-  officeName: PropTypes.string,
   politicianWeVoteId: PropTypes.string,
-  politicalParty: PropTypes.string,
-  stateCode: PropTypes.string,
 };

--- a/src/js/common/components/Widgets/OpenExternalWebSite.jsx
+++ b/src/js/common/components/Widgets/OpenExternalWebSite.jsx
@@ -1,6 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import TagManager from 'react-gtm-module';
+import CandidateStore from "../../../stores/CandidateStore";
+import PoliticianStore from "../../../common/stores/PoliticianStore";
 import VoterStore from '../../../stores/VoterStore';
 import { cordovaOpenSafariView } from '../../utils/cordovaUtils';
 import { isAndroid, isWebApp } from '../../utils/isCordovaOrWebApp';
@@ -11,7 +13,7 @@ import stringContains from '../../utils/stringContains';
 
 export default class OpenExternalWebSite extends Component {
   sendExternalLinkInfoToGTM = () => {
-    const { candidateDetails, destinationPageName, destinationPageType, linkIdAttribute, pageName, pageType, trackingOn, url } = this.props;
+    const { candidateWeVoteId, politicianWeVoteId, destinationPageName, destinationPageType, linkIdAttribute, pageName, pageType, trackingOn, url } = this.props;
     if (trackingOn) {
       const { location: { pathname: currentPathname } } = window;
       const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
@@ -25,9 +27,8 @@ export default class OpenExternalWebSite extends Component {
         actionDetails: {
           actionType: 'navigate',
           buttonId: linkIdAttribute,
-          ...(candidateDetails && { candidateDetails }),
         },
-        event: 'action',
+        event: 'click',
         destinationDetails: {
           destinationPageName: destinationPageName || destinationPageNameLocalBackup,
           destinationPageType: destinationPageType || destinationPageTypeLocalBackup,
@@ -44,7 +45,30 @@ export default class OpenExternalWebSite extends Component {
           voterWeVoteId: VoterStore.getVoterWeVoteId(),
         },
       };
-      //console.log('Sending dataLayerObj to GTM:', dataLayerObj);
+      if (candidateWeVoteId) {
+        const candidate = CandidateStore.getCandidateByWeVoteId(candidateWeVoteId);
+        if (candidate) {
+          dataLayerObj.candidateDetails = {
+            candidateWeVoteId: candidate.we_vote_id,
+            candidateName: candidate.ballot_item_display_name,
+            candidateTwitterHandle: candidate.twitter_handle,
+            candidatePoliticalParty: candidate.party,
+            contestOfficeWeVoteId: candidate.contest_office_we_vote_id,
+          };
+        }
+      }
+      if (politicianWeVoteId) {
+        const politician = PoliticianStore.getPoliticianByWeVoteId(politicianWeVoteId);
+        if (politician) {
+          dataLayerObj.politicianDetails = {
+            politicianWeVoteId: politician.we_vote_id,
+            politicianName: politician.politician_name,
+            politicianTwitterHandle: politician.twitter_handle,
+            politicianPoliticalParty: politician.political_party,
+          };
+        }
+      }
+      // console.log('Sending dataLayerObj to GTM:', dataLayerObj);
       TagManager.dataLayer({ dataLayer: dataLayerObj });
     }
   }
@@ -116,12 +140,10 @@ OpenExternalWebSite.propTypes = {
   title: PropTypes.string,
   trackingOn: PropTypes.bool,
   url: PropTypes.string.isRequired,
-  candidateDetails: PropTypes.shape({
-    candidateWeVoteId: PropTypes.string,
-    candidateName: PropTypes.string,
-    officeName: PropTypes.string,
-    politicianWeVoteId: PropTypes.string,
-    politicalParty: PropTypes.string,
-    stateCode: PropTypes.string,
-  }),
+  candidateWeVoteId: PropTypes.string,
+  candidateName: PropTypes.string,
+  officeName: PropTypes.string,
+  politicianWeVoteId: PropTypes.string,
+  politicalParty: PropTypes.string,
+  stateCode: PropTypes.string,
 };


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1138
### Changes included this pull request?

- passed candidateDetails to dataLayer + propTypes
- Added candidateDetails prop to CardForListBody.jsx and passed it into OpenExternalWebSite.jsx
- Updated sendExternalLinkInfoToGTM to include candidateDetails in dataLayer for enhanced tracking
- Defined PropTypes for candidateDetails in OpenExternalWebSite.jsx
- Cleaned up all lint errors and warnings in related files
