### PR TITLE
[Issue #WV-2153] Update icon colors for Choose and Oppose buttons

### DIFF
--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -1151,28 +1151,28 @@ const styles = (theme) => ({
     },
   },
   buttonIconDone: {
-    /* color: `${DesignTokenColors.primary700}`, *//* change to green */
+    color: `${DesignTokenColors.confirmation300}`, /* green color before selection */
     fontSize: 22,
     fontWeight: 'bold',
     marginRight: '.3rem',
     marginTop: '-2px',
   },
   buttonIconDoneSelected: {
-    color: `${DesignTokenColors.confirmation300}`, /* change to green */
+    color: `${DesignTokenColors.confirmation300}`, 
     fontSize: 22,
     fontWeight: 'bold',
     marginRight: '.3rem',
     marginTop: '-2px',
   },
   buttonIconNotInterested: {
-    /* color: `${DesignTokenColors.alert500}`, *//* change to red */
+    color: `${DesignTokenColors.alert500}`, /* red color before selection */
     fontSize: 18,
     fontWeight: 'bold',
     marginRight: '.3rem',
     marginTop: '-2px',
   },
   buttonIconNotInterestedSelected: {
-    color: `${DesignTokenColors.alert500}`, /* change to red */
+    color: `${DesignTokenColors.alert500}`,
     fontSize: 18,
     fontWeight: 'bold',
     marginRight: '.3rem',


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Issue #WV-2152

### Changes included this pull request?
This PR modifies the color of the icons in the `Choose` and `Oppose` buttons on the `Candidates` page. Prior to this change, the icons were initially blue until clicked. After the change, the checkmark on the side of the `Choose` button is green, and the icon on the side of the `Oppose` button is red even prior to clicking.
<img width="303" height="64" alt="Screenshot 2025-10-26 at 3 14 22 PM" src="https://github.com/user-attachments/assets/08460fa1-0cef-4257-911e-2e451d23ac70" />
