### PR TITLE
[Issue #WV-1193] Fix notifications page crashing upon refresh

### DIFF
--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -27,6 +27,7 @@ let shiftTabKeyPressed = false;
 class VoterEmailAddressEntry extends Component {
   constructor (props) {
     super(props);
+    this.emailInputRef = React.createRef();
     this.state = {
       disableEmailVerificationButton: true,
       displayEmailVerificationButton: false,
@@ -67,9 +68,9 @@ class VoterEmailAddressEntry extends Component {
     this.onVoterStoreChange();
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     VoterActions.voterEmailAddressRetrieve();
-    const inputFld = $('#enterVoterEmailAddress');
-    // console.log('enterVoterEmailAddress ', $(inputFld));
-    $(inputFld).blur();
+    if (this.emailInputRef && this.emailInputRef.current) {
+      this.emailInputRef.current.blur();
+    };
     this._isMounted = true;
   }
 
@@ -474,6 +475,7 @@ class VoterEmailAddressEntry extends Component {
             onKeyDown={this.onKeyDown}
             placeholder="Type email here..."
             type="email"
+            ref={this.emailInputRef}
             value={voterEmailAddress}
             variant="outlined"
           />


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

This PR addresses Issue #WV-1193, where the notifications page in settings crashes upon refresh. I tested the change using `npm run build` and `serve -s build`, and the page is able to reload without issues.

### Changes included this pull request?

This PR removes the jQuery `$` element in the `componentDidMount` function of the `VoterEmailAddressEntry` class, instead using React-native components to achieve the same purpose.