### PR TITLE
Fixed settings issue where /settings/securityAndSignIn was broken

### DIFF
--- a/src/js/pages/Settings/SettingsDashboard.jsx
+++ b/src/js/pages/Settings/SettingsDashboard.jsx
@@ -199,6 +199,7 @@ export default class SettingsDashboard extends Component {
     const { editMode } = this.state;
     switch (editMode) {
       case 'account':
+      case 'securityAndSignIn':
         settingsComponentToDisplayDesktop = <SignInOptionsPanel externalUniqueId="domainDesktop" />;
         settingsComponentToDisplayMobile = <SignInOptionsPanel externalUniqueId="domainMobile" />;
         break;

--- a/src/js/pages/Settings/SettingsDashboard.jsx
+++ b/src/js/pages/Settings/SettingsDashboard.jsx
@@ -198,8 +198,8 @@ export default class SettingsDashboard extends Component {
     let settingsComponentToDisplayMobile = null;
     const { editMode } = this.state;
     switch (editMode) {
-      case 'account':
       case 'securityAndSignIn':
+      case 'account':
         settingsComponentToDisplayDesktop = <SignInOptionsPanel externalUniqueId="domainDesktop" />;
         settingsComponentToDisplayMobile = <SignInOptionsPanel externalUniqueId="domainMobile" />;
         break;


### PR DESCRIPTION
Too many overlapping changes to find where this came from, but we use the two routes interchangeably, and we were not picking it up on the SettingsDashboard.jsx

As a result you could not get to /settings/securityAndSignIn

Did not want to make a change in components/Navigation/SettingsPersonalSideBar.jsx which is in the middle of a series of changes, by another developer.