### PR TITLE
[WV-2242] Add auto-focus to Invite Friends email input

### DIFF
--- a/src/js/components/Friends/AddFriendsByEmail.jsx
+++ b/src/js/components/Friends/AddFriendsByEmail.jsx
@@ -38,6 +38,7 @@ class AddFriendsByEmail extends Component {
       senderEmailAddressError: false,
       voterIsSignedIn: false,
     };
+    this.emailInputRef = React.createRef();
   }
 
   componentDidMount () {
@@ -52,6 +53,9 @@ class AddFriendsByEmail extends Component {
     if (apiCalming('friendListsAll', 30000)) {
       FriendActions.friendListsAll();
       FriendActions.friendListInvitationsWaitingForVerification();
+    }
+    if (this.emailInputRef.current) {
+      this.emailInputRef.current.focus();
     }
   }
 
@@ -318,6 +322,7 @@ class AddFriendsByEmail extends Component {
                       <TextField
                         classes={{ root: classes.textField }}
                         id={uniqueExternalId ? `EmailAddress-${uniqueExternalId}` : 'EmailAddress'}
+                        inputRef={this.emailInputRef}
                         label="Enter email addresses of friends"
                         margin="dense"
                         maxRows={3}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixes WV-2242

### Changes included this pull request?
- Added auto-focus to email input on Invite Friends page
- Created ref in constructor using React.createRef()
- Attached ref to TextField using inputRef prop
- Added focus logic in componentDidMount()

### Testing
- Tested on localhost → cursor automatically appears in input field
- User can start typing immediately without clicking
