### PR TITLE
[WV-2256] Convert OpenExternalWebSite imports to React.lazy()

### DIFF
--- a/src/js/common/components/Politician/PoliticianLinks.jsx
+++ b/src/js/common/components/Politician/PoliticianLinks.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import DesignTokenColors from '../Style/DesignTokenColors';
-import OpenExternalWebSite from '../Widgets/OpenExternalWebSite';
+
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../Widgets/OpenExternalWebSite'));
 
 const PoliticianLinks = ({ links }) => (
   <PoliticianLinksContainerOverflow>
@@ -15,16 +16,18 @@ const PoliticianLinks = ({ links }) => (
 
           return (
             <LinkContainer key={linkText} isFirst={index !== 0}>
-              <OpenExternalWebSite
-                body={linkText}
-                key={linkText}
-                linkIdAttribute={linkIdAttribute}
-                rel="noopener noreferrer"
-                url={externalLinkUrl}
-                target="_blank"
-                title={linkText}
-                trackingOn
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  body={linkText}
+                  key={linkText}
+                  linkIdAttribute={linkIdAttribute}
+                  rel="noopener noreferrer"
+                  url={externalLinkUrl}
+                  target="_blank"
+                  title={linkText}
+                  trackingOn
+                />
+              </Suspense>
             </LinkContainer>
           );
         })}

--- a/src/js/common/pages/Campaign/CampaignCommentsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignCommentsPage.jsx
@@ -5,7 +5,6 @@ import React, { Component, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { CampaignTitleText, CampaignTitleWrapper, CommentsSectionInnerWrapper, CommentsSectionOuterWrapper } from '../../components/Style/CampaignDetailsStyles';
 import { PageWrapper } from '../../components/Style/stepDisplayStyles';
-import OpenExternalWebSite from '../../components/Widgets/OpenExternalWebSite';
 import { isCordova } from '../../utils/isCordovaOrWebApp';
 import { renderLog } from '../../utils/logging';
 import CampaignTopNavigation from '../../components/Navigation/CampaignTopNavigation';
@@ -18,7 +17,7 @@ import { getCampaignXValuesFromIdentifiers } from '../../utils/campaignUtils';
 
 const CampaignCommentsList = React.lazy(() => import(/* webpackChunkName: 'CampaignCommentsList' */ '../../components/Campaign/CampaignCommentsList'));
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
-
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../components/Widgets/OpenExternalWebSite'));
 
 class CampaignCommentsPage extends Component {
   constructor (props) {
@@ -133,12 +132,14 @@ class CampaignCommentsPage extends Component {
             <BlockedReason>
               This campaign has been blocked by moderators from WeVote because it is currently violating our terms of service. It is only visible campaign owners. If you have any questions,
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>please contact WeVote support.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>please contact WeVote support.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />
@@ -167,12 +168,14 @@ class CampaignCommentsPage extends Component {
             <BlockedReason>
               Your campaign has been blocked by moderators from WeVote. Please make any requested modifications so you are in compliance with our terms of service and
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>contact WeVote support for help.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>contact WeVote support for help.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />

--- a/src/js/common/pages/Campaign/CampaignDetailsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignDetailsPage.jsx
@@ -34,7 +34,6 @@ import {
 } from '../../components/Style/CampaignDetailsStyles';
 import { PageWrapper } from '../../components/Style/stepDisplayStyles';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
-import OpenExternalWebSite from '../../components/Widgets/OpenExternalWebSite';
 import historyPush from '../../utils/historyPush';
 import { renderLog } from '../../utils/logging';
 import returnFirstXWords from '../../utils/returnFirstXWords';
@@ -56,6 +55,7 @@ const CampaignNewsItemList = React.lazy(() => import(/* webpackChunkName: 'Campa
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
 const CampaignSupportThermometer = React.lazy(() => import(/* webpackChunkName: 'CampaignSupportThermometer' */ '../../components/CampaignSupport/CampaignSupportThermometer'));
 const SupportButtonBeforeCompletionScreen = React.lazy(() => import(/* webpackChunkName: 'SupportButtonBeforeCompletionScreen' */ '../../components/CampaignSupport/SupportButtonBeforeCompletionScreen'));
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../components/Widgets/OpenExternalWebSite'));
 
 const futureFeaturesDisabled = true;
 
@@ -290,12 +290,14 @@ class CampaignDetailsPage extends Component {
             <BlockedReason>
               This campaign has been blocked by moderators from WeVote because it is currently violating our terms of service. If you have any questions,
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>please contact WeVote support.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>please contact WeVote support.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />
@@ -325,12 +327,14 @@ class CampaignDetailsPage extends Component {
             <BlockedReason>
               Your campaign has been blocked by moderators from WeVote. It is only visible campaign owners. Please make any requested modifications so you are in compliance with our terms of service and
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>contact WeVote support for help.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>contact WeVote support for help.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />

--- a/src/js/common/pages/Campaign/CampaignNewsItemDetailsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignNewsItemDetailsPage.jsx
@@ -17,7 +17,6 @@ import { CampaignDescription, CampaignDescriptionDesktop, CampaignDescriptionDes
 import { BlockedIndicator, BlockedReason, DraftModeIndicator, EditIndicator, ElectionInPast, IndicatorButtonWrapper, IndicatorRow } from '../../components/Style/CampaignIndicatorStyles';
 import { PageWrapper } from '../../components/Style/stepDisplayStyles';
 import DelayedLoad from '../../components/Widgets/DelayedLoad';
-import OpenExternalWebSite from '../../components/Widgets/OpenExternalWebSite';
 import AppObservableStore, { messageService } from '../../stores/AppObservableStore';
 import CampaignStore from '../../stores/CampaignStore';
 import CampaignSupporterStore from '../../stores/CampaignSupporterStore';
@@ -36,7 +35,7 @@ const CampaignDetailsActionSideBox = React.lazy(() => import(/* webpackChunkName
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
 const CampaignSupportThermometer = React.lazy(() => import(/* webpackChunkName: 'CampaignSupportThermometer' */ '../../components/CampaignSupport/CampaignSupportThermometer'));
 const SupportButtonBeforeCompletionScreen = React.lazy(() => import(/* webpackChunkName: 'SupportButtonBeforeCompletionScreen' */ '../../components/CampaignSupport/SupportButtonBeforeCompletionScreen'));
-
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../components/Widgets/OpenExternalWebSite'));
 
 class CampaignNewsItemDetailsPage extends Component {
   constructor (props) {
@@ -338,12 +337,14 @@ class CampaignNewsItemDetailsPage extends Component {
             <BlockedReason>
               This campaign has been blocked by moderators from WeVote because it is currently violating our terms of service. If you have any questions,
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>please contact WeVote support.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>please contact WeVote support.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />
@@ -458,12 +459,14 @@ class CampaignNewsItemDetailsPage extends Component {
             <BlockedReason>
               Your campaign has been blocked by moderators from WeVote. It is only visible campaign owners. Please make any requested modifications so you are in compliance with our terms of service and
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>contact WeVote support for help.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>contact WeVote support for help.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />

--- a/src/js/common/pages/Campaign/CampaignNewsPage.jsx
+++ b/src/js/common/pages/Campaign/CampaignNewsPage.jsx
@@ -5,7 +5,6 @@ import React, { Component, Suspense } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { CampaignTitleText, CampaignTitleWrapper, CommentsListWrapper, CommentsSectionInnerWrapper, CommentsSectionOuterWrapper, SupportButtonPanel } from '../../components/Style/CampaignDetailsStyles';
 import { PageWrapper } from '../../components/Style/stepDisplayStyles';
-import OpenExternalWebSite from '../../components/Widgets/OpenExternalWebSite';
 import { isCordova } from '../../utils/isCordovaOrWebApp';
 import { renderLog } from '../../utils/logging';
 import CampaignTopNavigation from '../../components/Navigation/CampaignTopNavigation';
@@ -19,6 +18,7 @@ import { getCampaignXValuesFromIdentifiers } from '../../utils/campaignUtils';
 const CampaignNewsItemList = React.lazy(() => import(/* webpackChunkName: 'CampaignNewsItemList' */ '../../components/Campaign/CampaignNewsItemList'));
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
 const CampaignNewsItemCreateButton = React.lazy(() => import(/* webpackChunkName: 'CampaignNewsItemCreateButton' */ '../../components/CampaignNewsItemPublish/CampaignNewsItemCreateButton'));
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../components/Widgets/OpenExternalWebSite'));
 
 class CampaignNewsPage extends Component {
   constructor (props) {
@@ -136,12 +136,14 @@ class CampaignNewsPage extends Component {
             <BlockedReason>
               This campaign has been blocked by moderators from WeVote because it is currently violating our terms of service. It is only visible campaign owners. If you have any questions,
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>please contact WeVote support.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>please contact WeVote support.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />
@@ -170,12 +172,14 @@ class CampaignNewsPage extends Component {
             <BlockedReason>
               Your campaign has been blocked by moderators from WeVote. Please make any requested modifications so you are in compliance with our terms of service and
               {' '}
-              <OpenExternalWebSite
-                linkIdAttribute="weVoteSupport"
-                url="https://help.wevote.us/hc/en-us/requests/new"
-                target="_blank"
-                body={<span>contact WeVote support for help.</span>}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="weVoteSupport"
+                  url="https://help.wevote.us/hc/en-us/requests/new"
+                  target="_blank"
+                  body={<span>contact WeVote support for help.</span>}
+                />
+              </Suspense>
               {isBlockedByWeVoteReason && (
                 <>
                   <br />

--- a/src/js/common/pages/CampaignStart/CampaignStartEditAll.jsx
+++ b/src/js/common/pages/CampaignStart/CampaignStartEditAll.jsx
@@ -7,7 +7,6 @@ import { Helmet } from 'react-helmet-async';
 import CampaignStartActions from '../../actions/CampaignStartActions';
 import commonMuiStyles from '../../components/Style/commonMuiStyles';
 import { OuterWrapper, PageWrapper } from '../../components/Style/stepDisplayStyles';
-import OpenExternalWebSite from '../../components/Widgets/OpenExternalWebSite';
 import historyPush from '../../utils/historyPush';
 import { renderLog } from '../../utils/logging';
 import AddCandidateInputField from '../../components/CampaignStart/AddPoliticianInputField';
@@ -22,9 +21,8 @@ import CampaignStore from '../../stores/CampaignStore';
 import { getCampaignXValuesFromIdentifiers, retrieveCampaignXFromIdentifiersIfNeeded } from '../../utils/campaignUtils';
 import initializejQuery from '../../utils/initializejQuery';
 
-
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
-
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../components/Widgets/OpenExternalWebSite'));
 
 class CampaignStartEditAll extends Component {
   constructor (props) {
@@ -266,12 +264,14 @@ class CampaignStartEditAll extends Component {
                       <BlockedReason>
                         Your campaign has been blocked by moderators from We Vote. Please make any requested modifications so you are in compliance with our terms of service and
                         {' '}
-                        <OpenExternalWebSite
-                          linkIdAttribute="weVoteSupport"
-                          url="https://help.wevote.us/hc/en-us/requests/new"
-                          target="_blank"
-                          body={<span>contact We Vote support for help.</span>}
-                        />
+                        <Suspense fallback={<></>}>
+                          <OpenExternalWebSite
+                            linkIdAttribute="weVoteSupport"
+                            url="https://help.wevote.us/hc/en-us/requests/new"
+                            target="_blank"
+                            body={<span>contact We Vote support for help.</span>}
+                          />
+                        </Suspense>
                         {isBlockedByWeVoteReason && (
                           <>
                             <br />

--- a/src/js/common/pages/ChallengeStart/ChallengeStartEditAll.jsx
+++ b/src/js/common/pages/ChallengeStart/ChallengeStartEditAll.jsx
@@ -7,7 +7,6 @@ import { Helmet } from 'react-helmet-async';
 import ChallengeStartActions from '../../actions/ChallengeStartActions';
 import commonMuiStyles from '../../components/Style/commonMuiStyles';
 import { OuterWrapper, PageWrapper } from '../../components/Style/stepDisplayStyles';
-import OpenExternalWebSite from '../../components/Widgets/OpenExternalWebSite';
 import historyPush from '../../utils/historyPush';
 import { renderLog } from '../../utils/logging';
 import ChallengeDescriptionInputField from '../../components/ChallengeStart/ChallengeDescriptionInputField';
@@ -21,9 +20,8 @@ import ChallengeStore from '../../stores/ChallengeStore';
 import { getChallengeValuesFromIdentifiers, retrieveChallengeFromIdentifiersIfNeeded } from '../../utils/challengeUtils';
 import initializejQuery from '../../utils/initializejQuery';
 
-
 const ChallengeRetrieveController = React.lazy(() => import(/* webpackChunkName: 'ChallengeRetrieveController' */ '../../components/Challenge/ChallengeRetrieveController'));
-
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../components/Widgets/OpenExternalWebSite'));
 
 class ChallengeStartEditAll extends Component {
   constructor (props) {
@@ -272,12 +270,14 @@ class ChallengeStartEditAll extends Component {
                       <BlockedReason>
                         Your challenge has been blocked by moderators from We Vote. Please make any requested modifications so you are in compliance with our terms of service and
                         {' '}
-                        <OpenExternalWebSite
-                          linkIdAttribute="weVoteSupport"
-                          url="https://help.wevote.us/hc/en-us/requests/new"
-                          target="_blank"
-                          body={<span>contact We Vote support for help.</span>}
-                        />
+                        <Suspense fallback={<></>}>
+                          <OpenExternalWebSite
+                            linkIdAttribute="weVoteSupport"
+                            url="https://help.wevote.us/hc/en-us/requests/new"
+                            target="_blank"
+                            body={<span>contact We Vote support for help.</span>}
+                          />
+                        </Suspense>
                         {isBlockedByWeVoteReason && (
                           <>
                             <br />

--- a/src/js/components/Navigation/FooterMainPrivateLabeled.jsx
+++ b/src/js/components/Navigation/FooterMainPrivateLabeled.jsx
@@ -1,11 +1,11 @@
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import AppObservableStore, { messageService } from '../../common/stores/AppObservableStore';
 
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
 class FooterMainPrivateLabeled extends Component {
   constructor (props) {
@@ -49,15 +49,17 @@ class FooterMainPrivateLabeled extends Component {
             <OneRow>
               <div id="footerLinkHowItWorks" className={classes.onClickDiv} onClick={this.openHowItWorksModal}>How It Works</div>
               <RowSpacer />
-              <OpenExternalWebSite
-                linkIdAttribute="footerLinkWeVoteHelp"
-                url="https://help.wevote.us/hc/en-us"
-                target="_blank"
-                body={(
-                  <span>Help</span>
-                )}
-                className={classes.link}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="footerLinkWeVoteHelp"
+                  url="https://help.wevote.us/hc/en-us"
+                  target="_blank"
+                  body={(
+                    <span>Help</span>
+                  )}
+                  className={classes.link}
+                />
+              </Suspense>
               <RowSpacer />
               <Link id="footerLinkPrivacy" className={classes.link} to="/privacy">Privacy</Link>
               <RowSpacer />
@@ -65,15 +67,17 @@ class FooterMainPrivateLabeled extends Component {
             </OneRow>
             {chosenAboutOrganizationExternalUrl && (
               <OneRow>
-                <OpenExternalWebSite
-                  linkIdAttribute="footerLinkAbout"
-                  url={chosenAboutOrganizationExternalUrl}
-                  target="_blank"
-                  body={(
-                    <span>About</span>
-                  )}
-                  className={classes.link}
-                />
+                <Suspense fallback={<></>}>
+                  <OpenExternalWebSite
+                    linkIdAttribute="footerLinkAbout"
+                    url={chosenAboutOrganizationExternalUrl}
+                    target="_blank"
+                    body={(
+                      <span>About</span>
+                    )}
+                    className={classes.link}
+                  />
+                </Suspense>
               </OneRow>
             )}
           </TopSectionInnerWrapper>

--- a/src/js/components/Navigation/FooterMainWeVote.jsx
+++ b/src/js/components/Navigation/FooterMainWeVote.jsx
@@ -4,7 +4,6 @@ import React, { Component, Suspense } from 'react';
 import TagManager from 'react-gtm-module';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import AppObservableStore from '../../common/stores/AppObservableStore';
 import { isWebApp } from '../../common/utils/isCordovaOrWebApp';
 import webAppConfig from '../../config';
@@ -15,6 +14,7 @@ import ToolBar from '../../common/components/Widgets/ToolBar';
 const BallotElectionListWithFilters = React.lazy(() => import(/* webpackChunkName: 'BallotElectionListWithFilters' */ '../Ballot/BallotElectionListWithFilters'));
 const DeleteAllContactsButton = React.lazy(() => import(/* webpackChunkName: 'DeleteAllContactsButton' */ '../SetUpAccount/DeleteAllContactsButton'));
 const FooterCandidateList = React.lazy(() => import(/* webpackChunkName: 'FooterCandidateList' */ './FooterCandidateList'));
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
 class FooterMainWeVote extends Component {
   constructor (props) {
@@ -141,14 +141,16 @@ class FooterMainWeVote extends Component {
                 How It Works
               </button>
               <RowSpacer />
-              <OpenExternalWebSite
-                linkIdAttribute="footerLinkWeVoteHelp"
-                url="https://help.wevote.us/hc/en-us"
-                target="_blank"
-                className={classes.link}
-                trackingOn
-                body={(<span>Help</span>)}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="footerLinkWeVoteHelp"
+                  url="https://help.wevote.us/hc/en-us"
+                  target="_blank"
+                  className={classes.link}
+                  trackingOn
+                  body={(<span>Help</span>)}
+                />
+              </Suspense>
               <RowSpacer />
               <Link
                 id="footerLinkPrivacy"
@@ -181,23 +183,27 @@ class FooterMainWeVote extends Component {
                   </Link>
                   <RowSpacer />
                   {/* Note: Team/Credits links will show 'notSet' in local dev but work correctly in production */}
-                  <OpenExternalWebSite
-                    linkIdAttribute="footerLinkTeam"
-                    url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/about`}
-                    target="_blank"
-                    trackingOn
-                    body={(<span>Team</span>)}
-                    className={classes.link}
-                  />
+                  <Suspense fallback={<></>}>
+                    <OpenExternalWebSite
+                      linkIdAttribute="footerLinkTeam"
+                      url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/about`}
+                      target="_blank"
+                      trackingOn
+                      body={(<span>Team</span>)}
+                      className={classes.link}
+                    />
+                  </Suspense>
                   <RowSpacer />
-                  <OpenExternalWebSite
-                    linkIdAttribute="footerLinkCredits"
-                    url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/credits`}
-                    target="_blank"
-                    trackingOn
-                    body={(<span>Credits &amp; Thanks</span>)}
-                    className={classes.link}
-                  />
+                  <Suspense fallback={<></>}>
+                    <OpenExternalWebSite
+                      linkIdAttribute="footerLinkCredits"
+                      url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/credits`}
+                      target="_blank"
+                      trackingOn
+                      body={(<span>Credits &amp; Thanks</span>)}
+                      className={classes.link}
+                    />
+                  </Suspense>
                 </>
               ) : (
                 <>
@@ -223,23 +229,27 @@ class FooterMainWeVote extends Component {
             </OneRow>
             {isWebApp() && (
               <OneRow>
-                <OpenExternalWebSite
-                  linkIdAttribute="footerLinkBlog"
-                  url="https://blog.wevote.us/"
-                  target="_blank"
-                  trackingOn
-                  body={(<span>Blog</span>)}
-                  className={classes.link}
-                />
+                <Suspense fallback={<></>}>
+                  <OpenExternalWebSite
+                    linkIdAttribute="footerLinkBlog"
+                    url="https://blog.wevote.us/"
+                    target="_blank"
+                    trackingOn
+                    body={(<span>Blog</span>)}
+                    className={classes.link}
+                  />
+                </Suspense>
                 <RowSpacer />
-                <OpenExternalWebSite
-                  linkIdAttribute="footerLinkVolunteer"
-                  url="https://wevote.applytojob.com/apply"
-                  target="_blank"
-                  trackingOn
-                  body={(<span>Volunteering Opportunities</span>)}
-                  className={classes.link}
-                />
+                <Suspense fallback={<></>}>
+                  <OpenExternalWebSite
+                    linkIdAttribute="footerLinkVolunteer"
+                    url="https://wevote.applytojob.com/apply"
+                    target="_blank"
+                    trackingOn
+                    body={(<span>Volunteering Opportunities</span>)}
+                    className={classes.link}
+                  />
+                </Suspense>
                 <RowSpacer />
                 <Link
                   className={classes.link}

--- a/src/js/components/Navigation/SettingsSectionFooter.jsx
+++ b/src/js/components/Navigation/SettingsSectionFooter.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { Component, Suspense } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import AppObservableStore, { messageService } from '../../common/stores/AppObservableStore';
 import { isIPad } from '../../common/utils/cordovaUtils';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
@@ -11,6 +10,7 @@ import webAppConfig from '../../config';
 import { DeviceInformationSpan, TermsAndPrivacyText } from '../Style/pageLayoutStyles';
 import DeviceDialog from '../Widgets/DeviceDialog';
 
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
 class SettingsSectionFooter extends Component {
   constructor (props) {
@@ -84,14 +84,16 @@ class SettingsSectionFooter extends Component {
           <Link to="/more/faq" onClick={this.closeDrawerHandler}><TermsAndPrivacyText id="footerLinkAbout&FAQ">About&nbsp;&amp;&nbsp;FAQ</TermsAndPrivacyText></Link>
         </OneRow>
         <OneRow centered={centered}>
-          <OpenExternalWebSite
-            linkIdAttribute="footerLinkWeVoteHelp"
-            url="https://help.wevote.us/hc/en-us"
-            target="_blank"
-            body={(
-              <TermsAndPrivacyText>Help</TermsAndPrivacyText>
-            )}
-          />
+          <Suspense fallback={<></>}>
+            <OpenExternalWebSite
+              linkIdAttribute="footerLinkWeVoteHelp"
+              url="https://help.wevote.us/hc/en-us"
+              target="_blank"
+              body={(
+                <TermsAndPrivacyText>Help</TermsAndPrivacyText>
+              )}
+            />
+          </Suspense>
           <span style={{ paddingLeft: 15 }} />
           <Link to="/privacy" onClick={this.closeDrawerHandler}><TermsAndPrivacyText id="footerLinkPrivacy">Privacy</TermsAndPrivacyText></Link>
           <span style={{ paddingLeft: 15 }} />
@@ -100,23 +102,27 @@ class SettingsSectionFooter extends Component {
         <OneRow centered={centered}>
           {(isWebApp() && !inPrivateLabelMode) && (
             <>
-              <OpenExternalWebSite
-                linkIdAttribute="footerLinkTeam"
-                url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/about`}
-                target="_blank"
-                body={(
-                  <TermsAndPrivacyText>Team</TermsAndPrivacyText>
-                )}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="footerLinkTeam"
+                  url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/about`}
+                  target="_blank"
+                  body={(
+                    <TermsAndPrivacyText>Team</TermsAndPrivacyText>
+                  )}
+                />
+              </Suspense>
               <span style={{ paddingLeft: 15 }} />
-              <OpenExternalWebSite
-                linkIdAttribute="footerLinkCredit"
-                url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/credits`}
-                target="_blank"
-                body={(
-                  <TermsAndPrivacyText className="u-no-break">Credits &amp; Thanks</TermsAndPrivacyText>
-                )}
-              />
+              <Suspense fallback={<></>}>
+                <OpenExternalWebSite
+                  linkIdAttribute="footerLinkCredit"
+                  url={`${webAppConfig.WE_VOTE_URL_PROTOCOL + webAppConfig.WE_VOTE_HOSTNAME}/more/credits`}
+                  target="_blank"
+                  body={(
+                    <TermsAndPrivacyText className="u-no-break">Credits &amp; Thanks</TermsAndPrivacyText>
+                  )}
+                />
+              </Suspense>
             </>
           )}
           {isCordova() && (

--- a/src/js/components/Share/shareButtonCommon.jsx
+++ b/src/js/components/Share/shareButtonCommon.jsx
@@ -6,7 +6,6 @@ import TagManager from 'react-gtm-module';
 import { FacebookIcon, FacebookShareButton, TwitterIcon, TwitterShareButton } from 'react-share'; // EmailIcon, EmailShareButton,
 import styled from 'styled-components';
 import AnalyticsActions from '../../actions/AnalyticsActions';
-import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import { openSnackbar } from '../../common/components/Widgets/SnackNotifier';
 import { cordovaOpenSafariView, hasDynamicIsland, hasIPhoneNotch, isIPhone6p5in } from '../../common/utils/cordovaUtils';
 import { normalizedHref } from '../../common/utils/hrefUtils';
@@ -16,6 +15,7 @@ import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import VoterStore from '../../stores/VoterStore';
 import ShareModalOption from './ShareModalOption';
 
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
 export const shareStyles = () => ({
   dialogPaper: {

--- a/src/js/pages/More/Donate.jsx
+++ b/src/js/pages/More/Donate.jsx
@@ -14,7 +14,6 @@ import DonationListForm from '../../common/components/Donation/DonationListForm'
 import DonorboxCordova from '../../common/components/Donation/DonorboxCordova';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import standardBoxShadow from '../../common/components/Style/standardBoxShadow';
-import OpenExternalWebSite from '../../common/components/Widgets/OpenExternalWebSite';
 import DonateStore from '../../common/stores/DonateStore';
 import initializejQuery from '../../common/utils/initializejQuery';
 import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
@@ -28,6 +27,7 @@ import VoterStore from '../../stores/VoterStore';
 import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const DonorboxEmbed = React.lazy(() => import(/* webpackChunkName: 'DonorboxEmbed' */ '../../common/components/Donation/DonorboxEmbed'));
+const OpenExternalWebSite = React.lazy(() => import(/* webpackChunkName: 'OpenExternalWebSite' */ '../../common/components/Widgets/OpenExternalWebSite'));
 
 /* global $ */
 
@@ -222,24 +222,26 @@ class Donate extends Component {
 
   preDonateDescriptionBottom = (isC4Donation) => (
     <span id="second_paragraph">
-      <OpenExternalWebSite
-        linkIdAttribute="annualBudget"
-        url={isC4Donation ? 'https://projects.propublica.org/nonprofits/organizations/811052585' : 'https://projects.propublica.org/nonprofits/organizations/472691544'}
-        target="_blank"
-        body={(
-          <span id="budgets_small">
-            Our budgets are small,
-            <Launch
-              style={{
-                height: 14,
-                marginLeft: 2,
-                marginTop: '-3px',
-                width: 14,
-              }}
-            />
-          </span>
-        )}
-      />
+      <Suspense fallback={<></>}>
+        <OpenExternalWebSite
+          linkIdAttribute="annualBudget"
+          url={isC4Donation ? 'https://projects.propublica.org/nonprofits/organizations/811052585' : 'https://projects.propublica.org/nonprofits/organizations/472691544'}
+          target="_blank"
+          body={(
+            <span id="budgets_small">
+              Our budgets are small,
+              <Launch
+                style={{
+                  height: 14,
+                  marginLeft: 2,
+                  marginTop: '-3px',
+                  width: 14,
+                }}
+              />
+            </span>
+          )}
+        />
+      </Suspense>
       so every
       {' '}
       {isC4Donation ? '' : 'tax-deductible '}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Fixes WV-2256

### Changes included this pull request?
* Replaced direct imports with React.lazy()
* Added Suspense wrapper with empty fallback to all usages
* Removed old import statements across 12 files

### Testing
* Verified footer "Help" link on localhost (home and campaign pages) opens properly in new tabl
* No console errors related to lazy loading or Suspense
