### PR TITLE
WV-2267-Change-social-mediaicons-colo-rand-remove-wordpress-icon-in-f…

### DIFF
--- a/src/js/common/components/Widgets/ToolBar.jsx
+++ b/src/js/common/components/Widgets/ToolBar.jsx
@@ -11,14 +11,14 @@ import normalizedImagePath from '../../utils/normalizedImagePath';
 
 const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ './OpenExternalWebSite'));
 
+function ToolBar(params) {
+  renderLog('ToolBar');
 
-function ToolBar (params) {
-  renderLog('ToolBar');  // Set LOG_RENDER_EVENTS to log all renders
-  // const { classes } = this.params;
-  const hideGitHub = params.hideGitHub ? params.hideGitHub : false;
+  const color = params.color || 'white';
+  const hideGitHub = params.hideGitHub || false;
+  const showBlog = params.showBlog !== false;
 
   if (isCordova()) {
-    // Turning off this display for the Cordova app
     return null;
   }
 
@@ -36,7 +36,7 @@ function ToolBar (params) {
             body={(
               <Tooltip title="TikTok">
                 <IconButton size="large">
-                  <TikTokStyled />
+                  <TikTokStyled color={color} />
                 </IconButton>
               </Tooltip>
             )}
@@ -54,7 +54,7 @@ function ToolBar (params) {
             body={(
               <Tooltip title="X / Twitter">
                 <IconButton size="large">
-                  <TwitterStyled />
+                  <TwitterStyled sx={{ color }} />
                 </IconButton>
               </Tooltip>
             )}
@@ -72,7 +72,7 @@ function ToolBar (params) {
             body={(
               <Tooltip title="Facebook">
                 <IconButton size="large">
-                  <FacebookStyled />
+                  <FacebookStyled sx={{ color }} />
                 </IconButton>
               </Tooltip>
             )}
@@ -90,7 +90,7 @@ function ToolBar (params) {
             body={(
               <Tooltip title="Instagram">
                 <IconButton size="large">
-                  <InstagramStyled />
+                  <InstagramStyled sx={{ color }} />
                 </IconButton>
               </Tooltip>
             )}
@@ -108,7 +108,7 @@ function ToolBar (params) {
             body={(
               <Tooltip title="Newsletter">
                 <IconButton size="large">
-                  <MailStyled />
+                  <MailStyled sx={{ color }} />
                 </IconButton>
               </Tooltip>
             )}
@@ -127,35 +127,38 @@ function ToolBar (params) {
               body={isMobileScreenSize() ? (<></>) : (
                 <Tooltip title="Github">
                   <IconButton size="large">
-                    <GitHubStyled />
+                    <GitHubStyled sx={{ color }} />
                   </IconButton>
                 </Tooltip>
               )}
             />
           </Suspense>
         )}
-        <Suspense fallback={<></>}>
-          <OpenExternalWebSite
-            linkIdAttribute="weVoteBlog"
-            className="u-no-underline"
-            url="https://blog.wevote.us/"
-            target="_blank"
-            trackingOn
-            ariaLabel="Blog"
-            body={(
-              <Tooltip title="Blog">
-                <IconButton size="large">
-                  <img src={normalizedImagePath('/img/global/svg-icons/wordpress-logo.svg')}
-                       width={24}
-                       height={24}
-                       color="white"
-                       alt="Wordpress"
-                  />
-                </IconButton>
-              </Tooltip>
-            )}
-          />
-        </Suspense>
+
+        {showBlog && (
+          <Suspense fallback={<></>}>
+            <OpenExternalWebSite
+              linkIdAttribute="weVoteBlog"
+              className="u-no-underline"
+              url="https://blog.wevote.us/"
+              target="_blank"
+              trackingOn
+              ariaLabel="Blog"
+              body={(
+                <Tooltip title="Blog">
+                  <IconButton size="large">
+                    <img
+                      src={normalizedImagePath('/img/global/svg-icons/wordpress-logo.svg')}
+                      width={24}
+                      height={24}
+                      alt="Wordpress"
+                    />
+                  </IconButton>
+                </Tooltip>
+              )}
+            />
+          </Suspense>
+        )}
       </ToolBarContainer>
     </div>
   );
@@ -183,19 +186,19 @@ const styles = (theme) => ({
   },
 });
 
-const TwitterStyled = muiStyled(Twitter)({ color: 'white' });
-const GitHubStyled = muiStyled(GitHub)({ color: 'white' });
-const FacebookStyled = muiStyled(Facebook)({ color: 'white' });
-const InstagramStyled = muiStyled(Instagram)({ color: 'white' });
-const MailStyled = muiStyled(Mail)({ color: 'white' });
+const TwitterStyled = muiStyled(Twitter)({});
+const GitHubStyled = muiStyled(GitHub)({});
+const FacebookStyled = muiStyled(Facebook)({});
+const InstagramStyled = muiStyled(Instagram)({});
+const MailStyled = muiStyled(Mail)({});
 
 const TikTokStyled = ({ color = 'white' }) => (
   <svg
-      fill={color}
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 50 50"
-      width="24"
-      height="24"
+    fill={color}
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 50 50"
+    width="24"
+    height="24"
   >
     <path d="M41,4H9C6.243,4,4,6.243,4,9v32c0,2.757,2.243,5,5,5h32c2.757,0,5-2.243,5-5V9C46,6.243,43.757,4,41,4z M37.006,22.323 c-0.227,0.021-0.457,0.035-0.69,0.035c-2.623,0-4.928-1.349-6.269-3.388c0,5.349,0,11.435,0,11.537c0,4.709-3.818,8.527-8.527,8.527 s-8.527-3.818-8.527-8.527s3.818-8.527,8.527-8.527c0.178,0,0.352,0.016,0.527,0.027v4.202c-0.175-0.021-0.347-0.053-0.527-0.053 c-2.404,0-4.352,1.948-4.352,4.352s1.948,4.352,4.352,4.352s4.527-1.894,4.527-4.298c0-0.095,0.042-19.594,0.042-19.594h4.016 c0.378,3.591,3.277,6.425,6.901,6.685V22.323z" />
   </svg>

--- a/src/js/components/Navigation/FooterMainWeVote.jsx
+++ b/src/js/components/Navigation/FooterMainWeVote.jsx
@@ -255,11 +255,10 @@ class FooterMainWeVote extends Component {
               <OneRow>
                 <div
                   style={{
-                    backgroundColor: '#b4c6ebff',
                     paddingTop: 20,
                   }}
                 >
-                  <ToolBar />
+                  <ToolBar color="#716e6eff" showBlog={false}/>
                 </div>
               </OneRow>
             )}


### PR DESCRIPTION
…ooter-of-the-landing-page

### What github.com/wevote/WebApp/issues does this fix?

- Change social media icon colors.
- Hiding wordpress icon because it lands on wevote blog page and we already added blog link in footer.

### Changes included this pull request?
**What’s changed**  
- Add new optional `color` prop to `ToolBar` to allow custom icon color (default remains white)  
- Apply `color` to all icons (MUI + SVG) via `sx` or `fill`  
- Add `showBlog` prop to conditionally hide the WordPress/blog icon  
- Default behavior: `showBlog` is `true` (blog icon still shown unless explicitly hidden)  

**Why it matters**  
- Allows `ToolBar` to be reused in different places (e.g. header, footer) with different styling  
- Reduces need for multiple “Toolbar variants” — more flexible via props  
- Keeps implementation simple and minimal — no duplication of toolbar components  

 Testing Notes

- [ ] Passing a custom `color` (example: `#716e6eff`) changes all the toolbar icons correctly  
- [ ] `showBlog={false}` successfully hides the WordPress / blog icon  
- [ ] Default behavior (no props) preserves original state (white icons, blog icon visible)  

---

Impact & Backwards Compatibility

- **Backward compatible**: existing usage of `ToolBar` without any new props still works unchanged  
- **No breaking changes**: props are optional 
