### PR TITLE
[WV-1472] Add blog to footer [NEEDS REVIEW]

### DIFF
--- a/src/js/components/Navigation/FooterMainWeVote.jsx
+++ b/src/js/components/Navigation/FooterMainWeVote.jsx
@@ -195,6 +195,15 @@ class FooterMainWeVote extends Component {
             {isWebApp() && (
               <OneRow>
                 <OpenExternalWebSite
+                  linkIdAttribute="footerLinkBlog"
+                  url="https://blog.wevote.us/"
+                  target="_blank"
+                  trackingOn
+                  body={(<span>Blog</span>)}
+                  className={classes.link}
+                />
+                <RowSpacer />
+                <OpenExternalWebSite
                   linkIdAttribute="footerLinkVolunteer"
                   url="https://wevote.applytojob.com/apply"
                   target="_blank"

--- a/src/js/utils/lookupPageNameAndPageTypeDictForExternalUrls.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDictForExternalUrls.js
@@ -26,6 +26,10 @@ const pageNameAndTypeSimpleDictForExternalUrls = {
     pageName: 'WeVoteBudget',
     pageType: 'donation',
   },
+  'https://blog.wevote.us/': {
+    pageName: 'WeVoteBlog',
+    pageType: 'blog',
+  },
 };
 
 /**


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-1472](https://wevoteusa.atlassian.net/jira/software/projects/WV/issues/WV-1472?jql=project%20%3D%20%22WV%22%20ORDER%20BY%20created%20DESC)
### Changes included this pull request?
- Added `Blog` as the new component to `FooterMainWeVote` in the third row of `<TopSectionInnerWrapper>`following alphabetical order
- Updated `lookupPageNameAndPageTypeDictForExternalUrls.js` to add pageName and pageType tracking for the blog page
```
'https://blog.wevote.us/': {
    pageName: 'WeVoteBlog',
    pageType: 'blog',
  }
``` 

[WV-1472]: https://wevoteusa.atlassian.net/browse/WV-1472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ