### PR TITLE
[WV-1170]Added datalayer tracking for Credits and Thanks [CLOSED]

### DIFF
--- a/src/js/common/components/CreditsBody.jsx
+++ b/src/js/common/components/CreditsBody.jsx
@@ -31,7 +31,7 @@ class Credits extends Component {
             {' '}
             Please also see the
             {' '}
-            <Link to="/more/attributions" id="attributions" class="u-link-color">
+            <Link to="/more/attributions" id="attributions" className="u-link-color">
               summary of open source software
             </Link>
             {' '}
@@ -110,7 +110,7 @@ class Credits extends Component {
             <span>
               , or by
               {' '}
-              <Link class="u-link-color" to="/donate">
+              <Link className="u-link-color" to="/donate">
                 donating now
               </Link>
             </span>

--- a/src/js/components/Navigation/FooterMainWeVote.jsx
+++ b/src/js/components/Navigation/FooterMainWeVote.jsx
@@ -165,14 +165,35 @@ class FooterMainWeVote extends Component {
                     className={classes.link}
                   />
                   <RowSpacer />
-                  <OpenExternalWebSite
-                    linkIdAttribute="footerLinkCredits"
-                    url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/credits`}
-                    target="_blank"
-                    trackingOn
-                    body={(<span>Credits &amp; Thanks</span>)}
+                  <Link
+                    id="footerLinkCredits"
+                    to="/more/credits"
                     className={classes.link}
-                  />
+                    onClick={() => {
+                      const currentPathname = '/more/credits';
+                      const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
+                      const dataLayerObject = {
+                        actionDetails: {
+                          buttonId: 'footerLinkCredits',
+                        },
+                        event: 'click',
+                        destinationDetails: {
+                          destinationPageName: currentPage.pageName,
+                          destinationPageType: currentPage.pageType,
+                          destinationPathname: currentPathname,
+                        },
+                        pageDetails: {
+                          pageName: currentPage.pageName,
+                          pageType: currentPage.pageType,
+                          pathname: window.location.pathname,
+                        },
+                        userDetails: VoterStore.getAnalyticsUserDetails(),
+                      };
+                      TagManager.dataLayer({ dataLayer: dataLayerObject });
+                    }}
+                  >
+                    <span>Credits &amp; Thanks</span>
+                  </Link>
                 </>
               ) : (
                 <>

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -82,6 +82,10 @@ const pageNameAndTypeSimpleDict = {
     pageName: 'TermsOfService',
     pageType: 'termsOfService',
   },
+  '/more/credits': {
+    pageName: 'CreditsAndThanks', // Added
+    pageType: 'about',
+  },
 };
 
 function calculatePageNameAndPageTypeDict (path) {


### PR DESCRIPTION
### Added datalayer tracking for Credits and Thanks using tagManager

Comment from QA Lead:
this doesn’t appear to grab the external link for credits and thanks page. the URL is [WeVote Sample Ballot](https://quality.wevote.us/more/credits) 

I believe if you use  lookupPageNameAndPageTypeDictForExternalUrls.js you can find your additional data.
