### PR TITLE
[WV-1012] Fix Add dataLayer code to all footer items [Merge Ready]

### DIFF
--- a/src/js/components/Navigation/FooterCandidateList.jsx
+++ b/src/js/components/Navigation/FooterCandidateList.jsx
@@ -23,8 +23,8 @@ export default function FooterCandidateList () {
       event: 'action',
       pageDetails: getPageDetails(),
       destinationDetails: {
-        destinationPageName: destinationPage.pageName,
-        destinationPageType: destinationPage.pageType,
+        destinationPageName: destinationPage.pageName || 'notSet',
+        destinationPageType: destinationPage.pageType || 'notSet',
         destinationPathname: linkTo,
       },
       userDetails: VoterStore.getAnalyticsUserDetails(),
@@ -45,14 +45,15 @@ export default function FooterCandidateList () {
           .toLowerCase();
         // console.log('tempStateCode:', tempStateCode, ', stateAlreadySelected:', stateAlreadySelected);
         const linkTo = `/${stateNamePhraseLowerCase}/cs/`;
+        const buttonId = `footerLink_${stateNamePhraseLowerCase}`;
 
         return (
           <SimpleModeItemWrapper key={stateCode}>
             <Link
-              id={`${stateNamePhraseLowerCase}_Link`}
+              id={buttonId}
               className="u-link-color"
               to={linkTo}
-              onClick={() => handleClick(linkTo, `${stateNamePhraseLowerCase}_Link`)}
+              onClick={() => handleClick(linkTo, buttonId)}
             >
               {stateName}
               {' '}

--- a/src/js/components/Navigation/FooterMainWeVote.jsx
+++ b/src/js/components/Navigation/FooterMainWeVote.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import AppObservableStore from '../../common/stores/AppObservableStore';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
-// import webAppConfig from '../../config';
+import webAppConfig from '../../config';
 import VoterStore from '../../stores/VoterStore';
 import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
@@ -64,46 +64,11 @@ class FooterMainWeVote extends Component {
   }
 
   pushDataLayer (destinationPath, buttonId = '') {
-    // Check if it's an external URL
-    const isExternal = destinationPath.startsWith('http://') || destinationPath.startsWith('https://');
-
-    let destinationPageName;
-    let destinationPageType;
-    let destinationPathname;
-    let destinationDetails;
-
-    if (isExternal) {
-      // For external links, extract domain name and set type to 'external'
-      try {
-        const url = new URL(destinationPath);
-        destinationPageName = url.hostname; // e.g., "help.wevote.us", "blog.wevote.us"
-      } catch {
-        destinationPageName = 'notSet';
-      }
-      destinationPageType = 'external';
-      destinationPathname = destinationPath; // Full URL for external
-
-      // Build destinationDetails with destinationUrl for external links
-      destinationDetails = {
-        destinationPageName,
-        destinationPageType,
-        destinationPathname,
-        destinationUrl: destinationPath, // Add this for clarity on external links
-      };
-    } else {
-      // For internal links, use the lookup function
-      const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
-      destinationPageName = destinationPage.pageName || 'notSet';
-      destinationPageType = destinationPage.pageType || 'notSet';
-      destinationPathname = destinationPath;
-
-      // Build destinationDetails without destinationUrl for internal links
-      destinationDetails = {
-        destinationPageName,
-        destinationPageType,
-        destinationPathname,
-      };
-    }
+    // For internal links only - external links are handled by OpenExternalWebSite
+    const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
+    const destinationPageName = destinationPage.pageName || 'notSet';
+    const destinationPageType = destinationPage.pageType || 'notSet';
+    const destinationPathname = destinationPath;
 
     const dataLayerObject = {
       actionDetails: {
@@ -112,7 +77,11 @@ class FooterMainWeVote extends Component {
       },
       event: 'action',
       pageDetails: getPageDetails(),
-      destinationDetails,
+      destinationDetails: {
+        destinationPageName,
+        destinationPageType,
+        destinationPathname,
+      },
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     TagManager.dataLayer({ dataLayer: dataLayerObject });
@@ -171,17 +140,14 @@ class FooterMainWeVote extends Component {
                 How It Works
               </button>
               <RowSpacer />
-              <span
-                onClick={() => this.pushDataLayer('https://help.wevote.us/hc/en-us', 'footerLinkWeVoteHelp')}
-              >
-                <OpenExternalWebSite
-                  linkIdAttribute="footerLinkWeVoteHelp"
-                  url="https://help.wevote.us/hc/en-us"
-                  target="_blank"
-                  className={classes.link}
-                  body={(<span>Help</span>)}
-                />
-              </span>
+              <OpenExternalWebSite
+                linkIdAttribute="footerLinkWeVoteHelp"
+                url="https://help.wevote.us/hc/en-us"
+                target="_blank"
+                className={classes.link}
+                trackingOn
+                body={(<span>Help</span>)}
+              />
               <RowSpacer />
               <Link
                 id="footerLinkPrivacy"
@@ -213,23 +179,24 @@ class FooterMainWeVote extends Component {
                     About &amp; FAQ
                   </Link>
                   <RowSpacer />
-                  <Link
-                    id="footerLinkTeam"
-                    to="/more/about"
+                  {/* Note: Team/Credits links will show 'notSet' in local dev but work correctly in production */}
+                  <OpenExternalWebSite
+                    linkIdAttribute="footerLinkTeam"
+                    url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/about`}
+                    target="_blank"
+                    trackingOn
+                    body={(<span>Team</span>)}
                     className={classes.link}
-                    onClick={() => this.pushDataLayer('/more/about', 'footerLinkTeam')}
-                  >
-                    Team
-                  </Link>
+                  />
                   <RowSpacer />
-                  <Link
-                    id="footerLinkCredits"
-                    to="/more/credits"
+                  <OpenExternalWebSite
+                    linkIdAttribute="footerLinkCredits"
+                    url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/credits`}
+                    target="_blank"
+                    trackingOn
+                    body={(<span>Credits &amp; Thanks</span>)}
                     className={classes.link}
-                    onClick={() => this.pushDataLayer('/more/credits', 'footerLinkCredits')}
-                  >
-                    Credits &amp; Thanks
-                  </Link>
+                  />
                 </>
               ) : (
                 <>
@@ -255,32 +222,23 @@ class FooterMainWeVote extends Component {
             </OneRow>
             {isWebApp() && (
               <OneRow>
-                <span
-                  onClick={() => this.pushDataLayer('https://blog.wevote.us/', 'footerLinkBlog')}
-                >
-                  <OpenExternalWebSite
-                    linkIdAttribute="footerLinkBlog"
-                    url="https://blog.wevote.us/"
-                    target="_blank"
-                    body={(<span>Blog</span>)}
-                    className={classes.link}
-                  />
-                </span>
+                <OpenExternalWebSite
+                  linkIdAttribute="footerLinkBlog"
+                  url="https://blog.wevote.us/"
+                  target="_blank"
+                  trackingOn
+                  body={(<span>Blog</span>)}
+                  className={classes.link}
+                />
                 <RowSpacer />
-                <span
-                  onClick={() => this.pushDataLayer(
-                    'https://wevote.applytojob.com/apply',
-                    'footerLinkVolunteer',
-                  )}
-                >
-                  <OpenExternalWebSite
-                    linkIdAttribute="footerLinkVolunteer"
-                    url="https://wevote.applytojob.com/apply"
-                    target="_blank"
-                    body={(<span>Volunteering Opportunities</span>)}
-                    className={classes.link}
-                  />
-                </span>
+                <OpenExternalWebSite
+                  linkIdAttribute="footerLinkVolunteer"
+                  url="https://wevote.applytojob.com/apply"
+                  target="_blank"
+                  trackingOn
+                  body={(<span>Volunteering Opportunities</span>)}
+                  className={classes.link}
+                />
                 <RowSpacer />
                 <Link
                   className={classes.link}
@@ -318,6 +276,7 @@ class FooterMainWeVote extends Component {
     );
   }
 }
+
 FooterMainWeVote.propTypes = {
   classes: PropTypes.object,
 };

--- a/src/js/components/Navigation/FooterMainWeVote.jsx
+++ b/src/js/components/Navigation/FooterMainWeVote.jsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import AppObservableStore from '../../common/stores/AppObservableStore';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
-import webAppConfig from '../../config';
+// import webAppConfig from '../../config';
 import VoterStore from '../../stores/VoterStore';
 import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
@@ -44,18 +44,19 @@ class FooterMainWeVote extends Component {
     AppObservableStore.setShowHowItWorksModal(true);
 
     const { location: { pathname: currentPathname } } = window;
-    const currentPage = lookupPageNameAndPageTypeDict(currentPathname);
+    const currentPageDetails = getPageDetails();
+
     const dataLayerObject = {
       actionDetails: {
         actionType: 'openModal',
         buttonId: 'footerLinkHowItWorks',
       },
       event: 'action',
-      pageDetails: getPageDetails(),
+      pageDetails: currentPageDetails,
       destinationDetails: {
         destinationPageName: 'HowItWorksModal',
-        destinationPageType: currentPage.pageType,
-        destinationPathname: currentPathname,
+        destinationPageType: currentPageDetails.pageType, // Use current page's pageType for modals
+        destinationPathname: currentPathname, // Use current pathname since modal doesn't navigate
       },
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
@@ -63,7 +64,47 @@ class FooterMainWeVote extends Component {
   }
 
   pushDataLayer (destinationPath, buttonId = '') {
-    const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
+    // Check if it's an external URL
+    const isExternal = destinationPath.startsWith('http://') || destinationPath.startsWith('https://');
+
+    let destinationPageName;
+    let destinationPageType;
+    let destinationPathname;
+    let destinationDetails;
+
+    if (isExternal) {
+      // For external links, extract domain name and set type to 'external'
+      try {
+        const url = new URL(destinationPath);
+        destinationPageName = url.hostname; // e.g., "help.wevote.us", "blog.wevote.us"
+      } catch {
+        destinationPageName = 'notSet';
+      }
+      destinationPageType = 'external';
+      destinationPathname = destinationPath; // Full URL for external
+
+      // Build destinationDetails with destinationUrl for external links
+      destinationDetails = {
+        destinationPageName,
+        destinationPageType,
+        destinationPathname,
+        destinationUrl: destinationPath, // Add this for clarity on external links
+      };
+    } else {
+      // For internal links, use the lookup function
+      const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
+      destinationPageName = destinationPage.pageName || 'notSet';
+      destinationPageType = destinationPage.pageType || 'notSet';
+      destinationPathname = destinationPath;
+
+      // Build destinationDetails without destinationUrl for internal links
+      destinationDetails = {
+        destinationPageName,
+        destinationPageType,
+        destinationPathname,
+      };
+    }
+
     const dataLayerObject = {
       actionDetails: {
         actionType: 'navigate',
@@ -71,11 +112,7 @@ class FooterMainWeVote extends Component {
       },
       event: 'action',
       pageDetails: getPageDetails(),
-      destinationDetails: {
-        destinationPageName: destinationPage.pageName,
-        destinationPageType: destinationPage.pageType,
-        destinationPathname: destinationPath,
-      },
+      destinationDetails,
       userDetails: VoterStore.getAnalyticsUserDetails(),
     };
     TagManager.dataLayer({ dataLayer: dataLayerObject });
@@ -84,7 +121,7 @@ class FooterMainWeVote extends Component {
   render () {
     const { classes } = this.props;
     const { voterContactEmailListCount } = this.state;
-    // const helpDestinationPage = lookupPageNameAndPageTypeDict("https://help.wevote.us/hc/en-us");
+
     return (
       <Wrapper>
         {isWebApp() && (
@@ -134,79 +171,122 @@ class FooterMainWeVote extends Component {
                 How It Works
               </button>
               <RowSpacer />
-              <OpenExternalWebSite
-                linkIdAttribute="footerLinkWeVoteHelp"
-                url="https://help.wevote.us/hc/en-us"
-                target="_blank"
+              <span
+                onClick={() => this.pushDataLayer('https://help.wevote.us/hc/en-us', 'footerLinkWeVoteHelp')}
+              >
+                <OpenExternalWebSite
+                  linkIdAttribute="footerLinkWeVoteHelp"
+                  url="https://help.wevote.us/hc/en-us"
+                  target="_blank"
+                  className={classes.link}
+                  body={(<span>Help</span>)}
+                />
+              </span>
+              <RowSpacer />
+              <Link
+                id="footerLinkPrivacy"
                 className={classes.link}
-                // destinationPageName={helpDestinationPage.pageName}
-                // destinationPageType={helpDestinationPage.pageType}
-                trackingOn
-                body={(<span>Help</span>)}
-              />
+                to="/privacy"
+                onClick={() => this.pushDataLayer('/privacy', 'footerLinkPrivacy')}
+              >
+                Privacy
+              </Link>
               <RowSpacer />
-              <Link id="footerLinkPrivacy" className={classes.link} to="/privacy" onClick={() => this.pushDataLayer('/privacy')}>Privacy</Link>
-              <RowSpacer />
-              <Link id="footerLinkTermsOfUse" className={classes.link} to="/more/terms" onClick={() => this.pushDataLayer('/more/terms')}>Terms</Link>
+              <Link
+                id="footerLinkTermsOfUse"
+                className={classes.link}
+                to="/more/terms"
+                onClick={() => this.pushDataLayer('/more/terms', 'footerLinkTermsOfUse')}
+              >
+                Terms
+              </Link>
             </OneRow>
             <OneRow>
               {isWebApp() ? (
                 <>
-                  <Link id="footerLinkAboutFAQ" to="/more/faq" className={classes.link} onClick={() => this.pushDataLayer('/more/faq')}>
+                  <Link
+                    id="footerLinkAboutFAQ"
+                    to="/more/faq"
+                    className={classes.link}
+                    onClick={() => this.pushDataLayer('/more/faq', 'footerLinkAboutFAQ')}
+                  >
                     About &amp; FAQ
                   </Link>
                   <RowSpacer />
-                  <OpenExternalWebSite
-                    linkIdAttribute="footerLinkTeam"
-                    url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/about`}
-                    target="_blank"
-                    trackingOn
-                    body={(<span>Team</span>)}
+                  <Link
+                    id="footerLinkTeam"
+                    to="/more/about"
                     className={classes.link}
-                  />
+                    onClick={() => this.pushDataLayer('/more/about', 'footerLinkTeam')}
+                  >
+                    Team
+                  </Link>
                   <RowSpacer />
-                  <OpenExternalWebSite
-                    linkIdAttribute="footerLinkCredits"
-                    url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/credits`}
-                    target="_blank"
-                    trackingOn
-                    body={(<span>Credits &amp; Thanks</span>)}
+                  <Link
+                    id="footerLinkCredits"
+                    to="/more/credits"
                     className={classes.link}
-                  />
+                    onClick={() => this.pushDataLayer('/more/credits', 'footerLinkCredits')}
+                  >
+                    Credits &amp; Thanks
+                  </Link>
                 </>
               ) : (
                 <>
-                  <Link to="/more/faq" className={classes.link} onClick={() => this.pushDataLayer('/more/faq')}>Frequently Asked Questions</Link>
+                  <Link
+                    id="footerLinkFAQ"
+                    to="/more/faq"
+                    className={classes.link}
+                    onClick={() => this.pushDataLayer('/more/faq', 'footerLinkFAQ')}
+                  >
+                    Frequently Asked Questions
+                  </Link>
                   <RowSpacer />
-                  <Link to="/more/attributions" className={classes.link} onClick={() => this.pushDataLayer('/more/attributions')}>Attributions</Link>
+                  <Link
+                    id="footerLinkAttributions"
+                    to="/more/attributions"
+                    className={classes.link}
+                    onClick={() => this.pushDataLayer('/more/attributions', 'footerLinkAttributions')}
+                  >
+                    Attributions
+                  </Link>
                 </>
               )}
             </OneRow>
             {isWebApp() && (
               <OneRow>
-                <OpenExternalWebSite
-                  linkIdAttribute="footerLinkBlog"
-                  url="https://blog.wevote.us/"
-                  target="_blank"
-                  trackingOn
-                  body={(<span>Blog</span>)}
-                  className={classes.link}
-                />
+                <span
+                  onClick={() => this.pushDataLayer('https://blog.wevote.us/', 'footerLinkBlog')}
+                >
+                  <OpenExternalWebSite
+                    linkIdAttribute="footerLinkBlog"
+                    url="https://blog.wevote.us/"
+                    target="_blank"
+                    body={(<span>Blog</span>)}
+                    className={classes.link}
+                  />
+                </span>
                 <RowSpacer />
-                <OpenExternalWebSite
-                  linkIdAttribute="footerLinkVolunteer"
-                  url="https://wevote.applytojob.com/apply"
-                  target="_blank"
-                  trackingOn
-                  body={(<span>Volunteering Opportunities</span>)}
-                  className={classes.link}
-                />
+                <span
+                  onClick={() => this.pushDataLayer(
+                    'https://wevote.applytojob.com/apply',
+                    'footerLinkVolunteer',
+                  )}
+                >
+                  <OpenExternalWebSite
+                    linkIdAttribute="footerLinkVolunteer"
+                    url="https://wevote.applytojob.com/apply"
+                    target="_blank"
+                    body={(<span>Volunteering Opportunities</span>)}
+                    className={classes.link}
+                  />
+                </span>
                 <RowSpacer />
                 <Link
                   className={classes.link}
                   id="footerMainLinkDonate"
                   to="/donate"
-                  onClick={() => this.pushDataLayer('/donate')}
+                  onClick={() => this.pushDataLayer('/donate', 'footerMainLinkDonate')}
                 >
                   Donate
                 </Link>

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -22,8 +22,8 @@ const pageNameAndTypeSimpleDict = {
     pageType: !isWeVoteMarketingSite() || window.isCordovaGlobal ? 'homepage' : 'donate',
   },
   '/more/about': {
-    pageName: 'About',
-    pageType: 'about',
+    pageName: 'Team',
+    pageType: 'team',
   },
   '/more/attributions': {
     pageName: 'Attributions',
@@ -81,6 +81,10 @@ const pageNameAndTypeSimpleDict = {
   '/terms': {
     pageName: 'TermsOfService',
     pageType: 'termsOfService',
+  },
+  '/more/credits': {
+    pageName: 'Credits',
+    pageType: 'credits',
   },
 };
 

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -22,8 +22,8 @@ const pageNameAndTypeSimpleDict = {
     pageType: !isWeVoteMarketingSite() || window.isCordovaGlobal ? 'homepage' : 'donate',
   },
   '/more/about': {
-    pageName: 'Team',
-    pageType: 'team',
+    pageName: 'About',
+    pageType: 'about',
   },
   '/more/attributions': {
     pageName: 'Attributions',

--- a/src/js/utils/lookupPageNameAndPageTypeDictForExternalUrls.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDictForExternalUrls.js
@@ -58,6 +58,14 @@ const pageNameAndTypeSimpleDictForExternalUrls = {
     pageName: 'WeVoteUSA',
     pageType: 'organization',
   },
+  'https://wevote.us/more/about': {
+    pageName: 'About',
+    pageType: 'about',
+  },
+  'https://wevote.us/more/credits': {
+    pageName: 'Credits',
+    pageType: 'credits',
+  },
 };
 
 /**


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-1012
### Changes included this pull request?
- Added missing buttonId to all footer links
- Fixed Team and Credits links from external to internal
- Updated pushDataLayer() to auto-detect external vs internal URLs
- Added destinationUrl field for external links
- Fixed modal tracking to use current page's pageType
- Added unique buttonId for each state candidate link
- Added fallback "notSet" values to prevent undefined errors
- External links now correctly show hostname (e.g., "blog.wevote.us")
- Internal links now use React Router Link component

Files changed:
- FooterMainWeVote.jsx
- FooterCandidateList.jsx
-lookupPageNameAndPageTypeDict