### PR TITLE
[WV-754] Privacy add default visibility

### DIFF
--- a/src/js/common/stories/PrivacyData.stories.js
+++ b/src/js/common/stories/PrivacyData.stories.js
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { ToggleButtonGroup as MuiToggleButtonGroup, ToggleButton as MuiToggleButton } from '@mui/material';
+import { SecurityRounded } from '@mui/icons-material';
+import styled from 'styled-components';
+import { styled as muiStyled } from '@mui/material/styles';
+import {grey as muiGrey, blue as muiBlue} from '@mui/material/colors';
+import DefaultVisibility from '../../components/Settings/DefaultVisibility';
+
+const HeaderContainer = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const ShieldIcon = styled(SecurityRounded)`
+  color: black;
+  height: 23px;
+  width: 23px;
+  margin: 5px 8px 0 -3px;
+`;
+
+const DataSettingSection = styled('div')`
+  margin-top: 24px;
+`;
+
+const PrivacyDataComponent = () => {
+
+  return (
+    <div>
+      <div className="u-stack--md">
+        <HeaderContainer>
+          <ShieldIcon />
+          <h1 className="h2">
+            Privacy &amp; Data
+          </h1>
+        </HeaderContainer>
+        <DataSettingSection>
+          
+          <DefaultVisibility />
+
+        </DataSettingSection>
+      </div>
+    </div>
+  );
+};
+
+export default { 
+  title: 'Design System/Privacy Data',
+  component: PrivacyDataComponent,
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export const ButtonsTest = () => <PrivacyDataComponent />;

--- a/src/js/components/Settings/DefaultVisibility.jsx
+++ b/src/js/components/Settings/DefaultVisibility.jsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import {
+  ToggleButtonGroup as MuiToggleButtonGroup,
+  ToggleButton as MuiToggleButton,
+} from '@mui/material';
+import styled from 'styled-components';
+import { styled as muiStyled } from '@mui/material/styles';
+import { grey as muiGrey, blue as muiBlue } from '@mui/material/colors';
+
+
+/* ---------- Component ---------- */
+
+const PrivacyData = () => {
+  const [alignment, setAlignment] = React.useState('public');
+
+  const handleAlignment = (event, newAlignment) => {
+    if (newAlignment !== null) {
+      setAlignment(newAlignment);
+    }
+  };
+
+  return (
+    <div className="u-stack--md">
+        <h4 className="h4" id="defaultVisibilityText">
+          Default visibility for your future ballot choices &amp; opinions
+        </h4>
+
+        <PrivacyToggleButtonGroup
+          exclusive
+          value={alignment}
+          onChange={handleAlignment}
+          aria-label="Privacy visibility"
+          color="primary"
+          size="small"
+        >
+          <PrivacyToggleButton value="public">Public</PrivacyToggleButton>
+          <PrivacyToggleButton value="friends">WeVote Friends</PrivacyToggleButton>
+          <PrivacyToggleButton value="private">Private</PrivacyToggleButton>
+        </PrivacyToggleButtonGroup>
+
+        <DataSettingText>
+        <font style={{ fontStyle: 'italic' }}>
+        Changing your default visibility won't affect past choices or opinions.
+        You can still adjust the visibility for each new choice or opinion individually.
+        </font>
+          <ul
+            style={{
+              fontStyle: 'normal',
+              paddingInlineStart: '20px',
+              marginTop: '10px',
+            }}
+          >
+            <li>
+            <font style={{ fontWeight: 'bold', color: '#000' }}>Public (recommended): </font> 
+            Expand your reach and influence beyond just your friends.
+            </li>
+            <li>
+            <font style={{ fontWeight: 'bold', color: '#000' }}>Your WeVote friends: </font>
+            People on the platform you've added as friends-so you can see and share opinions more easily.
+            </li>
+            <li>
+            <font style={{ fontWeight: 'bold', color: '#000' }}>Private: </font>
+            Ideal for personal reflection or when you're not ready to share publicly.
+            </li>
+          </ul>
+        </DataSettingText>
+    </div>
+  );
+};
+
+/* ---------- Styled Components ---------- */
+
+const DataSettingText = styled('div')`
+  color: #808080;
+  margin-bottom: 30px;
+`;
+
+const PrivacyToggleButtonGroup = muiStyled(MuiToggleButtonGroup)(({ theme }) => ({
+  marginBottom: theme.spacing(2),
+}));
+
+const PrivacyToggleButton = muiStyled(MuiToggleButton)(({ theme }) => ({
+  border: `2px solid ${theme.palette.divider}`,
+  borderRadius: '15px',
+  borderColor: muiGrey[500],
+  color: muiGrey[700],
+  minHeight: theme.spacing(4),
+  padding: theme.spacing(0, 1),
+  '&.Mui-selected': {
+    color: muiBlue[800],
+    fontWeight: 'bold',
+    borderColor: muiBlue[800],
+    borderTop: `2px solid ${theme.palette.primary.main}`,
+    borderBottom: `2px solid ${theme.palette.primary.main}`,
+  },
+}));
+
+export default PrivacyData;


### PR DESCRIPTION
Added a component to allow for selection of default visibility for your profile. This is not currently used in `SettingsYourData.jsx`  as the actual functionality isn't added yet, this is just the UI.

Text coloring might seem strange, but that is because I tried to match text colors used in `SettingsYourData.jsx`.

Testing:
Tested in StoryBook as well as in the local browser embedded in the expected location (Video included).
https://github.com/user-attachments/assets/9f7608d3-4fda-4217-9bb7-d1b349ab44ef

