### PR TITLE
[WV-1448] - add data layer on ready pages for landing event [LINT ISSUES FIXED]

### DIFF
--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -1,3 +1,4 @@
+import TagManager from 'react-gtm-module';
 import { Card } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
@@ -15,6 +16,7 @@ import apiCalming from '../common/utils/apiCalming';
 import historyPush from '../common/utils/historyPush';
 import { isAndroid, isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
+import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
 import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
@@ -51,6 +53,8 @@ class Ready extends Component {
       chosenReadyIntroductionTitle: '',
       voterIsSignedIn: false,
     };
+    // Terry - tracking whether dataLayer was fired, default set to false
+    this.dataLayerFired = false;
   }
 
   componentDidMount () {
@@ -115,6 +119,32 @@ class Ready extends Component {
 
   componentDidUpdate () {
     if (AppObservableStore.isSnackMessagePending()) openSnackbar({});
+
+    // Terry - Changes made for WV-1448 adding landing datalayers
+    // Terry - only fire datalayer when voter data is ready
+    const voterFirstRetrieveCompleted = VoterStore.voterFirstRetrieveCompleted();
+    // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
+    if (voterFirstRetrieveCompleted && !this.dataLayerFired) {
+      const { location: { pathname: currentPathname } } = window;
+      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
+
+      TagManager.dataLayer({
+        dataLayer: {
+          event: 'landing',
+          pageDetails: {
+            pageName: currentPage.pageName,
+            pageType: currentPage.pageType,
+            pathname: currentPathname,
+          },
+          userDetails: {
+            stateCode: VoterStore.getVoterStateCode(),
+            userCohort: VoterStore.getAnalyticsUserCohort(),
+            voterWeVoteId: VoterStore.getVoterWeVoteId(),
+          },
+        },
+      });
+      this.dataLayerFired = true;
+    }
   }
 
   componentDidCatch (error, info) {

--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -150,6 +150,7 @@ class Ready extends Component {
     }
   }
 
+
   componentDidCatch (error, info) {
     console.log('!!!Ready.jsx caught: ', error, info.componentStack);
   }

--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -131,7 +131,8 @@ class Ready extends Component {
         TagManager.dataLayer({
           dataLayer: {
             actionDetails:{
-              
+              actionType: 'landing',
+              componentName: 'readyPageReturnVisit',
             },
             event: 'landing',
             pageDetails: {

--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -51,10 +51,10 @@ class Ready extends Component {
     this.state = {
       chosenReadyIntroductionText: '',
       chosenReadyIntroductionTitle: '',
+      dataLayerFired: false, // Terry - tracking whether dataLayer was fired, default set to false
       voterIsSignedIn: false,
     };
-    // Terry - tracking whether dataLayer was fired, default set to false
-    this.dataLayerFired = false;
+    
   }
 
   componentDidMount () {
@@ -119,18 +119,20 @@ class Ready extends Component {
 
   componentDidUpdate () {
     if (AppObservableStore.isSnackMessagePending()) openSnackbar({});
-
+    const { dataLayerFired } = this.state;
     // Terry - Changes made for WV-1448 adding landing datalayers
     // Terry - only fire datalayer when voter data is ready
-    const voterFirstRetrieveCompleted = VoterStore.voterFirstRetrieveCompleted();
     // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
-    if (!this.dataLayerFired){  
-      if (voterFirstRetrieveCompleted) {
+    if (!dataLayerFired){  
+      if (VoterStore.voterFirstRetrieveCompleted()) {
         const { location: { pathname: currentPathname } } = window;
         const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
 
         TagManager.dataLayer({
           dataLayer: {
+            actionDetails:{
+              
+            },
             event: 'landing',
             pageDetails: {
               pageName: currentPage.pageName,
@@ -144,7 +146,9 @@ class Ready extends Component {
             },
           },
         });
-        this.dataLayerFired = true;
+        this.setState({
+          dataLayerFired: true
+        });
       }
     }
   }

--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -51,10 +51,9 @@ class Ready extends Component {
     this.state = {
       chosenReadyIntroductionText: '',
       chosenReadyIntroductionTitle: '',
-      dataLayerFired: false, // Terry - tracking whether dataLayer was fired, default set to false
+      dataLayerFired: false,
       voterIsSignedIn: false,
     };
-    
   }
 
   componentDidMount () {
@@ -120,17 +119,14 @@ class Ready extends Component {
   componentDidUpdate () {
     if (AppObservableStore.isSnackMessagePending()) openSnackbar({});
     const { dataLayerFired } = this.state;
-    // Terry - Changes made for WV-1448 adding landing datalayers
-    // Terry - only fire datalayer when voter data is ready
-    // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
-    if (!dataLayerFired){  
+    if (!dataLayerFired) {
       if (VoterStore.voterFirstRetrieveCompleted()) {
         const { location: { pathname: currentPathname } } = window;
         const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
 
         TagManager.dataLayer({
           dataLayer: {
-            actionDetails:{
+            actionDetails: {
               actionType: 'landing',
               componentName: 'readyPageReturnVisit',
             },
@@ -148,7 +144,7 @@ class Ready extends Component {
           },
         });
         this.setState({
-          dataLayerFired: true
+          dataLayerFired: true,
         });
       }
     }

--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -16,7 +16,7 @@ import apiCalming from '../common/utils/apiCalming';
 import historyPush from '../common/utils/historyPush';
 import { isAndroid, isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict from '../utils/lookupPageNameAndPageTypeDict';
 import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
@@ -124,26 +124,28 @@ class Ready extends Component {
     // Terry - only fire datalayer when voter data is ready
     const voterFirstRetrieveCompleted = VoterStore.voterFirstRetrieveCompleted();
     // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
-    if (voterFirstRetrieveCompleted && !this.dataLayerFired) {
-      const { location: { pathname: currentPathname } } = window;
-      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
+    if (!this.dataLayerFired){  
+      if (voterFirstRetrieveCompleted) {
+        const { location: { pathname: currentPathname } } = window;
+        const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
 
-      TagManager.dataLayer({
-        dataLayer: {
-          event: 'landing',
-          pageDetails: {
-            pageName: currentPage.pageName,
-            pageType: currentPage.pageType,
-            pathname: currentPathname,
+        TagManager.dataLayer({
+          dataLayer: {
+            event: 'landing',
+            pageDetails: {
+              pageName: currentPage.pageName,
+              pageType: currentPage.pageType,
+              pathname: currentPathname,
+            },
+            userDetails: {
+              stateCode: VoterStore.getVoterStateCode(),
+              userCohort: VoterStore.getAnalyticsUserCohort(),
+              voterWeVoteId: VoterStore.getVoterWeVoteId(),
+            },
           },
-          userDetails: {
-            stateCode: VoterStore.getVoterStateCode(),
-            userCohort: VoterStore.getAnalyticsUserCohort(),
-            voterWeVoteId: VoterStore.getVoterWeVoteId(),
-          },
-        },
-      });
-      this.dataLayerFired = true;
+        });
+        this.dataLayerFired = true;
+      }
     }
   }
 

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -1,3 +1,4 @@
+import TagManager from 'react-gtm-module';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
@@ -11,6 +12,7 @@ import apiCalming from '../common/utils/apiCalming';
 import historyPush from '../common/utils/historyPush';
 import { isAndroid, isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
+import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
 import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
@@ -42,6 +44,8 @@ class ReadyLight extends Component {
       chosenReadyIntroductionTitle: '',
       voterIsSignedIn: false,
     };
+    // Terry - tracking whether dataLayer was fired, default set to false
+    this.dataLayerFired = false;
   }
 
   componentDidMount () {
@@ -64,6 +68,34 @@ class ReadyLight extends Component {
       AnalyticsActions.saveActionReadyVisit(VoterStore.electionId());
     }, 8000);
     window.scrollTo(0, 0);
+  }
+
+  // Terry - Changes made for WV-1448 adding landing datalayers
+  componentDidUpdate () {
+    // Terry - only fire datalayer when voter data is ready
+    const voterFirstRetrieveCompleted = VoterStore.voterFirstRetrieveCompleted();
+    // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
+    if (voterFirstRetrieveCompleted && !this.dataLayerFired) {
+      const { location: { pathname: currentPathname } } = window;
+      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
+
+      TagManager.dataLayer({
+        dataLayer: {
+          event: 'landing',
+          pageDetails: {
+            pageName: currentPage.pageName,
+            pageType: currentPage.pageType,
+            pathname: currentPathname,
+          },
+          userDetails: {
+            stateCode: VoterStore.getVoterStateCode(),
+            userCohort: VoterStore.getAnalyticsUserCohort(),
+            voterWeVoteId: VoterStore.getVoterWeVoteId(),
+          },
+        },
+      });
+      this.dataLayerFired = true;
+    }
   }
 
   componentDidCatch (error, info) {

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -82,6 +82,10 @@ class ReadyLight extends Component {
 
         TagManager.dataLayer({
           dataLayer: {
+            actionDetails:{
+              actionType: 'landing',
+              componentName: 'readyPageFirstEntrance',
+            },
             event: 'landing',
             pageDetails: {
               pageName: currentPage.pageName,

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -42,10 +42,9 @@ class ReadyLight extends Component {
     this.state = {
       chosenReadyIntroductionText: '',
       chosenReadyIntroductionTitle: '',
-      dataLayerFired: false, // Terry - tracking whether dataLayer was fired, default set to false
+      dataLayerFired: false,
       voterIsSignedIn: false,
     };
-    
   }
 
   componentDidMount () {
@@ -70,19 +69,16 @@ class ReadyLight extends Component {
     window.scrollTo(0, 0);
   }
 
-  // Terry - Changes made for WV-1448 adding landing datalayers
   componentDidUpdate () {
     const { dataLayerFired } = this.state;
-    // Terry - only fire datalayer when voter data is ready
-    // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
-    if (!dataLayerFired){ 
+    if (!dataLayerFired) {
       if (VoterStore.voterFirstRetrieveCompleted()) {
         const { location: { pathname: currentPathname } } = window;
         const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
 
         TagManager.dataLayer({
           dataLayer: {
-            actionDetails:{
+            actionDetails: {
               actionType: 'landing',
               componentName: 'readyPageFirstEntrance',
             },
@@ -100,7 +96,7 @@ class ReadyLight extends Component {
           },
         });
         this.setState({
-          dataLayerFired: true
+          dataLayerFired: true,
         });
       }
     }

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -42,10 +42,10 @@ class ReadyLight extends Component {
     this.state = {
       chosenReadyIntroductionText: '',
       chosenReadyIntroductionTitle: '',
+      dataLayerFired: false, // Terry - tracking whether dataLayer was fired, default set to false
       voterIsSignedIn: false,
     };
-    // Terry - tracking whether dataLayer was fired, default set to false
-    this.dataLayerFired = false;
+    
   }
 
   componentDidMount () {
@@ -72,11 +72,11 @@ class ReadyLight extends Component {
 
   // Terry - Changes made for WV-1448 adding landing datalayers
   componentDidUpdate () {
+    const { dataLayerFired } = this.state;
     // Terry - only fire datalayer when voter data is ready
-    const voterFirstRetrieveCompleted = VoterStore.voterFirstRetrieveCompleted();
     // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
-    if (!this.dataLayerFired){ 
-      if (voterFirstRetrieveCompleted) {
+    if (!dataLayerFired){ 
+      if (VoterStore.voterFirstRetrieveCompleted()) {
         const { location: { pathname: currentPathname } } = window;
         const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
 
@@ -95,7 +95,9 @@ class ReadyLight extends Component {
             },
           },
         });
-        this.dataLayerFired = true;
+        this.setState({
+          dataLayerFired: true
+        });
       }
     }
   }

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -102,6 +102,7 @@ class ReadyLight extends Component {
     }
   }
 
+
   componentDidCatch (error, info) {
     console.log('ReadyLight.jsx caught: ', error, info.componentStack);
   }

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -12,7 +12,7 @@ import apiCalming from '../common/utils/apiCalming';
 import historyPush from '../common/utils/historyPush';
 import { isAndroid, isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict from '../utils/lookupPageNameAndPageTypeDict';
 import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
@@ -75,26 +75,28 @@ class ReadyLight extends Component {
     // Terry - only fire datalayer when voter data is ready
     const voterFirstRetrieveCompleted = VoterStore.voterFirstRetrieveCompleted();
     // Terry - set condition to have datalayer fire when voter data was retrieved & this.dataLayerFired == False
-    if (voterFirstRetrieveCompleted && !this.dataLayerFired) {
-      const { location: { pathname: currentPathname } } = window;
-      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
+    if (!this.dataLayerFired){ 
+      if (voterFirstRetrieveCompleted) {
+        const { location: { pathname: currentPathname } } = window;
+        const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
 
-      TagManager.dataLayer({
-        dataLayer: {
-          event: 'landing',
-          pageDetails: {
-            pageName: currentPage.pageName,
-            pageType: currentPage.pageType,
-            pathname: currentPathname,
+        TagManager.dataLayer({
+          dataLayer: {
+            event: 'landing',
+            pageDetails: {
+              pageName: currentPage.pageName,
+              pageType: currentPage.pageType,
+              pathname: currentPathname,
+            },
+            userDetails: {
+              stateCode: VoterStore.getVoterStateCode(),
+              userCohort: VoterStore.getAnalyticsUserCohort(),
+              voterWeVoteId: VoterStore.getVoterWeVoteId(),
+            },
           },
-          userDetails: {
-            stateCode: VoterStore.getVoterStateCode(),
-            userCohort: VoterStore.getAnalyticsUserCohort(),
-            voterWeVoteId: VoterStore.getVoterWeVoteId(),
-          },
-        },
-      });
-      this.dataLayerFired = true;
+        });
+        this.dataLayerFired = true;
+      }
     }
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

`WV-1448`

### Changes included this pull request?
- Added dataLayer to [quality.wevote.us](http://quality.wevote.us/) for both landing in `\` and `\ready` paths
- Tracks pageDetails & userDetails under the condition that only send dataLayers when voter's information was retrieved once per page visit.