### PR TITLE
WV-2264 Claim Profile: Add UI for saving Political Party [IN PROGRESS]

### DIFF
--- a/src/js/components/Drawers/PoliticianSelfEditDrawer.jsx
+++ b/src/js/components/Drawers/PoliticianSelfEditDrawer.jsx
@@ -17,6 +17,7 @@ import SettingsSectionFooter from '../Navigation/SettingsSectionFooter';
 import SettingsLinks from '../PoliticianSelfEdit/SettingsLinks';
 import SettingsNameAndPhoto from '../PoliticianSelfEdit/SettingsNameAndPhoto';
 import SettingsOfficialStatement from '../PoliticianSelfEdit/SettingsOfficialStatement';
+import SettingsPoliticalParty from '../PoliticianSelfEdit/SettingsPoliticalParty';
 import SettingsNotifications from '../Settings/SettingsNotifications';
 import { NavLinksContainer } from '../Style/drawerLayoutStyles';
 import DrawerTemplateHeaderProfile from './DrawerTemplateHeaderProfile';
@@ -66,6 +67,16 @@ const PoliticianSelfEditDrawer = () => {
       linkName: 'teamAccess',
       linkTextJsx: <LinkSpan $isActive={String(displayProfileOption) === 'teamAccess'}>Team Access</LinkSpan>,
     },
+    {
+      icon: <AccountCircle $isActive={String(displayProfileOption) === 'party'} />,
+      linkName: 'party',
+      linkTextJsx: (
+        <LinkSpan $isActive={String(displayProfileOption) === 'party'}>
+          Political Party
+        </LinkSpan>
+      ),
+    },
+
   ];
 
   // useEffect to handle which component to display from nav
@@ -104,6 +115,15 @@ const PoliticianSelfEditDrawer = () => {
           </>
         );
         break;
+      case 'party':
+        component = (
+          <SettingsPoliticalParty
+            externalUniqueId="politicianSelfEditDrawer"
+            politicianWeVoteId={politicianWeVoteId}
+          />
+        );
+        break;
+
       default:
         // console.log('In PoliticianSelfEditDrawer useEffect default case');
         if (!displayProfileOption) {

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -19,26 +19,31 @@ const SettingsPoliticalParty = () => {
     <Wrapper>
       <SectionTitle>Political Party</SectionTitle>
 
-      <Label>Select your political party:</Label>
+      <Label htmlFor="politicalPartySelect">Select from common political parties or enter your own</Label>
 
       <Select
+        id="politicalPartySelect"
         value={selectedParty}
         onChange={(e) => setSelectedParty(e.target.value)}
       >
-        <option value="">-- Please choose an option --</option>
-
+        <option value="">Select party</option>
         {partyOptions.map((party) => (
-          <option key={party} value={party}>{party}</option>
+          <option key={party} value={party}>
+            {party}
+          </option>
         ))}
       </Select>
 
+      {/* Only show the custom input when “Enter your own” is selected */}
       {selectedParty === "Enter your own" && (
         <CustomWrapper>
-          <Label>Type your party name:</Label>
+          <Label htmlFor="customPartyInput"></Label>
+
           <Input
+            id="customPartyInput"
             type="text"
             value={customParty}
-            placeholder="Enter your party name"
+            placeholder="Type your party name..."
             onChange={(e) => setCustomParty(e.target.value)}
           />
         </CustomWrapper>
@@ -72,13 +77,25 @@ const Select = styled('select')`
   width: 100%;
   padding: 12px;
   font-size: 16px;
+
   border-radius: 8px;
   border: 1px solid ${DesignTokenColors.neutralUI400};
-  background: ${DesignTokenColors.whiteUI};
+  background-color: ${DesignTokenColors.whiteUI};
+  color: ${DesignTokenColors.neutralUI900};
+
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  background-image: url("data:image/svg+xml;utf8,<svg fill='%23666' height='24' width='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
+  background-position: right 12px center;
+  background-repeat: no-repeat;
+
   outline: none;
 
   &:focus {
     border-color: ${DesignTokenColors.primary600};
+    box-shadow: 0 0 0 2px ${DesignTokenColors.primary200};
   }
 `;
 

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+
+const SettingsPoliticalParty = () => {
+  const partyOptions = [
+    "Democratic Party",
+    "Republican Party",
+    "Green Party",
+    "Libertarian Party",
+    "Independent",
+    "Enter your own"
+  ];
+
+  const [selectedParty, setSelectedParty] = useState("");
+  const [customParty, setCustomParty] = useState("");
+
+  return (
+    <Wrapper>
+      <SectionTitle>Political Party</SectionTitle>
+
+      <Label>Select your political party:</Label>
+
+      <Select
+        value={selectedParty}
+        onChange={(e) => setSelectedParty(e.target.value)}
+      >
+        <option value="">-- Please choose an option --</option>
+
+        {partyOptions.map((party) => (
+          <option key={party} value={party}>{party}</option>
+        ))}
+      </Select>
+
+      {selectedParty === "Enter your own" && (
+        <CustomWrapper>
+          <Label>Type your party name:</Label>
+          <Input
+            type="text"
+            value={customParty}
+            placeholder="Enter your party name"
+            onChange={(e) => setCustomParty(e.target.value)}
+          />
+        </CustomWrapper>
+      )}
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled('div')`
+  padding: 16px;
+  max-width: 700px;
+  color: ${DesignTokenColors.neutralUI900};
+`;
+
+const SectionTitle = styled('h2')`
+  font-size: 22px;
+  font-weight: 700;
+  margin-bottom: 24px;
+  color: ${DesignTokenColors.neutralUI900};
+`;
+
+const Label = styled('label')`
+  display: block;
+  margin-top: 16px;
+  margin-bottom: 8px;
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const Select = styled('select')`
+  width: 100%;
+  padding: 12px;
+  font-size: 16px;
+  border-radius: 8px;
+  border: 1px solid ${DesignTokenColors.neutralUI400};
+  background: ${DesignTokenColors.whiteUI};
+  outline: none;
+
+  &:focus {
+    border-color: ${DesignTokenColors.primary600};
+  }
+`;
+
+const Input = styled('input')`
+  width: 100%;
+  padding: 12px;
+  margin-top: 8px;
+  font-size: 16px;
+  border-radius: 8px;
+  border: 1px solid ${DesignTokenColors.neutralUI400};
+  outline: none;
+
+  &:focus {
+    border-color: ${DesignTokenColors.primary600};
+  }
+`;
+
+const CustomWrapper = styled('div')`
+  margin-top: 20px;
+`;
+
+export default SettingsPoliticalParty;

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -21,10 +21,12 @@ const SettingsPoliticalParty = () => {
         <h1 className="h2">Political Party</h1>
       </HeaderContainer>
 
-      <IntroductionText>
+      {/* Accessible label + same spacing as Official Statement intro text */}
+      <Label htmlFor="politicalPartySelect">
         Select your political party or enter your own below.
-      </IntroductionText>
+      </Label>
 
+      {/* Select input with proper accessible name */}
       <Select
         id="politicalPartySelect"
         value={selectedParty}
@@ -38,6 +40,7 @@ const SettingsPoliticalParty = () => {
         ))}
       </Select>
 
+      {/* Custom input only visible if needed */}
       {selectedParty === "Enter your own" && (
         <CustomWrapper>
           <Input
@@ -60,17 +63,23 @@ const Wrapper = styled('div')`
   color: ${DesignTokenColors.neutralUI900};
 `;
 
+/* Matches Official Statement header container */
 const HeaderContainer = styled('div')`
   display: flex;
   align-items: center;
+  margin-bottom: 4px;
 `;
 
-const IntroductionText = styled('div')`
-  margin-top: 8px;     /* SAME gap as Official Statement */
-  margin-bottom: 12px; /* same bottom spacing as IntroductionWrapper */
+/* Uses the same spacing behavior as IntroductionWrapper in Official Statement */
+const Label = styled('label')`
+  display: block;
+  margin-top: 8px;      /* Spacing between title and intro text */
+  margin-bottom: 12px;  /* Same spacing as Official Statement intro text */
   font-size: 15px;
   color: ${DesignTokenColors.neutralUI700};
+  font-weight: 600;
 `;
+
 const Select = styled('select')`
   width: 100%;
   padding: 12px;

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -17,9 +17,13 @@ const SettingsPoliticalParty = () => {
 
   return (
     <Wrapper>
-      <SectionTitle>Political Party</SectionTitle>
+      <HeaderContainer>
+        <h1 className="h2">Political Party</h1>
+      </HeaderContainer>
 
-      <Label htmlFor="politicalPartySelect">Select from common political parties or enter your own</Label>
+      <IntroductionText>
+        Select your political party or enter your own below.
+      </IntroductionText>
 
       <Select
         id="politicalPartySelect"
@@ -34,16 +38,14 @@ const SettingsPoliticalParty = () => {
         ))}
       </Select>
 
-      {/* Only show the custom input when “Enter your own” is selected */}
       {selectedParty === "Enter your own" && (
         <CustomWrapper>
-          <Label htmlFor="customPartyInput"></Label>
-
           <Input
             id="customPartyInput"
             type="text"
             value={customParty}
             placeholder="Type your party name..."
+            aria-label="Type your political party name"
             onChange={(e) => setCustomParty(e.target.value)}
           />
         </CustomWrapper>
@@ -58,21 +60,17 @@ const Wrapper = styled('div')`
   color: ${DesignTokenColors.neutralUI900};
 `;
 
-const SectionTitle = styled('h2')`
-  font-size: 22px;
-  font-weight: 700;
-  margin-bottom: 24px;
-  color: ${DesignTokenColors.neutralUI900};
+const HeaderContainer = styled('div')`
+  display: flex;
+  align-items: center;
 `;
 
-const Label = styled('label')`
-  display: block;
-  margin-top: 16px;
-  margin-bottom: 8px;
-  font-size: 16px;
-  font-weight: 600;
+const IntroductionText = styled('div')`
+  margin-top: 8px;     /* SAME gap as Official Statement */
+  margin-bottom: 12px; /* same bottom spacing as IntroductionWrapper */
+  font-size: 15px;
+  color: ${DesignTokenColors.neutralUI700};
 `;
-
 const Select = styled('select')`
   width: 100%;
   padding: 12px;
@@ -84,14 +82,9 @@ const Select = styled('select')`
   color: ${DesignTokenColors.neutralUI900};
 
   appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-
   background-image: url("data:image/svg+xml;utf8,<svg fill='%23666' height='24' width='24' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path d='M7 10l5 5 5-5z'/></svg>");
   background-position: right 12px center;
   background-repeat: no-repeat;
-
-  outline: none;
 
   &:focus {
     border-color: ${DesignTokenColors.primary600};

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -21,17 +21,17 @@ const SettingsPoliticalParty = () => {
         <h1 className="h2">Political Party</h1>
       </HeaderContainer>
 
-      {/* Accessible label + same spacing as Official Statement intro text */}
-      <Label htmlFor="politicalPartySelect">
+      <Label id="partyLabel" htmlFor="politicalPartySelect">
         Select your political party or enter your own below.
       </Label>
 
-      {/* Select input with proper accessible name */}
       <Select
         id="politicalPartySelect"
+        aria-labelledby="partyLabel"
         value={selectedParty}
         onChange={(e) => setSelectedParty(e.target.value)}
       >
+
         <option value="">Select party</option>
         {partyOptions.map((party) => (
           <option key={party} value={party}>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
This ticket is just about adding the UI and does not require connecting this UI to the WeVoteServer. Please use dummy data to populate the drop down.
### Changes included this pull request?
1. New Component: SettingsPoliticalParty.jsx

Styled using styled-components to match existing WeVote settings pages.

Contains:

A dropdown populated with dummy party values.

An “Enter your own” option that reveals a text input.

React state to track selected party and custom input.

Fully responsive and consistent with drawer layout.

2. Integration Into PoliticianSelfEditDrawer

Added a new navigation item labeled Party.

Added new icon highlighting logic for active tab.

Integrated SettingsPoliticalParty into existing component-switch structure.
