### PR TITLE
[WV-1733] Fix(header): correct tab highlight after navigation (sync ta…

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -72,29 +72,29 @@ class HeaderBar extends Component {
   }
 
   getTabsValueFromPage = () => {
-  const page = normalizedHrefPage();
-  switch (page) {
-    case 'ballot': return 1;
-    case 'candidatelist':
-    case 'politicianpage': return 2;
-    case 'friends': return 3;
-    case 'news': return 99;
-    case 'challenges': return 4;
-    case 'donate':
-    case 'more/donate': return 5;
-    case 'more':
-    case 'more/manage': return 99;
-    default: return false;
-  }
-};
+    const page = normalizedHrefPage();
+    switch (page) {
+      case 'ballot': return 1;
+      case 'candidatelist':
+      case 'politicianpage': return 2;
+      case 'friends': return 3;
+      case 'news': return 99;
+      case 'challenges': return 4;
+      case 'donate':
+      case 'more/donate': return 5;
+      case 'more':
+      case 'more/manage': return 99;
+      default: return false;
+    }
+  };
 
-syncTabsToRoute = () => {
-  const nextPage = normalizedHrefPage();
-  const nextValue = this.getTabsValueFromPage();
-  this.setState({ tabsValue: nextValue, page: nextPage }, () => {
-    this.customHighlightSelector(nextValue);
-  });
-};
+  syncTabsToRoute = () => {
+    const nextPage = normalizedHrefPage();
+    const nextValue = this.getTabsValueFromPage();
+    this.setState({ tabsValue: nextValue, page: nextPage }, () => {
+      this.customHighlightSelector(nextValue);
+    });
+  };
 
 
   componentDidMount () {
@@ -391,7 +391,7 @@ syncTabsToRoute = () => {
           more.css(highlight);
           break;
         case 'more/manage':
-                   more.css(highlight);
+          more.css(highlight);
           break;
         default:
           break;

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -42,8 +42,6 @@ const nextReleaseFeaturesEnabled = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES ===
 
 // TODO: Backport "@stripe/react-stripe-js" use from Campaigns
 // import PaidAccountUpgradeModal from '../Settings/PaidAccountUpgradeModal';
-
-
 class HeaderBar extends Component {
   constructor (props) {
     super(props);
@@ -70,9 +68,34 @@ class HeaderBar extends Component {
     this.debugLogging = this.debugLogging.bind(this);
     this.toggleSignInModal = this.toggleSignInModal.bind(this);
     this.transitionToYourVoterGuide = this.transitionToYourVoterGuide.bind(this);
-    this.handleTabChange = this.handleTabChange.bind(this);
     this.handleResizeLocal = this.handleResizeLocal.bind(this);
   }
+
+  getTabsValueFromPage = () => {
+  const page = normalizedHrefPage();
+  switch (page) {
+    case 'ballot': return 1;
+    case 'candidatelist':
+    case 'politicianpage': return 2;
+    case 'friends': return 3;
+    case 'news': return 99;
+    case 'challenges': return 4;
+    case 'donate':
+    case 'more/donate': return 5;
+    case 'more':
+    case 'more/manage': return 99;
+    default: return false;
+  }
+};
+
+syncTabsToRoute = () => {
+  const nextPage = normalizedHrefPage();
+  const nextValue = this.getTabsValueFromPage();
+  this.setState({ tabsValue: nextValue, page: nextPage }, () => {
+    this.customHighlightSelector(nextValue);
+  });
+};
+
 
   componentDidMount () {
     this.appStateSubscription = messageService.getMessage().subscribe((msg) => this.onAppObservableStoreChange(msg));
@@ -137,13 +160,14 @@ class HeaderBar extends Component {
         }
       }, 1000);
     }
+    this.syncTabsToRoute();
   }
 
   componentDidUpdate () {
     // console.log('HeaderBar componentDidUpdate');
     const { page } = this.state;
     if (page !== normalizedHrefPage()) {
-      this.customHighlightSelector();
+      this.syncTabsToRoute();
     }
   }
 


### PR DESCRIPTION
…bs with route) Body

- Fix tabs no longer stays highlighted after clicking the WeVote logo to return home; the active tab now matches the current route.
- Move getTabsValueFromPage and syncTabsToRoute into HeaderBar as class fields
- Call syncTabsToRoute() in componentDidMount and whenever the URL page changes
- Remove redundant handleTabChange bind; avoid double highlight calls
- Keep jQuery-based customHighlightSelector but drive it from route-derived state

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
