### PR TITLE
[WV-1010] [WV-1460] Add dataLayer code to the Header items, when they are clicked [NEEDS REVIEW]

### DIFF
--- a/src/js/common/pages/Challenge/ChallengesHome.jsx
+++ b/src/js/common/pages/Challenge/ChallengesHome.jsx
@@ -4,12 +4,14 @@ import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import ActivityActions from '../../../actions/ActivityActions';
 import BallotActions from '../../../actions/BallotActions';
 import IssueActions from '../../../actions/IssueActions';
 import OrganizationActions from '../../../actions/OrganizationActions';
 import SupportActions from '../../../actions/SupportActions';
 import ChallengeStore from '../../stores/ChallengeStore';
+import { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 import apiCalming from '../../utils/apiCalming';
 import arrayContains from '../../utils/arrayContains';
 import { getTodayAsInteger } from '../../utils/dateFormat';
@@ -36,6 +38,7 @@ class ChallengesHome extends Component {
     this.state = {
       challengeList: [],
       challengeListTimeStampOfChange: 0,
+      dataLayerFired: false,
       isSearching: false,
       listModeShown: 'showUpcomingEndorsements',
       listModeFiltersAvailable: [],
@@ -89,6 +92,28 @@ class ChallengesHome extends Component {
       }
     }, 5000);  // April 19, 2021: Tuned to keep performance above 83.  LCP at 597ms
     // AnalyticsActions.saveActionOffice(VoterStore.electionId(), params.office_we_vote_id);
+  }
+
+  componentDidUpdate () {
+    const { dataLayerFired } = this.state;
+    if (!dataLayerFired) {
+      if (VoterStore.voterFirstRetrieveCompleted()) {
+        const dataLayerObject = {
+          event: 'landing',
+          actionDetails: {
+            actionType: 'landing',
+          },
+          pageDetails: getPageDetails(),
+          userDetails: VoterStore.getAnalyticsUserDetails(),
+        };
+
+        TagManager.dataLayer({ dataLayer: dataLayerObject });
+
+        this.setState({
+          dataLayerFired: true,
+        });
+      }
+    }
   }
 
   componentWillUnmount () {

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -4,7 +4,7 @@ import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import styled from 'styled-components';
-import TagManager from 'react-gtm-module';
+// import TagManager from 'react-gtm-module';
 import OrganizationActions from '../../actions/OrganizationActions';
 import VoterActions from '../../actions/VoterActions';
 import VoterGuideActions from '../../actions/VoterGuideActions';
@@ -32,7 +32,7 @@ import HeaderBarLogo from './HeaderBarLogo';
 import HeaderBarModals from './HeaderBarModals';
 import TabWithPushHistory from './TabWithPushHistory';
 import webAppConfig from '../../config';
-import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
+// import lookupPageNameAndPageTypeDict from '../../utils/lookupPageNameAndPageTypeDict';
 
 
 const HeaderNotificationMenu = React.lazy(() => import(/* webpackChunkName: 'HeaderNotificationMenu' */ './HeaderNotificationMenu'));
@@ -158,7 +158,7 @@ class HeaderBar extends Component {
   handleTabChange (newValue) {
     this.customHighlightSelector();
     // console.log('handleTabChange ', newValue);
-    if (newValue === 4) {  // Check if the tab change is for challenges
+    /* if (newValue === 4) {  // Check if the tab change is for challenges
       const currentPathname = window.location.pathname;
       const destinationPathname = '/challenges';
       const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
@@ -181,7 +181,7 @@ class HeaderBar extends Component {
           userDetails: VoterStore.getAnalyticsUserDetails(),
         },
       });
-    }
+    } */
     this.setState({ tabsValue: newValue });
   }
 

--- a/src/js/components/Navigation/TabWithPushHistory.jsx
+++ b/src/js/components/Navigation/TabWithPushHistory.jsx
@@ -1,9 +1,10 @@
 import { Tab } from '@mui/material';
-import PropTypes from 'prop-types';
-import React from 'react';
+import TagManager from 'react-gtm-module';
 import { Link } from 'react-router-dom'; // useHistory
-
-
+import React from 'react';
+import PropTypes from 'prop-types';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import VoterStore from '../../stores/VoterStore';
 /*
  The simplest way to define a component is to write a JavaScript function:
  This function is a valid React component because it accepts a single “props”
@@ -11,12 +12,34 @@ import { Link } from 'react-router-dom'; // useHistory
  We call such components “function components” because they are literally JavaScript functions.
  https://reactrouter.com/native/api/Hooks/usehistory
 */
+
+// DataLayer helper function
+function pushDataLayer (destinationPath, buttonId = '') {
+  const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
+  const dataLayerObject = {
+    actionDetails: {
+      actionType: 'navigate',
+      buttonId,
+    },
+    event: 'click',
+    pageDetails: getPageDetails(),
+    destinationDetails: {
+      destinationPageName: destinationPage.pageName,
+      destinationPageType: destinationPage.pageType,
+      destinationPathname: destinationPath,
+    },
+    userDetails: VoterStore.getAnalyticsUserDetails(),
+  };
+  TagManager.dataLayer({ dataLayer: dataLayerObject });
+}
+
 export default function TabWithPushHistory (props) {
   const { classes, id, label, to, value, change: handleTabChange } = props;
 
   function handleClick () {
     if (handleTabChange) {
       handleTabChange(value);
+      pushDataLayer(to, id);
     }
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

[WV-1010](https://wevoteusa.atlassian.net/issues/?filter=10060&selectedIssue=WV-1010)

### Changes included this pull request?

1. Added dataLayer function in `TabWithPushHistory` to send click event and its corresponding tag information for HeaderBar items.
2. Fixed `ChallengesHome` landing event dataLayer
 - Commented out original code in `HeaderBar`
 - Added landing dataLayer in `ChallengesHome`

[WV-1010]: https://wevoteusa.atlassian.net/browse/WV-1010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ