### PR TITLE
[WV-1161] Align EditBanner width with menu container and style

### DIFF
--- a/src/js/components/Navigation/Header.jsx
+++ b/src/js/components/Navigation/Header.jsx
@@ -660,7 +660,9 @@ const EditBanner = styled.div`
   flex-wrap: wrap;
   font-size: 14px;
   justify-content: space-between;
+  max-width: 960px;
   padding: 12px 16px;
+  width: 100%;
 `;
 const EditButton = styled.button`
   background: ${DesignTokenColors.whiteUI};
@@ -681,7 +683,9 @@ const EditButton = styled.button`
   }
 `;
 const EditBannerWrapper = styled.div`
-  position: relative;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px;
 `;
 
 const TipsLink = styled.a`


### PR DESCRIPTION

WV-1161: Align EditBanner width with menu container and style

- Added EditBannerWrapper with horizontal padding and centered layout
- Set EditBanner max-width to 960px to match menu width

<img width="3060" height="1873" alt="image" src="https://github.com/user-attachments/assets/2a22821e-16c8-4926-a543-95cba57b749a" />
