### PR TITLE
WV-1197: Android "backbutton" suppressed in Chrome on Android device and in Cordova

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -192,6 +192,13 @@ class App extends Component {
     if (isAndroid()) {         // December 12, 2023: All sorts of problems with sign-in with Facebook on Android, so disabling it here
       webAppConfig.ENABLE_FACEBOOK = false;   // This overrides the config setting for the entire Android app
     }
+    if (isWebApp()) {
+      // July 2025, Android "backbutton" is not handled since pushHistory is only keeping the previous location, so pressing "backbutton" twice would be a mess
+      // Also it was originally noted as a bug in the How it Works dialog, which would be a special case that would not use pushHistory
+      // This listener is for Chrome on an Android device while browsing wevote.us
+      document.addEventListener("backbutton", () => {}, false);
+      // if isCordova(), then this is handled in startCordova, after the deviceready event
+    }
 
     if (webAppConfig.ENABLE_FACEBOOK) {
       setTimeout(() => {

--- a/src/js/pages/More/Donate.jsx
+++ b/src/js/pages/More/Donate.jsx
@@ -26,6 +26,7 @@ import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageType
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import Donation from '../../../img/global/photos/Donate_Screenshot.png';
 
+/* global $ */
 
 // const stripePromise = loadStripe(webAppConfig.STRIPE_API_KEY);
 
@@ -156,7 +157,7 @@ class Donate extends Component {
     const { isC4Donation } = this.state;
     if (isC4Donation) {
       // console.log('------------ onVerifyCaptcha: ', token);
-      $ajax({
+      $.ajax({
         endpoint: 'googleRecaptchaVerify',
         data: { token },
         success: (res) => {
@@ -173,7 +174,7 @@ class Donate extends Component {
               isSignedin,
             });
             if (!allowedToDonate) {
-              $ajax({
+              $.ajax({
                 endpoint: 'logToCloudWatch',
                 data: { message: `reCAPTCHA FAILED verification signedIn ${isSignedin}, results ${JSON.stringify(res)}` },
               });
@@ -193,8 +194,8 @@ class Donate extends Component {
   preDonateDescription = () => (
     <span id="first_paragraph">
       Thank you for being a voter! For every $10 donated, you help 50 Americans be voters too.
-      {/*When people feel prepared to vote, they’re more likely to cast a ballot — especially in local and primary elections, where participation is lowest. At*/}
-      {/*WeVote our mission is to close the confidence gap that keeps so many voters on the sidelines.*/}
+      {/* When people feel prepared to vote, they’re more likely to cast a ballot — especially in local and primary elections, where participation is lowest. At */}
+      {/* WeVote our mission is to close the confidence gap that keeps so many voters on the sidelines. */}
     </span>
   );
 
@@ -301,7 +302,7 @@ class Donate extends Component {
   render () {
     renderLog('Donate');  // Set LOG_RENDER_EVENTS to log all renders
     const { classes } = this.props;
-    const { isC4Donation, isSignedin, joining, showWaiting, value, isMonthly, preDonation, okToDonateWithoutAuth, windowWidth } = this.state;
+    const { isC4Donation, isSignedin, joining, value, isMonthly, preDonation, okToDonateWithoutAuth, windowWidth } = this.state;
 
     // Default donation goes to c3, unless we specify a donation to the c4
     let c3DonationHtml = '';
@@ -317,15 +318,15 @@ class Donate extends Component {
               {/* eslint-disable-next-line react/no-unknown-property */}
               <script src="https://donorbox.org/widget.js" paypalExpress="true" defer />
             </Helmet>
-            {/*<ContentTitle id="want_to_vote">*/}
-            {/*  Want more Americans to vote?*/}
-            {/*</ContentTitle>*/}
+            {/* <ContentTitle id="want_to_vote"> */}
+            {/*  Want more Americans to vote? */}
+            {/* </ContentTitle> */}
             <CenteredText className="u-show-mobile">
               <Section noTopMargin>
                 <DonateDescriptionContainer>
-                  {/*{this.preDonateDescription()}*/}
-                  {/*{' '}*/}
-                  {/*{this.preDonateDescriptionBottom(isC4Donation)}*/}
+                  {/* {this.preDonateDescription()} */}
+                  {/* {' '} */}
+                  {/* {this.preDonateDescriptionBottom(isC4Donation)} */}
                   {this.donationDescriptionReadMore(this.state.readMore, isC4Donation)}
                 </DonateDescriptionContainer>
                 <InnerWrapper>
@@ -340,9 +341,9 @@ class Donate extends Component {
             {windowWidth > 532 && (
               <TwoColumns>
                 <TextAndDonorboxColumn className="u-show-desktop-tablet">
-                  {/*{this.preDonateDescription()}*/}
-                  {/*{' '}*/}
-                  {/*{this.preDonateDescriptionBottom(isC4Donation)}*/}
+                  {/* {this.preDonateDescription()} */}
+                  {/* {' '} */}
+                  {/* {this.preDonateDescriptionBottom(isC4Donation)} */}
                   {this.donationDescriptionReadMore(this.state.readMore, isC4Donation)}
                   <InnerWrapper>
                     <DonorboxWrapper>
@@ -353,13 +354,13 @@ class Donate extends Component {
                   </InnerWrapper>
                 </TextAndDonorboxColumn>
                 <DonationImageContainer>
-                  {/*<InnerWrapper>*/}
-                  {/*  <DonorboxWrapper>*/}
-                  {/*    <Suspense fallback={<div>Loading...</div>}>*/}
-                  {/*      <DonorboxEmbed />*/}
-                  {/*    </Suspense>*/}
-                  {/*  </DonorboxWrapper>*/}
-                  {/*</InnerWrapper>*/}
+                  {/* <InnerWrapper> */}
+                  {/*  <DonorboxWrapper> */}
+                  {/*    <Suspense fallback={<div>Loading...</div>}> */}
+                  {/*      <DonorboxEmbed /> */}
+                  {/*    </Suspense> */}
+                  {/*  </DonorboxWrapper> */}
+                  {/* </InnerWrapper> */}
                   <DonationImage
                     src={Donation}
                   />

--- a/src/js/pages/More/DonateCordova.jsx
+++ b/src/js/pages/More/DonateCordova.jsx
@@ -1,4 +1,3 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 // Dummy Donate class, which at Cordova compile time, is copied over the production class to remove any trace of Stripe from Cordova
@@ -12,8 +11,6 @@ class Donate extends Component {
   }
 }
 Donate.propTypes = {
-  classes: PropTypes.object,
-  showFooter: PropTypes.bool,
 };
 
 export default Donate;

--- a/src/js/pages/Settings/SettingsDashboard.jsx
+++ b/src/js/pages/Settings/SettingsDashboard.jsx
@@ -199,6 +199,7 @@ export default class SettingsDashboard extends Component {
     const { editMode } = this.state;
     switch (editMode) {
       case 'account':
+      case 'securityAndSignIn':
         settingsComponentToDisplayDesktop = <SignInOptionsPanel externalUniqueId="domainDesktop" />;
         settingsComponentToDisplayMobile = <SignInOptionsPanel externalUniqueId="domainMobile" />;
         break;

--- a/src/js/pages/Settings/SettingsDashboard.jsx
+++ b/src/js/pages/Settings/SettingsDashboard.jsx
@@ -198,8 +198,8 @@ export default class SettingsDashboard extends Component {
     let settingsComponentToDisplayMobile = null;
     const { editMode } = this.state;
     switch (editMode) {
-      case 'account':
       case 'securityAndSignIn':
+      case 'account':
         settingsComponentToDisplayDesktop = <SignInOptionsPanel externalUniqueId="domainDesktop" />;
         settingsComponentToDisplayMobile = <SignInOptionsPanel externalUniqueId="domainMobile" />;
         break;

--- a/src/js/startCordova.js
+++ b/src/js/startCordova.js
@@ -111,7 +111,7 @@ export function initializationForCordova (startReact) {
     if (isAndroid()) {
       // July 2025, Android "backbutton" is not handled since pushHistory is only keeping the previous location, so pressing "backbutton" twice would be a mess
       // Also it was originally noted as a bug in the How it Works dialog, which would be a special case that would not use pushHistory
-      document.addEventListener("backbutton", () => {}, false);
+      document.addEventListener('backbutton', () => {}, false);
     }
     initializejQuery(() => {
       const { $ } = window;

--- a/src/js/startCordova.js
+++ b/src/js/startCordova.js
@@ -1,7 +1,7 @@
 import VoterActions from './actions/VoterActions';
 import { getCordovaScreenHeight, isIOS, isIOSAppOnMac, isIPad, isSimulator, prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from './common/utils/cordovaUtils';
 import initializejQuery from './common/utils/initializejQuery';
-import { isCordova } from './common/utils/isCordovaOrWebApp';
+import { isAndroid, isCordova } from './common/utils/isCordovaOrWebApp';
 import Cookies from './common/utils/js-cookie/Cookies';
 import { httpLog } from './common/utils/logging';
 import TwitterSignIn from './components/Twitter/TwitterSignIn';
@@ -107,6 +107,11 @@ export function initializationForCordova (startReact) {
     if (isIPad()) {
       document.querySelector('body').style.height = getCordovaScreenHeight();
       console.log('Cordova: Initial "body" height for iPad = calculation disabled '); // , result.height / result.scale);
+    }
+    if (isAndroid()) {
+      // July 2025, Android "backbutton" is not handled since pushHistory is only keeping the previous location, so pressing "backbutton" twice would be a mess
+      // Also it was originally noted as a bug in the How it Works dialog, which would be a special case that would not use pushHistory
+      document.addEventListener("backbutton", () => {}, false);
     }
     initializejQuery(() => {
       const { $ } = window;


### PR DESCRIPTION
It was too messy to fix as requested, and would have required a app-wide refactor of pushHistory, plus messy one-off fixes when navigating in a dialog, when not using routing/pushHistory.

"backbutton" which is an Android only feature, no longer kicks you out of Cordova, nor does it kick you out of Chrome when browsing the WebApp on an Android device. 

The "backbutton" kicking you out of Chrome when browsing the WebApp on an Android device, is a current bug, that is resolved by this PR.

Some lint cleanup in Donate.