### PR TITLE
WV-553 Implement politician page load analytics tracking

### DIFF
--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -51,6 +51,7 @@ import saveCampaignSupportAndGoToNextPage from '../../utils/saveCampaignSupportA
 import extractPoliticianDetailsFromUrl from '../../utils/extractPoliticianDetailsFromUrl';
 import VoterStore from '../../../stores/VoterStore';
 import VoterPositionEntryAndDisplay from '../../../components/PositionItem/VoterPositionEntryAndDisplay';
+import {getPageDetails} from "../../../utils/lookupPageNameAndPageTypeDict";
 
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
 const CampaignSupportThermometer = React.lazy(() => import(/* webpackChunkName: 'CampaignSupportThermometer' */ '../../components/CampaignSupport/CampaignSupportThermometer'));
@@ -308,23 +309,24 @@ class PoliticianDetailsPage extends Component {
       window.scrollTo(0, 0);
     }
     if (!this.state.dataLayerSent) {
-      // console.log('TagManager code executing...');
-      // console.log('Politician ID id exists? ', politician);
       if (politician && politician.politician_we_vote_id) {
-        // console.log('Politician Details retrieved, Adding DataLayer...');
-        const { location: { pathname: currentPathname } } = window;
         const dataLayerObject = {
           event: 'landing',
           userDetails: VoterStore.getAnalyticsUserDetails(),
-          pageDetails: {
-            pageName: this.constructor.name, // name of page from constructor itself
-            pageType: 'politician', // in which page we are currently
-            pathname: currentPathname,
+          pageDetails: getPageDetails(),
+          actionDetails: {
+            actionType: 'landing',
           },
         };
+        if (politician.candidate_we_vote_id) {
+          dataLayerObject.candidateDetails = CandidateStore.getAnalyticsCandidateDetails(politician.candidate_we_vote_id);
+        }
+
+        // Add politicianDetails if we have a politician ID
         if (politician.politician_we_vote_id) {
           dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politician.politician_we_vote_id);
         }
+        // console.log('DataLayer object being sent:', dataLayerObject);
         TagManager.dataLayer({ dataLayer: dataLayerObject });
         // Set the flag to true so that it runs just once
         this.setState({

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -318,11 +318,11 @@ class PoliticianDetailsPage extends Component {
           pageDetails: getPageDetails(),
           userDetails: VoterStore.getAnalyticsUserDetails(),
         };
-        if (politician.candidate_we_vote_id) {
-          dataLayerObject.candidateDetails = CandidateStore.getAnalyticsCandidateDetails(politician.candidate_we_vote_id);
+        const candidateWeVoteId = CandidateStore.getCandidateWeVoteIdRunningFromPoliticianWeVoteId(politician.politician_we_vote_id);
+        // console.log('candidateWeVoteId from getCandidateWeVoteIdRunningFromPoliticianWeVoteId:', candidateWeVoteId);
+        if (candidateWeVoteId) {
+          dataLayerObject.candidateDetails = CandidateStore.getAnalyticsCandidateDetails(candidateWeVoteId);
         }
-
-        // Add politicianDetails if we have a politician ID
         if (politician.politician_we_vote_id) {
           dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politician.politician_we_vote_id);
         }

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -51,7 +51,7 @@ import saveCampaignSupportAndGoToNextPage from '../../utils/saveCampaignSupportA
 import extractPoliticianDetailsFromUrl from '../../utils/extractPoliticianDetailsFromUrl';
 import VoterStore from '../../../stores/VoterStore';
 import VoterPositionEntryAndDisplay from '../../../components/PositionItem/VoterPositionEntryAndDisplay';
-import {getPageDetails} from "../../../utils/lookupPageNameAndPageTypeDict";
+import { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
 const CampaignSupportThermometer = React.lazy(() => import(/* webpackChunkName: 'CampaignSupportThermometer' */ '../../components/CampaignSupport/CampaignSupportThermometer'));
@@ -109,7 +109,7 @@ class PoliticianDetailsPage extends Component {
       finalElectionDateInPast: false,
       // inPrivateLabelMode: false,
       loadSlow: false,
-      officeHeldList: [],
+      // officeHeldList: [],
       opponentCandidateList: [],
       opponentCandidatesToShowCount: 5,
       payToPromoteStepCompleted: false,
@@ -125,7 +125,7 @@ class PoliticianDetailsPage extends Component {
       showMobileViewUpcomingBallot: false,
       stateText: '',
       step2Completed: false,
-      supporterEndorsementsWithText: [],
+      // supporterEndorsementsWithText: [],
       voterCanEditThisPolitician: false,
       wikipediaUrl: '',
       politicianStateParsedFromURLBeforeLoad: '',
@@ -379,13 +379,13 @@ class PoliticianDetailsPage extends Component {
 
   onCampaignSupporterStoreChange () {
     const { linkedCampaignXWeVoteId } = this.state;
-    const supporterEndorsementsWithText = CampaignSupporterStore.getLatestCampaignXSupportersWithTextList(linkedCampaignXWeVoteId);
+    // const supporterEndorsementsWithText = CampaignSupporterStore.getLatestCampaignXSupportersWithTextList(linkedCampaignXWeVoteId);
     const step2Completed = CampaignSupporterStore.voterSupporterEndorsementExists(linkedCampaignXWeVoteId);
     const payToPromoteStepCompleted = CampaignSupporterStore.voterChipInExists(linkedCampaignXWeVoteId);
     const sharingStepCompleted = false;
     // console.log('onCampaignSupporterStoreChange step2Completed: ', step2Completed, ', sharingStepCompleted: ', sharingStepCompleted, ', payToPromoteStepCompleted:', payToPromoteStepCompleted);
     this.setState({
-      supporterEndorsementsWithText,
+      // supporterEndorsementsWithText,
       sharingStepCompleted,
       step2Completed,
       payToPromoteStepCompleted,
@@ -429,7 +429,7 @@ class PoliticianDetailsPage extends Component {
       }
     }
     this.setState({
-      officeHeldList: officeHeldListFiltered,
+      // officeHeldList: officeHeldListFiltered,
       officeHeldNameForSearch,
     });
   }

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -311,12 +311,12 @@ class PoliticianDetailsPage extends Component {
     if (!this.state.dataLayerSent) {
       if (politician && politician.politician_we_vote_id) {
         const dataLayerObject = {
-          event: 'landing',
-          userDetails: VoterStore.getAnalyticsUserDetails(),
-          pageDetails: getPageDetails(),
           actionDetails: {
             actionType: 'landing',
           },
+          event: 'landing',
+          pageDetails: getPageDetails(),
+          userDetails: VoterStore.getAnalyticsUserDetails(),
         };
         if (politician.candidate_we_vote_id) {
           dataLayerObject.candidateDetails = CandidateStore.getAnalyticsCandidateDetails(politician.candidate_we_vote_id);

--- a/src/js/common/stores/PoliticianStore.js
+++ b/src/js/common/stores/PoliticianStore.js
@@ -59,7 +59,7 @@ class PoliticianStore extends ReduceStore {
       politicalParty: politician ? politician.political_party : '',
       politicianName: politician ? this.getPoliticianName(politicianWeVoteId) : '',
       politicianWeVoteId,
-      stateCode: politician ? politician.state_code || 'na' : '',
+      stateCode: politician ? (politician.state_code || 'na').toUpperCase() : '',
     };
   }
 
@@ -80,8 +80,11 @@ class PoliticianStore extends ReduceStore {
 
   getPoliticianName (politicianWeVoteId) {
     const politician = this.getState().allCachedPoliticians[politicianWeVoteId] || {};
-    if (politician && politician.ballot_item_display_name) {
-      return politician.ballot_item_display_name;
+    if (politician) {
+      return politician.ballot_item_display_name ||
+        politician.politician_name ||
+        politician.display_name ||
+        '';
     }
     return '';
   }

--- a/src/js/stores/CandidateStore.js
+++ b/src/js/stores/CandidateStore.js
@@ -151,7 +151,7 @@ class CandidateStore extends ReduceStore {
       officeName: candidate ? candidate.contest_office_name : '',
       politicianWeVoteId: candidate ? candidate.politician_we_vote_id : '',
       politicalParty: candidate ? candidate.party : '',
-      stateCode: candidate ? candidate.state_code : '',
+      stateCode: candidate ? (candidate.state_code).toUpperCase() : '',
       twitterHandle: candidate ? candidate.candidate_twitter_handle : '',
     };
   }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-553
### Changes included this pull request?
- Fixed the problem with pageName is only showing one character
- Fixed the politicianName so it is no longer missing
- Add dataLayer event for politician landing page loads
- Follow new analytics standards with structured data objects
- Include userDetails, pageDetails, actionDetails, and politicianDetails
- Add conditional candidateDetails when candidate_we_vote_id exists
- Use standardized store methods for analytics data
- Build complete dataLayerObject before TagManager call
- Add dataLayerSent state flag to prevent duplicate events
- Event fires on PoliticianDetailsPage component mount when politician data available
- Fixed all lint errors

Analytics store improvements:
- Update PoliticianStore.getAnalyticsPoliticianDetails() to return uppercase stateCode
- Update CandidateStore.getAnalyticsCandidateDetails() to return uppercase stateCode  
- Ensures consistent uppercase state codes (CA, NY, etc.) across all analytics data"