### PR TITLE
[Issue #WV-1050] Make CompleteYourProfile steps tabbable

### DIFF
--- a/src/js/components/CompleteYourProfile/Step.jsx
+++ b/src/js/components/CompleteYourProfile/Step.jsx
@@ -10,6 +10,14 @@ const Step = ({ onClick, step, label, completed, width }) => (
     completed={completed}
     id={`step${step}`}
     onClick={onClick}
+    onKeyDown={(e) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        onClick();
+      }
+    }}
+    role="button"
+    tabIndex={0}
     width={width}
   >
     <StepIcon


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Following up on #4527, this PR continues to address WV-1050 (the tabbing sequence on the ballot page).

### Changes included this pull request?
This PR gives the user the ability to tab through the three `CompleteYourProfile` steps.