### PR TITLE
[WV-2125] Added dataLayer for apple SignIn, Fixed naming convention for SignInModal navigation buttons [NEEDS REVIEW]

### DIFF
--- a/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
@@ -580,7 +580,7 @@ class SettingsVerifySecretCode extends Component {
               onClick={(e) => {
                 const buttonId = e.target.id;
                 this.closeVerifyModalLocal();
-                this.pushDataLayer(false, buttonId, 'back');
+                this.pushDataLayer(false, buttonId, 'navigate');
               }}
             >
               {isIOS() ? <ArrowBackIos /> : <ArrowBack />}
@@ -712,7 +712,7 @@ class SettingsVerifySecretCode extends Component {
               onClick={(e) => {
                 const buttonId = e.target.id;
                 this.voterVerifySecretCode();
-                this.pushDataLayer(false, buttonId, 'verify');
+                this.pushDataLayer(false, buttonId, 'navigate');
               }}
               variant="contained"
             >

--- a/src/js/components/Apple/AppleSignIn.jsx
+++ b/src/js/components/Apple/AppleSignIn.jsx
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import VoterActions from '../../actions/VoterActions';
+import VoterStore from '../../stores/VoterStore';
 import { openSnackbar } from '../../common/components/Widgets/SnackNotifier';
 import { isIOS } from '../../common/utils/cordovaUtils';
 import { isAndroid, isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import Cookies from '../../common/utils/js-cookie/Cookies';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import { oAuthLog, renderLog } from '../../common/utils/logging';
 import webAppConfig from '../../config';
 
@@ -20,6 +23,8 @@ class AppleSignIn extends Component {
   }
 
   componentDidMount () {
+    this.onVoterStoreChange();
+    this.voterStoreListener = VoterStore.addListener(this.onVoterStoreChange.bind(this));
     if (isWebApp()) {
       this.localInitializeSDK(false);
       document.addEventListener('AppleIDSignInOnSuccess', (data) => {
@@ -32,6 +37,9 @@ class AppleSignIn extends Component {
   }
 
   componentWillUnmount () {
+    if (this.voterStoreListener && typeof this.voterStoreListener.remove === 'function') {
+      this.voterStoreListener.remove();
+    }
     if (isWebApp()) {
       // document.removeEventListener('AppleIDSignInOnSuccess', this.onSignInSuccess());
       // document.removeEventListener('AppleIDSignInOnFailure', this.onSignInFailure());
@@ -44,6 +52,13 @@ class AppleSignIn extends Component {
 
   onSignInFailure (data) {
     console.log('onSignInFailure  data:', data);
+  }
+
+  onVoterStoreChange () {
+    // console.log('Ready, onVoterStoreChange voter: ', VoterStore.getVoter());
+    this.setState({
+      voterIsSignedIn: VoterStore.getVoterIsSignedIn(),
+    });
   }
 
   localInitializeSDK (signInAfterInit) {
@@ -73,6 +88,10 @@ class AppleSignIn extends Component {
 
   signInToAppleIOS () {
     console.log('SignInWithApple signInToAppleIOS: Button clicked');
+    
+    // Push dataLayer BEFORE the sign-in flow starts
+    this.pushDataLayer();
+    
     const { SignInWithApple: { signin } } = window.cordova.plugins;
 
     signin(
@@ -121,6 +140,10 @@ class AppleSignIn extends Component {
 
   signInToAppleWebApp () {  // https://i.stack.imgur.com/Le6Jf.png  https://stackoverflow.com/questions/61071848/sign-in-with-apple-js-returns-invalid-request-in
     oAuthLog('AppleSignIn signInToAppleWebApp button pressed');
+    
+    // Push dataLayer BEFORE the sign-in flow starts
+    this.pushDataLayer();
+    
     try {
       const { auth } = window.AppleID;
       auth.signIn();
@@ -140,6 +163,22 @@ class AppleSignIn extends Component {
     } else {
       this.signInToAppleIOS();
     }
+  }
+
+  pushDataLayer = () => {
+    const dataLayerObject = {
+      actionDetails: {
+        actionType: 'sendVerification',
+        buttonId: 'appleSignInButton',
+      },
+      event: 'click',
+      verifyDetails: {
+        verifyMethod: 'apple',
+      },
+      pageDetails: getPageDetails(),
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
   }
 
   render () {
@@ -180,7 +219,10 @@ class AppleSignIn extends Component {
                              id="appleSignInButton"
                              isWeb={isWeb}
                              tinyScreen={tinyScreen}
-                             onClick={() => this.signInClicked(enabled)}
+                             onClick={(e) => {
+                               const buttonId = e.currentTarget.id;
+                               this.signInClicked(enabled);
+                             }}
           >
             <AppleLogo signedIn={signedIn} enabled={enabled} />
             <AppleSignInText id="appleSignInText" enabled={enabled}>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[[WV-2125]](https://wevoteusa.atlassian.net/browse/WV-2125)
### Changes included this pull request?
- Already added dataLayer with actionType "sendVerification" for email and phone signIn buttons, so just added on for appleSignIn
- Fixed naming convention for signInModal buttons' action to "navigate"

[WV-2125]: https://wevoteusa.atlassian.net/browse/WV-2125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ