### PR TITLE
[TEAM REVIEW] WV-1734 Fix the destinationPathname in the dataLayer for Share on Ballot Page

### DIFF
--- a/src/js/components/Share/ShareButtonDesktopTablet.jsx
+++ b/src/js/components/Share/ShareButtonDesktopTablet.jsx
@@ -146,7 +146,7 @@ class ShareButtonDesktopTablet extends Component {
       default:
         buttonId = 'ballotShareButtonDesktopTablet';
     }
-
+    const pageDetails = getPageDetails()
     const dataLayerObject = {
       event: 'action',
       userDetails: VoterStore.getAnalyticsUserDetails(),
@@ -159,11 +159,11 @@ class ShareButtonDesktopTablet extends Component {
         withOpinions: withOpinionsModified,
         whatAndHowMuchToShare,
       },
-      pageDetails: getPageDetails(),
+      pageDetails,
       destinationDetails: {
-        destinationPageName: destinationPage.pageName,
-        destinationPageType: destinationPage.pageType,
-        destinationPathname: pathnameWithModalShare,
+        destinationPageName: 'ShareModal',
+        destinationPageType: pageDetails.pageType,
+        destinationPathname: pageDetails.pathname,
       },
     };
     const electionDetails = BallotStore.getAnalyticsElectionDetails();


### PR DESCRIPTION
Please review changes in src/js/components/Share/ShareButtonDesktopTablet.jsx. From the property name destinationDetails :
 destinationPathName : Path you are taking the browser to. If modal, use same pathname as pageDetails UNLESS modal page has it's own path.