### PR TITLE
GoogleAutoComplete working again in WebApp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@storybook/addon-actions": "^7.6.20",
         "@stripe/react-stripe-js": "^1.3.0",
         "@stripe/stripe-js": "^1.13.0",
+        "@vis.gl/react-google-maps": "^1.7.1",
         "classnames": "^2.3.1",
         "clsx": "^1.1.1",
         "d3-geo": "^2.0.1",
@@ -212,6 +213,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2076,6 +2078,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2118,6 +2121,7 @@
       "version": "11.14.0",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.0.tgz",
       "integrity": "sha512-XxfOnXFffatap2IyCeJyNov3kiDQWoR08gPUQxvbL7fxKryGBKUZUkG6Hz48DZwVrJSVh9sJboyV1Ds4OW6SgA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -4135,6 +4139,7 @@
       "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.16.14.tgz",
       "integrity": "sha512-heL4S+EawrP61xMXBm59QH6HODsu0gxtZi5JtnXF2r+rghzyU/3Uftlt1ij8rmJh+cFdKTQug1L9KkZB5JgpMQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9"
       },
@@ -4210,6 +4215,7 @@
       "version": "5.17.1",
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.17.1.tgz",
       "integrity": "sha512-2B33kQf+GmPnrvXXweWAx+crbiUEsxCdCN979QDYnlH9ox4pd+0/IBriWLV+l6ORoBF60w39cWjFnJYGFdzXcw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.17.1",
@@ -10227,7 +10233,8 @@
       "version": "1.54.2",
       "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.54.2.tgz",
       "integrity": "sha512-R1PwtDvUfs99cAjfuQ/WpwJ3c92+DAMy9xGApjqlWQMj0FKQabUAys2swfTRNzuYAYJh7NqK2dzcYVNkKLEKUg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@swc/core": {
       "version": "1.12.1",
@@ -10236,6 +10243,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.23"
@@ -10894,6 +10902,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/google.maps": {
+      "version": "3.58.1",
+      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
+      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
@@ -11012,13 +11026,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.7.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.7.tgz",
-      "integrity": "sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==",
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -11086,6 +11100,7 @@
       "version": "17.0.83",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.83.tgz",
       "integrity": "sha512-l0m4ArKJvmFtR4e8UmKrj1pB4tUgOhJITf+mADyF/p69Ts1YAR/E+G9XEM0mHXKVRa1dQNHseyyDNzeuAXfXQw==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "^0.16",
@@ -11426,6 +11441,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vis.gl/react-google-maps": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@vis.gl/react-google-maps/-/react-google-maps-1.7.1.tgz",
+      "integrity": "sha512-F/GJzJyri7Jqf+bkLNxoi2RcH2hCIo1I3//PyiILqQzdzglMoqZVO1DLXlHPifNdebk1/zib6dMJA3i73nwmuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/google.maps": "^3.54.10",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": ">=16.8.0 || ^19.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "0.34.7",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.7.tgz",
@@ -11595,6 +11624,7 @@
       "resolved": "https://registry.npmjs.org/@wdio/cli/-/cli-9.20.0.tgz",
       "integrity": "sha512-dGkZFp09aIyoN6HlJah7zJApG/FzN0O/HaTfTkWrOM5GBli9th/9VIfbsT3vx4I9mBdETiYPmgfl4LqDP2p0VQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^2.1.1",
         "@wdio/config": "9.20.0",
@@ -12014,6 +12044,16 @@
         "node": "^16.13 || >=18"
       }
     },
+    "node_modules/@wdio/spec-reporter/node_modules/@types/node": {
+      "version": "22.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.1.tgz",
+      "integrity": "sha512-LCCV0HdSZZZb34qifBsyWlUmok6W7ouER+oQIGBScS8EsZsQbrtFTUrDX4hOl+CS6p7cnNC4td+qrSVGSCTUfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@wdio/spec-reporter/node_modules/@wdio/logger": {
       "version": "8.38.0",
       "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-8.38.0.tgz",
@@ -12102,6 +12142,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@wdio/spec-reporter/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@wdio/types": {
       "version": "9.20.0",
@@ -12504,6 +12551,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12586,6 +12634,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -13908,16 +13957,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/browserify-zlib": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pako": "~0.2.0"
-      }
-    },
     "node_modules/browserslist": {
       "version": "4.25.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
@@ -13937,6 +13976,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -14075,6 +14115,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -15892,7 +15949,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
       "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-timer": {
       "version": "3.0.1",
@@ -16622,7 +16680,8 @@
       "version": "0.0.1312386",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1312386.tgz",
       "integrity": "sha512-DPnhUXvmvKT2dFA/j7B+riVLUt9Q6RKJlcppojL5CoRywJJKLDYnRlw0gTFKfgDPHP5E04UoB71SxoJlVZy8FA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff": {
       "version": "8.0.2",
@@ -16816,6 +16875,20 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/duplexer": {
@@ -17280,13 +17353,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       }
@@ -17355,10 +17425,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
-      "dev": true,
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -17417,6 +17486,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -17534,6 +17604,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -17683,6 +17754,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -17740,6 +17812,7 @@
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -17771,6 +17844,7 @@
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -17804,6 +17878,7 @@
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -17972,6 +18047,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -18440,6 +18516,7 @@
       "resolved": "https://registry.npmjs.org/expect-webdriverio/-/expect-webdriverio-5.4.3.tgz",
       "integrity": "sha512-/XxRRR90gNSuNf++w1jOQjhC5LE9Ixf/iAQctVb/miEI3dwzPZTuG27/omoh5REfSLDoPXofM84vAH/ULtz35g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/snapshot": "^3.2.4",
         "deep-eql": "^5.0.2",
@@ -18795,7 +18872,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -19066,6 +19142,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -19492,13 +19569,19 @@
       }
     },
     "node_modules/for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-callable": "^1.1.3"
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/foreground-child": {
@@ -19553,6 +19636,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -20114,16 +20198,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -20172,6 +20261,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -20506,12 +20608,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -20559,6 +20661,23 @@
       "bin": {
         "gunzip-maybe": "bin.js"
       }
+    },
+    "node_modules/gunzip-maybe/node_modules/browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pako": "~0.2.0"
+      }
+    },
+    "node_modules/gunzip-maybe/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -20650,6 +20769,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
       "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -20659,9 +20779,9 @@
       }
     },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -22000,13 +22120,13 @@
       }
     },
     "node_modules/is-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
-      "integrity": "sha512-uZ25/bUAlUY5fR4OKT4rZQEBrzQWYV9ZJYGGsUmEJ6thodVJ1HX64ePQ6Z0qPWP+m+Uq6e9UugrE38jeYsDSMw==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "which-typed-array": "^1.1.14"
+        "which-typed-array": "^1.1.16"
       },
       "engines": {
         "node": ">= 0.4"
@@ -23363,13 +23483,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jszip/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true,
-      "license": "(MIT AND Zlib)"
-    },
     "node_modules/jszip/node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -24050,6 +24163,15 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-definitions": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-4.0.0.tgz",
@@ -24640,6 +24762,7 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -25500,11 +25623,11 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
-      "license": "MIT"
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -26079,6 +26202,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -26869,6 +26993,7 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -27293,6 +27418,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -27414,6 +27540,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -27599,7 +27726,8 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-lifecycles-compat": {
       "version": "3.0.4",
@@ -27645,6 +27773,7 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -27732,6 +27861,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
       "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -30174,6 +30304,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
       "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -31241,7 +31372,8 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
       "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -31712,6 +31844,7 @@
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
+      "peer": true,
       "engines": {
         "node": ">=12.20"
       },
@@ -31735,15 +31868,15 @@
       }
     },
     "node_modules/typed-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bound": "^1.0.3",
         "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.13"
+        "is-typed-array": "^1.1.14"
       },
       "engines": {
         "node": ">= 0.4"
@@ -31930,9 +32063,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -32274,12 +32407,6 @@
       "dependencies": {
         "pako": "^1.0.11"
       }
-    },
-    "node_modules/utif2/node_modules/pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -32675,6 +32802,7 @@
       "integrity": "sha512-7b0dTKR3Ed//AD/6kkx/o7duS8H3f1a4w3BYpIriX4BzIhjkn4teo05cptsxvLesHFKK5KObnadmCHBwGc+51A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -32911,6 +33039,7 @@
       "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.13",
         "@types/connect-history-api-fallback": "^1.5.4",
@@ -33686,16 +33815,18 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.15.tgz",
-      "integrity": "sha512-oV0jmFtUky6CXfkqehVvBP/LSWJ2sy4vWMioiENyJLePrBO/yKyV9OyJySfAKosh+RYkIl5zJCNZ8/4JncrpdA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "@storybook/addon-actions": "^7.6.20",
     "@stripe/react-stripe-js": "^1.3.0",
     "@stripe/stripe-js": "^1.13.0",
+    "@vis.gl/react-google-maps": "^1.7.1",
     "classnames": "^2.3.1",
     "clsx": "^1.1.1",
     "d3-geo": "^2.0.1",

--- a/src/js/common/components/CampaignSupport/PayToPromoteProcessCordova.jsx
+++ b/src/js/common/components/CampaignSupport/PayToPromoteProcessCordova.jsx
@@ -12,9 +12,9 @@ class PayToPromoteProcess extends Component {
   }
 }
 PayToPromoteProcess.propTypes = {
-  campaignXWeVoteId: PropTypes.string,
-  chipInPaymentValueDefault: PropTypes.string,
-  classes: PropTypes.object,
-  lowerDonations: PropTypes.bool,
+  // campaignXWeVoteId: PropTypes.string,
+  // chipInPaymentValueDefault: PropTypes.string,
+  // classes: PropTypes.object,
+  // lowerDonations: PropTypes.bool,
 };
 export default PayToPromoteProcess;

--- a/src/js/common/utils/cordovaUtils.js
+++ b/src/js/common/utils/cordovaUtils.js
@@ -147,19 +147,20 @@ export function getThisAppleDeviceParameters () {
   // console.log('at thisAppleDeviceParameters window.device?.model: ', window.device?.model);
   if (window.device?.model) {
     thisAppleDeviceParameters = jsonModelsData.find((leaf) => leaf.modelId === window.device.model);
-    logMatch('Cordova:   getThisAppleDeviceParameters: ', JSON.stringify(thisAppleDeviceParameters));
-    console.log(`Cordova:   getThisAppleDeviceParameters (%c${thisAppleDeviceParameters.name}%c): ${JSON.stringify(thisAppleDeviceParameters)}`, 'font-weight: bold;', 'font-weight: 400;');
-    if (thisAppleDeviceParameters) return thisAppleDeviceParameters;
+    if (thisAppleDeviceParameters) {
+      logMatch('Cordova:   getThisAppleDeviceParameters: ', JSON.stringify(thisAppleDeviceParameters));
+      console.log(`Cordova:   getThisAppleDeviceParameters (%c${thisAppleDeviceParameters.name}%c): ${JSON.stringify(thisAppleDeviceParameters)}`, 'font-weight: bold;', 'font-weight: 400;');
+      return thisAppleDeviceParameters;
+    }
   }
-  console.log('Cordova:  Possible first-day device model -- Default (and wrong) values used.');
-  return {   // Default, usually wrong data, to avoid crash before device ready in Cordova, or to handle unknown new device
-    class: 'iPhone6p5in',
-    size: 6.9,
-    type: 'phone',
-    marketingNumber: 'unknown',
-    name: 'Unknown device, or if Cordova, deviceready has not fired',
-    modelId: 'iPhone18,2',
-  };
+  console.error('Cordova:  Possible first-day device model -- Default (and wrong) values used.');
+  // Default, usually wrong data, to avoid crash before device ready in Cordova, or to handle unknown new device
+  if (window.device?.model && window.device.model.startsWith('iPad')) {
+    thisAppleDeviceParameters = jsonModelsData.find((leaf) => leaf.modelId === 'iPad16,4');
+  } else {
+    thisAppleDeviceParameters = jsonModelsData.find((leaf) => leaf.modelId === 'iPhone18,4');
+  }
+  return thisAppleDeviceParameters;
 }
 
 export function getIOSSizeString () {

--- a/src/js/common/utils/iPhoneModels.json
+++ b/src/js/common/utils/iPhoneModels.json
@@ -1366,5 +1366,23 @@
     "marketingNumber": "M4",
     "name": "iPad Pro M4",
     "modelId": "iPad16,6"
+  },
+  {
+    "class": "iPad13in",
+    "size": 13,
+    "iOSSpacer": 26,
+    "type": "ipad",
+    "marketingNumber": "M5",
+    "name": "iPad Pro M5",
+    "modelId": "iPad17,3"
+  },
+  {
+    "class": "iPad13in",
+    "size": 13,
+    "iOSSpacer": 26,
+    "type": "ipad",
+    "marketingNumber": "M5",
+    "name": "iPad Pro M5",
+    "modelId": "iPad17,4"
   }
 ]

--- a/src/js/common/utils/iPhoneModels.txt
+++ b/src/js/common/utils/iPhoneModels.txt
@@ -162,5 +162,7 @@ iPad11in;11.0;26;ipad;M4;iPad Pro M4;iPad16,3
 iPad11in;11.0;26;ipad;M4;iPad Pro M4;iPad16,4
 iPad13in;13.0;26;ipad;M4;iPad Pro M4;iPad16,5
 iPad13in;13.0;26;ipad;M4;iPad Pro M4;iPad16,6
+iPad13in;13.0;26;ipad;M5;iPad Pro M5;iPad17,3
+iPad13in;13.0;26;ipad;M5;iPad Pro M5;iPad17,4
 
 

--- a/src/js/components/Ballot/MeasureStickyHeader.jsx
+++ b/src/js/components/Ballot/MeasureStickyHeader.jsx
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
 import styled from 'styled-components';
 import standardBoxShadow from '../../common/components/Style/standardBoxShadow';
-import { isIOSAppOnMac, isIPad } from '../../common/utils/cordovaUtils';
+import { isIOSAppOnMac, isIPad, isIPadMini } from '../../common/utils/cordovaUtils';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import MeasureStore from '../../stores/MeasureStore';
 import { cordovaStickyHeaderPaddingTop } from '../../utils/cordovaOffsets';
-import { getTopOffsetDueToHeadroomWrapper } from '../Style/pageLayoutStyles';
 
 const ReadMore = React.lazy(() => import(/* webpackChunkName: 'ReadMore' */ '../../common/components/Widgets/ReadMore'));
 const BallotItemSupportOpposeComment = React.lazy(() => import(/* webpackChunkName: 'BallotItemSupportOpposeComment' */ '../Widgets/BallotItemSupportOpposeComment'));
@@ -107,11 +106,9 @@ const MeasureStickyHeaderWrapper = styled('div')(({ theme }) => (`
   ${isWebApp() ? 'margin-top: 47px;' : ''}
   max-width: 100%;
   position: fixed;
-  padding-right: 16px;
-  padding-bottom: 8px;
   padding-left: 16px;
-  padding-bottom: ${getTopOffsetDueToHeadroomWrapper()}
-  padding-top: ${getTopOffsetDueToHeadroomWrapper()}
+  padding-right: 16px;
+  padding-bottom: ${isIPadMini() ? '16px' : '8px'};
   top: ${cordovaStickyHeaderPaddingTop()};
   width: 100vw;
   z-index: 2;

--- a/src/js/components/Navigation/HeaderBackTo.jsx
+++ b/src/js/components/Navigation/HeaderBackTo.jsx
@@ -172,11 +172,13 @@ class HeaderBackTo extends Component {
   }
 
   goToSettings () {
-    if (isMobileScreenSize()) {
-      historyPush('/settings/hamburger');
-    } else {
-      historyPush('/settings/profile');
-    }
+    console.log('goToSettings IN HeaderBackTo historyPush');
+    AppObservableStore.setDrawerOpen('headerProfileDrawerOpen', true);   // 11/20/25 Strongly suspect that this is right, and what follows is wrong
+    // if (isMobileScreenSize()) {
+    //   historyPush('/settings/hamburger');
+    // } else {
+    //   historyPush('/settings/profile');
+    // }
   }
 
   closeSignInModal () {

--- a/src/js/components/Navigation/HeaderBackToBallot.jsx
+++ b/src/js/components/Navigation/HeaderBackToBallot.jsx
@@ -588,11 +588,8 @@ class HeaderBackToBallot extends Component {
   }
 
   goToSettings () {
-    if (isMobileScreenSize()) {
-      historyPush('/settings/hamburger');
-    } else {
-      historyPush('/settings/profile');
-    }
+    console.log('goToSettings IN HeaderBackToBallot historyPush');
+    AppObservableStore.setDrawerOpen('headerProfileDrawerOpen', true);
   }
 
   toggleSignInModal () {

--- a/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
+++ b/src/js/components/Navigation/HeaderBackToVoterGuides.jsx
@@ -187,11 +187,13 @@ class HeaderBackToVoterGuides extends Component {
   }
 
   goToSettings () {
-    if (isMobileScreenSize()) {
-      historyPush('/settings/hamburger');
-    } else {
-      historyPush('/settings/general');
-    }
+    console.log('goToSettings IN HeaderBackToVoterGuides historyPush');
+    AppObservableStore.setDrawerOpen('headerProfileDrawerOpen', true);   // 11/20/25 Strongly suspect that this is right, and what follows is wrong
+    // if (isMobileScreenSize()) {
+    //   historyPush('/settings/hamburger');
+    // } else {
+    //   historyPush('/settings/general');
+    // }
   }
 
   transitionToYourVoterGuide () {
@@ -257,7 +259,7 @@ class HeaderBackToVoterGuides extends Component {
     const electionName = BallotStore.currentBallotElectionName;
     // const atLeastOnePositionFoundForThisElection = positionListForOneElection && positionListForOneElection.length !== 0;
 
-    const changeElectionButtonHtml = isMobileScreenSize() ? (<></>) : (
+    const changeElectionButtonHtml = isMobileScreenSize() && isWebApp() ? (<></>) : (
       <Tooltip title="Change Election" aria-label="Change Election" classes={{ tooltipPlacementBottom: classes.tooltipPlacementBottom }}>
         <span>
           <IconButton

--- a/src/js/components/Navigation/HeaderBar.jsx
+++ b/src/js/components/Navigation/HeaderBar.jsx
@@ -414,12 +414,8 @@ class HeaderBar extends Component {
   }
 
   goToSettings () {
+    console.log('goToSettings IN HeaderBar setDrawerOpen');
     AppObservableStore.setDrawerOpen('headerProfileDrawerOpen', true);
-    // if (isMobileScreenSize()) {
-    //   historyPush('/settings/hamburger');
-    // } else {
-    //   historyPush('/settings/profile');
-    // }
   }
 
   toggleSignInModal () {

--- a/src/js/components/SetUpAccount/AddContactsFromGoogleButton.jsx
+++ b/src/js/components/SetUpAccount/AddContactsFromGoogleButton.jsx
@@ -117,6 +117,8 @@ class AddContactsFromGoogleButton extends Component {
     const { gapi } = window;
     // 2022-06-23 We always want to give the voter a chance to choose another account to import from
     try {
+      const gapiTest = gapi.auth2.getAuthInstance();
+      console.log('after gapiTest', gapiTest);
       const isSignedIn = gapi.auth2.getAuthInstance().isSignedIn.get();
       // console.log('onButtonClickWebApp isSignedIn:', isSignedIn);
       if (isSignedIn) {

--- a/src/js/components/Style/BallotTitleHeaderStyles.jsx
+++ b/src/js/components/Style/BallotTitleHeaderStyles.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import colors from '../../common/components/Style/Colors';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
-import { isIOs6p1OrSmaller, isIOSAppOnMac, isIPadGiantSize, isIPhoneSmall } from '../../common/utils/cordovaUtils';
+import { isIOs6p1OrSmaller, isIOSAppOnMac, isIPad, isIPadGiantSize, isIPhoneSmall } from '../../common/utils/cordovaUtils';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import showBallotDecisionsTabs from '../../utilsApi/showBallotDecisionsTabs'; // 2024-04-16 Upgrade to using this
@@ -152,6 +152,8 @@ export function ballotWrapperBodyStyles () {
 
   if (showBallotDecisionsTabs()) {
     styles.paddingTop = '36px';
+  } else if (isIPad()) {
+    styles.paddingTop = '10px';
   } else if (isWebApp() || twoColumnDisplay) {
     styles.paddingTop = '105px';
   } else {

--- a/src/js/components/Style/pageLayoutStyles.js
+++ b/src/js/components/Style/pageLayoutStyles.js
@@ -10,8 +10,8 @@ import { cordovaOffsetLog } from '../../common/utils/logging';
 import CordovaPageConstants from '../../constants/CordovaPageConstants';
 import { cordovaFullyCalculatedHeaderContainerTopOffset, offsetToBottomOfHeadroomWrapper } from '../../utils/cordovaCalculatedOffsets';
 import { cordovaBallotFilterTopMargin } from '../../utils/cordovaOffsets';
-import scrollablePaneTopPaddingWebApp from '../../utils/scrollablePaneTopPaddingWebApp';
 import { pageEnumeration } from '../../utils/cordovaUtilsPageEnumeration';
+import scrollablePaneTopPaddingWebApp from '../../utils/scrollablePaneTopPaddingWebApp';
 
 /* global $ */
 
@@ -40,12 +40,12 @@ function getPaddingTop () {
       } else {
         const dualHeaderContainer = $(`div[class*="${'DualHeaderContainer'}"]`);
         const offs = dualHeaderContainer.length > 0 ? dualHeaderContainer.height() : 0;
-        // console.log(`paddingTop PageContentContainer Android ballot: '${offs}px !important'   for page: ${normalizedHref}`);
+        cordovaOffsetLog(`PageContentContainer paddingTop Android ballot: '${offs}px !important'   for page: ${normalizedHref}`);
         return `${offs}px !important`;
       }
     } else {
       const offs = offsetToBottomOfHeadroomWrapper('getPaddingTop', 'HeadroomWrapper');
-      // console.log(`paddingTop PageContentContainer: '${offs}px !important'   for page: ${normalizedHref}`);
+      cordovaOffsetLog(`PageContentContainer paddingTop iOS: '${offs}px !important' for page: ${normalizedHref}`);
       return `${offs}px !important`;
     }
   }

--- a/src/js/components/Widgets/GoogleAutoComplete.jsx
+++ b/src/js/components/Widgets/GoogleAutoComplete.jsx
@@ -89,7 +89,7 @@ function GoogleAutoComplete (props) {
     });
   };
 
-  const paperSx = { boxShadow: 'none'};
+  const paperSx = { boxShadow: 'none' };
   if (isCordovaPhone) {
     paperSx.paddingLeft = '33px';
   }

--- a/src/js/components/Widgets/GoogleAutoComplete.jsx
+++ b/src/js/components/Widgets/GoogleAutoComplete.jsx
@@ -1,8 +1,8 @@
 import { LocationOn } from '@mui/icons-material';
-import { Paper, TextField } from '@mui/material';
+import { Paper, styled, TextField } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import AutoComplete from 'react-google-autocomplete';
 import { isCordovaPhone, isIPad } from '../../common/utils/cordovaUtils';
 import initializejQuery from '../../common/utils/initializejQuery';
@@ -12,15 +12,19 @@ import webAppConfig from '../../config';
 import $ajax from '../../utils/service';
 import GoogleSelectMenuReplica from './GoogleSelectMenuReplica';
 
+/* global $ */
+
 /*
 Google cloud console http referrers (Website)
 https://console.cloud.google.com/apis/credentials/key/db...45?inv=1&invt=Ab27OA&project=wevoteapps
 (If you turn them off temporarily, the list is erased, so here it is...)
+  http://localhost:3000/
+  https://wevotedeveloper.com:3000
+  https://*.wevote.us/
+  https://api.wevoteusa.org
+  app://localhost/index.html                (Might not work anymore November 2025)
+  file_url//android_asset/www/index.html#/  (Might not work anymore November 2025)
 */
-// app://localhost/index.html
-// file_url//android_asset/www/index.html#/
-// https://*.wevote.us/
-// https://wevotedeveloper.com:3000
 
 
 // November 2025:  WebApp uses AutoComplete (react-google-autocomplete) which in turn uses the deprecated
@@ -34,6 +38,13 @@ function GoogleAutoComplete (props) {
   const [showCordovaSuggestions, setShowCordovaSuggestions] = useState(false);
   const [cordovaSuggestions, setCordovaSuggestions] = useState([]);
   const [cordovaMatchText, setCordovaMatchText] = useState('');
+
+  useEffect(() => () => {
+    // console.log('Component unmounted! Hiding google address choices');
+    $('.pac-container').css({
+      display: 'none',
+    });
+  }, []);
 
   const optionClickedCordova = (value) => {
     const txtFld = document.getElementById('cordovaTextField');
@@ -72,19 +83,41 @@ function GoogleAutoComplete (props) {
           setShowCordovaSuggestions(true);
           setCordovaSuggestions(resp.matches);
           setCordovaMatchText(event.target.value);
+          $('.ion-input-icon').css('display', 'none');
         },
       });
     });
   };
 
+  const paperSx = { boxShadow: 'none'};
+  if (isCordovaPhone) {
+    paperSx.paddingLeft = '33px';
+  }
+
+  const handleAddressChangeWebApp = (place) => {
+    $('.pac-container').css({
+      display: 'block',
+      zIndex: 1400,
+    });
+    updateTextForMapSearchInParent((place && place.target && place.target.value) || '');
+  };
+
+  const handleAddressSelectionWebApp = (place) => {
+    $('.pac-container').css({
+      display: 'none',
+    });
+    updateTextForMapSearchInParentFromGoogle((place && place.formatted_address) || '');
+  };
+
+
   return (
-    <Paper id="GAC-Paper" classes={{ root: classes.addressBoxPaperStyles }} elevation={2} sx={isCordovaPhone() ? { paddingLeft: '33px', boxShadow: 'none' } : {}}>
+    <Paper id="GAC-Paper" classes={{ root: classes.addressBoxPaperStyles }} elevation={2} sx={paperSx}>
       <LocationOn className="ion-input-icon" sx={isCordova() ? { display: 'none' } : {}} />
       {isWebApp() ? (
         <AutoComplete
           apiKey={webAppConfig.GOOGLE_MAPS_API_KEY}
-          onChange={(place) => updateTextForMapSearchInParent((place && place.target && place.target.value) || '')}
-          onPlaceSelected={(place) => updateTextForMapSearchInParentFromGoogle((place && place.formatted_address) || '')}
+          onChange={(place) => handleAddressChangeWebApp(place)}
+          onPlaceSelected={(place) => handleAddressSelectionWebApp(place)}
           defaultValue="" // {textForMapSearch}
           style={{
             width: '100%',
@@ -101,7 +134,7 @@ function GoogleAutoComplete (props) {
           inputAutocompleteValue="off"
         />
       ) : (
-        <div style={{ display: 'grid', width: '100%', transform: 'translateX(-33px)' }}>
+        <AddressEntryBox>
           <TextField
             fullWidth
             placeholder="Street number, full address and ZIP..."
@@ -124,7 +157,7 @@ function GoogleAutoComplete (props) {
             inputText={cordovaMatchText}
             clickHandler={optionClickedCordova}
           />
-        </div>
+        </AddressEntryBox>
       )}
     </Paper>
   );
@@ -156,5 +189,11 @@ const styles = (theme) => ({
     paddingLeft: getPadLeft(),
     boxShadow: getBoxShadow(),
   } });
+
+const AddressEntryBox = styled('div')`
+  display: grid;
+  width: 100%;
+  ${isCordova() ? 'transform: translateX(-33px)' : ''};
+`;
 
 export default withStyles(styles)(GoogleAutoComplete);

--- a/src/js/components/Widgets/ReactNewPlacesAutocomplete.jsx
+++ b/src/js/components/Widgets/ReactNewPlacesAutocomplete.jsx
@@ -1,0 +1,55 @@
+// Note 12/2/25, this relies on unreleased features "from the alpha stream"
+// https://github.com/visgl/react-google-maps/discussions/707
+
+/*
+December 2025: This console log warning does not stop operation with GOOGLE_MAPS_API_KEY that were setup prior to this notice.
+console log: As of March 1st, 2025, google.maps.places.Autocomplete is not available to new customers.
+Please use google.maps.places.PlaceAutocompleteElement instead. At this time,
+google.maps.places.Autocomplete is not scheduled to be discontinued, but
+google.maps.places.PlaceAutocompleteElement is recommended over google.maps.places.Autocomplete.
+While google.maps.places.Autocomplete will continue to receive bug fixes for any major regressions,
+existing bugs in google.maps.places.Autocomplete will not be addressed.
+At least 12 months notice will be given before support is discontinued.
+Please see https://developers.google.com/maps/legacy for additional details and https://developers.google.com/maps/documentation/javascript/places-migration-overview for the migration guide.
+*/
+import { APIProvider } from '@vis.gl/react-google-maps';
+import React, { useEffect, useRef } from 'react';
+import webAppConfig from '../../config';
+
+const ReactNewPlacesAutocomplete = () => {
+  const mapRef = useRef(null);
+  const autocompleteRef = useRef(null);
+
+  useEffect(() => {
+    if (window.google && mapRef.current) {
+      // Initialize the map
+      // const map = new window.google.maps.Map(mapRef.current, {
+      //   center: { lat: -34.397, lng: 150.644 },
+      //   zoom: 8,
+      // });
+
+      // Initialize the PlaceAutocompleteElement
+      const placeAutocomplete = new window.google.maps.places.PlaceAutocompleteElement();
+      autocompleteRef.current.appendChild(placeAutocomplete);
+
+      // Add listener for place selection
+      placeAutocomplete.addListener('place_changed', () => {
+        const place = placeAutocomplete.getPlace();
+        if (place.geometry && place.geometry.location) {
+          // map.setCenter(place.geometry.location);
+          // You can also add a marker or display place details here
+        }
+      });
+    }
+  }, []);
+
+  return (
+    <APIProvider apiKey={webAppConfig.GOOGLE_MAPS_API_KEY} libraries={['places']}>
+      <div ref={mapRef} style={{ height: '400px', width: '100%' }}>&nbsp;</div>
+      {/* This div will host the autocomplete element */}
+      <div ref={autocompleteRef}>&nbsp;</div>
+    </APIProvider>
+  );
+};
+
+export default ReactNewPlacesAutocomplete;

--- a/src/js/pages/Ballot/Ballot.jsx
+++ b/src/js/pages/Ballot/Ballot.jsx
@@ -21,7 +21,7 @@ import SnackNotifier, { openSnackbar } from '../../common/components/Widgets/Sna
 import AppObservableStore, { messageService } from '../../common/stores/AppObservableStore';
 import CampaignStore from '../../common/stores/CampaignStore';
 import apiCalming from '../../common/utils/apiCalming';
-import { chipLabelText, isAndroidSizeWide, isIOSAppOnMac, isIPad, isIPad11in, isIPadGiantSize, isIPadMini, isIPhone6p1in } from '../../common/utils/cordovaUtils';
+import { chipLabelText, isAndroidSizeWide, isIOSAppOnMac, isIPad, isIPadGiantSize, isIPhone6p1in } from '../../common/utils/cordovaUtils';
 import getBooleanValue from '../../common/utils/getBooleanValue';
 import historyPush from '../../common/utils/historyPush';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
@@ -46,6 +46,7 @@ import TwitterStore from '../../stores/TwitterStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
 import { dumpCssFromId } from '../../utils/appleSiliconUtils';
+import { outerHeightOfDualHeaderContainer } from '../../utils/cordovaCalculatedOffsets';
 import { pageEnumeration } from '../../utils/cordovaUtilsPageEnumeration';
 import isMobile from '../../utils/isMobile';
 // Lint is not smart enough to know that lazyPreloadPages will not attempt to preload/reload this page
@@ -1348,10 +1349,8 @@ class Ballot extends Component {
     let showLoadingText = true;
     let searchTextString = '';
     let paddingTop = '';
-    if (isIPadMini() || isIPad11in()) {
-      paddingTop = '22%';
-    } else if (isIPad()) {
-      paddingTop = '5%';
+    if (isIPad()) {
+      paddingTop = `${outerHeightOfDualHeaderContainer()}px`;
     }
 
     return (

--- a/src/js/utils/CordovaOverlayTrigger.jsx
+++ b/src/js/utils/CordovaOverlayTrigger.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-/* Replace CordovaOverlayTrigger with CordovaOverlayTrigger to disable
+/* Replace OverlayTrigger with CordovaOverlayTrigger to disable
  We need to add...
      {
       "compilerOptions": {

--- a/src/js/utils/cordovaCalculatedOffsets.js
+++ b/src/js/utils/cordovaCalculatedOffsets.js
@@ -107,15 +107,19 @@ function calcOffset (wrapper, wrapperContainer, type, pageHref, heightOfHW) {
   return offset;
 }
 
+export function outerHeightOfDualHeaderContainer () {
+  const dualHeaderContainer = $(`div[class*="${'DualHeaderContainer'}"]`);
+  return dualHeaderContainer.length > 0 ? dualHeaderContainer.outerHeight() : 0;
+}
 
 // eslint-disable-next-line no-unused-vars
 export function offsetToBottomOfHeadroomWrapper (type, override = false) {
   const headroomWrapper = $(`div[class*="${'HeadroomWrapper'}"]`);
   const heightOfHW = headroomWrapper.length > 0 ? headroomWrapper.height() : 0;
-  const dualHeaderContainer = $(`div[class*="${'DualHeaderContainer'}"]`);
-  const outerHeightOfDHC = dualHeaderContainer.length > 0 ? dualHeaderContainer.outerHeight() : 0;
+  const outerHeightOfDHC = outerHeightOfDualHeaderContainer();
   const pageHref = normalizedHrefPage();
   // console.log('offsetToBottomOfHeadroomWrapper heightOfHW', heightOfHW);
+  const dualHeaderContainer = $(`div[class*="${'DualHeaderContainer'}"]`);
   if (isAndroid() && dualHeaderContainer.length && outerHeightOfDHC > 0) {
     return heightOfHW;
   } else if (headroomWrapper.length > 0) {

--- a/src/js/utils/cordovaOffsets.js
+++ b/src/js/utils/cordovaOffsets.js
@@ -270,10 +270,11 @@ export function cordovaVoteMiniHeader () {
 // Easier to calculate the size, than keep working on removing the Top attribute from an AppBar
 export function cordovaStickyHeaderPaddingTop () {
   if (isIOS()) {
-    const headerBack = $('#headerBackToBallotAppBar');
-    if (isIOS() && headerBack.length) {
+    // 11/20/25, we want to cover the Measure title (on TopRowTwo), so it does not appear twice
+    const rowOneLeft = $("div[class^='TopRowOneLeftContainer']");
+    if (isIOS() && rowOneLeft.length) {
       const height = heightOfIOSSpacer();
-      const heightAppBar = headerBack.outerHeight();
+      const heightAppBar = rowOneLeft.outerHeight();
       const total = height + heightAppBar;
       const ret = total > 0 ? `${total}px` : '';
       cordovaOffsetLog(`cordovaStickyHeaderPaddingTop : ${total}, ret: '${ret}', page: ${pageEnumeration()}`);
@@ -299,32 +300,32 @@ export function cordovaStickyHeaderPaddingTop () {
   return '';
 }
 
-export function cordovaSignInModalTopPosition (collapsed) {
-  if (isIOS()) {
-    if (isIPhone6p5in()) {                    //  11 Pro Max and XS Max
-      return collapsed ? '01%' : '-25%';
-    } else if (isIPhone6p1in()) {             // XR and 11
-      return collapsed ? '01%' : '-25%';
-    } else if (isIPhone5p8in()) {             //  X and 11 Pro
-      return collapsed ? '300px' : '-206px';
-    } else if (isIPhone5p5inEarly()) {        //  6 Plus, 7 Plus and 8 Plus
-      return collapsed ? '-3%' : '-170px';
-    } else if (isIPhone5p5inMini()) {        //  12 Mini, 13 Mini
-      return collapsed ? '-3%' : '-170px';
-    } else if (isIPhone4p7in()) {             // 6, 7, 8
-      return collapsed ? 'unset' : '-24%';
-    } else if (isIPhone4in()) {               // SE
-      return collapsed ? '30px' : '-18%';
-    } else if (isIPad()) {
-      return collapsed ? '-5%' : '-22%';
-    } else {
-      return collapsed ? '-30%' : '-15%';
-    }
-  } else if (isAndroid()) {
-    return collapsed ? '-30%' : '-25%';
-  }
-  return '';
-}
+// export function cordovaSignInModalTopPosition (collapsed) {
+//   if (isIOS()) {
+//     if (isIPhone6p5in()) {                    //  11 Pro Max and XS Max
+//       return collapsed ? '01%' : '-25%';
+//     } else if (isIPhone6p1in()) {             // XR and 11
+//       return collapsed ? '01%' : '-25%';
+//     } else if (isIPhone5p8in()) {             //  X and 11 Pro
+//       return collapsed ? '300px' : '-206px';
+//     } else if (isIPhone5p5inEarly()) {        //  6 Plus, 7 Plus and 8 Plus
+//       return collapsed ? '-3%' : '-170px';
+//     } else if (isIPhone5p5inMini()) {        //  12 Mini, 13 Mini
+//       return collapsed ? '-3%' : '-170px';
+//     } else if (isIPhone4p7in()) {             // 6, 7, 8
+//       return collapsed ? 'unset' : '-24%';
+//     } else if (isIPhone4in()) {               // SE
+//       return collapsed ? '30px' : '-18%';
+//     } else if (isIPad()) {
+//       return collapsed ? '-5%' : '-22%';
+//     } else {
+//       return collapsed ? '-30%' : '-15%';
+//     }
+//   } else if (isAndroid()) {
+//     return collapsed ? '-30%' : '-25%';
+//   }
+//   return '';
+// }
 
 function measureFooterContainer () {
   try {
@@ -385,7 +386,7 @@ export function cordovaFriendsWrapper () {
     }
     if (isIPad()) {
       return {
-        paddingTop: '145px',
+        paddingTop: `${heightOfIOSSpacer(false) + 10}px`,
         paddingBottom: '90px',
       };
     }

--- a/src/js/utilsApi/showBallotDecisionsTabs.js
+++ b/src/js/utilsApi/showBallotDecisionsTabs.js
@@ -1,8 +1,11 @@
+import { isWebApp } from '../common/utils/isCordovaOrWebApp';
 import BallotStore from '../stores/BallotStore';  // eslint-disable-line import/no-cycle
 
 export default function showBallotDecisionsTabs () {
-  const isMobileScreenSize = window.innerWidth < 500;
+  // src/js/common/utils/isMobileScreenSize.js should be used to avoid problems, 500 is an imperfect criteria
+  const isMobileScreenSizeForShowBallotDecisionsTabs = window.innerWidth < 500;
   return (BallotStore.ballotLength !== BallotStore.ballotRemainingChoicesLength) &&
     (BallotStore.ballotRemainingChoicesLength > 0) &&
-    !isMobileScreenSize;
+    !isMobileScreenSizeForShowBallotDecisionsTabs &&
+    isWebApp();  // November 2025:  Disabled for Cordova until the feature is finished and released to production
 }


### PR DESCRIPTION
This had nothing to do with API keys or permissions, and almost for sure had nothing to do with Cordova.
It was some sort of css problem related to the pop-up address dialog -- I just overrode the css for now.  
This is a short lived fix, because we will have to upgrade to Google places.PlaceAutocompleteElement() at some point in the future, to avoid using "Places Services (Legacy)". 
Ideally we can wait for 'react-google-autocomplete' to get updated.

This console message is true, but isnot the cause of the problem:  
**As of March 1st, 2025, google.maps.places.Autocomplete is not available to new customers. Please use google.maps.places.PlaceAutocompleteElement instead. At this time, google.maps.places.Autocomplete is not scheduled to be discontinued, but google.maps.places.PlaceAutocompleteElement is recommended over google.maps.places.Autocomplete. While google.maps.places.Autocomplete will continue to receive bug fixes for any major regressions, existing bugs in google.maps.places.Autocomplete will not be addressed. At least 12 months notice will be given before support is discontinued. Please see https://developers.google.com/maps/legacy for additional details and https://developers.google.com/maps/documentation/javascript/places-migration-overview for the migration guide.**

------------
Also added some lint cleanup
Some header size code for iPads (already in the released version)
And fully removed the historyPush('/settings/hamburger'), which has been replaced with a drawer, but was still incorrectly tripping in some circumstances.