### PR TITLE
[WV-1445] Add dataLayer on Topic page for endorser logo or name

### DIFF
--- a/src/js/components/Organization/OrganizationDisplayForList.jsx
+++ b/src/js/components/Organization/OrganizationDisplayForList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
+import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
 import removeTwitterNameFromDescription from '../../common/utils/removeTwitterNameFromDescription';
@@ -10,6 +11,8 @@ import PositionInformationOnlySnippet from '../PositionItem/PositionInformationO
 import PositionRatingSnippet from '../PositionItem/PositionRatingSnippet';
 import PositionSupportOpposeSnippet from '../PositionItem/PositionSupportOpposeSnippet';
 import TwitterAccountStats from '../Widgets/TwitterAccountStats';
+import VoterStore from '../../stores/VoterStore';
+import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
 
 const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ '../Widgets/FollowToggle'));
 
@@ -103,6 +106,37 @@ class OrganizationDisplayForList extends Component {
     });
   }
 
+  sendEndorserClickEvent (buttonId) {
+    const { location: { pathname: currentPathname } } = window;
+    const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
+    const { twitterHandle } = this.state;
+    const { organizationWeVoteId } = this.props;
+    const destinationPathname = twitterHandle ? `/${twitterHandle}` : `/voterguide/${organizationWeVoteId}`;
+    const { pageName: destinationPageName, pageType: destinationPageType } = lookupPageNameAndPageTypeDict(destinationPathname);
+
+    const dataLayerObject = {
+      actionDetails: {
+        actionType: 'navigate',
+        buttonId,
+      },
+      event: 'action',
+      destinationDetails: {
+        destinationPageName,
+        destinationPageType,
+        destinationPathname,
+
+      },
+      pageDetails: {
+        pageName,
+        pageType,
+        pathname: currentPathname,
+      },
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+  }
+
+
   render () {
     renderLog('OrganizationDisplayForList');  // Set LOG_RENDER_EVENTS to log all renders
     // console.log('OrganizationDisplayForList render');
@@ -186,13 +220,20 @@ class OrganizationDisplayForList extends Component {
       <OrganizationDisplayForListWrapper>
         <OrganizationDetailsWrapper>
           <OrganizationLogoWrapper>
-            <Link id="organizationDisplayLogo" to={voterGuideLink} className="u-no-underline">
+            <Link id="organizationDisplayLogo"
+            to={voterGuideLink}
+            className="u-no-underline"
+            onClick={() => this.sendEndorserClickEvent(organizationName)}
+            >
               {organizationLogo}
             </Link>
           </OrganizationLogoWrapper>
           <div>
             <NameAndTwitter>
-              <Link id="organizationDisplayName" to={voterGuideLink}>
+              <Link id="organizationDisplayName"
+              to={voterGuideLink}
+              onClick={() => this.sendEndorserClickEvent(organizationName)}
+              >
                 <OrganizationName>{organizationName}</OrganizationName>
               </Link>
               {twitterHandle && (


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1445 

### Changes included this pull request?

- Created function `sendEndorserClickEvent` that takes in `buttonId `
- Added onClick handlers on `organizationDisplayLogo` and `organizationDisplayName` to call this function.

\***Question***
When an organization has a Twitter handle, the URL takes the form /{twitterHandle}, and destinationDetails reports for example: 
<img width="310" alt="Screenshot 2025-07-08 at 4 31 16 PM" src="https://github.com/user-attachments/assets/b539a916-42ee-4da9-99b8-ddd8a928f912" />

If the organization doesn’t have a Twitter handle, the fallback URL is /voterguide/{organizationId}, and destinationDetails for example, looks like:
<img width="421" alt="Screenshot 2025-07-08 at 4 31 07 PM" src="https://github.com/user-attachments/assets/53a3133a-5e3b-4626-950d-1754b7156fe4" />

Should I leave this distinction as-is, or try to normalize these values so they follow a consistent structure regardless of the URL format?
