### PR TITLE
[WV-2048] Invite voters: "Invite selected" modal (Manage My Candidates) [TEAM REVIEW]

### DIFF
--- a/src/js/components/More/ConfirmCloseModal.jsx
+++ b/src/js/components/More/ConfirmCloseModal.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { createGlobalStyle } from 'styled-components';
+import { Info } from '@mui/icons-material';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+import ModalDisplayTemplateB from '../Widgets/ModalDisplayTemplateB';
+
+export default function ConfirmCloseModal({
+  isOpen,
+  onConfirm,
+  onCancel
+}) {
+  return (
+    <>
+      <HideDivider />
+      <SoftenCorners />
+      <RemoveTopPadding />
+      <ModalDisplayTemplateB
+        show={isOpen}
+        toggleModal={onCancel}
+        externalUniqueId="confirmCloseModal"
+        textFieldJSX={
+          <Content>
+            <MessageRow>
+              <StyledInfoIcon />
+              <Message>
+                You have not sent any invites.<br/>
+                Are you sure you want to close?
+              </Message>
+            </MessageRow>
+            <ButtonRow>
+              <TextButton onClick={onConfirm}>
+                Yes, close
+              </TextButton>
+              <CloseButton onClick={onCancel}>
+                No, go back
+              </CloseButton>
+            </ButtonRow>
+          </Content>
+        }
+        tallMode={false}
+      />
+    </>
+  );
+}
+
+ConfirmCloseModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onConfirm: PropTypes.func.isRequired,
+  onCancel: PropTypes.func.isRequired,
+};
+
+// Global Styles
+const HideDivider = createGlobalStyle`
+  .MuiDialogTitle-root:has(#closeModalDisplayTemplateBconfirmCloseModal) > hr {
+    display: none !important;
+  }
+`;
+
+const SoftenCorners = createGlobalStyle`
+  .MuiDialog-paper:has(#closeModalDisplayTemplateBconfirmCloseModal) {
+    border-radius: 20px !important;
+  }
+`;
+
+const RemoveTopPadding = createGlobalStyle`
+  .MuiDialog-paper:has(#closeModalDisplayTemplateBconfirmCloseModal) .MuiDialogContent-root {
+    padding-top: 0 !important;
+    overflow: visible !important;
+  }
+  .MuiDialog-paper:has(#closeModalDisplayTemplateBconfirmCloseModal) .MuiDialogContent-root > div {
+    margin-top: 0 !important;
+  }
+  .MuiDialog-paper:has(#closeModalDisplayTemplateBconfirmCloseModal) {
+    overflow: visible !important;
+  }
+`;
+
+// Styles
+
+const ButtonRow = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-right: -14px;
+  margin-bottom: -8px;
+`;
+
+const CloseButton = styled.button`
+  background: ${DesignTokenColors.primary700};
+  padding: 10px 18px;
+  color: white;
+  border-radius: 50px;
+  border: none;
+  cursor: pointer;
+  &:hover {
+    background: ${DesignTokenColors.primary800};
+  }
+`;
+
+const Content = styled.div`
+  padding: 0 22px 18px 8px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 110px;
+`;
+
+const Message = styled.div`
+  font-size: 17px;
+`;
+
+const MessageRow = styled.div`
+  display: flex;
+  gap: 2px;
+  align-items: flex-start;
+  margin-top: -12px;
+`;
+
+const StyledInfoIcon = styled(Info)`
+  color: ${DesignTokenColors.neutralUI600};
+  margin-right: 5px;
+  flex-shrink: 0;
+`;
+
+const TextButton = styled.button`
+  background: none;
+  border: none;
+  color: ${DesignTokenColors.primary700};
+  cursor: pointer;
+  margin-right: 25px;
+  font-size: 16px;
+  &:hover {
+    text-decoration: underline;
+  }
+`;

--- a/src/js/components/More/EditInvitationModal.jsx
+++ b/src/js/components/More/EditInvitationModal.jsx
@@ -83,6 +83,7 @@ const EditInvitationModal = ({
 
   return (
     <>
+      <ChangeTitleFont />
       <HideTemplateADivider />
       <WidenEditModal />
       <SoftenCorners />
@@ -108,6 +109,12 @@ EditInvitationModal.propTypes = {
 };
 
 // Global Styles
+
+const ChangeTitleFont = createGlobalStyle`
+  .MuiDialogTitle-root:has(#closeModalDisplayTemplateAeditInvitationModal) * {
+    font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
+  }
+`;
 
 const HideTemplateADivider = createGlobalStyle`
   .MuiDialogTitle-root:has(#closeModalDisplayTemplateAeditInvitationModal) > hr {

--- a/src/js/components/More/InviteSelectedModal.jsx
+++ b/src/js/components/More/InviteSelectedModal.jsx
@@ -1,0 +1,543 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { createGlobalStyle } from 'styled-components';
+import { CheckCircle, Warning, Visibility } from '@mui/icons-material';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+import ModalDisplayTemplateA from '../Widgets/ModalDisplayTemplateA';
+
+import ConfirmCloseModal from './ConfirmCloseModal';
+
+export default function InviteSelectedModal({
+  isOpen,
+  toggleModal,
+  voters,
+  onInviteEmail,
+  onInviteText,
+  onOpenPreview,
+  onRemove,
+}) {
+
+  // Set to true to use hard-coded test data
+  const TEST_MODE = false;
+
+  if (TEST_MODE) {
+    voters = [
+      { id: 1, name: 'John Smith', email: 'jd@email.com', phone: '(212)-123-4567' },
+      { id: 2, name: 'Jane Smith', email: 'jd@email.com', phone: '(213)-123-4567' },
+      { id: 3, name: 'Kate Smith', email: null, phone: null },
+      { id: 4, name: 'John Doooooooooooough', email: 'jd@email.com', phone: '(213)-123-4567' },
+      { id: 5, name: 'Jane Dough', email: 'jd@email.com', phone: null },
+      { id: 6, name: 'Belcalis Almanzar', email: null, phone: '(213)-123-4567' },
+      { id: 7, name: 'Ricardo Reynoso', email: 'rr@email.com', phone: null },
+      { id: 8, name: 'Jalen Richardson', email: 'jr@email.com', phone: '(213)-123-4567' },
+      { id: 9, name: 'Michael Montgomery', email: null, phone: null },
+    ];
+  }
+
+  const count = voters.length;
+
+  // Categorizing voters with missing contact info
+  const missingEmail = voters.filter(v => !v.email);
+  const missingEmailOnly = voters.filter(v => !v.email && v.phone);
+  const missingPhoneOnly = voters.filter(v => v.email && !v.phone);
+  const missingBoth = voters.filter(v => !v.email && !v.phone);
+
+  const missingEmailCount = missingEmail.length;
+  const missingEmailOnlyCount = missingEmailOnly.length;
+  const missingPhoneOnlyCount = missingPhoneOnly.length;
+  const missingBothCount = missingBoth.length;
+
+  const hasAnyMissingInfo = missingEmailOnlyCount > 0 || missingPhoneOnlyCount > 0 || missingBothCount > 0;
+
+  // State management
+  const [batchEmailSent, setBatchEmailSent] = React.useState(false);
+  const [emailSentIds, setEmailSentIds] = React.useState(new Set());
+  const [textSentIds, setTextSentIds] = React.useState(new Set());
+  const [showConfirmClose, setShowConfirmClose] = React.useState(false);
+
+  // Event handlers
+  const handleSendBatchEmail = () => {
+    if (onInviteEmail) {
+      onInviteEmail(voters);
+    }
+    setBatchEmailSent(true);
+    setEmailSentIds(new Set(voters.map(v => v.id || v._idx)));
+  };
+
+  const handleSendText = (voter) => {
+    if (onInviteText) {
+      onInviteText([voter]);
+    }
+    setTextSentIds(prev => new Set(prev).add(voter.id || voter._idx));
+  };
+
+  const handleClose = () => {
+    if (emailSentIds.size === 0 && textSentIds.size === 0) {
+      setShowConfirmClose(true);
+    } else {
+      toggleModal();
+    }
+  };
+
+  const handleConfirmClose = () => {
+    toggleModal();
+    setShowConfirmClose(false);
+  };
+
+  const renderClickableNames = (voters) => {
+    return voters.map((v, index) => (
+      <React.Fragment key={v.id || v._idx || index}>
+        {index > 0 && ', '}
+        <ClickableName onClick={() => console.log('TODO: implement voter edit', v.name)}>
+          {v.name || "Unknown"}
+        </ClickableName>
+      </React.Fragment>
+    ));
+  };
+
+  const dialogTitleJSX = (
+    <HeaderRow>
+      <Title>Invite by email and/or text&nbsp;</Title>
+      <Count>({count} voter{count > 1 ? 's' : ''} selected)</Count>
+    </HeaderRow>
+  );
+
+  const textFieldJSX = (
+    <Container>
+      <TopRow>
+        <IntroList>
+          <li>Batch invites can only be sent via email.</li>
+          <li>Send text invites separately for each supporter.</li>
+        </IntroList>
+        <HeaderDivider />
+        <PreviewButton
+          onClick={() => {
+            toggleModal();
+            onOpenPreview();
+          }}
+        >
+          <Visibility/>
+          <span>Preview invitation</span>
+        </PreviewButton>
+      </TopRow>
+
+      {hasAnyMissingInfo && (
+        <WarningBox>
+          <Warning size={18} style={{ flexShrink: 0, alignSelf: 'flex-start' }} />
+          <WarningList>
+            {missingEmailOnlyCount > 0 && (
+              <li>
+                Email not entered for {missingEmailOnlyCount} voter{missingEmailOnlyCount > 1 && 's'}:{' '}
+                {renderClickableNames(missingEmailOnly)}
+              </li>
+            )}
+            {missingPhoneOnlyCount > 0 && (
+              <li>
+                Mobile phone not entered for {missingPhoneOnlyCount} voter{missingPhoneOnlyCount > 1 && 's'}:{' '}
+                {renderClickableNames(missingPhoneOnly)}
+              </li>
+            )}
+            {missingBothCount > 0 && (
+              <>
+                <li>
+                  <span style={{ color: DesignTokenColors.neutralUI400 }}>
+                    {missingBothCount} voter{missingBothCount > 1 && 's'} cannot be invited (no email or mobile phone entered) -
+                  </span>
+                </li>
+                <div>
+                  not selectable: {renderClickableNames(missingBoth)}
+                </div>
+              </>
+            )}
+          </WarningList>
+        </WarningBox>
+      )}
+
+      <SectionTitleRow>Batch-invite by email</SectionTitleRow>
+      {batchEmailSent ? (
+        <SentStatus style={{ marginBottom: '20px' }}>
+          <SuccessIcon />
+          Sent
+        </SentStatus>
+      ) : (
+        <>
+          <SendButton onClick={handleSendBatchEmail}>
+            Send email invite to {count} supporter{count > 1 && 's'}
+          </SendButton>
+          {missingEmailCount > 0 && (
+            <WarningBox style={{ marginTop: '8px', marginBottom: '30px', paddingLeft: '0' }}>
+              <Warning size={18} style={{ flexShrink: 0 }} />
+              <span>
+                No email entered for: {renderClickableNames(missingEmail)}
+              </span>
+            </WarningBox>
+          )}
+        </>
+      )}
+
+      <SectionTitleRow>
+        <SectionTitle>Invite by text</SectionTitle>
+        <SmallDivider />
+        <SmallActionLink onClick={() => console.log("TODO: send list to phone")}>
+          Send list to phone
+        </SmallActionLink>
+      </SectionTitleRow>
+      {voters.map(v => {
+        const id = v.id || v._idx;
+        return (
+          <VoterRow key={id}>
+            <VoterName>{v.name}</VoterName>
+            {v.phone ? (
+              textSentIds.has(id) ? (
+                <SentButton>
+                  <SuccessIcon />
+                  Text invite sent
+                </SentButton>
+              ) : (
+                <SendTextButton onClick={() => handleSendText(v)}>
+                  Send text invite
+                </SendTextButton>
+              )
+            ) : (
+              <MissingPhone onClick={() => console.log("TODO: implement add phone number")}>
+                <Warning size={18} />
+                <span>Enter mobile phone</span>
+              </MissingPhone>
+            )}
+
+            <EmailStatus>
+              {emailSentIds.has(id) && (
+                <SentStatus>
+                  <SuccessIcon />
+                  Email sent
+                </SentStatus>
+              )}
+            </EmailStatus>
+
+            <Remove
+              disabled={count === 1}
+              onClick={() => count > 1 && onRemove(v)}
+            >
+              Remove from list
+            </Remove>
+          </VoterRow>
+        );
+      })}
+
+      <Footer>
+        <CloseButton type="button" onClick={handleClose}>
+          Close
+        </CloseButton>
+      </Footer>
+    </Container>
+  );
+
+  return (
+    <>
+      <ChangeTitleFont />
+      <HideTemplateADivider />
+      <WidenInviteModal />
+      <SoftenCorners />
+      <ModalDisplayTemplateA
+        show={isOpen}
+        toggleModal={toggleModal}
+        externalUniqueId="inviteSelectedModal"
+        dialogTitleJSX={dialogTitleJSX}
+        textFieldJSX={textFieldJSX}
+        tallMode={false}
+      />
+
+      {/* Confirm-close modal if no invites sent */}
+      <ConfirmCloseModal
+        isOpen={showConfirmClose}
+        onConfirm={handleConfirmClose}
+        onCancel={() => setShowConfirmClose(false)}
+      />
+    </>
+  );
+}
+
+InviteSelectedModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  toggleModal: PropTypes.func.isRequired,
+  voters: PropTypes.array.isRequired,
+  onInviteEmail: PropTypes.func.isRequired,
+  onInviteText: PropTypes.func.isRequired,
+  onOpenPreview: PropTypes.func.isRequired,
+  onRemove: PropTypes.func.isRequired,
+};
+
+// Global Styles
+
+const ChangeTitleFont = createGlobalStyle`
+  .MuiDialogTitle-root:has(#closeModalDisplayTemplateAinviteSelectedModal) * {
+    font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
+    font-weight: 400 !important;
+  }
+`;
+
+const HideTemplateADivider = createGlobalStyle`
+  .MuiDialogTitle-root:has(#closeModalDisplayTemplateAinviteSelectedModal) > hr {
+    display: none !important;
+  }
+`;
+
+const SoftenCorners = createGlobalStyle`
+  .MuiDialog-paper:has(#closeModalDisplayTemplateAinviteSelectedModal) {
+    border-radius: 14px !important;
+  }
+`;
+
+const WidenInviteModal = createGlobalStyle`
+  .MuiDialog-paper:has(#closeModalDisplayTemplateAinviteSelectedModal) {
+    max-width: 860px !important;
+    width: 96% !important;
+  }
+`;
+
+// Styles
+
+const ClickableName = styled.span`
+  color: ${DesignTokenColors.primary700};
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const CloseButton = styled.button`
+  background: ${DesignTokenColors.primary700};
+  padding: 10px 18px;
+  color: white;
+  border-radius: 50px;
+  border: none;
+  cursor: pointer;
+  &:hover {
+    background: ${DesignTokenColors.primary800};
+  }
+`;
+
+const Container = styled.div`
+  padding: 0 22px 24px;
+`;
+
+const Count = styled.h3`
+  font-size: 16px;
+  font-weight: 500;
+`;
+
+const EmailStatus = styled.span`
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 22px;
+`;
+
+const HeaderDivider = styled.div`
+  width: 1.5px;
+  height: 60px;
+  background: ${DesignTokenColors.neutralUI100};
+  margin: 0 6px;
+  align-self: center;
+`;
+
+const HeaderRow = styled.div`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 12px 0 18px;
+`;
+
+const IntroList = styled.ul`
+  padding-left: 18px;
+  line-height: 1.45;
+  margin: 0 4px 0 0;
+`;
+
+const MissingPhone = styled.div`
+  display: flex;
+  height: 42px;
+  align-items: center;
+  padding: 6px 0;
+  gap: 6px;
+  color: ${DesignTokenColors.primary700};
+  cursor: pointer;
+  font-size: 14px;
+  width: fit-content;
+  &:hover { text-decoration: underline; }
+
+  svg { color: ${DesignTokenColors.tertiary900}; }
+`;
+
+const PreviewButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: none;
+  color: ${DesignTokenColors.primary700};
+  font-size: 16px;
+  cursor: pointer;
+  white-space: nowrap;
+  padding: 6px 8px;
+  &:hover {
+    text-decoration: underline;
+  }
+  svg { font-size: 22px; }
+`;
+
+const Remove = styled.span`
+  justify-self: end;
+  color: ${props => (props.disabled ? DesignTokenColors.neutralUI300 : DesignTokenColors.primary700)};
+  cursor: ${props => (props.disabled ? 'not-allowed' : 'pointer')};
+  pointer-events: ${props => (props.disabled ? 'none' : 'auto')};
+  text-align: right;
+  padding-right: 10px;
+  &:hover {
+    text-decoration: ${props => (props.disabled ? 'none' : 'underline')};
+  }
+`;
+
+const SectionTitle = styled.h3`
+  font-size: 19px;
+  font-weight: 500;
+  margin: 0;
+`;
+
+const SectionTitleRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 20px 0 5px;
+  font-size: 19px;
+  font-weight: 500;
+`;
+
+const SendButton = styled.button`
+  background: ${DesignTokenColors.primary700};
+  border: 1px solid ${DesignTokenColors.primary700};
+  border-radius: 9999px;
+  color: ${DesignTokenColors.whiteUI};
+  cursor: pointer;
+  padding: 0 16px;
+  font-size: 12px;
+  height: 42px;
+  width: fit-content;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  &:hover {
+    background: ${DesignTokenColors.primary800};
+    border-color: ${DesignTokenColors.primary800};
+  }
+`;
+
+const SendTextButton = styled(SendButton)`
+  font-size: 13px;
+  width: 150px;
+`;
+
+const SentButton = styled(SendTextButton)`
+  background: ${DesignTokenColors.neutralUI50};
+  border-color: ${DesignTokenColors.neutralUI50};
+  color: ${DesignTokenColors.neutralUI500};
+  cursor: default;
+  pointer-events: none;
+  &:hover {
+    background: ${DesignTokenColors.neutralUI100};
+    border-color: ${DesignTokenColors.neutralUI100};
+  }
+`;
+
+const SmallActionLink = styled.button`
+  background: none;
+  border: none;
+  color: ${DesignTokenColors.primary700};
+  font-size: 16px;
+  font-weight: 400;
+  cursor: pointer;
+  padding: 0;
+  white-space: nowrap;
+  &:hover { text-decoration: underline; }
+`;
+
+const SmallDivider = styled.div`
+  width: 1.5px;
+  height: 25px;
+  background: ${DesignTokenColors.neutralUI100};
+  margin: 0 6px;
+  align-self: center;
+`;
+
+const SuccessIcon = styled(CheckCircle)`
+  color: ${DesignTokenColors.confirmation500};
+  display: inline-flex;
+  font-size: 18px;
+  line-height: 1;
+`;
+
+const Title = styled.h3`
+  font-size: 28px;
+  font-weight: 400;
+`;
+
+const TopRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-bottom: 14px;
+`;
+
+const VoterName = styled.span`
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const SentStatus = styled(VoterName)`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+const VoterRow = styled.div`
+  border-bottom: 2px solid ${DesignTokenColors.neutralUI100};
+  padding: 12px 0;
+  display: grid;
+  grid-template-columns: 95px 170px auto 1fr;
+  align-items: center;
+  column-gap: 24px;
+`;
+
+const WarningBox = styled.div`
+  padding-left: 18px;
+  display: flex;
+  gap: 6px;
+  align-items: flex-start;
+  margin: 0 8px 14px 0;
+  font-size: 15px;
+  svg {
+    color: ${DesignTokenColors.tertiary900};
+    margin-top: 0;
+    align-self: flex-start;
+  }
+`;
+
+const WarningList = styled.ul`
+  margin: 0;
+  padding-left: 18px;
+  line-height: 1.45;
+  li {
+    margin-bottom: 4px;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+`;

--- a/src/js/components/More/PasteListModal.jsx
+++ b/src/js/components/More/PasteListModal.jsx
@@ -188,6 +188,7 @@ John Dough, jd@email.com, (213)-123-4567`}
 
   return (
     <>
+      <ChangeTitleFont />
       <HideTemplateADivider />
       <WidenPasteModal />
       <SoftenCorners />
@@ -210,6 +211,12 @@ PasteListModal.propTypes = {
 };
 
 // Global Styles
+
+const ChangeTitleFont = createGlobalStyle`
+  .MuiDialogTitle-root:has(#closeModalDisplayTemplateApasteListModal) * {
+    font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
+  }
+`;
 
 const HideTemplateADivider = createGlobalStyle`
   .MuiDialogTitle-root:has(#closeModalDisplayTemplateApasteListModal) > hr {

--- a/src/js/components/More/PreviewInvitationModal.jsx
+++ b/src/js/components/More/PreviewInvitationModal.jsx
@@ -68,6 +68,7 @@ const PreviewInvitationModal = ({
 
   return (
     <>
+      <ChangeTitleFont />
       <HideTemplateADivider />
       <WidenPreviewModal />
       <SoftenCorners />
@@ -93,6 +94,12 @@ PreviewInvitationModal.propTypes = {
 };
 
 // Global Styles
+
+const ChangeTitleFont = createGlobalStyle`
+  .MuiDialogTitle-root:has(#closeModalDisplayTemplateApreviewInvitationModal) * {
+    font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
+  }
+`;
 
 const HideTemplateADivider = createGlobalStyle`
   .MuiDialogTitle-root:has(#closeModalDisplayTemplateApreviewInvitationModal) > hr {
@@ -146,7 +153,7 @@ const HeaderRow = styled.div`
   align-items: center;
   display: flex;
   justify-content: space-between;
-  padding: 0px 12px 0 18px;
+  padding: 0 12px 0 18px;
 `;
 
 const InfoDot = styled.span`

--- a/src/js/components/More/UploadCSVModal.jsx
+++ b/src/js/components/More/UploadCSVModal.jsx
@@ -149,6 +149,7 @@ export default function UploadCSVModal ({
 
   return (
     <>
+      <ChangeTitleFont />
       <HideTemplateADivider />
       <WidenUploadModal />
       <SoftenCorners />
@@ -172,6 +173,12 @@ UploadCSVModal.propTypes = {
 };
 
 // Global Styles
+
+const ChangeTitleFont = createGlobalStyle`
+  .MuiDialogTitle-root:has(#closeModalDisplayTemplateAuploadCSVModal) * {
+    font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
+  }
+`;
 
 const HideTemplateADivider = createGlobalStyle`
   .MuiDialogTitle-root:has(#closeModalDisplayTemplateAuploadCSVModal) > hr {

--- a/src/js/components/PoliticiansManaged/ImportedVotersList.jsx
+++ b/src/js/components/PoliticiansManaged/ImportedVotersList.jsx
@@ -15,6 +15,8 @@ import {
 } from '@mui/icons-material';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 
+import InviteSelectedModal from '../More/InviteSelectedModal';
+
 function formatWhen (iso) {
   try {
     const d = iso ? new Date(iso) : new Date();
@@ -26,11 +28,11 @@ function formatWhen (iso) {
 
 export default function ImportedVotersList ({
   voters,
-  onInviteSelected,
   onInviteEmail,
   onInviteText,
   onHide,
   onHideSelected,
+  onOpenPreview,
   onShowHidden,
   onViewHistory,
   onDeleteSelected,
@@ -40,6 +42,9 @@ export default function ImportedVotersList ({
   const [selected, setSelected] = useState(() => new Set());
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef(null);
+
+  const [inviteModalOpen, setInviteModalOpen] = useState(false);
+  const [inviteList, setInviteList] = useState([]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -79,241 +84,261 @@ export default function ImportedVotersList ({
   };
 
   return (
-    <Card aria-label="Imported voters (not invited)">
-      <ListTopBar>
-        <TopBarLeft>
-          <ListHeading>Imported voters (not invited)</ListHeading>
-          <TopDivider aria-hidden />
-          <SearchField aria-label="Search imported voters">
-            <SearchIcon aria-hidden />
-            <SearchInput
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-            />
-          </SearchField>
-        </TopBarLeft>
+    <>
+      <Card aria-label="Imported voters (not invited)">
+        <ListTopBar>
+          <TopBarLeft>
+            <ListHeading>Imported voters (not invited)</ListHeading>
+            <TopDivider aria-hidden />
+            <SearchField aria-label="Search imported voters">
+              <SearchIcon aria-hidden />
+              <SearchInput
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+            </SearchField>
+          </TopBarLeft>
 
-        <TopBarRight>
-          <InviteButton
-            type="button"
-            disabled={selectedList.length === 0}
-            onClick={() => onInviteSelected(selectedList)}
-            aria-label={`Invite selected (${selectedList.length})`}
-            title={
-              selectedList.length ?
-                `Invite selected (${selectedList.length})` :
-                'Invite selected'
-            }
-          >
-            Invite selected (
-            {selectedList.length}
-            )
-          </InviteButton>
-
-          <OverflowWrap>
-            <OverflowBtn
+          <TopBarRight>
+            <InviteButton
               type="button"
-              aria-label="More options"
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
-              onClick={() => setMenuOpen((o) => !o)}
-              title="More options"
+              disabled={selectedList.length === 0}
+              onClick={() => {
+                setInviteList(selectedList);
+                setInviteModalOpen(true);
+              }}
+              aria-label={`Invite selected (${selectedList.length})`}
+              title={
+                selectedList.length ?
+                  `Invite selected (${selectedList.length})` :
+                  'Invite selected'
+              }
             >
-              <OverflowIcon fontSize="small" />
-            </OverflowBtn>
-            {menuOpen && (
-              <MenuCard role="menu" ref={menuRef}>
-                <MenuItem
-                  role="menuitem"
-                  onClick={() => {
-                    onShowHidden?.();
-                    setMenuOpen(false);
-                  }}
-                >
-                  <ShowIcon fontSize="small" />
-                  <span>Show hidden</span>
-                </MenuItem>
+              Invite selected (
+              {selectedList.length}
+              )
+            </InviteButton>
 
-                <MenuItem
-                  role="menuitem"
-                  onClick={() => {
-                    onViewHistory?.();
-                    setMenuOpen(false);
-                  }}
-                >
-                  <HistoryIcon fontSize="small" />
-                  <span>View history of imports</span>
-                </MenuItem>
-                <MenuDivider />
+            <OverflowWrap>
+              <OverflowBtn
+                type="button"
+                aria-label="More options"
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                onClick={() => setMenuOpen((o) => !o)}
+                title="More options"
+              >
+                <OverflowIcon fontSize="small" />
+              </OverflowBtn>
+              {menuOpen && (
+                <MenuCard role="menu" ref={menuRef}>
+                  <MenuItem
+                    role="menuitem"
+                    onClick={() => {
+                      onShowHidden?.();
+                      setMenuOpen(false);
+                    }}
+                  >
+                    <ShowIcon fontSize="small" />
+                    <span>Show hidden</span>
+                  </MenuItem>
 
-                {selectedList.length > 0 ? (
-                  <>
-                    <MenuItem
-                      role="menuitem"
-                      onClick={() => {
-                        onHideSelected?.(selectedList);
-                        setMenuOpen(false);
-                      }}
-                    >
-                      <HideIcon fontSize="small" />
-                      <span>Hide</span>
-                    </MenuItem>
+                  <MenuItem
+                    role="menuitem"
+                    onClick={() => {
+                      onViewHistory?.();
+                      setMenuOpen(false);
+                    }}
+                  >
+                    <HistoryIcon fontSize="small" />
+                    <span>View history of imports</span>
+                  </MenuItem>
+                  <MenuDivider />
 
-                    <MenuItem
-                      role="menuitem"
-                      onClick={() => {
-                        onDeleteSelected?.(selectedList);
-                        setMenuOpen(false);
-                      }}
-                    >
-                      <DeleteIcon fontSize="small" />
-                      <span>Delete</span>
-                    </MenuItem>
-                  </>
-                ) : (
-                  <>
-                    <TooltipWrap>
-                      <MenuItem role="menuitem" disabled>
+                  {selectedList.length > 0 ? (
+                    <>
+                      <MenuItem
+                        role="menuitem"
+                        onClick={() => {
+                          onHideSelected?.(selectedList);
+                          setMenuOpen(false);
+                        }}
+                      >
                         <HideIcon fontSize="small" />
                         <span>Hide</span>
                       </MenuItem>
-                      <TooltipBubble>
-                        Select voters to allow hiding or deleting.
-                      </TooltipBubble>
-                    </TooltipWrap>
 
-                    <TooltipWrap>
-                      <MenuItem role="menuitem" disabled>
+                      <MenuItem
+                        role="menuitem"
+                        onClick={() => {
+                          onDeleteSelected?.(selectedList);
+                          setMenuOpen(false);
+                        }}
+                      >
                         <DeleteIcon fontSize="small" />
                         <span>Delete</span>
                       </MenuItem>
-                      <TooltipBubble>
-                        Select voters to allow hiding or deleting.
-                      </TooltipBubble>
-                    </TooltipWrap>
-                  </>
-                )}
-              </MenuCard>
-            )}
-          </OverflowWrap>
-        </TopBarRight>
-      </ListTopBar>
+                    </>
+                  ) : (
+                    <>
+                      <TooltipWrap>
+                        <MenuItem role="menuitem" disabled>
+                          <HideIcon fontSize="small" />
+                          <span>Hide</span>
+                        </MenuItem>
+                        <TooltipBubble>
+                          Select voters to allow hiding or deleting.
+                        </TooltipBubble>
+                      </TooltipWrap>
 
-      <Toolbar>
-        <label>
-          <input
-            type="checkbox"
-            checked={allVisibleSelected}
-            onChange={toggleAllVisible}
-          />
-          <span>Select all</span>
-        </label>
-      </Toolbar>
+                      <TooltipWrap>
+                        <MenuItem role="menuitem" disabled>
+                          <DeleteIcon fontSize="small" />
+                          <span>Delete</span>
+                        </MenuItem>
+                        <TooltipBubble>
+                          Select voters to allow hiding or deleting.
+                        </TooltipBubble>
+                      </TooltipWrap>
+                    </>
+                  )}
+                </MenuCard>
+              )}
+            </OverflowWrap>
+          </TopBarRight>
+        </ListTopBar>
 
-      <Table role="table" aria-label="Imported voters table">
-        <TrHead role="row">
-          <ThCenter role="columnheader" aria-label="Select" />
-          <ThCenter role="columnheader" aria-label="Expand" />
-          <Th role="columnheader">Name</Th>
-          <Th role="columnheader">Email</Th>
-          <Th role="columnheader">Phone</Th>
-          <ThRight role="columnheader" aria-label="Actions" />
-        </TrHead>
+        <Toolbar>
+          <label>
+            <input
+              type="checkbox"
+              checked={allVisibleSelected}
+              onChange={toggleAllVisible}
+            />
+            <span>Select all</span>
+          </label>
+        </Toolbar>
 
-        <Tbody role="rowgroup">
-          {filtered.map((v, idx) => {
-            const id = v.id || v._idx || `row_${idx}`;
-            const isOpen = expandedId === id;
-            const isChecked = selected.has(id);
-            const showDetails = isOpen || isChecked; // no hover reveal
+        <Table role="table" aria-label="Imported voters table">
+          <TrHead role="row">
+            <ThCenter role="columnheader" aria-label="Select" />
+            <ThCenter role="columnheader" aria-label="Expand" />
+            <Th role="columnheader">Name</Th>
+            <Th role="columnheader">Email</Th>
+            <Th role="columnheader">Phone</Th>
+            <ThRight role="columnheader" aria-label="Actions" />
+          </TrHead>
 
-            return (
-              <React.Fragment key={id}>
-                <Tr role="row" className={isChecked ? 'selected' : undefined}>
-                  <TdCheck role="cell">
-                    <Checkbox
-                      type="checkbox"
-                      checked={isChecked}
-                      onChange={() => toggleOne(id)}
-                      aria-label={`Select ${v.name || 'voter'}`}
-                    />
-                  </TdCheck>
+          <Tbody role="rowgroup">
+            {filtered.map((v, idx) => {
+              const id = v.id || v._idx || `row_${idx}`;
+              const isOpen = expandedId === id;
+              const isChecked = selected.has(id);
+              const showDetails = isOpen || isChecked; // no hover reveal
 
-                  <TdExpand role="cell">
-                    <ExpandBtn
-                      type="button"
-                      aria-expanded={isOpen}
-                      aria-label={isOpen ? 'Collapse row' : 'Expand row'}
-                      onClick={() => toggleRow(id)}
-                    >
-                      {isOpen ? (
-                        <CollapseIcon fontSize="small" />
-                      ) : (
-                        <ExpandIcon fontSize="small" />
-                      )}
-                    </ExpandBtn>
-                  </TdExpand>
+              return (
+                <React.Fragment key={id}>
+                  <Tr role="row" className={isChecked ? 'selected' : undefined}>
+                    <TdCheck role="cell">
+                      <Checkbox
+                        type="checkbox"
+                        checked={isChecked}
+                        onChange={() => toggleOne(id)}
+                        aria-label={`Select ${v.name || 'voter'}`}
+                      />
+                    </TdCheck>
 
-                  <Td role="cell" title={v.name || '—'}>
-                    {v.name || '—'}
-                  </Td>
-                  <Td role="cell" title={v.email || '—'}>
-                    {v.email || '—'}
-                  </Td>
-                  <Td role="cell" title={v.phone || '—'}>
-                    {v.phone || '—'}
-                  </Td>
-
-                  <TdActions role="cell">
-                    <ActionsInline className="row-actions">
-                      <ActionPill
+                    <TdExpand role="cell">
+                      <ExpandBtn
                         type="button"
-                        onClick={() => onInviteEmail([v])}
+                        aria-expanded={isOpen}
+                        aria-label={isOpen ? 'Collapse row' : 'Expand row'}
+                        onClick={() => toggleRow(id)}
                       >
-                        <MailIcon fontSize="small" />
-                        <span>Send email invite</span>
-                      </ActionPill>
-                      <ActionPill
-                        type="button"
-                        onClick={() => onInviteText([v])}
-                      >
-                        <SmsIcon fontSize="small" />
-                        <span>Send text invite</span>
-                      </ActionPill>
-                      <ActionPill type="button" onClick={() => onHide(v)}>
-                        <HideIcon fontSize="small" />
-                        <span>Hide</span>
-                      </ActionPill>
-                    </ActionsInline>
-                  </TdActions>
-                </Tr>
+                        {isOpen ? (
+                          <CollapseIcon fontSize="small" />
+                        ) : (
+                          <ExpandIcon fontSize="small" />
+                        )}
+                      </ExpandBtn>
+                    </TdExpand>
 
-                {showDetails && (
-                  <TrDetails role="row">
-                    <TdFull>
-                      <DetailsGrid>
-                        <DetailBlock>
-                          <DetailLabel>Added via</DetailLabel>
-                          <div>{v.source || 'Manual entry'}</div>
-                        </DetailBlock>
-                        <DetailBlock>
-                          <DetailLabel>Added by</DetailLabel>
-                          <div>{v.addedBy || 'You'}</div>
-                        </DetailBlock>
-                        <DetailBlock>
-                          <DetailLabel>Added on</DetailLabel>
-                          <div>{formatWhen(v.addedAt)}</div>
-                        </DetailBlock>
-                      </DetailsGrid>
-                    </TdFull>
-                  </TrDetails>
-                )}
-              </React.Fragment>
-            );
-          })}
-        </Tbody>
-      </Table>
-    </Card>
+                    <Td role="cell" title={v.name || '—'}>
+                      {v.name || '—'}
+                    </Td>
+                    <Td role="cell" title={v.email || '—'}>
+                      {v.email || '—'}
+                    </Td>
+                    <Td role="cell" title={v.phone || '—'}>
+                      {v.phone || '—'}
+                    </Td>
+
+                    <TdActions role="cell">
+                      <ActionsInline className="row-actions">
+                        <ActionPill
+                          type="button"
+                          onClick={() => onInviteEmail([v])}
+                        >
+                          <MailIcon fontSize="small" />
+                          <span>Send email invite</span>
+                        </ActionPill>
+                        <ActionPill
+                          type="button"
+                          onClick={() => onInviteText([v])}
+                        >
+                          <SmsIcon fontSize="small" />
+                          <span>Send text invite</span>
+                        </ActionPill>
+                        <ActionPill type="button" onClick={() => onHide(v)}>
+                          <HideIcon fontSize="small" />
+                          <span>Hide</span>
+                        </ActionPill>
+                      </ActionsInline>
+                    </TdActions>
+                  </Tr>
+
+                  {showDetails && (
+                    <TrDetails role="row">
+                      <TdFull>
+                        <DetailsGrid>
+                          <DetailBlock>
+                            <DetailLabel>Added via</DetailLabel>
+                            <div>{v.source || 'Manual entry'}</div>
+                          </DetailBlock>
+                          <DetailBlock>
+                            <DetailLabel>Added by</DetailLabel>
+                            <div>{v.addedBy || 'You'}</div>
+                          </DetailBlock>
+                          <DetailBlock>
+                            <DetailLabel>Added on</DetailLabel>
+                            <div>{formatWhen(v.addedAt)}</div>
+                          </DetailBlock>
+                        </DetailsGrid>
+                      </TdFull>
+                    </TrDetails>
+                  )}
+                </React.Fragment>
+              );
+            })}
+          </Tbody>
+        </Table>
+      </Card>
+
+      {/* Invite selected modal */}
+      <InviteSelectedModal
+        isOpen={inviteModalOpen}
+        toggleModal={() => setInviteModalOpen(false)}
+        voters={inviteList}
+        onInviteEmail={onInviteEmail}
+        onInviteText={onInviteText}
+        onOpenPreview={onOpenPreview}
+        onRemove={(v) =>
+          setInviteList(prev =>
+            prev.filter(p => (p.id || p._idx) !== (v.id || v._idx))
+          )
+        }
+      />
+    </>
   );
 }
 
@@ -329,12 +354,12 @@ ImportedVotersList.propTypes = {
       addedAt: PropTypes.string,
     }),
   ).isRequired,
-  onInviteSelected: PropTypes.func.isRequired,
   onInviteEmail: PropTypes.func.isRequired,
   onInviteText: PropTypes.func.isRequired,
   onHide: PropTypes.func.isRequired,
   onHideSelected: PropTypes.func.isRequired,
   onShowHidden: PropTypes.func,
+  onOpenPreview: PropTypes.func,
   onViewHistory: PropTypes.func,
   onDeleteSelected: PropTypes.func,
 };

--- a/src/js/pages/More/ManageMyCandidates.jsx
+++ b/src/js/pages/More/ManageMyCandidates.jsx
@@ -72,9 +72,9 @@ Thanks for your help!`);
 
   const emailRE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
 
-  const handleInviteSelected = useCallback((rows) => {
-    notify(`Invited ${rows.length} voter${rows.length === 1 ? '' : 's'} by email.`);
-  }, [notify]);
+  // const handleInviteSelected = useCallback((rows) => {
+  //   notify(`Invited ${rows.length} voter${rows.length === 1 ? '' : 's'} by email.`);
+  // }, [notify]);
 
   const handleInviteEmailOneOrMany = useCallback((rows) => {
     notify(`Email invite sent to ${rows.length} voter${rows.length === 1 ? '' : 's'}.`);
@@ -198,11 +198,12 @@ Thanks for your help!`);
         <Suspense fallback={<></>}>
           <ImportedVotersList
             voters={importedVoters.map((v, _idx) => ({ _idx, ...v }))} // ensure stable key if no id
-            onInviteSelected={handleInviteSelected}
+            // onInviteSelected={handleInviteSelected}
             onInviteEmail={handleInviteEmailOneOrMany}
             onInviteText={handleInviteTextOneOrMany}
             onHide={handleHideOne}
             onHideSelected={handleHideMany}
+            onOpenPreview={handlePreviewOpen}
           />
         </Suspense>
       )}


### PR DESCRIPTION
Some notes:

- **IMPORTANT** The "Paste list" modal doesn't let you import voters without an email, so in order to test for voters with missing emails, I hardcoded a list of invitees that overrides whatever list you currently had selected. To enable this, simply set const TEST_MODE to true.

- We might want to add a 'Back to invite' button to "Preview invitation" modal when accessing it from the "Invite selected" modal

- Currently, the first column on the invitees list (their names) has a fixed length of 95px, so any long names get cut off with ellipses. This column can be adjusted to be longer, and the subsequent columns will shift accordingly with no issue, but an idea is to maybe have every voter's last name just be their initial so we can leave the first column short for mobile. Currently any name longer than "John Smith" gets cut off.

- When there's only 1 invitee left, its respective "Remove from list" button becomes un-selectable to prevent an empty list

- Minor change, but I fixed the font for all the other modals' dialogTitleJSX since they had broken during the migration to Template A