### PR TITLE
[Issue #WV-1050] Fix ballot page and ready page incorrect tabbing behavior

### DIFF
--- a/src/js/components/Ballot/BallotTitleHeader.jsx
+++ b/src/js/components/Ballot/BallotTitleHeader.jsx
@@ -205,7 +205,7 @@ class BallotTitleHeader extends Component {
                         {electionName}
                       </ElectionNameH1>
                       {(showBallotCaveat && ballotCaveat) ? (
-                        <BallotAddress
+                        <BallotAddress tabIndex={-1}
                           allowTextWrap={allowTextWrap}
                           centerText={centerText}
                           className={linksOff ? '' : 'u-cursor--pointer'}
@@ -219,7 +219,7 @@ class BallotTitleHeader extends Component {
                       ) : (
                         <>
                           {((textForMapSearch && textForMapSearch !== '' && textForMapSearch.length >= 2) || (originalTextAddress && originalTextAddress !== '' && originalTextAddress.length >= 2)) ? (
-                            <BallotAddress
+                            <BallotAddress tabIndex={-1}
                               allowTextWrap={allowTextWrap}
                               centerText={centerText}
                               className={linksOff ? '' : 'u-cursor--pointer'}
@@ -255,7 +255,7 @@ class BallotTitleHeader extends Component {
                                   {linksOff ? <></> : editIconStyled}
                                 </BallotAddress>
                               ) : (
-                                <BallotAddress
+                                <BallotAddress tabIndex={-1}
                                   allowTextWrap={allowTextWrap}
                                   centerText={centerText}
                                   className={linksOff ? '' : 'u-cursor--pointer'}

--- a/src/js/components/Ballot/BallotTitleHeaderNationalPlaceholder.jsx
+++ b/src/js/components/Ballot/BallotTitleHeaderNationalPlaceholder.jsx
@@ -163,7 +163,7 @@ class BallotTitleHeaderNationalPlaceholder extends Component {
                         {electionName}
                       </ElectionNameH1>
                       {(textForMapSearch && textForMapSearch !== '' && textForMapSearch.length > 1) ? (
-                        <BallotAddress
+                        <BallotAddress tabIndex={-1}
                           centerText={centerText}
                           className={linksOff ? '' : 'u-cursor--pointer'}
                           id="ballotTitleBallotAddress"
@@ -183,7 +183,7 @@ class BallotTitleHeaderNationalPlaceholder extends Component {
                           </span>
                         </BallotAddress>
                       ) : (
-                        <BallotAddress
+                        <BallotAddress tabIndex={-1}
                           allowTextWrap={allowTextWrap}
                           centerText={centerText}
                           className={linksOff ? '' : 'u-cursor--pointer'}

--- a/src/js/components/Filter/FilterBaseSearch.jsx
+++ b/src/js/components/Filter/FilterBaseSearch.jsx
@@ -284,6 +284,7 @@ class FilterBaseSearch extends Component {
           <InputBase
             classes={{ input: inputBaseInputClasses, root: inputBaseRootClasses }}
             id="searchInput"
+            inputProps={{ tabIndex: -1 }}
             inputRef={(input) => { this.searchInput = input; }}
             onChange={(event) => this.handleSearch(event, 'searchInput')}
             value={searchText}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

This PR addresses Issue #WV-1050, where, on the ballot page and the ready page, hitting `tab` after focusing on the sign-in icon does not move directly to focusing on `Ballot for` line, which allows address editing. 

### Changes included this pull request?

Since the `Ballot for` line already has `tabIndex={0}`, this PR adds `tabIndex={-1}` for each reference of the `BallotAddress` button on the ballot and ready pages to remove an extraneous focus that doesn't show up visually. This extraneous focus was what prevented the focus to shift directly from the sign-in icon to the `Ballot for` line. 
This PR also fixes a similar issue regarding the tabbing of the search icon on the ballot page by enforcing that the `tabIndex` for the `searchInput` `InputBase` is also -1.

I tested the change using `npm run build` and `serve -s build`, and the tabbing is working as expected.