### PR TITLE
WV-1191 Add dataLayer for Endorsements in 'Follow Popular Topics' on Ready Page[CHANGES REQUESTED]

### DIFF
--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -154,6 +154,7 @@ class IssueCard extends Component {
       dataLayer: {
         actionDetails: {
           buttonId: 'valueListLink',
+          actionType: 'navigate', // By AnujaL
         },
         event: 'action',
         pageDetails: {
@@ -466,6 +467,7 @@ class IssueCard extends Component {
               {includeLinkToIssue ? (
                 <Link id="issueAdvocatesLink"
                       to={this.getIssueLink}
+                      onClick={this.handleIssueClick} // By AnujaL
                 >
                   {issueAdvocates}
                 </Link>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixed issue [WV-1191](https://wevoteusa.atlassian.net/browse/WV-1191). I fixed all the changes that were requested in ([#4397](https://github.com/wevote/WebApp/pull/4397)) . Now getting the dataLayer with all details.

### Changes included this pull request?
yes, I added all changes. Call the  handleIssueClick() which was already present in the component to add dataLayer.

[WV-1191]: https://wevoteusa.atlassian.net/browse/WV-1191?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ