### PR TITLE
Made a getPageDetails() convenience function to get rid of tons of inconsistent boilerplate

### DIFF
--- a/src/js/common/components/CampaignShare/ShareByCopyLink.jsx
+++ b/src/js/common/components/CampaignShare/ShareByCopyLink.jsx
@@ -5,13 +5,13 @@ import React, { Component } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
+import VoterStore from '../../../stores/VoterStore';
+import { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
-import { renderLog } from '../../utils/logging';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
 import CampaignStore from '../../stores/CampaignStore';
-import VoterStore from '../../../stores/VoterStore';
+import { renderLog } from '../../utils/logging';
 import { generateSharingLink } from './shareButtonCommon';
-import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
 
 class ShareByCopyLink extends Component {
   constructor (props) {
@@ -101,20 +101,13 @@ class ShareByCopyLink extends Component {
     }
 
     // adding dataLayer for "Copy link" on Share Ballot
-    const { location: { pathname: currentPathname } } = window;
-    const page = lookupPageNameAndPageTypeDict(currentPathname);
-
     const dataLayerObject = {
       event: 'ShareBallotCopyLinkClick',
       shareDetails: {
         shareType: this.props.shareType || 'ballotWithChoices',
         campaignXWeVoteId: this.props.campaignXWeVoteId || null,
       },
-      pageDetails: {
-        pageName: page.pageName,
-        pageType: page.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     // console.log('DataLayer for copy link:', dataLayerObject);

--- a/src/js/common/components/CampaignShare/ShareOnTwitterButton.jsx
+++ b/src/js/common/components/CampaignShare/ShareOnTwitterButton.jsx
@@ -1,10 +1,11 @@
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import { TwitterShareButton } from 'react-share';
 import TagManager from 'react-gtm-module';
+import { TwitterShareButton } from 'react-share';
 import styled from 'styled-components';
 import VoterStore from '../../../stores/VoterStore';
+import { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 import CampaignSupporterActions from '../../actions/CampaignSupporterActions';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
 import CampaignStore from '../../stores/CampaignStore';
@@ -12,7 +13,6 @@ import { isAndroid, isCordova } from '../../utils/isCordovaOrWebApp';
 import { renderLog } from '../../utils/logging';
 import politicianListToSentenceString from '../../utils/politicianListToSentenceString';
 import { androidTwitterClickHandler, generateQuoteForSharing, generateSharingLink } from './shareButtonCommon';
-import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
 
 class ShareOnTwitterButton extends Component {
   constructor (props) {
@@ -90,8 +90,6 @@ class ShareOnTwitterButton extends Component {
 
     // datalayer for Twitter
     const { shareType, campaignXWeVoteId } = this.props;
-    const { location: { pathname: currentPathname } } = window;
-    const page = lookupPageNameAndPageTypeDict(currentPathname);
 
     const dataLayerObject = {
       event: 'ShareBallotTwitterClick',
@@ -100,11 +98,7 @@ class ShareOnTwitterButton extends Component {
         shareType: shareType || 'ballotWithChoices',
         campaignXWeVoteId: campaignXWeVoteId || null,
       },
-      pageDetails: {
-        pageName: page.pageName,
-        pageType: page.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     // console.log('DataLayer for Twitter share:', dataLayerObject);

--- a/src/js/common/components/CampaignSupport/PayToPromoteProcess.jsx
+++ b/src/js/common/components/CampaignSupport/PayToPromoteProcess.jsx
@@ -24,7 +24,7 @@ import CampaignStore from '../../stores/CampaignStore';
 import { getCampaignXValuesFromIdentifiers, retrieveCampaignXFromIdentifiersIfNeeded } from '../../utils/campaignUtils';
 import initializejQuery from '../../utils/initializejQuery';
 import SplitIconButton from '../Widgets/SplitIconButton';
-import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 import VoterStore from '../../../stores/VoterStore';
 
 const stripePromise = loadStripe(webAppConfig.STRIPE_API_KEY);
@@ -192,11 +192,7 @@ class PayToPromoteProcess extends Component {
       },
       event: 'action',
       userDetails: VoterStore.getAnalyticsUserDetails(),
-      pageDetails: {
-        pageType: currentPage.pageType,
-        pageName: currentPage.pageName,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: currentPage.destinationPageName,
         destinationPageType: currentPage.destinationPageType,

--- a/src/js/common/components/Challenge/JoinChallengeButton.jsx
+++ b/src/js/common/components/Challenge/JoinChallengeButton.jsx
@@ -12,7 +12,7 @@ import ChallengeParticipantActions from '../../actions/ChallengeParticipantActio
 import ReadyStore from '../../../stores/ReadyStore';
 import VoterStore from '../../../stores/VoterStore';
 import { getChallengeValuesFromIdentifiers } from '../../utils/challengeUtils';
-import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 
 class JoinChallengeButton extends React.Component {
   constructor (props) {
@@ -128,7 +128,6 @@ class JoinChallengeButton extends React.Component {
     // console.log('goToInviteFriends currentPathname: ', currentPathname);
 
     // Adding event data to dataLayer for Google Tag Manager to fire the inviteFriendsToChallenge tag
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
     const destinationPage = lookupPageNameAndPageTypeDict(inviteFriendsPath);
     const dataLayerObject = {
       actionDetails: {
@@ -140,11 +139,7 @@ class JoinChallengeButton extends React.Component {
       challengeDetails: {
         challengeWeVoteId,
       },
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: destinationPage.pageName,
         destinationPageType: destinationPage.pageType,
@@ -178,7 +173,6 @@ class JoinChallengeButton extends React.Component {
       AppObservableStore.setSetUpAccountEntryPath(joinChallengeNextStepPath);
       // console.log('goToJoinChallenge currentPathname: ', currentPathname);
       // Adding event data to dataLayer for Google Tag Manager to fire the inviteFriendsToChallenge tag
-      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
       const destinationPage = lookupPageNameAndPageTypeDict(joinChallengeNextStepPath);
       const dataLayerObject = {
         actionDetails: {
@@ -190,11 +184,7 @@ class JoinChallengeButton extends React.Component {
         challengeDetails: {
           challengeWeVoteId,
         },
-        pageDetails: {
-          pageName: currentPage.pageName,
-          pageType: currentPage.pageType,
-          pathname: currentPathname,
-        },
+        pageDetails: getPageDetails(),
         destinationDetails: {
           destinationPageName: destinationPage.pageName,
           destinationPageType: destinationPage.pageType,

--- a/src/js/common/components/FAQBody.jsx
+++ b/src/js/common/components/FAQBody.jsx
@@ -5,7 +5,7 @@ import { isCordova, isWebApp } from '../utils/isCordovaOrWebApp';
 import { renderLog } from '../utils/logging';
 import ToolBar from './Widgets/ToolBar';
 import { Video, PlayerContainer } from './Style/VideoStyles';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import VoterStore from '../../stores/VoterStore';
 import historyPush from '../utils/historyPush';
 
@@ -18,8 +18,6 @@ export default class FAQBody extends Component {
   }
 
   pushDataLayer (destinationPath, buttonId) {
-    const { location: { pathname: currentPathname } } = window;
-    const page = lookupPageNameAndPageTypeDict(currentPathname);
     const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
 
     const dataLayerObj = {
@@ -28,11 +26,7 @@ export default class FAQBody extends Component {
         actionType: 'navigate',
         buttonId,
       },
-      pageDetails: {
-        pageName: page.pageName,
-        pageType: page.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageType: destinationPage.pageType,
         destinationPageName: destinationPage.pageName,

--- a/src/js/common/components/Search/SearchBar2024.jsx
+++ b/src/js/common/components/Search/SearchBar2024.jsx
@@ -2,11 +2,11 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
+import VoterStore from '../../../stores/VoterStore';
+import { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 import { blurTextFieldAndroid, focusTextFieldAndroid } from '../../utils/cordovaUtils';
 import { renderLog } from '../../utils/logging';
 import SearchBase from './SearchBase';
-import VoterStore from '../../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
 
 /* eslint-disable jsx-a11y/control-has-associated-label  */
 class SearchBar2024 extends Component {
@@ -60,9 +60,6 @@ class SearchBar2024 extends Component {
   }
 
   handleSearchBarKeyPress = () => {
-    const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
-
     if (this.timer) {
       clearTimeout(this.timer);
     }
@@ -80,11 +77,7 @@ class SearchBar2024 extends Component {
         },
         event: 'action',
         userDetails: VoterStore.getAnalyticsUserDetails(),
-        pageDetails: {
-          pageType: currentPage.pageType,
-          pageName: currentPage.pageName,
-          pathname: currentPathname,
-        },
+        pageDetails: getPageDetails(),
         searchString,
       };
       // console.log(dataLayerObject)

--- a/src/js/common/components/Widgets/ReadMore.jsx
+++ b/src/js/common/components/Widgets/ReadMore.jsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import TruncateMarkup from 'react-truncate-markup';
 import TagManager from 'react-gtm-module';
+import TruncateMarkup from 'react-truncate-markup';
 import styled from 'styled-components';
-import { renderLog } from '../../utils/logging';
-import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
 import IssueStore from '../../../stores/IssueStore';
 import VoterStore from '../../../stores/VoterStore';
+import { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 import PoliticianStore from '../../stores/PoliticianStore';
+import { renderLog } from '../../utils/logging';
 
 export default class ReadMore extends Component {
   constructor (...args) {
@@ -33,8 +33,6 @@ export default class ReadMore extends Component {
     event.preventDefault();
     const { readMore } = this.state;
     const showMoreLabel = readMore ? 'showMore' : 'showLess';
-    const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
     const { politicianWeVoteId } = this.props;
     const { buttonId, issueWeVoteId } = this.props;
 
@@ -44,11 +42,7 @@ export default class ReadMore extends Component {
         actionType: showMoreLabel,
         buttonId,
       },
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     if (politicianWeVoteId) {

--- a/src/js/components/Ballot/BallotScrollingContainer.jsx
+++ b/src/js/components/Ballot/BallotScrollingContainer.jsx
@@ -28,7 +28,7 @@ import { PositionRowListInnerWrapper, PositionRowListOneWrapper, PositionRowList
 import BallotMatchIndicator from '../BallotItem/BallotMatchIndicator';
 import PositionRowListCompressed from './PositionRowListCompressed';
 import BallotMatchIndicator2024 from '../BallotItem/BallotMatchIndicator2024';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import webAppConfig from '../../config';
 
 // const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
@@ -96,11 +96,7 @@ class BallotScrollingContainer extends Component {
         buttonId,
       },
       event: 'action',
-      pageDetails: {
-        pageName: currentPageDetails.pageName,
-        pageType: currentPageDetails.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         pageName: 'CandidateModal',
         pageType: currentPageDetails.pageType,

--- a/src/js/components/Ballot/BallotTitleHeader.jsx
+++ b/src/js/components/Ballot/BallotTitleHeader.jsx
@@ -1,11 +1,11 @@
 import { Edit } from '@mui/icons-material';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
+import parser from 'parse-address';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
-import parser from 'parse-address';
-import styled from 'styled-components';
 import TagManager from 'react-gtm-module';
+import styled from 'styled-components';
 import AppObservableStore from '../../common/stores/AppObservableStore';
 import { isAndroidSizeWide, isIPad } from '../../common/utils/cordovaUtils';
 import { formatDateToMonthDayYear } from '../../common/utils/dateFormat';
@@ -15,9 +15,8 @@ import { renderLog } from '../../common/utils/logging';
 import stringContains from '../../common/utils/stringContains';
 import BallotStore from '../../stores/BallotStore';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
-import { BallotAddress, ClickBlockWrapper, ContentWrapper, ElectionDateBelow, ElectionDateRight, ElectionNameBlock, ElectionNameH1, ElectionNameScrollContent,
-  ElectionStateLabel, OverflowContainer, OverflowContent, VoteByBelowLabel, VoteByBelowWrapper, VoteByRightLabel, VoteByRightWrapper } from '../Style/BallotTitleHeaderStyles';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import { BallotAddress, ClickBlockWrapper, ContentWrapper, ElectionDateBelow, ElectionDateRight, ElectionNameBlock, ElectionNameH1, ElectionNameScrollContent, ElectionStateLabel, OverflowContainer, OverflowContent, VoteByBelowLabel, VoteByBelowWrapper, VoteByRightLabel, VoteByRightWrapper } from '../Style/BallotTitleHeaderStyles';
 import BallotTitleHeaderNationalPlaceholder from './BallotTitleHeaderNationalPlaceholder';
 
 const ShareButtonDesktopTablet = React.lazy(() => import(/* webpackChunkName: 'ShareButtonDesktopTablet' */ '../Share/ShareButtonDesktopTablet'));
@@ -113,8 +112,6 @@ class BallotTitleHeader extends Component {
       const showEditAddress = true;
       const showSelectBallotModal = true;
       // this.props.toggleSelectBallotModal('', showEditAddress, false);
-      const { location: { pathname: currentPathname } } = window;
-      const page = lookupPageNameAndPageTypeDict(currentPathname);
 
       const address = VoterStore.getTextForMapSearch();
       let city = '';
@@ -137,11 +134,7 @@ class BallotTitleHeader extends Component {
         },
         event: 'action',
         userDetails: VoterStore.getAnalyticsUserDetails(),
-        pageDetails: {
-          pageName: page.pageName,
-          pageType: page.pageType,
-          pathname: currentPathname,
-        },
+        pageDetails: getPageDetails(),
         electionDetails: {
           electionGeo: {
             city,

--- a/src/js/components/Ballot/BallotTitleHeaderNationalPlaceholder.jsx
+++ b/src/js/components/Ballot/BallotTitleHeaderNationalPlaceholder.jsx
@@ -1,33 +1,17 @@
 import { Edit } from '@mui/icons-material';
+import parser from 'parse-address';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import parser from 'parse-address';
-import styled from 'styled-components';
 import TagManager from 'react-gtm-module';
+import styled from 'styled-components';
+import AppObservableStore from '../../common/stores/AppObservableStore';
 import daysUntil from '../../common/utils/daysUntil';
 import { renderLog } from '../../common/utils/logging';
 import stringContains from '../../common/utils/stringContains';
-import AppObservableStore from '../../common/stores/AppObservableStore';
 import BallotStore from '../../stores/BallotStore';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
-import {
-  BallotAddress,
-  ClickBlockWrapper,
-  ContentWrapper,
-  ElectionDateBelow,
-  ElectionDateRight,
-  ElectionNameBlock,
-  ElectionNameH1,
-  ElectionNameScrollContent,
-  ElectionStateLabel,
-  OverflowContainer,
-  OverflowContent,
-  VoteByBelowLabel,
-  VoteByBelowWrapper,
-  VoteByRightLabel,
-  VoteByRightWrapper,
-} from '../Style/BallotTitleHeaderStyles';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import { BallotAddress, ClickBlockWrapper, ContentWrapper, ElectionDateBelow, ElectionDateRight, ElectionNameBlock, ElectionNameH1, ElectionNameScrollContent, ElectionStateLabel, OverflowContainer, OverflowContent, VoteByBelowLabel, VoteByBelowWrapper, VoteByRightLabel, VoteByRightWrapper, } from '../Style/BallotTitleHeaderStyles';
 
 
 class BallotTitleHeaderNationalPlaceholder extends Component {
@@ -87,9 +71,6 @@ class BallotTitleHeaderNationalPlaceholder extends Component {
       const showEditAddress = true;
       const showSelectBallotModal = true;
       // this.props.toggleSelectBallotModal('', showEditAddress, false);
-      const { location: { pathname: currentPathname } } = window;
-      const page = lookupPageNameAndPageTypeDict(currentPathname);
-
       const address = VoterStore.getTextForMapSearch();
       let city = '';
       let region = '';
@@ -111,11 +92,7 @@ class BallotTitleHeaderNationalPlaceholder extends Component {
         },
         event: 'action',
         userDetails: VoterStore.getAnalyticsUserDetails(),
-        pageDetails: {
-          pageName: page.pageName,
-          pageType: page.pageType,
-          pathname: currentPathname,
-        },
+        pageDetails: getPageDetails(),
         electionDetails: {
           electionGeo: {
             city,

--- a/src/js/components/Ballot/PositionRowListCompressed.jsx
+++ b/src/js/components/Ballot/PositionRowListCompressed.jsx
@@ -27,7 +27,7 @@ import OrganizationStore from '../../stores/OrganizationStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
 import { avatarGeneric } from '../../utils/applicationUtils';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 
 const STARTING_NUMBER_OF_IMAGES_TO_DISPLAY = 10;
@@ -112,11 +112,7 @@ class PositionRowListCompressed extends Component {
         organizationCount: this.getOrganizationCount(),
         talkingAboutText: this.getTalkingAboutText(),
       },
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     // Add candidate or measure details based on ballotItemWeVoteId

--- a/src/js/components/CompleteYourProfile/CompleteYourProfile2024.jsx
+++ b/src/js/components/CompleteYourProfile/CompleteYourProfile2024.jsx
@@ -7,7 +7,7 @@ import BallotStore from '../../stores/BallotStore';
 import SupportStore from '../../stores/SupportStore';
 import VoterStore from '../../stores/VoterStore';
 import CompleteYourProfileWizard from './CompleteYourProfileWizard';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../../common/components/SignIn/SignInModal'));
 
@@ -33,20 +33,13 @@ class CompleteYourProfile2024 extends Component {
 
   componentDidMount () {
     // Track component load/impression for analytics
-    const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
-
     const dataLayerObject = {
       actionDetails: {
         actionType: 'landing',
         componentName: 'CompleteYourProfile2024',
       },
       event: 'landing',
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     // console.log('CompleteYourProfile2024 component loaded:', dataLayerObject);
@@ -223,11 +216,7 @@ class CompleteYourProfile2024 extends Component {
         destinationPageType: currentPage.pageType, // Use same pageType as current page
         destinationPathname: currentPathname,
       },
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     // console.log('openHowItWorksModal dataLayer:', dataLayerObject);
@@ -252,11 +241,7 @@ class CompleteYourProfile2024 extends Component {
         destinationPageType: currentPage.pageType,
         destinationPathname: currentPathname,
       },
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     // console.log('openPersonalizedScoreIntroModal dataLayer:', dataLayerObject);

--- a/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
+++ b/src/js/components/CompleteYourProfile/HowItWorksModal.jsx
@@ -1,10 +1,10 @@
 import { Close } from '@mui/icons-material';
 import { Dialog, DialogContent, IconButton } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
-import TagManager from 'react-gtm-module';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import VoterActions from '../../actions/VoterActions';
 import { hasIPhoneNotch } from '../../common/utils/cordovaUtils';
@@ -12,7 +12,7 @@ import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { renderLog } from '../../common/utils/logging';
 import VoterConstants from '../../constants/VoterConstants';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const HowItWorks = React.lazy(() => import(/* webpackChunkName: 'HowItWorks' */ '../../pages/HowItWorks'));
 
@@ -40,19 +40,13 @@ class HowItWorksModal extends Component {
   }
 
   sendHowItWorksCloseEvent (buttonId) {
-    const { location: { pathname: currentPathname } } = window;
-    const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
     const dataLayerObject = {
       actionDetails: {
         actionType: 'closeModal',
         buttonId,
       },
       event: 'action',
-      pageDetails: {
-        pageName,
-        pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     TagManager.dataLayer({ dataLayer: dataLayerObject });

--- a/src/js/components/Navigation/FooterCandidateList.jsx
+++ b/src/js/components/Navigation/FooterCandidateList.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import TagManager from 'react-gtm-module';
 import { convertStateTextToStateCode, stateCodeMap } from '../../common/utils/addressFunctions';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import VoterStore from '../../stores/VoterStore';
 // React functional component example
 export default function FooterCandidateList () {
@@ -13,8 +13,6 @@ export default function FooterCandidateList () {
   let stateNamePhraseLowerCase;
 
   function handleClick (linkTo, buttonId = '') {
-    const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
     const destinationPage = lookupPageNameAndPageTypeDict(linkTo);
 
     const dataLayerObject = {
@@ -23,11 +21,7 @@ export default function FooterCandidateList () {
         buttonId,
       },
       event: 'action',
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: destinationPage.pageName,
         destinationPageType: destinationPage.pageType,

--- a/src/js/components/Navigation/FooterMainWeVote.jsx
+++ b/src/js/components/Navigation/FooterMainWeVote.jsx
@@ -1,15 +1,15 @@
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import TagManager from 'react-gtm-module';
 import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import AppObservableStore from '../../common/stores/AppObservableStore';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
-import VoterStore from '../../stores/VoterStore';
 import webAppConfig from '../../config';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import VoterStore from '../../stores/VoterStore';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const BallotElectionListWithFilters = React.lazy(() => import(/* webpackChunkName: 'BallotElectionListWithFilters' */ '../Ballot/BallotElectionListWithFilters'));
 const DeleteAllContactsButton = React.lazy(() => import(/* webpackChunkName: 'DeleteAllContactsButton' */ '../SetUpAccount/DeleteAllContactsButton'));
@@ -51,11 +51,7 @@ class FooterMainWeVote extends Component {
         buttonId: 'footerLinkHowItWorks',
       },
       event: 'action',
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: 'HowItWorksModal',
         destinationPageType: currentPage.pageType,
@@ -67,8 +63,6 @@ class FooterMainWeVote extends Component {
   }
 
   pushDataLayer (destinationPath, buttonId = '') {
-    const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
     const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
     const dataLayerObject = {
       actionDetails: {
@@ -76,11 +70,7 @@ class FooterMainWeVote extends Component {
         buttonId,
       },
       event: 'action',
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: destinationPage.pageName,
         destinationPageType: destinationPage.pageType,

--- a/src/js/components/Navigation/HeaderBarLogo.jsx
+++ b/src/js/components/Navigation/HeaderBarLogo.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import normalizedImagePath from '../../common/utils/normalizedImagePath';
 import HeaderLogoImage from './HeaderLogoImage';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import VoterStore from '../../stores/VoterStore';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
@@ -18,8 +18,6 @@ const HeaderBarLogo = ({ chosenSiteLogoUrl, isBeta, light }) => {
   const homepagePath = '/ready';
 
   function handleClick () {
-    const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
     const destinationPage = lookupPageNameAndPageTypeDict(homepagePath);
     const dataLayerObject = {
       actionDetails: {
@@ -27,11 +25,7 @@ const HeaderBarLogo = ({ chosenSiteLogoUrl, isBeta, light }) => {
         buttonId: 'logoHeaderBar',
       },
       event: 'action',
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: destinationPage.pageName,
         destinationPageType: destinationPage.pageType,

--- a/src/js/components/Navigation/HeaderNotificationMenu.jsx
+++ b/src/js/components/Navigation/HeaderNotificationMenu.jsx
@@ -17,7 +17,7 @@ import ActivityStore from '../../stores/ActivityStore';
 import VoterStore from '../../stores/VoterStore';
 import { createDescriptionOfFriendPosts } from '../../utils/activityUtils';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const ImageHandler = React.lazy(() => import(/* webpackChunkName: 'ImageHandler' */ '../ImageHandler'));
 
@@ -98,8 +98,6 @@ class HeaderNotificationMenu extends Component {
 
 
 onSettingsClick = (buttonId) => {
-  const { location: { pathname: currentPathname } } = window;
-  const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
   const destinationPathname = '/settings/notifications';
   const destinationPage = lookupPageNameAndPageTypeDict(destinationPathname);
   const dataLayerObject = {
@@ -108,11 +106,7 @@ onSettingsClick = (buttonId) => {
       buttonId,
     },
     event: 'action',
-    pageDetails: {
-      pageName: currentPage.pageName,
-      pageType: currentPage.pageType,
-      pathname: currentPathname,
-    },
+    pageDetails: getPageDetails(),
     destinationDetails: {
       destinationPageName: destinationPage.pageName,
       destinationPageType: destinationPage.pageType,
@@ -282,11 +276,7 @@ onSettingsClick = (buttonId) => {
         buttonId: 'headerNotificationMenuIcon',
       },
       event: 'action',
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: 'NotificationsModal',
         destinationPageType: currentPage.pageType,

--- a/src/js/components/Navigation/SettingsPersonalSideBar.jsx
+++ b/src/js/components/Navigation/SettingsPersonalSideBar.jsx
@@ -10,6 +10,7 @@ import AppObservableStore, { messageService } from '../../common/stores/AppObser
 import { renderLog } from '../../common/utils/logging';
 import webAppConfig from '../../config';
 import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const SettingsAccountLevelChip = React.lazy(() => import(/* webpackChunkName: 'SettingsAccountLeveLChip' */ '../Settings/SettingsAccountLevelChip'));
 
@@ -87,10 +88,7 @@ export default class SettingsPersonalSideBar extends Component {
         userCohort: VoterStore.getAnalyticsUserCohort(),
         voterWeVoteId: voterWeVoteId || VoterStore.getVoterWeVoteId(),
       },
-      pageDetails: {
-        pageTitle: document.title,
-        pagePath: window.location.pathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: destinationPage.pageName || '',
         destinationPageType: destinationPage.pageType || '',

--- a/src/js/components/Organization/OrganizationDisplayForList.jsx
+++ b/src/js/components/Organization/OrganizationDisplayForList.jsx
@@ -12,7 +12,7 @@ import PositionRatingSnippet from '../PositionItem/PositionRatingSnippet';
 import PositionSupportOpposeSnippet from '../PositionItem/PositionSupportOpposeSnippet';
 import TwitterAccountStats from '../Widgets/TwitterAccountStats';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const FollowToggle = React.lazy(() => import(/* webpackChunkName: 'FollowToggle' */ '../Widgets/FollowToggle'));
 
@@ -107,8 +107,6 @@ class OrganizationDisplayForList extends Component {
   }
 
   sendEndorserClickEvent (buttonId) {
-    const { location: { pathname: currentPathname } } = window;
-    const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
     const { twitterHandle } = this.state;
     const { organizationWeVoteId } = this.props;
     const destinationPathname = twitterHandle ? `/${twitterHandle}` : `/voterguide/${organizationWeVoteId}`;
@@ -126,11 +124,7 @@ class OrganizationDisplayForList extends Component {
         destinationPathname,
 
       },
-      pageDetails: {
-        pageName,
-        pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     TagManager.dataLayer({ dataLayer: dataLayerObject });

--- a/src/js/components/Ready/ViewUpcomingBallotButton.jsx
+++ b/src/js/components/Ready/ViewUpcomingBallotButton.jsx
@@ -11,7 +11,7 @@ import BallotStore from '../../stores/BallotStore';
 import VoterStore from '../../stores/VoterStore';
 import VoterActions from '../../actions/VoterActions';
 import apiCalming from '../../common/utils/apiCalming';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 class ViewUpcomingBallotButton extends React.Component {
   constructor (props) {
@@ -68,8 +68,6 @@ class ViewUpcomingBallotButton extends React.Component {
 
   goToBallotLocal = () => {
     if (this.props.goToBallotFunction) {
-      const { location: { pathname: currentPathname } } = window;
-      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
       const destinationPathname = '/ballot';
       const destinationPage = lookupPageNameAndPageTypeDict(destinationPathname);
       const dataLayerObject = {
@@ -84,11 +82,7 @@ class ViewUpcomingBallotButton extends React.Component {
           destinationPageType: destinationPage.pageType,
           destinationPathname,
         },
-        pageDetails: {
-          pageName: currentPage.pageName,
-          pageType: currentPage.pageType,
-          pathname: currentPathname,
-        },
+        pageDetails: getPageDetails(),
       };
       TagManager.dataLayer({ dataLayer: dataLayerObject });
       this.props.goToBallotFunction();

--- a/src/js/components/Share/ShareButtonDesktopTablet.jsx
+++ b/src/js/components/Share/ShareButtonDesktopTablet.jsx
@@ -13,7 +13,7 @@ import { renderLog } from '../../common/utils/logging';
 import stringContains from '../../common/utils/stringContains';
 import AppObservableStore, { messageService } from '../../common/stores/AppObservableStore';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 class ShareButtonDesktopTablet extends Component {
   constructor (props) {
@@ -122,8 +122,6 @@ class ShareButtonDesktopTablet extends Component {
     }
 
     // Add dataLayer tracking after kindOfShare and whatAndHowMuchToShare are calculated
-    const { location: { pathname: currentPathname } } = window;
-    const page = lookupPageNameAndPageTypeDict(currentPathname);
     const destinationPage = lookupPageNameAndPageTypeDict(pathnameWithModalShare);
 
     // Determine buttonId based on kindOfShare
@@ -160,11 +158,7 @@ class ShareButtonDesktopTablet extends Component {
         withOpinions: withOpinionsModified,
         whatAndHowMuchToShare,
       },
-      pageDetails: {
-        pageName: page.pageName,
-        pageType: page.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: destinationPage.pageName,
         destinationPageType: destinationPage.pageType,

--- a/src/js/components/Share/ShareModalOption.jsx
+++ b/src/js/components/Share/ShareModalOption.jsx
@@ -5,10 +5,11 @@ import React, { Component, Suspense } from 'react';
 import CopyToClipboard from 'react-copy-to-clipboard';
 import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
-import VoterStore from '../../stores/VoterStore';
-import { renderLog } from '../../common/utils/logging';
-import AppObservableStore, { messageService } from '../../common/stores/AppObservableStore';
 import { openSnackbar } from '../../common/components/Widgets/SnackNotifier';
+import AppObservableStore, { messageService } from '../../common/stores/AppObservableStore';
+import { renderLog } from '../../common/utils/logging';
+import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
@@ -63,7 +64,6 @@ class ShareModalOption extends Component {
 
   copyLink = () => {
     // console.log('ShareModalOption copyLink');
-    const { location: { pathname: currentPathname } } = window;
     openSnackbar({ message: 'Copied!' });
     this.setState({
       copyLinkCopied: true,
@@ -77,10 +77,7 @@ class ShareModalOption extends Component {
         title: this.props.title || 'Copy link',
         urlShared: this.props.urlToShare || '',
       },
-      pageDetails: {
-        pageName: 'ShareModal',
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     // console.log('DataLayer for ShareModal Copy Link:', dataLayerObject);

--- a/src/js/components/Values/IssueCard.jsx
+++ b/src/js/components/Values/IssueCard.jsx
@@ -18,7 +18,7 @@ import convertToInteger from '../../common/utils/convertToInteger';
 import { convertNameToSlug } from '../../common/utils/textFormat';
 import IssueFollowToggleButton from './IssueFollowToggleButton';
 import IssueImageDisplay from './IssueImageDisplay';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
 const SignInModal = React.lazy(() => import(/* webpackChunkName: 'SignInModal' */ '../../common/components/SignIn/SignInModal'));
@@ -144,9 +144,7 @@ class IssueCard extends Component {
   }
 
   handleIssueClick = (buttonId) => {
-    const { location: { pathname: currentPathname } } = window;
     const { issue } = this.state;
-    const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
     const destinationPathname = this.getIssueLink();
     const { pageName: destinationPageName, pageType: destinationPageType } = lookupPageNameAndPageTypeDict(destinationPathname);
     const dataLayerObject = {
@@ -155,11 +153,7 @@ class IssueCard extends Component {
         buttonId,
       },
       event: 'action',
-      pageDetails: {
-        pageName,
-        pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
       destinationDetails: {
         destinationPageName,

--- a/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
+++ b/src/js/components/Values/IssuesByBallotItemDisplayList.jsx
@@ -1,15 +1,15 @@
-import styled from 'styled-components';
-import TagManager from 'react-gtm-module';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import TagManager from 'react-gtm-module';
+import styled from 'styled-components';
+import signInModalGlobalState from '../../common/components/Widgets/signInModalGlobalState';
+import PoliticianStore from '../../common/stores/PoliticianStore';
 import { renderLog } from '../../common/utils/logging';
 import CandidateStore from '../../stores/CandidateStore';
 import IssueStore from '../../stores/IssueStore';
-import PoliticianStore from '../../common/stores/PoliticianStore';
-import VoterStore from '../../stores/VoterStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
-import signInModalGlobalState from '../../common/components/Widgets/signInModalGlobalState';
+import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import ValueNameWithPopoverDisplay from './ValueNameWithPopoverDisplay';
 
 // Show a voter a horizontal list of all the issues they are following that relate to this ballot item
@@ -145,8 +145,6 @@ class IssuesByBallotItemDisplayList extends Component {
 
   handleExpandIssues = (buttonId) => {
     const { expandIssues, totalLengthOfIssuesToRenderList, ballotItemWeVoteId } = this.state;
-    const { location: { pathname: currentPathname } } = window;
-    const page = lookupPageNameAndPageTypeDict(currentPathname);
     // dataLayer
     const dataLayerObject = {
       event: 'action',
@@ -154,11 +152,7 @@ class IssuesByBallotItemDisplayList extends Component {
         actionType: 'showMore',
         buttonId,
       },
-      pageDetails: {
-        pageName: page.pageName,
-        pageType: page.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     let candidate = {};

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -16,6 +16,7 @@ import VoterActions from '../../../actions/VoterActions';
 import DesignTokenColors from '../../../common/components/Style/DesignTokenColors';
 import { openSnackbar } from '../../../common/components/Widgets/SnackNotifier';
 import AppObservableStore from '../../../common/stores/AppObservableStore';
+import PoliticianStore from '../../../common/stores/PoliticianStore';
 import convertToInteger from '../../../common/utils/convertToInteger';
 import { isWebApp } from '../../../common/utils/isCordovaOrWebApp';
 import isMobileScreenSize from '../../../common/utils/isMobileScreenSize';
@@ -24,15 +25,14 @@ import { renderLog } from '../../../common/utils/logging';
 import normalizedImagePath from '../../../common/utils/normalizedImagePath';
 import stringContains from '../../../common/utils/stringContains';
 import webAppConfig from '../../../config';
-import PoliticianStore from '../../../common/stores/PoliticianStore';
-import SupportStore from '../../../stores/SupportStore';
 import VoterConstants from '../../../constants/VoterConstants';
+import CandidateStore from '../../../stores/CandidateStore';
+import SupportStore from '../../../stores/SupportStore';
 import VoterStore from '../../../stores/VoterStore';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 import PositionPublicToggle from '../../PositionItem/PositionPublicToggle';
 import PositionStatementModal from '../PositionStatementModal'; // eslint-disable-line import/no-cycle
 import ShareButtonDropDown from '../ShareButtonDropdown';
-import lookupPageNameAndPageTypeDict from '../../../utils/lookupPageNameAndPageTypeDict';
-import CandidateStore from '../../../stores/CandidateStore';
 
 const HelpWinOrDefeatModal = React.lazy(() => import(/* webpackChunkName: 'HelpWinOrDefeatModal' */ '../../../common/components/CampaignSupport/HelpWinOrDefeatModal')); // eslint-disable-line import/no-cycle
 
@@ -277,11 +277,7 @@ class ItemActionBar extends PureComponent {
       },
       event: 'action',
       userDetails: VoterStore.getAnalyticsUserDetails(),
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       destinationDetails: {
         destinationPageName: isHelpWinOrHelpDefeat,
         destinationPageType: currentPage.pageType,

--- a/src/js/components/Widgets/ShowMoreButtons.jsx
+++ b/src/js/components/Widgets/ShowMoreButtons.jsx
@@ -6,9 +6,9 @@ import React from 'react';
 import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import { renderLog } from '../../common/utils/logging';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
-import VoterStore from '../../stores/VoterStore';
 import OfficeStore from '../../stores/OfficeStore';
+import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 class ShowMoreButtons extends React.Component {
   handleShowMoreClick = () => {
@@ -21,20 +21,13 @@ class ShowMoreButtons extends React.Component {
 
     const actionType = showMoreButtonWasClicked ? 'showLess' : 'showMore';
 
-    const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
-
     const dataLayerObject = {
       event: 'action',
       actionDetails: {
         actionType,
         buttonId: showMoreId,
       },
-      pageDetails: {
-        pageName: currentPage.pageName,
-        pageType: currentPage.pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     const officeData = OfficeStore.getOffice(this.props.officeWeVoteId) || {};

--- a/src/js/components/Widgets/SignInButton.jsx
+++ b/src/js/components/Widgets/SignInButton.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 
 // A function component
@@ -14,7 +14,7 @@ export default function SignInButton (props) {
   renderLog('SignInButton');  // Set LOG_RENDER_EVENTS to log all renders
 
   const { location: { pathname: currentPathname } } = window;
-  const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
+  const { pageType } = lookupPageNameAndPageTypeDict(currentPathname);
   const handleClick = () => {
     const dataLayerObject = {
       actionDetails: {
@@ -28,11 +28,7 @@ export default function SignInButton (props) {
         destinationPageType: pageType,
         destinationPathname: currentPathname,
       },
-      pageDetails: {
-        pageName,
-        pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
     };
     TagManager.dataLayer({ dataLayer: dataLayerObject });
     // Trigger the actual sign-in modal

--- a/src/js/pages/Campaigns/CampaignsHome.jsx
+++ b/src/js/pages/Campaigns/CampaignsHome.jsx
@@ -25,7 +25,7 @@ import CandidateStore from '../../stores/CandidateStore';
 import IssueStore from '../../stores/IssueStore';
 import RepresentativeStore from '../../stores/RepresentativeStore';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const CandidateListRoot = React.lazy(() => import(/* webpackChunkName: 'CandidateListRoot' */ '../../components/CandidateListRoot/CandidateListRoot'));
 const CampaignListRoot = React.lazy(() => import(/* webpackChunkName: 'CampaignListRoot' */ '../../common/components/CampaignListRoot/CampaignListRoot'));
@@ -234,12 +234,7 @@ class CampaignsHome extends Component {
       }
       const dataLayerObject = {
         event: 'landing',
-        pageDetails: {
-          pageName: currentPage.pageName,
-          pageType: currentPage.pageType,
-          pathname: currentPathname,
-          stateCode: urlStateCode,
-        },
+        pageDetails: getPageDetails(urlStateCode),
         userDetails: VoterStore.getAnalyticsUserDetails(),
       };
       TagManager.dataLayer({ dataLayer: dataLayerObject });

--- a/src/js/pages/HowItWorks.jsx
+++ b/src/js/pages/HowItWorks.jsx
@@ -1,11 +1,12 @@
 import { Button } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
-import TagManager from 'react-gtm-module';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import { Helmet } from 'react-helmet-async';
 import styled from 'styled-components';
 import VoterActions from '../actions/VoterActions';
+import AppObservableStore from '../common/stores/AppObservableStore';
 import { isCordova } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
 import Header, { Container, Title } from '../components/Welcome/howItWorksHeaderStyles';
@@ -13,10 +14,9 @@ import AnnotatedSlideshow from '../components/Widgets/AnnotatedSlideshow';
 import HeaderSwitch from '../components/Widgets/HeaderSwitch';
 import StepsChips from '../components/Widgets/StepsChips';
 import VoterConstants from '../constants/VoterConstants';
-import AppObservableStore from '../common/stores/AppObservableStore';
 import VoterStore from '../stores/VoterStore';
 import cordovaScrollablePaneTopPadding from '../utils/cordovaScrollablePaneTopPadding';
-import lookupPageNameAndPageTypeDict from '../utils/lookupPageNameAndPageTypeDict';
+import { getPageDetails } from '../utils/lookupPageNameAndPageTypeDict';
 
 const WelcomeAppbar = React.lazy(() => import(/* webpackChunkName: 'WelcomeAppbar' */ '../components/Navigation/WelcomeAppbar'));
 const WelcomeFooter = React.lazy(() => import(/* webpackChunkName: 'WelcomeFooter' */ '../components/Welcome/WelcomeFooter'));
@@ -318,8 +318,6 @@ class HowItWorks extends Component {
   };
 
   sendHowItWorksSlideEvent (stepIndex) {
-    const { location: { pathname: currentPathname } } = window;
-    const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
     const titleId = this.getTitleIdFromIndex(stepIndex);
     const dataLayerObject = {
       actionDetails: {
@@ -327,11 +325,7 @@ class HowItWorks extends Component {
         buttonId: titleId,
       },
       event: 'action',
-      pageDetails: {
-        pageName,
-        pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     TagManager.dataLayer({ dataLayer: dataLayerObject });

--- a/src/js/pages/More/Donate.jsx
+++ b/src/js/pages/More/Donate.jsx
@@ -25,7 +25,7 @@ import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import { Section } from '../../components/Welcome/sectionStyles';
 import webAppConfig from '../../config';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 /* global $ */
 
@@ -84,15 +84,9 @@ class Donate extends Component {
     }
 
     if (!dataLayerSent && VoterStore.getVoterWeVoteId()) {
-      const { location: { pathname: currentPathname } } = window;
-      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
       const dataLayerObject = {
         event: 'landing',
-        pageDetails: {
-          pageName: currentPage.pageName,
-          pageType: currentPage.pageType,
-          pathname: currentPathname,
-        },
+        pageDetails: getPageDetails(),
         userDetails: VoterStore.getAnalyticsUserDetails(),
       };
       // console.log('WV-1462: dataLayerObject:', dataLayerObject);

--- a/src/js/pages/Ready.jsx
+++ b/src/js/pages/Ready.jsx
@@ -1,9 +1,9 @@
-import TagManager from 'react-gtm-module';
 import { Card } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import { Helmet } from 'react-helmet-async';
 import ActivityActions from '../actions/ActivityActions';
 import AnalyticsActions from '../actions/AnalyticsActions';
@@ -16,7 +16,6 @@ import apiCalming from '../common/utils/apiCalming';
 import historyPush from '../common/utils/historyPush';
 import { isAndroid, isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
-import lookupPageNameAndPageTypeDict from '../utils/lookupPageNameAndPageTypeDict';
 import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
@@ -32,6 +31,7 @@ import { cordovaSimplePageContainerTopOffset } from '../utils/cordovaCalculatedO
 // Lint is not smart enough to know that lazyPreloadPages will not attempt to preload/reload this page
 // eslint-disable-next-line import/no-cycle
 import lazyPreloadPages from '../utils/lazyPreloadPages';
+import { getPageDetails } from '../utils/lookupPageNameAndPageTypeDict';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../common/components/Widgets/DelayedLoad'));
 const ElectionCountdown = React.lazy(() => import(/* webpackChunkName: 'ElectionCountdown' */ '../components/Ready/ElectionCountdown'));
@@ -121,19 +121,12 @@ class Ready extends Component {
     const { dataLayerFired } = this.state;
     if (!dataLayerFired) {
       if (VoterStore.voterFirstRetrieveCompleted()) {
-        const { location: { pathname: currentPathname } } = window;
-        const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
-
         const dataLayerObject = {
           actionDetails: {
             actionType: 'landing',
           },
           event: 'landing',
-          pageDetails: {
-            pageName: currentPage.pageName,
-            pageType: currentPage.pageType,
-            pathname: currentPathname,
-          },
+          pageDetails: getPageDetails(),
           userDetails: VoterStore.getAnalyticsUserDetails(),
         };
 

--- a/src/js/pages/ReadyLight.jsx
+++ b/src/js/pages/ReadyLight.jsx
@@ -1,8 +1,8 @@
-import TagManager from 'react-gtm-module';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import { Helmet } from 'react-helmet-async';
 import ActivityActions from '../actions/ActivityActions';
 import AnalyticsActions from '../actions/AnalyticsActions';
@@ -12,7 +12,6 @@ import apiCalming from '../common/utils/apiCalming';
 import historyPush from '../common/utils/historyPush';
 import { isAndroid, isWebApp } from '../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../common/utils/logging';
-import lookupPageNameAndPageTypeDict from '../utils/lookupPageNameAndPageTypeDict';
 import ReadyFinePrint from '../components/Ready/ReadyFinePrint';
 import ReadyIntroduction from '../components/Ready/ReadyIntroduction';
 import ReadyTaskPlan from '../components/Ready/ReadyTaskPlan';
@@ -25,6 +24,7 @@ import webAppConfig from '../config';
 import VoterStore from '../stores/VoterStore';
 import { cordovaSimplePageContainerTopOffset } from '../utils/cordovaCalculatedOffsets';
 import lazyPreloadPages from '../utils/lazyPreloadPages';
+import { getPageDetails } from '../utils/lookupPageNameAndPageTypeDict';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../common/components/Widgets/DelayedLoad'));
 const ElectionCountdown = React.lazy(() => import(/* webpackChunkName: 'ElectionCountdown' */ '../components/Ready/ElectionCountdown'));
@@ -73,19 +73,12 @@ class ReadyLight extends Component {
     const { dataLayerFired } = this.state;
     if (!dataLayerFired) {
       if (VoterStore.voterFirstRetrieveCompleted()) {
-        const { location: { pathname: currentPathname } } = window;
-        const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
-
         const dataLayerObject = {
           actionDetails: {
             actionType: 'landing',
           },
           event: 'landing',
-          pageDetails: {
-            pageName: currentPage.pageName,
-            pageType: currentPage.pageType,
-            pathname: currentPathname,
-          },
+          pageDetails: getPageDetails(),
           userDetails: VoterStore.getAnalyticsUserDetails(),
         };
 

--- a/src/js/pages/Values/OneValue.jsx
+++ b/src/js/pages/Values/OneValue.jsx
@@ -3,25 +3,25 @@ import withStyles from '@mui/styles/withStyles';
 import { filter } from 'lodash-es';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import { Helmet } from 'react-helmet-async';
 import styled from 'styled-components';
-import TagManager from 'react-gtm-module';
 import IssueActions from '../../actions/IssueActions';
 import OrganizationActions from '../../actions/OrganizationActions';
+import SearchBar2024 from '../../common/components/Search/SearchBar2024';
 import apiCalming from '../../common/utils/apiCalming';
 import { renderLog } from '../../common/utils/logging';
-import SearchBar2024 from '../../common/components/Search/SearchBar2024';
+import { convertNameToSlug } from '../../common/utils/textFormat';
+import NoSearchResult from '../../components/Search/NoSearchResult';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import GuideList from '../../components/VoterGuide/GuideList';
+import EndorsementCard from '../../components/Widgets/EndorsementCard';
 import IssueStore from '../../stores/IssueStore';
 import OrganizationStore from '../../stores/OrganizationStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
-import ValuesList from './ValuesList';
-import { convertNameToSlug } from '../../common/utils/textFormat';
-import NoSearchResult from '../../components/Search/NoSearchResult';
-import EndorsementCard from '../../components/Widgets/EndorsementCard';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
 import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import ValuesList from './ValuesList';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
 const IssueCard = React.lazy(() => import(/* webpackChunkName: 'IssueCard' */ '../../components/Values/IssueCard'));
@@ -153,8 +153,6 @@ class OneValue extends Component {
   }
 
   changeListModeShown = (buttonId) => {
-    const { location: { pathname: currentPathname } } = window;
-    const { pageName, pageType } = lookupPageNameAndPageTypeDict(currentPathname);
     const { issue } = this.state;
     const dataLayerObject = {
       actionDetails: {
@@ -162,11 +160,7 @@ class OneValue extends Component {
         buttonId,
       },
       event: 'action',
-      pageDetails: {
-        pageName,
-        pageType,
-        pathname: currentPathname,
-      },
+      pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     if (issue.issue_we_vote_id) {

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -149,3 +149,23 @@ export default function lookupPageNameAndPageTypeDict (path) {
     return calculatePageNameAndPageTypeDict(path);
   }
 }
+
+export function getPageDetails (stateCode = null) {
+  const { location: { pathname } } = window;
+  const currentPage = lookupPageNameAndPageTypeDict(pathname);
+  console.log(currentPage);
+
+  if (stateCode) {
+    return {
+      pageType: currentPage.pageType,
+      pageName: currentPage.pageName,
+      pathname,
+      stateCode,
+    };
+  }
+  return {
+    pageType: currentPage.pageType,
+    pageName: currentPage.pageName,
+    pathname,
+  };
+}


### PR DESCRIPTION
1) pageDetails: getPageDetails(): I left about 5 of the old ones in place in case their code did something valuable. 
2) destinationDetails could use one too.
3) lookupPageNameAndPageTypeDict(currentPathname); very rarely needs a path to be passed in (unless destination).  That could eliminate some more boilerplate
