### PR TITLE
[WV-1102] [WV-1104] Add dataLayer to Share Modal Copy Link & Twitter Buttons [NEEDS REVIEW]

### DIFF
--- a/src/js/components/Navigation/TabWithPushHistory.jsx
+++ b/src/js/components/Navigation/TabWithPushHistory.jsx
@@ -21,7 +21,7 @@ function pushDataLayer (destinationPath, buttonId = '') {
       actionType: 'navigate',
       buttonId,
     },
-    event: 'click',
+    event: 'action',
     pageDetails: getPageDetails(),
     destinationDetails: {
       destinationPageName: destinationPage.pageName,

--- a/src/js/components/Share/ShareModalOption.jsx
+++ b/src/js/components/Share/ShareModalOption.jsx
@@ -72,10 +72,15 @@ class ShareModalOption extends Component {
       this.props.onClickFunction();
     }
     const dataLayerObject = {
+      actionDetails: {
+        actionType: 'share',
+        buttonId: `shareModalOption-${this.props.uniqueExternalId}`,
+      },
       event: 'ShareModalCopyLinkClick',
       shareDetails: {
-        title: this.props.title || 'Copy link',
+        shareType: this.props.title || 'Copy link',
         urlShared: this.props.urlToShare || '',
+        contentToggle: AppObservableStore.getWhatAndHowMuchToShare(),
       },
       pageDetails: getPageDetails(),
       userDetails: VoterStore.getAnalyticsUserDetails(),

--- a/src/js/components/Share/shareButtonCommon.jsx
+++ b/src/js/components/Share/shareButtonCommon.jsx
@@ -1,7 +1,8 @@
 import { FileCopyOutlined } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import PropTypes from 'prop-types';
-import React, { Suspense } from 'react';
+import React, { Suspense, useRef } from 'react';
+import TagManager from 'react-gtm-module';
 import { FacebookIcon, FacebookShareButton, TwitterIcon, TwitterShareButton } from 'react-share'; // EmailIcon, EmailShareButton,
 import styled from 'styled-components';
 import AnalyticsActions from '../../actions/AnalyticsActions';
@@ -10,6 +11,8 @@ import { openSnackbar } from '../../common/components/Widgets/SnackNotifier';
 import { cordovaOpenSafariView, hasDynamicIsland, hasIPhoneNotch, isIPhone6p5in } from '../../common/utils/cordovaUtils';
 import { normalizedHref } from '../../common/utils/hrefUtils';
 import { isAndroid, isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
+import AppObservableStore from '../../common/stores/AppObservableStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import VoterStore from '../../stores/VoterStore';
 import ShareModalOption from './ShareModalOption';
 
@@ -320,6 +323,30 @@ const ShareWrapper = styled('div')`
   }
 `;
 
+function pushDataLayer (buttonId, destinationPageName, destinationPageType, shareType, linkToBeShared, destinationUrl) {
+  const dataLayerObject = {
+    actionDetails: {
+      actionType: 'share',
+      buttonId,
+    },
+    event: 'click',
+    shareDetails: {
+      shareType,
+      urlShared: linkToBeShared,
+      contentToggle: AppObservableStore.getWhatAndHowMuchToShare(),
+    },
+    pageDetails: getPageDetails(),
+    destinationDetails: {
+      destinationPageName,
+      destinationPageType,
+      destinationUrl,
+    },
+    userDetails: VoterStore.getAnalyticsUserDetails(),
+  };
+  // console.log('DataLayer for Twitter Share:', dataLayerObject);
+  TagManager.dataLayer({ dataLayer: dataLayerObject });
+}
+
 // React functional component example
 export function CopyLink (props) {
   const { saveActionShareButtonCopy, linkToBeSharedCopy } = props;
@@ -429,6 +456,16 @@ ShareFacebook.propTypes = {
 // React functional component example
 export function ShareTwitter (props) {
   const { titleText, saveActionShareButtonTwitter, linkToBeSharedTwitter } = props;
+  const twitterButtonRef = useRef(null);
+  const handleTwitterClick = () => {
+    if (saveActionShareButtonTwitter) {
+      saveActionShareButtonTwitter();
+    }
+    const twitterRedirectUrl = `https://x.com/intent/post?url=${encodeURIComponent(linkToBeSharedTwitter)}&text=${encodeURIComponent('Please join me and vote.')}`;
+    const buttonId = twitterButtonRef.current.id;
+    pushDataLayer(buttonId, 'TwitterShare', 'share', 'twitter', linkToBeSharedTwitter, twitterRedirectUrl);
+  };
+
   return (
     <>
       <ShareWrapper>
@@ -437,9 +474,10 @@ export function ShareTwitter (props) {
                androidTwitterClickHandler(linkToBeSharedTwitter)}
         >
           <TwitterShareButton
+            ref={twitterButtonRef}
             className="no-decoration"
             id="shareFooterTwitterButton"
-            onClick={saveActionShareButtonTwitter}
+            onClick={handleTwitterClick}
             title={titleText}
             url={`${linkToBeSharedTwitter}`}
             windowWidth={750}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[[WV-1102]](https://wevoteusa.atlassian.net/browse/WV-1102)
[[WV-1104]](https://wevoteusa.atlassian.net/browse/WV-1104)
### Changes included this pull request?
- Added pushDataLayer function in `shareButtonCommon`
- Modified dataLayer elements for Copy Link in `shareModalOption`

[WV-1102]: https://wevoteusa.atlassian.net/browse/WV-1102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WV-1104]: https://wevoteusa.atlassian.net/browse/WV-1104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ