### PR TITLE
[WV-1098] Add dataLayer for Search on Ballot Page [TEAM REVIEW]

### DIFF
--- a/src/js/components/Filter/FilterBaseSearch.jsx
+++ b/src/js/components/Filter/FilterBaseSearch.jsx
@@ -2,6 +2,7 @@ import { Close, Search } from '@mui/icons-material';
 import { IconButton, InputBase } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
+import TagManager from 'react-gtm-module';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import styled from 'styled-components';
@@ -15,6 +16,8 @@ import ballotSearchPriority from '../../utils/ballotSearchPriority';
 import opinionsAndBallotItemsSearchPriority from '../../utils/opinionsAndBallotItemsSearchPriority';
 import positionSearchPriority from '../../utils/positionSearchPriority';
 import voterGuidePositionSearchPriority from '../../utils/voterGuidePositionSearchPriority';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import VoterStore from '../../stores/VoterStore';
 
 const delayBeforeSearchExecution = 600;
 
@@ -204,18 +207,19 @@ class FilterBaseSearch extends Component {
   }
 
   searchNewItems = (searchText) => {
-    const { opinionsAndBallotItemsSearchMode } = this.props;
+    // const { opinionsAndBallotItemsSearchMode } = this.props;
     const { searchTextAlreadyRetrieved } = this.state;
     // console.log('searchNewItems searchText:', searchText, ', searchTextAlreadyRetrieved:', searchTextAlreadyRetrieved);
-    if (opinionsAndBallotItemsSearchMode) {
-      // Reach out to API server to get more Organizations or Ballot items.
-      if (!searchTextAlreadyRetrieved.includes(searchText)) {
-        OrganizationActions.organizationSearch(searchText);
-        BallotActions.ballotItemOptionsRetrieve('', searchText);
-        searchTextAlreadyRetrieved.push(searchText);
-        this.setState({ searchTextAlreadyRetrieved });
-      }
+    // if (opinionsAndBallotItemsSearchMode) {
+    // Reach out to API server to get more Organizations or Ballot items.
+    if (!searchTextAlreadyRetrieved.includes(searchText)) {
+      this.sendSearchEvent(searchText);
+      OrganizationActions.organizationSearch(searchText);
+      BallotActions.ballotItemOptionsRetrieve('', searchText);
+      searchTextAlreadyRetrieved.push(searchText);
+      this.setState({ searchTextAlreadyRetrieved });
     }
+    // }
   }
 
   bigAndroidClick = (isSearching, alwaysOpen) => {
@@ -223,6 +227,19 @@ class FilterBaseSearch extends Component {
     if (isAndroid() && !isSearching && !alwaysOpen) {
       this.toggleSearch();
     }
+  }
+
+  sendSearchEvent (searchText) {
+    const dataLayerObject = {
+      actionDetails: {
+        actionType: 'search',
+        searchKeyword: searchText,
+      },
+      event: 'action',
+      pageDetails: getPageDetails(),
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
   }
 
   render () {

--- a/src/js/components/Filter/FilterBaseSearch.jsx
+++ b/src/js/components/Filter/FilterBaseSearch.jsx
@@ -213,7 +213,7 @@ class FilterBaseSearch extends Component {
     // if (opinionsAndBallotItemsSearchMode) {
     // Reach out to API server to get more Organizations or Ballot items.
     if (!searchTextAlreadyRetrieved.includes(searchText)) {
-      this.sendSearchEvent(searchText);
+      this.sendSearchDataLayer(searchText);
       OrganizationActions.organizationSearch(searchText);
       BallotActions.ballotItemOptionsRetrieve('', searchText);
       searchTextAlreadyRetrieved.push(searchText);
@@ -229,7 +229,7 @@ class FilterBaseSearch extends Component {
     }
   }
 
-  sendSearchEvent (searchText) {
+  sendSearchDataLayer (searchText) {
     const dataLayerObject = {
       actionDetails: {
         actionType: 'search',


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1098

### Changes included this pull request?

- Added function `sendSearchEvent` that takes in `searchText`
- Updated `searchNewItems` to call `sendSearchEvent` when a new unique search term is entered.

In the previous PR (#4344), dataLayer was recommended to be placed inside the uniqueness check (`if (!searchTextAlreadyRetrieved.includes(searchText))`). However, the outer guard `if (opinionsAndBallotItemsSearchMode)` seems to always be undefined, so the whole block never runs. I wasn’t able to determine why `opinionsAndBallotItemsSearchMode` remains undefined here, so I’d appreciate any insight!

I’ve commented out that guard to allow data fetching and event sending for every unique search term per session, preserving uniqueness.

If keeping `opinionsAndBallotItemsSearchMode` is necessary, I can move the event call outside that check, but that would lose the uniqueness control and trigger on every search. Appreciate any feedback! 