### PR TITLE
 WV-1446 - Add dataLayer on Ballot page when "show more" is clicked under Values [NEEDS REVIEW]

### DIFF
--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -1,8 +1,11 @@
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
 import { renderLog } from '../../common/utils/logging';
 import IssueStore from '../../stores/IssueStore';
+import VoterStore from '../../stores/VoterStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import signInModalGlobalState from '../../common/components/Widgets/signInModalGlobalState';
 import ValueNameWithPopoverDisplay from './ValueNameWithPopoverDisplay';
@@ -139,12 +142,38 @@ class IssuesByBallotItemDisplayList extends Component {
   };
 
   handleExpandIssues = () => {
-    const { expandIssues, totalLengthOfIssuesToRenderList } = this.state;
+    const { expandIssues, totalLengthOfIssuesToRenderList, ballotItemWeVoteId, ballotItemDisplayName } = this.state;
+    const { location: { pathname: currentPathname } } = window;
+    const page = lookupPageNameAndPageTypeDict(currentPathname);
+    // dataLayer
+    const dataLayerObject = {
+      event: 'ShowMoreValuesClick',
+      context: {
+        ballotItemDisplayName,
+        ballotItemWeVoteId,
+      },
+      pageDetails: {
+        pageName: page.pageName,
+        pageType: page.pageType,
+        pathname: currentPathname,
+      },
+      userDetails: {
+        voterWeVoteId: VoterStore.getVoterWeVoteId(),
+        stateCode: VoterStore.getVoterStateCode(),
+        userCohort: VoterStore.getAnalyticsUserCohort(),
+      },
+      timestamp: new Date().toISOString(),
+    };
+
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+
     this.setState({
       expandIssues: !expandIssues,
       currentNumberOfIssuesToDisplay: totalLengthOfIssuesToRenderList,
     });
   };
+
+
 
   handleHideIssues = () => {
     const { defaultNumberOfIssuesToDisplay } = this.state;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1446

### Changes included this pull request?
- Added datalayer for when "Show more" is clicked under Values/Topics/Issues on the Ballot page
- Added to `handleExpandIssues` in `IssuesByBallotItemDisplayList.jsx`
- It tracks Ballot name & ID, Page details, user details, timestamp

Not too sure if I added it to the right one