### PR TITLE
[WV-2157] Fix: Hide endorsement tooltip for candidates with zero endorsements

### DIFF
--- a/src/js/components/Ballot/PositionRowListCompressed.jsx
+++ b/src/js/components/Ballot/PositionRowListCompressed.jsx
@@ -396,7 +396,7 @@ class PositionRowListCompressed extends Component {
     let filteredPositionListTooltip = <></>;
     let onePositionNameCount = 1;
     const displayedSpeakerNames = new Set();
-    if (filteredPositionList) {
+    if (filteredPositionList && filteredPositionList.length > 0) {
       filteredPositionListTooltip = isMobileScreenSize() ? (<></>) : (
         <Tooltipstyle className="u-z-index-9020" id="filteredPositionListTooltip">
           <div>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixes WV-2157

### Changes included this pull request?
* Fixed bug where endorsement tooltip appeared on candidates with 0 endorsements
* Updated condition in `PositionRowListCompressed.jsx` to check `filteredPositionList.length > 0` instead of just checking if array exists

### Testing
* Tested on localhost with candidates that have 0 endorsements → tooltip no longer appears
* Tested with candidates that have 1+ endorsements → tooltip still appears correctly
