### PR TITLE
[WV-2086] Add DataLayer for Verification Code Modal

### DIFF
--- a/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
@@ -733,7 +733,7 @@ class SettingsVerifySecretCode extends Component {
               onClick={(e) => {
                 const buttonId = e.target.id;
                 this.closeVerifyModalLocal();
-                this.pushDataLayer(false, buttonId, 'tryDifferent');
+                this.pushDataLayer(false, buttonId, 'navigate');
               }}
               variant={voterMustRequestNewCode ? 'contained' : 'outlined'}
             >

--- a/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
@@ -2,6 +2,7 @@ import { ArrowBack, ArrowBackIos } from '@mui/icons-material';
 import { Button, Dialog, OutlinedInput } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
+import TagManager from 'react-gtm-module';
 import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
@@ -11,6 +12,7 @@ import { hasIPhoneNotch, isIOS, isIPhone4in } from '../../utils/cordovaUtils';
 import { isCordova, isWebApp } from '../../utils/isCordovaOrWebApp';
 import { renderLog } from '../../utils/logging';
 import VoterStore from '../../../stores/VoterStore';
+import { getPageDetails } from '../../../utils/lookupPageNameAndPageTypeDict';
 
 /* global $ */
 
@@ -20,6 +22,7 @@ class SettingsVerifySecretCode extends Component {
     this.state = {
       cancelingVerifyModal: false,
       condensed: false,
+      dataLayerFired: false,
       digit1: '',
       digit2: '',
       digit3: '',
@@ -77,6 +80,16 @@ class SettingsVerifySecretCode extends Component {
     }, delayBeforeClearingVerificationStatus);
 
     window.addEventListener('paste', this.onPaste);
+
+    const { dataLayerFired } = this.state;
+    if (!dataLayerFired) {
+      if (VoterStore.voterFirstRetrieveCompleted()) {
+        this.pushDataLayer(true, null, 'landing');
+        this.setState({
+          dataLayerFired: true,
+        });
+      }
+    }
   }
 
   shouldComponentUpdate (nextProps, nextState) {
@@ -98,6 +111,18 @@ class SettingsVerifySecretCode extends Component {
     if (this.state.digit6 !== nextState.digit6) return true;
     // console.log('shouldComponentUpdate return false');
     return false;
+  }
+
+  componentDidUpdate () {
+    const { dataLayerFired } = this.state;
+    if (!dataLayerFired) {
+      if (VoterStore.voterFirstRetrieveCompleted()) {
+        this.pushDataLayer(true, null, 'landing');
+        this.setState({
+          dataLayerFired: true,
+        });
+      }
+    }
   }
 
   componentWillUnmount () {
@@ -492,6 +517,22 @@ class SettingsVerifySecretCode extends Component {
     }
   };
 
+  pushDataLayer = (landing, buttonId, actionType) => {
+    const dataLayerObject = {
+      actionDetails: {
+        actionType,
+        ...(buttonId && { buttonId }),
+      },
+      event: landing ? 'landing' : 'click',
+      verifyDetails: {
+        verifyMethod: this.voterPhoneNumber ? 'SMS' : 'email',
+      },
+      pageDetails: getPageDetails(),
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+  };
+
   render () {
     renderLog('SettingsVerifySecretCode');  // Set LOG_RENDER_EVENTS to log all renders
     // console.log('SettingsVerifySecretCode render');
@@ -532,7 +573,14 @@ class SettingsVerifySecretCode extends Component {
       >
         <ModalTitleArea condensed={condensed}>
           {isWebApp() && (
-            <Button onClick={this.closeVerifyModalLocal} id="emailVerificationBackButton">
+            <Button
+              id={voterPhoneNumber ? 'phoneVerificationBackButton' : 'emailVerificationBackButton'}
+              onClick={(e) => {
+                const buttonId = e.target.id;
+                this.closeVerifyModalLocal();
+                this.pushDataLayer(false, buttonId, 'back');
+              }}
+            >
               {isIOS() ? <ArrowBackIos /> : <ArrowBack />}
               {' '}
               Back
@@ -655,11 +703,15 @@ class SettingsVerifySecretCode extends Component {
           <ButtonsContainer condensed={condensed}>
             <Button
               classes={{ root: classes.verifyButton }}
-              id="emailVerifyButton"
+              id={voterPhoneNumber ? 'phoneVerifyButton' : 'emailVerifyButton'}
               color="primary"
               disabled={this.state.digit1 === '' || this.state.digit2 === '' || this.state.digit3 === '' || this.state.digit4 === '' || this.state.digit5 === '' || this.state.digit6 === '' || voterMustRequestNewCode || voterSecretCodeRequestsLocked || voterVerifySecretCodeSubmitted}
               fullWidth
-              onClick={this.voterVerifySecretCode}
+              onClick={(e) => {
+                const buttonId = e.target.id;
+                this.voterVerifySecretCode();
+                this.pushDataLayer(false, buttonId, 'verify');
+              }}
               variant="contained"
             >
               {voterVerifySecretCodeSubmitted ? 'Verifying...' : 'Verify'}
@@ -674,11 +726,15 @@ class SettingsVerifySecretCode extends Component {
             </Button>
             */}
             <Button
-              id="tryADifferentEmailOrNumber"
+              id={voterPhoneNumber ? 'tryADifferentNumber' : 'tryADifferentEmail'}
               classes={{ root: classes.button }}
               color="primary"
               disabled={voterVerifySecretCodeSubmitted}
-              onClick={this.closeVerifyModalLocal}
+              onClick={(e) => {
+                const buttonId = e.target.id;
+                this.closeVerifyModalLocal();
+                this.pushDataLayer(false, buttonId, 'tryDifferent');
+              }}
               variant={voterMustRequestNewCode ? 'contained' : 'outlined'}
             >
               {voterPhoneNumber ? 'Try a different number' : 'Try a different email'}

--- a/src/js/components/Settings/VoterEmailAddressEntry.jsx
+++ b/src/js/components/Settings/VoterEmailAddressEntry.jsx
@@ -6,6 +6,7 @@ import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import styled from 'styled-components';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import TagManager from 'react-gtm-module';
 import Tooltip from 'react-bootstrap/Tooltip';
 import VoterActions from '../../actions/VoterActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
@@ -19,6 +20,7 @@ import { FirstRowPhoneOrEmail, SecondRowPhoneOrEmail, SecondRowPhoneOrEmailDiv, 
 import { ButtonContainerHorizontal } from '../Welcome/sectionStyles';
 import SettingsVerifySecretCode from '../../common/components/Settings/SettingsVerifySecretCode';
 import { validateEmail } from '../../utils/regex-checks';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
@@ -70,7 +72,7 @@ class VoterEmailAddressEntry extends Component {
     VoterActions.voterEmailAddressRetrieve();
     if (this.emailInputRef && this.emailInputRef.current) {
       this.emailInputRef.current.blur();
-    };
+    }
     this._isMounted = true;
   }
 
@@ -373,6 +375,22 @@ class VoterEmailAddressEntry extends Component {
     }
   };
 
+  pushDataLayer = (buttonId, actionType) => {
+    const dataLayerObject = {
+      actionDetails: {
+        actionType,
+        buttonId,
+      },
+      event: 'click',
+      verifyDetails: {
+        verifyMethod: 'email',
+      },
+      pageDetails: getPageDetails(),
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+  };
+
   render () {
     renderLog('VoterEmailAddressEntry');  // Set LOG_RENDER_EVENTS true to log all renders
     const { doNotRender } = this.props;
@@ -498,7 +516,11 @@ class VoterEmailAddressEntry extends Component {
                   color="primary"
                   disabled={disableEmailVerificationButton || signInCodeEmailSentAndWaitingForResponse}
                   id="voterEmailAddressEntrySendCode"
-                  onClick={this.sendSignInCodeEmail}
+                  onClick={(e) => {
+                    const buttonId = e.target.id;
+                    this.sendSignInCodeEmail();
+                    this.pushDataLayer(buttonId, 'sendVerification');
+                  }}
                   onAnimationEnd={this.onAnimationEndSend}
                   variant="contained"
                 >

--- a/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
+++ b/src/js/components/Settings/VoterPhoneVerificationEntry.jsx
@@ -11,6 +11,7 @@ import React, { Component, Suspense } from 'react';
 import { isValidPhoneNumber } from 'react-phone-number-input';
 import styled from 'styled-components';
 import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import TagManager from 'react-gtm-module';
 import Tooltip from 'react-bootstrap/Tooltip';
 import VoterActions from '../../actions/VoterActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
@@ -23,6 +24,7 @@ import VoterStore from '../../stores/VoterStore';
 import { FirstRowPhoneOrEmail, SecondRowPhoneOrEmail, SecondRowPhoneOrEmailDiv, AllPhoneOrEmailTypes } from '../Style/pageLayoutStyles';
 import { ButtonContainerHorizontal } from '../Welcome/sectionStyles';
 import SettingsVerifySecretCode from '../../common/components/Settings/SettingsVerifySecretCode';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 // import { validatePhoneOrEmail } from '../../utils/regex-checks';
 
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
@@ -430,6 +432,22 @@ class VoterPhoneVerificationEntry extends Component {
     }
   };
 
+  pushDataLayer = (buttonId, actionType) => {
+    const dataLayerObject = {
+      actionDetails: {
+        actionType,
+        buttonId,
+      },
+      event: 'click',
+      verifyDetails: {
+        verifyMethod: 'SMS',
+      },
+      pageDetails: getPageDetails(),
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+  };
+
   render () {
     renderLog('VoterPhoneVerificationEntry');  // Set LOG_RENDER_EVENTS to log all renders
     const { doNotRender } = this.props;
@@ -559,7 +577,11 @@ class VoterPhoneVerificationEntry extends Component {
                   color="primary"
                   disabled={disablePhoneVerificationButton || signInCodeSMSSentAndWaitingForResponse}
                   id="voterPhoneSendSMS"
-                  onClick={this.sendSignInCodeSMS}
+                  onClick={(e) => {
+                    const buttonId = e.target.id;
+                    this.sendSignInCodeSMS();
+                    this.pushDataLayer(buttonId, 'sendVerification');
+                  }}
                   onAnimationEnd={() => this.onAnimationEndSend()}
                   variant="contained"
                 >


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

[[WV-2086]](https://wevoteusa.atlassian.net/browse/WV-2086)

### Changes included this pull request?
- Added dataLayer for below buttons:
 - Send Verification for both email and phone number sign in options
 - Back Button in verification modal
 - Verify in verification modal
 - Try a Different Number/Email in verification modal
- Added landing dataLayer for verification modal

[WV-2086]: https://wevoteusa.atlassian.net/browse/WV-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ