### PR TITLE
[WV-2047] ImportedVotersList UX polish + overflow fixes

### DIFF
--- a/src/js/components/PoliticiansManaged/ImportedVotersList.jsx
+++ b/src/js/components/PoliticiansManaged/ImportedVotersList.jsx
@@ -211,7 +211,6 @@ export default function ImportedVotersList ({
       </Toolbar>
 
       <Table role="table" aria-label="Imported voters table">
-        {/* header row INSIDE the table, uses the same grid */}
         <TrHead role="row">
           <ThCenter role="columnheader" aria-label="Select" />
           <ThCenter role="columnheader" aria-label="Expand" />

--- a/src/js/components/PoliticiansManaged/ImportedVotersList.jsx
+++ b/src/js/components/PoliticiansManaged/ImportedVotersList.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useRef, useEffect } from 'react';
+import React, { useMemo, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import {
@@ -9,10 +9,12 @@ import {
   VisibilityOff as HideIcon,
   Search as SearchIcon,
   MoreVert as OverflowIcon,
+  Visibility as ShowIcon,
+  History as HistoryIcon,
+  DeleteOutline as DeleteIcon,
 } from '@mui/icons-material';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 
-/* utils */
 function formatWhen (iso) {
   try {
     const d = iso ? new Date(iso) : new Date();
@@ -21,6 +23,7 @@ function formatWhen (iso) {
     return '—';
   }
 }
+
 export default function ImportedVotersList ({
   voters,
   onInviteSelected,
@@ -28,10 +31,15 @@ export default function ImportedVotersList ({
   onInviteText,
   onHide,
   onHideSelected,
+  onShowHidden,
+  onViewHistory,
+  onDeleteSelected,
 }) {
   const [query, setQuery] = useState('');
   const [expandedId, setExpandedId] = useState(null);
   const [selected, setSelected] = useState(() => new Set());
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -41,6 +49,7 @@ export default function ImportedVotersList ({
 
   const allVisibleSelected =
     filtered.length > 0 && filtered.every((v) => selected.has(v.id || v._idx));
+
   const selectedList = useMemo(
     () => voters.filter((v) => selected.has(v.id || v._idx)),
     [voters, selected],
@@ -68,31 +77,23 @@ export default function ImportedVotersList ({
       return next;
     });
   };
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef(null);
-  useEffect(() => {
-    function onDocClick (e) {
-      if (!menuRef.current) return;
-      if (!menuRef.current.contains(e.target)) setMenuOpen(false);
-    }
-    if (menuOpen) document.addEventListener('mousedown', onDocClick);
-    return () => document.removeEventListener('mousedown', onDocClick);
-  }, [menuOpen]);
 
   return (
     <Card aria-label="Imported voters (not invited)">
-      <Header>
-        <Title>Imported voters (not invited)</Title>
-        <HeaderRight>
-          <SearchWrap>
+      <ListTopBar>
+        <TopBarLeft>
+          <ListHeading>Imported voters (not invited)</ListHeading>
+          <TopDivider aria-hidden />
+          <SearchField aria-label="Search imported voters">
             <SearchIcon aria-hidden />
             <SearchInput
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search name, email, phone"
-              aria-label="Search imported voters"
             />
-          </SearchWrap>
+          </SearchField>
+        </TopBarLeft>
+
+        <TopBarRight>
           <InviteButton
             type="button"
             disabled={selectedList.length === 0}
@@ -108,12 +109,8 @@ export default function ImportedVotersList ({
             {selectedList.length}
             )
           </InviteButton>
-          <OverflowWrap
-            ref={menuRef}
-            onMouseEnter={() => setMenuOpen(true)}
-            onMouseLeave={() => setMenuOpen(false)}
-            className="overflow-menu"
-          >
+
+          <OverflowWrap>
             <OverflowBtn
               type="button"
               aria-label="More options"
@@ -125,31 +122,83 @@ export default function ImportedVotersList ({
               <OverflowIcon fontSize="small" />
             </OverflowBtn>
             {menuOpen && (
-              <MenuCard role="menu">
+              <MenuCard role="menu" ref={menuRef}>
                 <MenuItem
                   role="menuitem"
-                  disabled={selectedList.length === 0}
                   onClick={() => {
-                    onHideSelected?.(selectedList);
+                    onShowHidden?.();
                     setMenuOpen(false);
                   }}
-                  title={
-                    selectedList.length ? undefined : 'Select voters first'
-                  }
                 >
-                  <HideIcon fontSize="small" />
-                  {' '}
-                  <span>Hide selected</span>
+                  <ShowIcon fontSize="small" />
+                  <span>Show hidden</span>
                 </MenuItem>
-                {/* Optional: wire up when handlers exist
-       <MenuItem role="menuitem" onClick={() => props.onShowHidden?.()}>Show hidden</MenuItem>
-       <MenuItem role="menuitem" onClick={() => props.onViewHistory?.()}>View history of imports</MenuItem>
-       */}
+
+                <MenuItem
+                  role="menuitem"
+                  onClick={() => {
+                    onViewHistory?.();
+                    setMenuOpen(false);
+                  }}
+                >
+                  <HistoryIcon fontSize="small" />
+                  <span>View history of imports</span>
+                </MenuItem>
+                <MenuDivider />
+
+                {selectedList.length > 0 ? (
+                  <>
+                    <MenuItem
+                      role="menuitem"
+                      onClick={() => {
+                        onHideSelected?.(selectedList);
+                        setMenuOpen(false);
+                      }}
+                    >
+                      <HideIcon fontSize="small" />
+                      <span>Hide</span>
+                    </MenuItem>
+
+                    <MenuItem
+                      role="menuitem"
+                      onClick={() => {
+                        onDeleteSelected?.(selectedList);
+                        setMenuOpen(false);
+                      }}
+                    >
+                      <DeleteIcon fontSize="small" />
+                      <span>Delete</span>
+                    </MenuItem>
+                  </>
+                ) : (
+                  <>
+                    <TooltipWrap>
+                      <MenuItem role="menuitem" disabled>
+                        <HideIcon fontSize="small" />
+                        <span>Hide</span>
+                      </MenuItem>
+                      <TooltipBubble>
+                        Select voters to allow hiding or deleting.
+                      </TooltipBubble>
+                    </TooltipWrap>
+
+                    <TooltipWrap>
+                      <MenuItem role="menuitem" disabled>
+                        <DeleteIcon fontSize="small" />
+                        <span>Delete</span>
+                      </MenuItem>
+                      <TooltipBubble>
+                        Select voters to allow hiding or deleting.
+                      </TooltipBubble>
+                    </TooltipWrap>
+                  </>
+                )}
               </MenuCard>
             )}
           </OverflowWrap>
-        </HeaderRight>
-      </Header>
+        </TopBarRight>
+      </ListTopBar>
+
       <Toolbar>
         <label>
           <input
@@ -160,31 +209,63 @@ export default function ImportedVotersList ({
           <span>Select all</span>
         </label>
       </Toolbar>
+
       <Table role="table" aria-label="Imported voters table">
-        <Thead role="rowgroup">
-          <Tr role="row">
-            <Th role="columnheader" aria-label="Select" />
-            <Th role="columnheader" aria-label="Expand" />
-            <Th role="columnheader">Name</Th>
-            <Th role="columnheader">Email</Th>
-            <Th role="columnheader">Phone</Th>
-          </Tr>
-        </Thead>
+        {/* header row INSIDE the table, uses the same grid */}
+        <TrHead role="row">
+          <ThCenter role="columnheader" aria-label="Select" />
+          <ThCenter role="columnheader" aria-label="Expand" />
+          <Th role="columnheader">Name</Th>
+          <Th role="columnheader">Email</Th>
+          <Th role="columnheader">Phone</Th>
+          <ThRight role="columnheader" aria-label="Actions" />
+        </TrHead>
 
         <Tbody role="rowgroup">
           {filtered.map((v, idx) => {
             const id = v.id || v._idx || `row_${idx}`;
             const isOpen = expandedId === id;
             const isChecked = selected.has(id);
+            const showDetails = isOpen || isChecked; // no hover reveal
+
             return (
               <React.Fragment key={id}>
-                <Tr role="row">
-                  <Td role="cell">
+                <Tr role="row" className={isChecked ? 'selected' : undefined}>
+                  <TdCheck role="cell">
                     <Checkbox
                       type="checkbox"
                       checked={isChecked}
                       onChange={() => toggleOne(id)}
+                      aria-label={`Select ${v.name || 'voter'}`}
                     />
+                  </TdCheck>
+
+                  <TdExpand role="cell">
+                    <ExpandBtn
+                      type="button"
+                      aria-expanded={isOpen}
+                      aria-label={isOpen ? 'Collapse row' : 'Expand row'}
+                      onClick={() => toggleRow(id)}
+                    >
+                      {isOpen ? (
+                        <CollapseIcon fontSize="small" />
+                      ) : (
+                        <ExpandIcon fontSize="small" />
+                      )}
+                    </ExpandBtn>
+                  </TdExpand>
+
+                  <Td role="cell" title={v.name || '—'}>
+                    {v.name || '—'}
+                  </Td>
+                  <Td role="cell" title={v.email || '—'}>
+                    {v.email || '—'}
+                  </Td>
+                  <Td role="cell" title={v.phone || '—'}>
+                    {v.phone || '—'}
+                  </Td>
+
+                  <TdActions role="cell">
                     <ActionsInline className="row-actions">
                       <ActionPill
                         type="button"
@@ -205,35 +286,16 @@ export default function ImportedVotersList ({
                         <span>Hide</span>
                       </ActionPill>
                     </ActionsInline>
-                  </Td>
-                  <Td role="cell" style={{ width: 34 }}>
-                    <ExpandBtn
-                      type="button"
-                      aria-expanded={isOpen}
-                      aria-label={isOpen ? 'Collapse row' : 'Expand row'}
-                      onClick={() => toggleRow(id)}
-                    >
-                      {isOpen ? (
-                        <CollapseIcon fontSize="small" />
-                      ) : (
-                        <ExpandIcon fontSize="small" />
-                      )}
-                    </ExpandBtn>
-                  </Td>
-                  <Td role="cell">
-                    <Strong>{v.name || '—'}</Strong>
-                  </Td>
-                  <Td role="cell">{v.email || '—'}</Td>
-                  <Td role="cell">{v.phone || '—'}</Td>
+                  </TdActions>
                 </Tr>
 
-                {isOpen && (
+                {showDetails && (
                   <TrDetails role="row">
                     <TdFull>
                       <DetailsGrid>
                         <DetailBlock>
                           <DetailLabel>Added via</DetailLabel>
-                          <div>{v.source || 'One-by-one'}</div>
+                          <div>{v.source || 'Manual entry'}</div>
                         </DetailBlock>
                         <DetailBlock>
                           <DetailLabel>Added by</DetailLabel>
@@ -243,30 +305,6 @@ export default function ImportedVotersList ({
                           <DetailLabel>Added on</DetailLabel>
                           <div>{formatWhen(v.addedAt)}</div>
                         </DetailBlock>
-
-                        <Actions>
-                          <RowAction
-                            type="button"
-                            onClick={() => onInviteEmail([v])}
-                          >
-                            <MailIcon fontSize="small" />
-                            {' '}
-                            <span>Send email invite</span>
-                          </RowAction>
-                          <RowAction
-                            type="button"
-                            onClick={() => onInviteText([v])}
-                          >
-                            <SmsIcon fontSize="small" />
-                            {' '}
-                            <span>Send text invite</span>
-                          </RowAction>
-                          <RowAction type="button" onClick={() => onHide(v)}>
-                            <HideIcon fontSize="small" />
-                            {' '}
-                            <span>Hide</span>
-                          </RowAction>
-                        </Actions>
                       </DetailsGrid>
                     </TdFull>
                   </TrDetails>
@@ -276,30 +314,6 @@ export default function ImportedVotersList ({
           })}
         </Tbody>
       </Table>
-
-      {selectedList.length > 0 && (
-        <FooterBar>
-          <span>
-            {selectedList.length}
-            {' '}
-            selected
-          </span>
-          <FooterButtons>
-            <SmallBtn
-              type="button"
-              onClick={() => onInviteSelected(selectedList)}
-            >
-              Invite selected
-            </SmallBtn>
-            <SmallBtn
-              type="button"
-              onClick={() => onHideSelected(selectedList)}
-            >
-              Hide selected
-            </SmallBtn>
-          </FooterButtons>
-        </FooterBar>
-      )}
     </Card>
   );
 }
@@ -321,6 +335,9 @@ ImportedVotersList.propTypes = {
   onInviteText: PropTypes.func.isRequired,
   onHide: PropTypes.func.isRequired,
   onHideSelected: PropTypes.func.isRequired,
+  onShowHidden: PropTypes.func,
+  onViewHistory: PropTypes.func,
+  onDeleteSelected: PropTypes.func,
 };
 
 /* styles */
@@ -331,46 +348,55 @@ const Card = styled.div`
   background: ${DesignTokenColors.whiteUI};
 `;
 
-const Header = styled.div`
+const ListTopBar = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 12px 14px;
+  justify-content: space-between;
+  padding: 8px 12px;
   border-bottom: 1px solid ${DesignTokenColors.neutralUI200};
 `;
 
-const Title = styled.h3`
-  margin: 0;
+const ListHeading = styled.div`
   font-weight: 600;
-  color: ${DesignTokenColors.neutralUI900};
   font-size: 14px;
+  color: ${DesignTokenColors.neutralUI900};
 `;
 
-const HeaderRight = styled.div`
-  display: flex;
-  gap: 10px;
+const TopBarRight = styled.div`
+  display: inline-flex;
   align-items: center;
-  flex-wrap: wrap;
+  gap: 10px;
 `;
 
-const SearchWrap = styled.div`
+const SearchField = styled.label`
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid ${DesignTokenColors.neutralUI300};
-  background: ${DesignTokenColors.whiteUI};
-  border-radius: 10px;
-  padding: 6px 10px;
+  min-width: 320px;
+  height: 36px;
+  padding: 0 10px;
+  border: none;
+  border-radius: 0;
+  background: transparent;
   color: ${DesignTokenColors.neutralUI700};
+  svg {
+    flex: 0 0 auto;
+    transform: translateY(3px);
+  }
 `;
 
 const SearchInput = styled.input`
-  border: none;
-  outline: none;
-  font: inherit;
-  min-width: 220px;
+  flex: 1;
+  border: 0;
+  outline: 0;
   background: transparent;
+  font: inherit;
   color: ${DesignTokenColors.neutralUI900};
+  &::placeholder {
+    color: ${DesignTokenColors.neutralUI500};
+  }
+  line-height: 1;
+  transform: translateY(3px);
 `;
 
 const InviteButton = styled.button`
@@ -384,6 +410,53 @@ const InviteButton = styled.button`
   &:disabled {
     background: ${DesignTokenColors.neutralUI200};
     border-color: ${DesignTokenColors.neutralUI200};
+    cursor: not-allowed;
+  }
+`;
+
+const OverflowWrap = styled.div`
+  position: relative;
+`;
+const OverflowBtn = styled.button`
+  background: transparent;
+  border: 0;
+  padding: 6px;
+  border-radius: 8px;
+  color: ${DesignTokenColors.neutralUI700};
+  cursor: pointer;
+  &:hover {
+    background: ${DesignTokenColors.neutralUI50};
+    color: ${DesignTokenColors.neutralUI900};
+  }
+`;
+const MenuCard = styled.div`
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  background: ${DesignTokenColors.whiteUI};
+  border: 1px solid ${DesignTokenColors.neutralUI200};
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.08);
+  min-width: 220px;
+  padding: 6px;
+  z-index: 10;
+`;
+const MenuItem = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  background: transparent;
+  border: 0;
+  border-radius: 8px;
+  color: ${DesignTokenColors.neutralUI900};
+  padding: 8px 10px;
+  text-align: left;
+  &:hover {
+    background: ${DesignTokenColors.neutralUI50};
+  }
+  &:disabled {
+    color: ${DesignTokenColors.neutralUI500};
     cursor: not-allowed;
   }
 `;
@@ -403,46 +476,85 @@ const Toolbar = styled.div`
 
 const Table = styled.div`
   width: 100%;
+  overflow-x: auto; /* if columns still can’t fit, scroll the table, not the page */
 `;
 
-const Thead = styled.div``;
 const Tbody = styled.div``;
+const gridCols = '34px 34px 1.2fr 1.2fr 0.9fr auto';
+
+const Th = styled.div`
+  padding: 10px 14px;
+  font-size: 12px;
+  font-weight: 600;
+  color: ${DesignTokenColors.neutralUI600};
+  min-width: 0;
+`;
+
+const ThCenter = styled(Th)`
+  text-align: center;
+`;
+const ThRight = styled(Th)`
+  text-align: right;
+`;
 
 const Tr = styled.div`
   display: grid;
-  grid-template-columns: 34px 34px 1.2fr 1.2fr 0.9fr;
+  grid-template-columns: ${gridCols};
   align-items: center;
   padding: 10px 14px;
   column-gap: 10px;
   border-bottom: 1px solid ${DesignTokenColors.neutralUI100};
+  box-sizing: border-box;
+
   &:hover .row-actions,
   &:focus-within .row-actions {
     opacity: 1;
     visibility: visible;
   }
-`;
 
-const TrDetails = styled(Tr)`
-  background: ${DesignTokenColors.neutralUI50};
-`;
-
-const Th = styled.div`
-  font-size: 12px;
-  font-weight: 600;
-  color: ${DesignTokenColors.neutralUI600};
-  padding: 10px 14px;
-  &:first-child {
-    padding-left: 14px;
+  &.selected {
+    background: ${DesignTokenColors.primary50 || DesignTokenColors.neutralUI50};
+    border-left: 3px solid ${DesignTokenColors.primary700};
+  }
+  &.selected .row-actions {
+    opacity: 1;
+    visibility: visible;
   }
 `;
 
-const Td = styled.div`
-  font-size: 14px;
-  color: ${DesignTokenColors.neutralUI900};
+const TrHead = styled(Tr)`
+  background: ${DesignTokenColors.neutralUI50};
 `;
 
-const Strong = styled.span`
-  font-weight: 600;
+const TrDetails = styled(Tr)`
+  background: none;
+`;
+
+const Td = styled.div`
+  padding: 10px 14px;
+  font-size: 14px;
+  color: ${DesignTokenColors.neutralUI900};
+  min-width: 0; /* key: allow shrinking inside CSS grid */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+const TdCheck = styled(Td)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const TdExpand = styled(Td)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const TdActions = styled(Td)`
+  display: flex;
+  justify-content: flex-end;
 `;
 
 const Checkbox = styled.input``;
@@ -459,9 +571,30 @@ const ExpandBtn = styled.button`
   }
 `;
 
+const ActionsInline = styled.div`
+  display: inline-flex;
+  gap: 10px;
+  justify-content: flex-end;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.12s ease-in-out;
+`;
+
+const ActionPill = styled.button`
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  background: transparent;
+  border: none;
+  padding: 6px 10px;
+  color: ${DesignTokenColors.neutralUI800};
+  cursor: pointer;
+  white-space: nowrap;
+`;
+
 const DetailsGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(3, minmax(140px, 1fr)) 1.4fr;
+  grid-template-columns: repeat(3, minmax(140px, 1fr));
   gap: 10px 16px;
   padding: 8px 0;
   align-items: center;
@@ -476,148 +609,51 @@ const DetailLabel = styled.div`
   color: ${DesignTokenColors.neutralUI600};
   font-size: 12px;
 `;
-const ActionsInline = styled.div`
-  display: inline-flex;
-  gap: 10px;
-  justify-content: flex-end;
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.12s ease-in-out;
-`;
-
-// Small pill button reused for inline actions
-const ActionPill = styled.button`
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  background: transparent;
-  border: 1px solid ${DesignTokenColors.neutralUI300};
-  border-radius: 999px;
-  padding: 6px 10px;
-  color: ${DesignTokenColors.neutralUI800};
-  cursor: pointer;
-  white-space: nowrap;
-  &:hover {
-    background: ${DesignTokenColors.neutralUI100};
-  }
-`;
-
-const Actions = styled.div`
-  display: inline-flex;
-  gap: 10px;
-  justify-content: flex-end;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.12s ease;
-
-  ${TrDetails}:hover & {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  ${Tr}:hover + ${TrDetails} & {
-    opacity: 1;
-    pointer-events: auto;
-  }
-
-  ${TrDetails}:focus-within & {
-    opacity: 1;
-    pointer-events: auto;
-  }
-`;
 
 const TdFull = styled(Td)`
   grid-column: 1 / -1;
 `;
 
-const RowAction = styled.button`
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  background: transparent;
-  border: 1px solid ${DesignTokenColors.neutralUI300};
-  border-radius: 999px;
-  padding: 6px 10px;
-  color: ${DesignTokenColors.neutralUI800};
-  cursor: pointer;
-  &:hover {
-    background: ${DesignTokenColors.neutralUI100};
-  }
+const MenuDivider = styled.div`
+  height: 1px;
+  background: ${DesignTokenColors.neutralUI200};
+  margin: 6px;
+  border-radius: 1px;
 `;
 
-const FooterBar = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 10px;
-  padding: 10px 14px;
-  border-top: 1px solid ${DesignTokenColors.neutralUI200};
-  color: ${DesignTokenColors.neutralUI700};
-  font-size: 14px;
-`;
-
-const FooterButtons = styled.div`
-  display: inline-flex;
-  gap: 8px;
-`;
-
-const SmallBtn = styled.button`
-  background: ${DesignTokenColors.whiteUI};
-  color: ${DesignTokenColors.neutralUI900};
-  border: 1px solid ${DesignTokenColors.neutralUI300};
-  border-radius: 999px;
-  padding: 6px 10px;
-  cursor: pointer;
-  &:hover {
-    background: ${DesignTokenColors.neutralUI50};
-  }
-`;
-
-const OverflowBtn = styled.button`
-  background: transparent;
-  border: 0;
-  padding: 6px;
-  border-radius: 8px;
-  color: ${DesignTokenColors.neutralUI700};
-  cursor: pointer;
-  &:hover {
-    background: ${DesignTokenColors.neutralUI50};
-    color: ${DesignTokenColors.neutralUI900};
-  }
-`;
-const OverflowWrap = styled.div`
+const TooltipWrap = styled.div`
   position: relative;
 `;
 
-const MenuCard = styled.div`
+const TooltipBubble = styled.div`
   position: absolute;
-  right: 0;
-  top: calc(100% + 6px);
-  background: ${DesignTokenColors.whiteUI};
-  border: 1px solid ${DesignTokenColors.neutralUI200};
-  border-radius: 10px;
-  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.08);
-  min-width: 220px;
-  padding: 6px;
-  z-index: 10;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  background: #111827;
+  color: white;
+  font-size: 12px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  white-space: nowrap;
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.14);
+  opacity: 0;
+  pointer-events: none;
+
+  ${TooltipWrap}:hover & {
+    opacity: 1;
+  }
 `;
 
-const MenuItem = styled.button`
-  display: flex;
+const TopBarLeft = styled.div`
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  width: 100%;
-  background: transparent;
-  border: 0;
-  border-radius: 8px;
-  color: ${DesignTokenColors.neutralUI900};
-  padding: 8px 10px;
-  text-align: left;
-  &:hover {
-    background: ${DesignTokenColors.neutralUI50};
-  }
-  &:disabled {
-    color: ${DesignTokenColors.neutralUI500};
-    cursor: not-allowed;
-  }
+  gap: 12px;
+`;
+
+const TopDivider = styled.span`
+  width: 1px;
+  height: 20px;
+  background: ${DesignTokenColors.neutralUI200};
+  display: inline-block;
 `;


### PR DESCRIPTION
1) Move search next to “Imported voters (not invited)” with a thin divider. 
2)  Remove search field chrome/placeholder; align icon & input baselines (-3px).
3) Align table headers (Name/Email/Phone) with data columns; left-align where appropriate. 
4) Grid tune: 34px 34px minmax(160px,1.2fr) minmax(260px,1.4fr) minmax(120px,0.9fr) auto. 
5) Prevent horizontal blow-out on long name/email:- cells use min-width:0, text-overflow: ellipsis, no-wrap 
6) Table container allows horizontal scroll as fallback (overflow-x:auto). 
7) Show full values via title tooltips on hover. 
8) Add 3-dot overflow menu (Show hidden, View history of imports; Hide/Delete enabled only with selection + helper tooltip). 9) Accessibility: roles/aria-labels on table, buttons, and search; label wraps checkbox. 
10) Code style: fix indentation/closing-bracket locations to satisfy eslint.
11) long emails no longer expand the card; headers line up with cells; search sits on the same row as the title per spec.

