### PR TITLE
[Issue #WV-2055] Modify UI for `SettingsAddress` and add warning for address removal

### DIFF
--- a/src/js/components/Settings/SettingsAddress.jsx
+++ b/src/js/components/Settings/SettingsAddress.jsx
@@ -3,6 +3,8 @@ import { Helmet } from 'react-helmet-async';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import EditOutlinedIcon from '@mui/icons-material/EditOutlined';
 import DeleteIcon from '@mui/icons-material/Delete';
+import { Button, Dialog, DialogTitle, DialogContent, DialogActions } from '@mui/material';
+import WarningAmberIcon from '@mui/icons-material/WarningAmber';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import AnalyticsActions from '../../actions/AnalyticsActions';
@@ -13,6 +15,9 @@ import { renderLog } from '../../common/utils/logging';
 import SettingsAddressBox from '../SettingsAddressBox';
 import BrowserPushMessage from '../Widgets/BrowserPushMessage';
 import AppObservableStore from '../../common/stores/AppObservableStore';
+import webAppConfig from '../../config';
+
+const nextReleaseFeaturesEnabled = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES === undefined ? false : webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;
 
 export default class SettingsAddressForDrawer extends Component {
   constructor (props, context) {
@@ -21,6 +26,7 @@ export default class SettingsAddressForDrawer extends Component {
       textForMapSearch: '',
       originalTextAddress: false,
       addressSaved: false,
+      showWarningDialoge: false,
     };
     this.handleAddressSaveSuccess = this.handleAddressSaveSuccess.bind(this);
     this.removeAddress = this.removeAddress.bind(this);
@@ -68,10 +74,24 @@ export default class SettingsAddressForDrawer extends Component {
     this.setState({ addressSaved: false });
   }
 
+  openWarningDialog = () => {
+  this.setState({ showWarningDialog: true });
+  };
+
+  closeWarningDialog = () => {
+    this.setState({ showWarningDialog: false });
+  };
+
+  confirmRemoveAddress = () => {
+    VoterActions.voterAddressSave('');
+    this.setState({ addressSaved: false, showWarningDialog: false });
+  };
+
   render () {
     renderLog('SettingsAddressForDrawer');  // Set LOG_RENDER_EVENTS to log all renders
     const { addressSaved, originalTextAddress } = this.state;
     return (
+      nextReleaseFeaturesEnabled && (
       <div className="u-stack--md u-f4">
         <Helmet title="Enter Address - WeVote" />
         <BrowserPushMessage incomingProps={this.props} />
@@ -105,7 +125,7 @@ export default class SettingsAddressForDrawer extends Component {
                   <div>
                     <CurrentBallotText className="u-gray-darker">We will never share your address or send you any mail.</CurrentBallotText>
                     <div className="u-margin-top--md u-flex u-cursor--pointer"
-                      onClick={this.removeAddress}
+                      onClick={this.openWarningDialog}
                     >
                       <DeleteIcon className="u-gray-mid" />
                       <span className="u-gray-darker u-margin-left--xs">Remove address</span>
@@ -130,7 +150,9 @@ export default class SettingsAddressForDrawer extends Component {
                         {this.state.textForMapSearch}
                         {' '}
                       </span>
-                      <span className="u-gray-mid"><br/>(approximate location from your internet provider)</span>
+                      {!this.state.addressSaved && (
+                        <span className="u-gray-mid"><br />(approximate location from your internet provider)</span>
+                      )}
                     </p>
                   </div>
                   <SettingsAddressBox
@@ -151,7 +173,26 @@ export default class SettingsAddressForDrawer extends Component {
             </div>
           </div>
         </div>
+        <Dialog
+          open={this.state.showWarningDialog}
+          onClose={this.closeWarningDialog}
+        >
+          <DialogTitle>
+            <WarningAmberIcon color="warning" style={{ marginRight: 8, verticalAlign: 'middle' }} />
+            Warning
+          </DialogTitle>
+          <DialogContent>
+            Not entering an address may result in an inaccurate ballot.
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.closeWarningDialog}>Cancel</Button>
+            <Button onClick={this.confirmRemoveAddress} color="error" variant="contained">
+              Remove Address
+            </Button>
+          </DialogActions>
+        </Dialog>
       </div>
+      )
     );
   }
 }

--- a/src/js/components/Settings/SettingsAddress.jsx
+++ b/src/js/components/Settings/SettingsAddress.jsx
@@ -25,7 +25,7 @@ export default class SettingsAddressForDrawer extends Component {
     this.state = {
       textForMapSearch: '',
       originalTextAddress: false,
-      addressSaved: false,
+      addressSaved: VoterStore.getVoterSavedAddress(),
       showWarningDialoge: false,
       editingAddress: false
     };

--- a/src/js/components/Settings/SettingsAddress.jsx
+++ b/src/js/components/Settings/SettingsAddress.jsx
@@ -27,6 +27,7 @@ export default class SettingsAddressForDrawer extends Component {
       originalTextAddress: false,
       addressSaved: false,
       showWarningDialoge: false,
+      editingAddress: false
     };
     this.handleAddressSaveSuccess = this.handleAddressSaveSuccess.bind(this);
     this.removeAddress = this.removeAddress.bind(this);
@@ -40,7 +41,7 @@ export default class SettingsAddressForDrawer extends Component {
 
   handleAddressSaveSuccess () {
     setTimeout(() => {
-      this.setState({ addressSaved: true });
+      this.setState({ addressSaved: true, editingAddress: false });
     }, 2000);
   }
 
@@ -63,12 +64,6 @@ export default class SettingsAddressForDrawer extends Component {
     }
   }
 
-  showSelectBallotModalEditAddress = () => {
-    const showEditAddress = true;
-    const showSelectBallotModal = true;
-    AppObservableStore.setShowSelectBallotModal(showSelectBallotModal, showEditAddress);
-  }
-
   removeAddress () {
     VoterActions.voterAddressSave('');
     this.setState({ addressSaved: false });
@@ -89,7 +84,7 @@ export default class SettingsAddressForDrawer extends Component {
 
   render () {
     renderLog('SettingsAddressForDrawer');  // Set LOG_RENDER_EVENTS to log all renders
-    const { addressSaved, originalTextAddress } = this.state;
+    const { addressSaved, editingAddress } = this.state;
     return (
       nextReleaseFeaturesEnabled && (
       <div className="u-stack--md u-f4">
@@ -109,14 +104,14 @@ export default class SettingsAddressForDrawer extends Component {
                   </Link>
                 </Disclaimer>
               </Header>
-              {addressSaved ? (
+              {addressSaved && !editingAddress ? (
                 <div className="u-margin-top--lg">
                   <span>Address where you are registered to vote</span>
                   <div className="u-padding-top--sm u-flex">
                     <BallotAddressText className="u-bold">{this.state.textForMapSearch}</BallotAddressText>
                     <div className="u-cursor--pointer"
                       id="editAddress"
-                      onClick={this.showSelectBallotModalEditAddress}
+                      onClick={() => this.setState({ editingAddress: true })}
                     >
                       <EditOutlinedIcon className="u-link-color u-f3 u-margin-left--sm" />
                       <span className="u-no-break u-link-color u-f3 u-margin-left--xs">Edit</span>

--- a/src/js/components/SettingsAddressBox.jsx
+++ b/src/js/components/SettingsAddressBox.jsx
@@ -273,7 +273,7 @@ class SettingsAddressBox extends Component {
             classes={{root: classes.fullWidthSaveButton}}
             // fullWidth={!showCancelEditAddressButton}
             fullWidth
-            // disabled={!this.state.isAddressVerified}
+            disabled={!this.state.isAddressVerified}
           >
             Update ballot
           </Button>

--- a/src/js/components/SettingsAddressBox.jsx
+++ b/src/js/components/SettingsAddressBox.jsx
@@ -1,4 +1,4 @@
-import { Button } from '@mui/material';
+import { Box, Button } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -23,13 +23,14 @@ class SettingsAddressBox extends Component {
       loading: false,
       textForMapSearch: '',
       ballotCaveat: '',
+      isAddressVerified: false,
       voterSavedAddress: false,
     };
   }
 
   // eslint-disable-next-line camelcase,react/sort-comp
   UNSAFE_componentWillMount () {
-    prepareForCordovaKeyboard('AddressBox');
+    prepareForCordovaKeyboard('SettingsAddressBox');
   }
 
   componentDidMount () {
@@ -59,20 +60,20 @@ class SettingsAddressBox extends Component {
 
   componentDidCatch (error, info) {
     // We should get this information to Splunk!
-    console.error('!!!AddressBox caught error: ', `${error} with info: `, info);
+    console.error('!!!SettingsAddressBox caught error: ', `${error} with info: `, info);
   }
 
   componentWillUnmount () {
     this.voterStoreListener.remove();
     this.ballotStoreListener.remove();
     clearTimeout(this.closeModalTimer);
-    restoreStylesAfterCordovaKeyboard('AddressBox');
+    restoreStylesAfterCordovaKeyboard('SettingsAddressBox');
   }
 
   // See https://reactjs.org/docs/error-boundaries.html
   static getDerivedStateFromError (error) { // eslint-disable-line no-unused-vars
     // Update state so the next render will show the fallback UI, We should have a "Oh snap" page
-    console.log('!!!AddressBox error', error);
+    console.log('!!!SettingsAddressBox error', error);
     return { hasError: true };
   }
 
@@ -182,13 +183,13 @@ class SettingsAddressBox extends Component {
 
   updateTextForMapSearch = (textForMapSearch) => {
     // console.log('AddressBox updateTextForMapSearch textForMapSearch:', textForMapSearch);
-    this.setState({ textForMapSearch });
+    this.setState({ textForMapSearch, isAddressVerified: false });
   }
 
   updateTextForMapSearchFromGoogle = (textForMapSearch) => {
     // console.log('AddressBox updateTextForMapSearchFromGoogle textForMapSearch:', textForMapSearch);
     if (textForMapSearch) {
-      this.setState({ textForMapSearch });
+      this.setState({ textForMapSearch, isAddressVerified: true });
     }
   }
 
@@ -200,7 +201,7 @@ class SettingsAddressBox extends Component {
   }
 
   render () {
-    renderLog('AddressBox');  // Set LOG_RENDER_EVENTS to log all renders
+    renderLog('SettingsAddressBox');  // Set LOG_RENDER_EVENTS to log all renders
     // console.log('AddressBox render');
     let { waitingMessage } = this.props;
     const { classes, externalUniqueId, introductionHtml, showCancelEditAddressButton, toggleEditingAddress } = this.props;
@@ -233,14 +234,24 @@ class SettingsAddressBox extends Component {
 
     return (
       <div className="container">
-        {introductionHtml}
-        <div className="row" style={{ paddingTop: 10 }}>
-          <GoogleAutoComplete
-            id="entryBox"
-            updateTextForMapSearchInParent={this.updateTextForMapSearch}
-            updateTextForMapSearchInParentFromGoogle={this.updateTextForMapSearchFromGoogle}
-          />
-        </div>
+        <Box sx={{
+            backgroundColor: 'grey.200',
+            pl: 6,
+            pr: 6,
+            pt: 2,
+            pb: 2,
+            borderRadius: 8,
+          }}
+        >
+          {introductionHtml}
+          <div className="row" style={{ paddingTop: 10 }}>
+            <GoogleAutoComplete
+              id="entryBox"
+              updateTextForMapSearchInParent={this.updateTextForMapSearch}
+              updateTextForMapSearchInParentFromGoogle={this.updateTextForMapSearchFromGoogle}
+            />
+          </div>
+        </Box>
         <div className="row" style={{ paddingTop: 10 }}>
           {/* {showCancelEditAddressButton ? (
             <Button
@@ -262,6 +273,7 @@ class SettingsAddressBox extends Component {
             classes={{root: classes.fullWidthSaveButton}}
             // fullWidth={!showCancelEditAddressButton}
             fullWidth
+            // disabled={!this.state.isAddressVerified}
           >
             Update ballot
           </Button>
@@ -304,7 +316,7 @@ const styles = {
     left: 16,
   },
   fullWidthSaveButton: {
-    borderRadius: '4px',
+    borderRadius: '32px',
     height: 'fit-content',
     margin: 0,
   },


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
This PR is a followup on #4553 and addresses WV-2055 — integrating the ballot address entry feature into `HeaderProfileDrawer`. It addresses the rest of the UI changes.

### Changes included this pull request?

**Before the user enters address** (note that in the production version, the "update ballot" button is disabled until the user enters a verified address):
<img width="940" height="524" alt="Screenshot 2025-10-11 at 5 05 54 PM" src="https://github.com/user-attachments/assets/c4e4029a-251c-40b2-b908-f46c6b6ffa5f" />

**After they enter address:**
<img width="964" height="392" alt="Screenshot 2025-10-11 at 5 06 18 PM" src="https://github.com/user-attachments/assets/6e29ddaf-5ea5-4e26-a725-0df3139196c8" />

**When they click "Remove address":**
<img width="954" height="433" alt="Screenshot 2025-10-11 at 5 06 41 PM" src="https://github.com/user-attachments/assets/010b2f6a-3d8a-4a27-ab1f-d006bdf53f2d" />

**When they click the "edit" icon:**
<img width="981" height="438" alt="Screenshot 2025-10-11 at 5 07 04 PM" src="https://github.com/user-attachments/assets/66236dcc-9b7a-4b06-b957-bf97a6921a11" />
