### PR TITLE
[WV-1196] Replace stepIndex with titleId for slide tracking [TEAM REVIEW]

### DIFF
--- a/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
+++ b/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
@@ -52,6 +52,7 @@ class HowItWorksModal extends Component {
         },
         actionDetails: {
           buttonId: 'profileCloseHowItWorksModal',
+          actionType: 'closeModal',
         },
         userDetails: {
           stateCode: VoterStore.getVoterStateCode(),

--- a/src/js/pages/HowItWorks.jsx
+++ b/src/js/pages/HowItWorks.jsx
@@ -274,6 +274,31 @@ class HowItWorks extends Component {
     this.setState({ selectedStepIndex: selectedStepIndex - 1 });
   };
 
+  getTitleIdFromIndex (stepIndex) {
+    const {
+      selectedCategoryIndex,
+      forVoterSteps,
+      forOrganizationsSteps,
+      forCampaignsSteps,
+    } = this.state;
+
+    let steps = {};
+    if (selectedCategoryIndex === 0) {
+      steps = forVoterSteps;
+    } else if (selectedCategoryIndex === 1) {
+      steps = forOrganizationsSteps;
+    } else if (selectedCategoryIndex === 2) {
+      steps = forCampaignsSteps;
+    }
+
+    const step = Object.values(steps).find((stepObj) => stepObj.index === stepIndex);
+    if (step && step.titleId) {
+      return step.titleId;
+    } else {
+      return '';
+    }
+  }
+
   switchToDifferentCategoryFunction = (selectedCategoryIndex) => {
     let getStartedMode = 'getStartedForVoters';
     // let getStartedUrl = '/ballot';
@@ -295,6 +320,8 @@ class HowItWorks extends Component {
   sendHowItWorksSlideEvent (stepIndex) {
     const { location: { pathname: currentPathname } } = window;
     const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
+    const titleId = this.getTitleIdFromIndex(stepIndex);
+
     TagManager.dataLayer({
       dataLayer: {
         event: 'action',
@@ -304,8 +331,8 @@ class HowItWorks extends Component {
           pathname: currentPathname,
         },
         actionDetails: {
+          buttonId: titleId,
           eventType: 'slideChange',
-          stepIndex,
         },
         userDetails: {
           stateCode: VoterStore.getVoterStateCode(),


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1196
### Changes included this pull request?

- Created `getTitleIdFromIndex` function to convert `stepIndex` to corresponding `titleId` for slide tracking
- Updated `sendHowItWorksSlideEvent` to use `titleId` instead of `stepIndex` as `buttonId`
- Added actionType: `closeModal` to dataLayer event when `HowItWorks` modal is closed