### PR TITLE
[WV-1733]-more-header-menu

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -606,7 +606,7 @@ class HeaderBar extends Component {
 
                     {nextReleaseFeaturesEnabled && (
                       <StyledMoreMenuItem
-                        selected={normalizedHrefPage() === 'manage'}
+                        selected={['manage', 'more/manage'].includes(normalizedHrefPage())}
                         onClick={this.navTo('/more/manage', 99)}
                         disableRipple
                       >


### PR DESCRIPTION
Make 'Candidates I’m managing' menu item highlight correctly by matching both 'manage' and 'more/manage'.

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
