### PR TITLE
[WV-2285] Added condition to handle empty voter opinion in SupportStore.jsx

### DIFF
--- a/src/js/stores/SupportStore.js
+++ b/src/js/stores/SupportStore.js
@@ -459,6 +459,23 @@ class SupportStore extends ReduceStore {
               voter_statement_text: assign({}, revisedState.voter_statement_text, { [politicianWeVoteId]: action.res.statement_text }),
             };
           }
+        } else if (action.res.statement_text === '') { // Handle case where the voter deletes their opinion
+          // Make a shallow copy of the existing dictionary
+          const updatedVoterStatementText = { ...revisedState.voter_statement_text };
+
+          // If a ballot item ID exists and there’s an entry for it, delete the voter’s opinion for that ballot item
+          if (ballotItemWeVoteId && updatedVoterStatementText[ballotItemWeVoteId]) {
+            delete updatedVoterStatementText[ballotItemWeVoteId];
+          }
+          // If a politician ID exists and there’s an entry for it, delete the voter’s opinion for that politician
+          if (politicianWeVoteId && updatedVoterStatementText[politicianWeVoteId]) {
+            delete updatedVoterStatementText[politicianWeVoteId];
+          }
+          // Update the state with the modified voter_statement_text dictionary
+          revisedState = {
+            ...revisedState,
+            voter_statement_text: updatedVoterStatementText,
+          };
         }
         revisedState = { ...revisedState,
           voter_opposes: voterOpposes,


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix? WV-2285

### Changes included this pull request?
This PR addresses the issue where deleting an opinion from the “Delete Opinion” menu did not immediately update the UI.
The problem occurred because SupportStore.js did not properly handle the case where statement_text was an empty string.
As a result, the local state was never updated when a voter deleted their opinion, and the deleted comment would remain visible until the page was refreshed.

This fix introduces logic within the voterPositionCommentSave case to explicitly check for statement_text === ''.
When this condition is true, the voter’s opinion entry is removed from the voter_statement_text dictionary (for both ballotItemWeVoteId and politicianWeVoteId, if present).