### PR TITLE
WV-1138 Quick fixes to destinationPathname from full url to pathname of url

### DIFF
--- a/src/js/common/components/Widgets/OpenExternalWebSite.jsx
+++ b/src/js/common/components/Widgets/OpenExternalWebSite.jsx
@@ -22,6 +22,14 @@ export default class OpenExternalWebSite extends Component {
       const destinationPage = lookupPageNameAndPageTypeDictForExternalUrls(url);
       const destinationPageNameLocalBackup = destinationPage.pageName;
       const destinationPageTypeLocalBackup = destinationPage.pageType;
+
+      let destinationPathname;
+      try {
+        destinationPathname = new URL(url).pathname;
+      } catch (error) {
+        // Fallback to the full URL if parsing fails
+        destinationPathname = url;
+      }
       // console.log('External link clicked:', this.props.url);
       const dataLayerObject = {
         actionDetails: {
@@ -32,7 +40,7 @@ export default class OpenExternalWebSite extends Component {
         destinationDetails: {
           destinationPageName: destinationPageName || destinationPageNameLocalBackup,
           destinationPageType: destinationPageType || destinationPageTypeLocalBackup,
-          destinationPathname: url,
+          destinationPathname,
         },
         pageDetails: {
           pageName: pageName || pageNameLocalBackup,


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1138
### Changes included this pull request?
- Update OpenExternalWebSite to use URL pathname instead of full URL for destinationPathname
- Add error handling for malformed URLs with fallback to original URL
- Improves consistency with internal navigation tracking patterns