### PR TITLE
Now using PoliticianRetrieveAsOwner for anyone who has the right to edit the politician, so we don't have to wait 1 hour to see the changes due to the CDN. Turned off the display of social media links for the Nov 2025 trial.

### DIFF
--- a/src/js/common/actions/PoliticianActions.js
+++ b/src/js/common/actions/PoliticianActions.js
@@ -41,11 +41,18 @@ export default {
     Dispatcher.dispatch({ type: 'profilePhotoTooBigReset', payload: true });
   },
 
-  politicianRetrieve (politicianWeVoteId) {
-    Dispatcher.loadEndpoint('politicianRetrieve',
-      {
-        politician_we_vote_id: politicianWeVoteId,
-      });
+  politicianRetrieve (politicianWeVoteId, asOwner = false) {
+    if (asOwner) {
+      Dispatcher.loadEndpoint('politicianRetrieveAsOwner',
+        {
+          politician_we_vote_id: politicianWeVoteId,
+        });
+    } else {
+      Dispatcher.loadEndpoint('politicianRetrieve',
+        {
+          politician_we_vote_id: politicianWeVoteId,
+        });
+    }
   },
 
   politicianStatementSave (politicianWeVoteId, politicianStatement) {
@@ -75,14 +82,22 @@ export default {
       });
   },
 
-  politicianRetrieveBySEOFriendlyPath (politicianSEOFriendlyPath) {
+  politicianRetrieveBySEOFriendlyPath (politicianSEOFriendlyPath, asOwner = false) {
     let { hostname } = window.location;
     hostname = hostname || '';
-    Dispatcher.loadEndpoint('politicianRetrieve',
-      {
-        hostname,
-        seo_friendly_path: politicianSEOFriendlyPath,
-      });
+    if (asOwner) {
+      Dispatcher.loadEndpoint('politicianRetrieveAsOwner',
+        {
+          hostname,
+          seo_friendly_path: politicianSEOFriendlyPath,
+        });
+    } else {
+      Dispatcher.loadEndpoint('politicianRetrieve',
+        {
+          hostname,
+          seo_friendly_path: politicianSEOFriendlyPath,
+        });
+    }
   },
 
   positionListForBallotItemPublic (ballotItemWeVoteId) {
@@ -110,5 +125,9 @@ export default {
         ballot_item_we_vote_id: ballotItemWeVoteId,
         kind_of_ballot_item: 'POLITICIAN',
       });
+  },
+
+  voterCanEditPolitician (politicianWeVoteId) {
+    Dispatcher.dispatch({ type: 'voterCanEditPolitician', payload: politicianWeVoteId });
   },
 };

--- a/src/js/common/components/Politician/PoliticianRetrieveController.jsx
+++ b/src/js/common/components/Politician/PoliticianRetrieveController.jsx
@@ -2,7 +2,9 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import initializejQuery from '../../utils/initializejQuery';
 import { renderLog } from '../../utils/logging';
-import { retrievePoliticianFromIdentifiers } from '../../utils/politicianUtils';
+import { politicianRetrieveFromIdentifiers } from '../../utils/politicianUtils';
+// import PoliticianActions from '../../actions/PoliticianActions';
+import PoliticianStore from '../../stores/PoliticianStore';
 import VoterStore from '../../../stores/VoterStore';
 
 
@@ -11,11 +13,13 @@ class PoliticianRetrieveController extends Component {
     super(props);
     this.state = {
       politicianRetrieveInitiated: false,
+      politicianRetrieveAsOwnerInitiated: false, // If the voter is the owner of the politician, use different API call that doesn't run through the CDN
     };
   }
 
   componentDidMount () {
     // console.log('PoliticianRetrieveController componentDidMount');
+    this.politicianStoreListener = PoliticianStore.addListener(this.onPoliticianStoreChange.bind(this));
     this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     this.politicianFirstRetrieve();
   }
@@ -38,7 +42,12 @@ class PoliticianRetrieveController extends Component {
   }
 
   componentWillUnmount () {
+    this.politicianStoreListener.remove();
     this.voterStoreListener.remove();
+  }
+
+  onPoliticianStoreChange () {
+    this.politicianFirstRetrieve();
   }
 
   onVoterStoreChange () {
@@ -47,17 +56,20 @@ class PoliticianRetrieveController extends Component {
 
   politicianFirstRetrieve = (politicianRetrieveOverride = false) => {
     const { politicianSEOFriendlyPath, politicianWeVoteId } = this.props;
-    // console.log('PoliticianRetrieveController politicianSEOFriendlyPath: ', politicianSEOFriendlyPath, ', politicianWeVoteId: ', politicianWeVoteId);
+    // console.log('PoliticianRetrieveController politicianFirstRetrieve politicianSEOFriendlyPath: ', politicianSEOFriendlyPath, ', politicianWeVoteId: ', politicianWeVoteId);
     if (politicianSEOFriendlyPath || politicianWeVoteId) {
-      const { politicianRetrieveInitiated } = this.state;
+      const { politicianRetrieveAsOwnerInitiated, politicianRetrieveInitiated } = this.state;
       initializejQuery(() => {
+        const voterIsOwner = PoliticianStore.getVoterCanEditThisPolitician(politicianWeVoteId);
         // console.log('PoliticianRetrieveController politicianRetrieveInitiated: ', politicianRetrieveInitiated, ', voterFirstRetrieveCompleted: ', voterFirstRetrieveCompleted);
-        const triggerRetrieve = politicianRetrieveOverride || !politicianRetrieveInitiated;
+        const triggerRetrieve = politicianRetrieveOverride || !politicianRetrieveInitiated || (voterIsOwner && !politicianRetrieveAsOwnerInitiated);
         if (triggerRetrieve) {
+          // console.log('PoliticianRetrieveController politicianFirstRetrieve triggerRetrieve politicianSEOFriendlyPath: ', politicianSEOFriendlyPath, ', politicianWeVoteId: ', politicianWeVoteId, ', voterIsOwner: ', voterIsOwner);
           // console.log('politicianRetrieveInitiated:', politicianRetrieveInitiated, 'updatedPoliticianRetrieveInitiated:', updatedPoliticianRetrieveInitiated);
           this.setState({
             politicianRetrieveInitiated: true,
-          }, () => retrievePoliticianFromIdentifiers(politicianSEOFriendlyPath, politicianWeVoteId));
+            politicianRetrieveAsOwnerInitiated: voterIsOwner,
+          }, () => politicianRetrieveFromIdentifiers(politicianSEOFriendlyPath, politicianWeVoteId));
         }
       });
     }

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -45,7 +45,7 @@ import { isCordova, isWebApp } from '../../utils/isCordovaOrWebApp';
 import keepHelpingDestination from '../../utils/keepHelpingDestination';
 import { cordovaOffsetLog, renderLog } from '../../utils/logging';
 import normalizedImagePath from '../../utils/normalizedImagePath';
-import { getPoliticianValuesFromIdentifiers, retrievePoliticianFromIdentifiersIfNeeded } from '../../utils/politicianUtils';
+import { getPoliticianValuesFromIdentifiers, politicianRetrieveFromIdentifiersIfNeeded } from '../../utils/politicianUtils';
 import returnFirstXWords from '../../utils/returnFirstXWords';
 import saveCampaignSupportAndGoToNextPage from '../../utils/saveCampaignSupportAndGoToNextPage';
 import extractPoliticianDetailsFromUrl from '../../utils/extractPoliticianDetailsFromUrl';
@@ -187,7 +187,7 @@ class PoliticianDetailsPage extends Component {
       }, () => this.onFirstRetrievalOfPoliticianWeVoteId());
     }
     // Take the "calculated" identifiers and retrieve if missing
-    retrievePoliticianFromIdentifiersIfNeeded(politicianSEOFriendlyPathFromUrl, politicianWeVoteId);
+    politicianRetrieveFromIdentifiersIfNeeded(politicianSEOFriendlyPathFromUrl, politicianWeVoteId);
 
     if (apiCalming('organizationsFollowedRetrieve', 60000)) {
       OrganizationActions.organizationsFollowedRetrieve();
@@ -311,7 +311,7 @@ class PoliticianDetailsPage extends Component {
     if (triggerFreshRetrieve) {
       // Take the "calculated" identifiers and retrieve if missing
       // console.log('componentDidUpdate triggerFreshRetrieve: ', triggerFreshRetrieve, ', politicianWeVoteId: ', politicianWeVoteId);
-      retrievePoliticianFromIdentifiersIfNeeded(politicianSEOFriendlyPathFromUrl, politicianWeVoteId);
+      politicianRetrieveFromIdentifiersIfNeeded(politicianSEOFriendlyPathFromUrl, politicianWeVoteId);
     }
     if (triggerFreshRetrieve || triggerSEOPathRedirect) {
       // Take the "calculated" identifiers and retrieve if missing
@@ -367,6 +367,7 @@ class PoliticianDetailsPage extends Component {
     // window.removeEventListener('scroll', this.onScroll);
     AppObservableStore.setCampaignXWeVoteIdBeingViewed('');
     AppObservableStore.setPoliticianWeVoteIdBeingViewed('');
+    AppObservableStore.setShowNotificationBannerAboveHeader(false);
   }
 
   onFirstRetrievalOfPoliticianWeVoteId () {
@@ -486,6 +487,9 @@ class PoliticianDetailsPage extends Component {
         voterSupportsThisPolitician,
       }, () => this.onFirstRetrievalOfPoliticianWeVoteId());
       AppObservableStore.setPoliticianWeVoteIdBeingViewed(politicianWeVoteId);
+      if (!AppObservableStore.getShowNotificationBannerAboveHeader() && PoliticianStore.getVoterCanEditThisPolitician(politicianWeVoteId)) {
+        AppObservableStore.setShowNotificationBannerAboveHeader(true);
+      }
     }
     const politicianDescriptionLimited = returnFirstXWords(politicianDescription, 200);
     const filteredCandidateCampaignList = candidateCampaignList.sort(this.orderCandidatesByUltimateDate);
@@ -700,60 +704,63 @@ class PoliticianDetailsPage extends Component {
         externalLinkUrl: politicianUrl,
       });
     }
-    if (instagramHandle) {
-      const instagramHandleCleaned = instagramHandle.trim();
-      politicianLinksList.push({
-        linkText: `instagram.com/${instagramHandleCleaned}`,
-        externalLinkUrl: `https://instagram.com/${instagramHandleCleaned}`,
-      });
-    }
-    if (youtubeUrl) {
-      politicianLinksList.push({
-        linkText: 'youtube.com',
-        externalLinkUrl: youtubeUrl,
-      });
-    }
-    if (wikipediaUrl) {
-      politicianLinksList.push({
-        linkText: 'wikipedia.org',
-        externalLinkUrl: wikipediaUrl,
-      });
-    }
-    if (ballotpediaPoliticianUrl) {
-      politicianLinksList.push({
-        linkText: 'ballotpedia.org',
-        externalLinkUrl: ballotpediaPoliticianUrl,
-      });
-    }
-    if (politicianName || officeHeldNameForSearch) {
-      const googleQuery = `${politicianName} ${stateText} ${officeHeldNameForSearch}`;
-      const googleQueryUrlFriendly = googleQuery.replace(/ /g, '+');
-      const googleSearchUrl = `https://www.google.com/search?q=${googleQueryUrlFriendly}&oq=${googleQueryUrlFriendly}`;
-      politicianLinksList.push({
-        linkText: 'Google search',
-        externalLinkUrl: googleSearchUrl,
-      });
-      const bingQuery = `${politicianName} ${stateText} ${officeHeldNameForSearch}`;
-      const bingQueryUrlFriendly = bingQuery.replace(/ /g, '+');
-      const bingSearchUrl = `https://www.bing.com/search?q=${bingQueryUrlFriendly}&pq=${bingQueryUrlFriendly}`;
-      politicianLinksList.push({
-        linkText: 'Bing AI',
-        externalLinkUrl: bingSearchUrl,
-      });
-    }
-    if (twitterHandle) {
-      const twitterHandleCleaned = twitterHandle.trim();
-      politicianLinksList.push({
-        linkText: `X.com/${twitterHandleCleaned}`,
-        externalLinkUrl: `https://x.com/${twitterHandleCleaned}`,
-      });
-    }
-    if (twitterHandle2 && (twitterHandle2 !== twitterHandle)) {
-      const twitterHandle2Cleaned = twitterHandle2.trim();
-      politicianLinksList.push({
-        linkText: `X.com/${twitterHandle2Cleaned}`,
-        externalLinkUrl: `https://x.com/${twitterHandle2Cleaned}`,
-      });
+    if (nextReleaseFeaturesEnabled) {
+      // For the November 2025 trial, we are turning off other social media links.
+      if (instagramHandle) {
+        const instagramHandleCleaned = instagramHandle.trim();
+        politicianLinksList.push({
+          linkText: `instagram.com/${instagramHandleCleaned}`,
+          externalLinkUrl: `https://instagram.com/${instagramHandleCleaned}`,
+        });
+      }
+      if (youtubeUrl) {
+        politicianLinksList.push({
+          linkText: 'youtube.com',
+          externalLinkUrl: youtubeUrl,
+        });
+      }
+      if (wikipediaUrl) {
+        politicianLinksList.push({
+          linkText: 'wikipedia.org',
+          externalLinkUrl: wikipediaUrl,
+        });
+      }
+      if (ballotpediaPoliticianUrl) {
+        politicianLinksList.push({
+          linkText: 'ballotpedia.org',
+          externalLinkUrl: ballotpediaPoliticianUrl,
+        });
+      }
+      if (politicianName || officeHeldNameForSearch) {
+        const googleQuery = `${politicianName} ${stateText} ${officeHeldNameForSearch}`;
+        const googleQueryUrlFriendly = googleQuery.replace(/ /g, '+');
+        const googleSearchUrl = `https://www.google.com/search?q=${googleQueryUrlFriendly}&oq=${googleQueryUrlFriendly}`;
+        politicianLinksList.push({
+          linkText: 'Google search',
+          externalLinkUrl: googleSearchUrl,
+        });
+        const bingQuery = `${politicianName} ${stateText} ${officeHeldNameForSearch}`;
+        const bingQueryUrlFriendly = bingQuery.replace(/ /g, '+');
+        const bingSearchUrl = `https://www.bing.com/search?q=${bingQueryUrlFriendly}&pq=${bingQueryUrlFriendly}`;
+        politicianLinksList.push({
+          linkText: 'Bing AI',
+          externalLinkUrl: bingSearchUrl,
+        });
+      }
+      if (twitterHandle) {
+        const twitterHandleCleaned = twitterHandle.trim();
+        politicianLinksList.push({
+          linkText: `X.com/${twitterHandleCleaned}`,
+          externalLinkUrl: `https://x.com/${twitterHandleCleaned}`,
+        });
+      }
+      if (twitterHandle2 && (twitterHandle2 !== twitterHandle)) {
+        const twitterHandle2Cleaned = twitterHandle2.trim();
+        politicianLinksList.push({
+          linkText: `X.com/${twitterHandle2Cleaned}`,
+          externalLinkUrl: `https://x.com/${twitterHandle2Cleaned}`,
+        });
+      }
     }
 
     const campaignAdminEditUrl = `${webAppConfig.WE_VOTE_SERVER_ROOT_URL}campaign/${linkedCampaignXWeVoteId}/summary`;
@@ -809,7 +816,8 @@ class PoliticianDetailsPage extends Component {
     ) : <PoliticianLinksWrapper />;
 
     let opponentCandidatesHtml = '';
-    const opponentsSubtitle = finalElectionDateInPast ? 'Candidates who ran for same office' : 'Candidates running for same office';
+    // const opponentsSubtitle = finalElectionDateInPast ? 'Candidates who ran for same office' : 'Candidates running for same office';
+    const opponentsSubtitle = 'Other candidates, same office';
     let priorCandidateCampaignsHtml = '';
     const currentYear = 2023;
     let nextYearElectionExists = false;
@@ -1094,13 +1102,6 @@ class PoliticianDetailsPage extends Component {
               {/* )} */}
               {!!(voterCanEditThisPolitician || voterSupportsThisPolitician) && (
                 <IndicatorRow>
-                  {voterCanEditThisPolitician && (
-                    <IndicatorButtonWrapper>
-                      <EditIndicator onClick={this.onPoliticianCampaignEditClick}>
-                        Edit Politician
-                      </EditIndicator>
-                    </IndicatorButtonWrapper>
-                  )}
                   {voterSupportsThisPolitician && (
                     <IndicatorButtonWrapper>
                       <EditIndicator onClick={this.onPoliticianCampaignShareClick}>
@@ -1276,15 +1277,6 @@ class PoliticianDetailsPage extends Component {
                   {/*    </IndicatorButtonWrapper> */}
                   {/*  </IndicatorRow> */}
                   {/* )} */}
-                  {voterCanEditThisPolitician && (
-                    <IndicatorRow>
-                      <IndicatorButtonWrapper>
-                        <EditIndicator onClick={this.onPoliticianCampaignEditClick}>
-                          Edit This Politician
-                        </EditIndicator>
-                      </IndicatorButtonWrapper>
-                    </IndicatorRow>
-                  )}
                 </CampaignDescriptionDesktopWrapper>
                 {/* Show links to this campaign in the admin tools */}
                 <LinkToAdminTools

--- a/src/js/common/stores/CampaignStore.js
+++ b/src/js/common/stores/CampaignStore.js
@@ -701,6 +701,8 @@ class CampaignStore extends ReduceStore {
         return revisedState;
 
       case 'politicianRetrieve':
+      case 'politicianRetrieveAsOwner':
+      case 'politicianSave':
         // For the candidate-related data attached to the Politician, create a pseudo-CampaignX object
         //  which is needed for objects like HeartFavoriteToggle
         candidateList = action.res.candidate_list;

--- a/src/js/common/stores/PoliticianStore.js
+++ b/src/js/common/stores/PoliticianStore.js
@@ -204,8 +204,8 @@ class PoliticianStore extends ReduceStore {
   }
 
   getVoterCanEditThisPolitician (politicianWeVoteId = '') {
-    console.log('getVoterCanEditThisPolitician:', politicianWeVoteId);
-    return false;
+    // console.log('getVoterCanEditThisPolitician:', politicianWeVoteId, ', YES: ', arrayContains(politicianWeVoteId, this.getState().voterOwnedPoliticianWeVoteIds), 'voterOwnedPoliticianWeVoteIds: ', this.getState().voterOwnedPoliticianWeVoteIds);
+    return arrayContains(politicianWeVoteId, this.getState().voterOwnedPoliticianWeVoteIds);
   }
 
   getVoterSupportsThisPolitician (politicianWeVoteId) {
@@ -464,6 +464,7 @@ class PoliticianStore extends ReduceStore {
         }
         revisedState = state;
         politician = action.res;
+        // console.log('PoliticianStore ', action.type, ', politician:', politician);
         opponentCandidateList = action.res.opponent_candidate_list;
         // console.log('PoliticianStore politicianRetrieve, politician:', politician);
         if (allCachedPoliticians === undefined) {
@@ -595,6 +596,20 @@ class PoliticianStore extends ReduceStore {
           allCachedPoliticians,
           politicianListsByOfficeWeVoteId,
         };
+
+      case 'voterCanEditPolitician':
+        // console.log('PoliticianStore voterCanEditPolitician: ', action.payload);
+        if (action.payload === undefined) {
+          return state;
+        } else {
+          revisedState = state;
+          const politicianWeVoteId = action.payload;
+          if (!arrayContains(politicianWeVoteId, voterOwnedPoliticianWeVoteIds)) {
+            voterOwnedPoliticianWeVoteIds.push(politicianWeVoteId);
+            revisedState = { ...revisedState, voterOwnedPoliticianWeVoteIds };
+          }
+          return revisedState;
+        }
 
       case 'voterSignOut':
         // console.log('PoliticianStore voterSignOut, state:', state);

--- a/src/js/common/utils/politicianUtils.js
+++ b/src/js/common/utils/politicianUtils.js
@@ -121,18 +121,23 @@ export function getPoliticianValuesFromIdentifiers (politicianSEOFriendlyPath, p
   };
 }
 
-export function retrievePoliticianFromIdentifiers (politicianSEOFriendlyPath, politicianWeVoteId) {
-  // console.log('retrievePoliticianFromIdentifiersIfNeeded politicianSEOFriendlyPath: ', politicianSEOFriendlyPath, ', politicianWeVoteId: ', politicianWeVoteId);
+export function politicianRetrieveFromIdentifiers (politicianSEOFriendlyPath, politicianWeVoteId) {
+  // console.log('politicianRetrieveFromIdentifiersIfNeeded politicianSEOFriendlyPath: ', politicianSEOFriendlyPath, ', politicianWeVoteId: ', politicianWeVoteId);
+  const asOwner = PoliticianStore.getVoterCanEditThisPolitician(politicianWeVoteId);
   if (politicianSEOFriendlyPath) {
     initializejQuery(() => {
-      if (apiCalming(`politicianRetrieve-${politicianSEOFriendlyPath}`, 2000)) {
-        PoliticianActions.politicianRetrieveBySEOFriendlyPath(politicianSEOFriendlyPath);
+      if (asOwner) {
+        PoliticianActions.politicianRetrieveBySEOFriendlyPath(politicianSEOFriendlyPath, asOwner);
+      } else if (apiCalming(`politicianRetrieve-${politicianSEOFriendlyPath}`, 2000)) {
+        PoliticianActions.politicianRetrieveBySEOFriendlyPath(politicianSEOFriendlyPath, asOwner);
       }
     });
     return true;
   } else if (politicianWeVoteId) {
     initializejQuery(() => {
-      if (apiCalming(`politicianRetrieve-${politicianWeVoteId}`, 2000)) {
+      if (asOwner) {
+        PoliticianActions.politicianRetrieve(politicianWeVoteId, asOwner);
+      } else if (apiCalming(`politicianRetrieve-${politicianWeVoteId}`, 2000)) {
         PoliticianActions.politicianRetrieve(politicianWeVoteId);
       }
     });
@@ -142,15 +147,16 @@ export function retrievePoliticianFromIdentifiers (politicianSEOFriendlyPath, po
   }
 }
 
-export function retrievePoliticianFromIdentifiersIfNeeded (politicianSEOFriendlyPath, politicianWeVoteId) {
-  // console.log('retrievePoliticianFromIdentifiersIfNeeded politicianSEOFriendlyPath: ', politicianSEOFriendlyPath, ', politicianWeVoteId: ', politicianWeVoteId);
+export function politicianRetrieveFromIdentifiersIfNeeded (politicianSEOFriendlyPath, politicianWeVoteId) {
+  // console.log('politicianRetrieveFromIdentifiersIfNeeded politicianSEOFriendlyPath: ', politicianSEOFriendlyPath, ', politicianWeVoteId: ', politicianWeVoteId);
   let politician = {};
   let mustRetrieveCampaign = false;
 
-  // console.log('retrievePoliticianFromIdentifiersIfNeeded voter:', voter);
+  // console.log('politicianRetrieveFromIdentifiersIfNeeded voter:', voter);
+  const asOwner = PoliticianStore.getVoterCanEditThisPolitician(politicianWeVoteId);
   if (politicianSEOFriendlyPath) {
     politician = PoliticianStore.getPoliticianBySEOFriendlyPath(politicianSEOFriendlyPath);
-    // console.log('retrievePoliticianFromIdentifiersIfNeeded politician:', politician);
+    // console.log('politicianRetrieveFromIdentifiersIfNeeded politician:', politician);
     if (politician.constructor === Object) {
       if (!politician.politician_we_vote_id) {
         mustRetrieveCampaign = true;
@@ -158,10 +164,12 @@ export function retrievePoliticianFromIdentifiersIfNeeded (politicianSEOFriendly
     } else {
       mustRetrieveCampaign = true;
     }
-    // console.log('retrievePoliticianFromIdentifiersIfNeeded mustRetrieveCampaign:', mustRetrieveCampaign, ', politicianSEOFriendlyPath:', politicianSEOFriendlyPath);
+    // console.log('politicianRetrieveFromIdentifiersIfNeeded mustRetrieveCampaign:', mustRetrieveCampaign, ', politicianSEOFriendlyPath:', politicianSEOFriendlyPath);
     if (mustRetrieveCampaign) {
       initializejQuery(() => {
-        if (apiCalming(`politicianRetrieve-${politicianSEOFriendlyPath}`, 2000)) {
+        if (asOwner) {
+          PoliticianActions.politicianRetrieveBySEOFriendlyPath(politicianSEOFriendlyPath, asOwner);
+        } else if (apiCalming(`politicianRetrieve-${politicianSEOFriendlyPath}`, 2000)) {
           PoliticianActions.politicianRetrieveBySEOFriendlyPath(politicianSEOFriendlyPath);
         }
       });
@@ -175,10 +183,12 @@ export function retrievePoliticianFromIdentifiersIfNeeded (politicianSEOFriendly
     } else {
       mustRetrieveCampaign = true;
     }
-    // console.log('retrievePoliticianFromIdentifiersIfNeeded mustRetrieveCampaign:', mustRetrieveCampaign, ', politicianWeVoteId:', politicianWeVoteId);
+    // console.log('politicianRetrieveFromIdentifiersIfNeeded mustRetrieveCampaign:', mustRetrieveCampaign, ', politicianWeVoteId:', politicianWeVoteId);
     if (mustRetrieveCampaign) {
       initializejQuery(() => {
-        if (apiCalming(`politicianRetrieve-${politicianWeVoteId}`, 2000)) {
+        if (asOwner) {
+          PoliticianActions.politicianRetrieve(politicianWeVoteId, asOwner);
+        } else if (apiCalming(`politicianRetrieve-${politicianWeVoteId}`, 2000)) {
           PoliticianActions.politicianRetrieve(politicianWeVoteId);
         }
       });
@@ -187,12 +197,12 @@ export function retrievePoliticianFromIdentifiersIfNeeded (politicianSEOFriendly
   return true;
 }
 
-export function retrievePoliticianFromIdentifiersIfNotAlreadyRetrieved (politicianSEOFriendlyPath, politicianWeVoteId) {
+export function politicianRetrieveFromIdentifiersIfNotAlreadyRetrieved (politicianSEOFriendlyPath, politicianWeVoteId) {
   if (
     (politicianSEOFriendlyPath && PoliticianStore.getPoliticianBySEOFriendlyPath() !== {}) &&
     (politicianWeVoteId && PoliticianStore.getPoliticianByWeVoteId(politicianWeVoteId) !== {})
   ) {
     return false;
   }
-  return retrievePoliticianFromIdentifiersIfNeeded(politicianSEOFriendlyPath, politicianWeVoteId);
+  return politicianRetrieveFromIdentifiersIfNeeded(politicianSEOFriendlyPath, politicianWeVoteId);
 }

--- a/src/js/hooks/useVoterCanEditPolitician.js
+++ b/src/js/hooks/useVoterCanEditPolitician.js
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import PoliticianActions from '../common/actions/PoliticianActions';
 import VoterActions from '../actions/VoterActions';
 import AppObservableStore, { messageService } from '../common/stores/AppObservableStore';
 import CampaignStore from '../common/stores/CampaignStore';
+import PoliticianStore from '../common/stores/PoliticianStore';
 import VoterStore from '../stores/VoterStore';
 import voterCanEditPolitician from '../common/utils/voterCanEditPolitician';
 import apiCalming from '../common/utils/apiCalming';
@@ -10,6 +12,7 @@ export default function useVoterCanEditPolitician () {
   const [voterCanEditPoliticianProfile, setVoterCanEditPoliticianProfile] = useState(false);
   const campaignXWeVoteIdRef = useRef('');
   const politicianWeVoteIdRef = useRef('');
+  const voterCanEditPoliticianHasDispatchedRef = useRef(false);
 
   const updateVoterCanEditPoliticianProfile = useCallback(() => {
     const currentCampaignXWeVoteId = campaignXWeVoteIdRef.current;
@@ -17,6 +20,13 @@ export default function useVoterCanEditPolitician () {
     // console.log('useVoterCanEditPolitician, politicianWeVoteId: ', politicianWeVoteId, ', currentCampaignXWeVoteId: ', currentCampaignXWeVoteId);
     if (voterCanEditPolitician(politicianWeVoteId, currentCampaignXWeVoteId)) {
       setVoterCanEditPoliticianProfile(true);
+      // console.log('useVoterCanEditPolitician, voterCanEditPoliticianProfile set to true, voterCanEditPoliticianHasDispatchedRef.current:', voterCanEditPoliticianHasDispatchedRef.current);
+      if (!voterCanEditPoliticianHasDispatchedRef.current && !PoliticianStore.getVoterCanEditThisPolitician(politicianWeVoteId)) {
+        setTimeout(() => {
+          PoliticianActions.voterCanEditPolitician(politicianWeVoteId);
+          voterCanEditPoliticianHasDispatchedRef.current = true;
+        }, 0);
+      }
     } else {
       setVoterCanEditPoliticianProfile(false);
     }
@@ -24,6 +34,9 @@ export default function useVoterCanEditPolitician () {
 
   const onAppObservableStoreChange = useCallback(() => {
     campaignXWeVoteIdRef.current = AppObservableStore.getCampaignXWeVoteIdBeingViewed();
+    if (politicianWeVoteIdRef.current !== AppObservableStore.getPoliticianWeVoteIdBeingViewed()) {
+      voterCanEditPoliticianHasDispatchedRef.current = false;
+    }
     politicianWeVoteIdRef.current = AppObservableStore.getPoliticianWeVoteIdBeingViewed();
     updateVoterCanEditPoliticianProfile();
   }, [updateVoterCanEditPoliticianProfile]);

--- a/src/js/stores/CandidateStore.js
+++ b/src/js/stores/CandidateStore.js
@@ -437,6 +437,7 @@ class CandidateStore extends ReduceStore {
         };
 
       case 'politicianRetrieve':
+      case 'politicianRetrieveAsOwner':
         incomingCandidateCount = 0;
         candidateList = action.res.candidate_list;
         opponentCandidateList = action.res.opponent_candidate_list;


### PR DESCRIPTION
Now using PoliticianRetrieveAsOwner for anyone who has the right to edit the politician, so we don't have to wait 1 hour to see the changes due to the CDN. Turned off the display of social media links for the Nov 2025 trial.