### PR TITLE
More menu in Cordova Tablet now matches the one for Phone.

### DIFF
--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -579,14 +579,16 @@ class HeaderBar extends Component {
                       Friends
                     </StyledMoreMenuItem>
 
-                    <StyledMoreMenuItem
-                      id="discussTabHeaderBar"
-                      selected={normalizedHrefPage() === 'news'}
-                      onClick={this.navTo('/news', 99)}
-                      disableRipple
-                    >
-                      Discuss
-                    </StyledMoreMenuItem>
+                    {isWebApp() && (  // Not in Cordova release 2.7.4 phones or tablets
+                      <StyledMoreMenuItem
+                        id="discussTabHeaderBar"
+                        selected={normalizedHrefPage() === 'news'}
+                        onClick={this.navTo('/news', 99)}
+                        disableRipple
+                      >
+                        Discuss
+                      </StyledMoreMenuItem>
+                    )}
 
                     {nextReleaseFeaturesEnabled && (
                       <StyledMoreMenuItem
@@ -610,19 +612,21 @@ class HeaderBar extends Component {
                       </StyledMoreMenuItem>
                     )}
 
-                    <Suspense fallback={<></>}>
-                      <StyledMoreMenuItem>
-                        <OpenExternalWebSite
-                          linkIdAttribute="footerLinkBlog"
-                          url="https://blog.wevote.us/"
-                          target="_blank"
-                          body={(
-                            <span>Blog</span>
-                          )}
-                          className={classes.tabRootBlog}
-                        />
-                      </StyledMoreMenuItem>
-                    </Suspense>
+                    {isWebApp() && (      // Not in Cordova release 2.7.4 phones or tablets
+                      <Suspense fallback={<></>}>
+                        <StyledMoreMenuItem>
+                          <OpenExternalWebSite
+                            linkIdAttribute="footerLinkBlog"
+                            url="https://blog.wevote.us/"
+                            target="_blank"
+                            body={(
+                              <span>Blog</span>
+                            )}
+                            className={classes.tabRootBlog}
+                          />
+                        </StyledMoreMenuItem>
+                      </Suspense>
+                    )}
                   </StyledMoreMenu>
                 </>
               )}

--- a/src/js/components/Widgets/GoogleAutoComplete.jsx
+++ b/src/js/components/Widgets/GoogleAutoComplete.jsx
@@ -13,8 +13,6 @@ import $ajax from '../../utils/service';
 import GoogleSelectMenuReplica from './GoogleSelectMenuReplica';
 
 /*
-GoogleAutoComplete does not work on the iOS simulators, but does work on a usb tethered physical phone
-
 Google cloud console http referrers (Website)
 https://console.cloud.google.com/apis/credentials/key/db...45?inv=1&invt=Ab27OA&project=wevoteapps
 (If you turn them off temporarily, the list is erased, so here it is...)
@@ -24,20 +22,12 @@ https://console.cloud.google.com/apis/credentials/key/db...45?inv=1&invt=Ab27OA&
 // https://*.wevote.us/
 // https://wevotedeveloper.com:3000
 
-/*
-August 24, 2025: Google Places/Maps disabled in Cordova by not setting a value for GOOGLE_MAPS_API_KEY in config.js
-July 2025: http referrers are not going to work for Cordova anymore
-   https://github.com/apache/cordova/discussions/560
-   And setting
-       <preference name="hostname" value="wevote.us" />
-       <preference name="scheme" value="https" />
-   in Cordova, had no effect. Google still replied with a console error:
-       ERROR: Google Maps JavaScript API error: RefererNotAllowedMapError
-       https://developers.google.com/maps/documentation/javascript/error-messages#referer-not-allowed-map-error
-       Your site URL to be authorized: app://localhost/index.html
-*/
 
-
+// November 2025:  WebApp uses AutoComplete (react-google-autocomplete) which in turn uses the deprecated
+// "google.maps.places.AutocompleteService" -- Google says "As of March 1st, 2025, google.maps.places.AutocompleteService is not available to new customers."
+// See  https://github.com/ErrorPro/react-google-autocomplete/issues/246
+// Our Cordova uses <GoogleSelectMenuReplica>, a "roll your own" implementation that does the search from the Python server, this
+// allows us to use and API key that is hidden from the world which was not possible in a WebView within Cordova.
 function GoogleAutoComplete (props) {
   renderLog('GoogleAutoComplete  functional component');
   const { id, classes, updateTextForMapSearchInParentFromGoogle, updateTextForMapSearchInParent } = props;


### PR DESCRIPTION
Was unable to release 2.7.3 from testflight, so I had to rebuild.
For cordova release 2.7.4, Hid the late breaking additions that had not been tested for this release.