### PR TITLE
WV-23 - Added a Smart Tooltip wrapper around React Tooltip to use for different tooltip behaviors. Added tooltip on hover for Ballot tabs.

### DIFF
--- a/src/js/common/components/Widgets/ClaimedProfileIcon.jsx
+++ b/src/js/common/components/Widgets/ClaimedProfileIcon.jsx
@@ -1,78 +1,33 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import React, { useRef } from 'react';
 import SvgImage from './SvgImage';
+import SmartTooltip from './SmartToolTip';
 import normalizedImagePath from '../../utils/normalizedImagePath';
-import claimedProfileIcon from '../../../../img/global/svg-icons/claimed-profile-icon.svg'; // Claimed profile SVG asset.
+import claimedProfileIcon from '../../../../img/global/svg-icons/claimed-profile-icon.svg';
 import DesignTokenColors from '../Style/DesignTokenColors';
-import { useTheme } from '@mui/material/styles';
-import  useMediaQuery from '@mui/material/useMediaQuery';
 
 // Behavior: renders a claimed-profile icon that shows a tooltip reading
 // "Profile claimed by politician." The tooltip appears below the politician image:
 // - Desktop: shows on hover via OverlayTrigger (no navigation triggered).
 // - Mobile: shows on tap and does not navigate; tapping again or elsewhere closes it.
-function ClaimedProfileIcon() {
-  // Pull theme breakpoints to detect desktop vs mobile layout.
-  const theme = useTheme();
-  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
-
-  // using state to control the click behavior on mobile
-  const [showTooltip, setShowTooltip] = useState(false);
-  const iconRef = useRef(null); // Ref used to anchor tooltip and detect outside clicks.
-
-  // Attach listeners for outside clicks and sibling tooltip events.
-  useEffect(() => {
-    function handleClickOutside(e) {
-      if (!e.target.closest('.claimed-profile-icon')) {
-        setShowTooltip(false);
-      }
-    }
-    // Close this tooltip if another claimed profile tooltip was opened.
-    function handleTooltipOpened(e) {
-      if (iconRef.current && e.detail !== iconRef.current) {
-        setShowTooltip(false);
-      }
-    }
-    // Mobile only: register and clean up click listeners.
-    if (!isDesktop) {
-      document.addEventListener('click', handleClickOutside);
-      window.addEventListener('claimedProfileTooltipOpened', handleTooltipOpened);
-      return () => {
-        document.removeEventListener('click', handleClickOutside);
-        window.removeEventListener('claimedProfileTooltipOpened', handleTooltipOpened);
-      };
-    }
-  }, [isDesktop]);
-
-  // Prebuilt tooltip element reused by the overlay trigger.
-  const claimedProfileToolTip = (
-    <Tooltip className="u-z-index-9020" id="claimedProfileTooltip">
-      <div><span>Profile claimed by politician.</span></div>
-    </Tooltip>
-  );
-
-  // Mobile toggle: open/close tooltip and broadcast opening to other instances.
-  const handleClick = () => {
-    if (!showTooltip) {
-      window.dispatchEvent(new CustomEvent('claimedProfileTooltipOpened', { detail: iconRef.current }));
-    }
-    setShowTooltip(prev => !prev);
-  };
+function ClaimedProfileIcon () {
+  const iconRef = useRef(null);
 
   return (
-    <>
-      {/* Show tooltip below on hover/focus for desktop, controlled click for mobile. */}
-      <OverlayTrigger overlay={claimedProfileToolTip} placement="bottom" {...(!isDesktop ? { show: showTooltip } : {})}>
-        {/* Wrapper required by OverlayTrigger child expectations. */}
-        <span ref={iconRef} className="claimed-profile-icon" onClick={!isDesktop ? handleClick : undefined}>
-          <SvgImage
-            color={DesignTokenColors.neutral500}
-            imageName={normalizedImagePath(claimedProfileIcon)} // Provide normalized path to the SVG asset.
-            opacity="1.0"
-          />
-        </span>
-      </OverlayTrigger>
-    </>
+    <SmartTooltip
+      title={<div><span>Profile claimed by politician.</span></div>}
+      placement="bottom"
+      triggerType="both"
+      tooltipId="claimedProfileTooltip"
+    >
+      <span ref={iconRef} className="claimed-profile-icon">
+        <SvgImage
+          applyFillColor
+          color={DesignTokenColors.neutral500}
+          imageName={normalizedImagePath(claimedProfileIcon)}
+          opacity="1.0"
+        />
+      </span>
+    </SmartTooltip>
   );
 }
 

--- a/src/js/common/components/Widgets/SmartToolTip.jsx
+++ b/src/js/common/components/Widgets/SmartToolTip.jsx
@@ -1,0 +1,110 @@
+import React, { useState, useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { useTheme } from '@mui/material/styles';
+import useMediaQuery from '@mui/material/useMediaQuery';
+
+const SmartTooltip = ({ title, placement, triggerType, children, tooltipId }) => {
+  const theme = useTheme();
+  const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
+
+  const [showTooltip, setShowTooltip] = useState(false);
+  const wrapperRef = useRef(null);
+  const idRef = useRef(tooltipId || `smartTooltip-${Math.random().toString(36).slice(2, 11)}`);
+
+  // Determine effective mode (desktop: hover-only, mobile: click-only) based on prop.
+  // "hover" -> desktop only, "click" -> mobile only, "both" -> hover desktop + click mobile.
+  let effectiveMode = 'none';
+  if (triggerType === 'both') {
+    effectiveMode = isDesktop ? 'hover' : 'click';
+  } else if (triggerType === 'hover') {
+    effectiveMode = isDesktop ? 'hover' : 'none';
+  } else if (triggerType === 'click') {
+    effectiveMode = isDesktop ? 'none' : 'click';
+  }
+
+  // Mobile-only: close tooltip when clicking outside and close when another tooltip opens.
+  useEffect(() => {
+    if (effectiveMode !== 'click' || !showTooltip) {
+      return undefined;
+    }
+
+    function handleClickOutside (e) {
+      if (!e.target.closest('.smart-tooltip')) {
+        setShowTooltip(false);
+      }
+    }
+
+    function handleTooltipOpened (e) {
+      if (wrapperRef.current && e.detail !== wrapperRef.current) {
+        setShowTooltip(false);
+      }
+    }
+
+    if (!isDesktop) {
+      document.addEventListener('click', handleClickOutside);
+      window.addEventListener('smartTooltipOpened', handleTooltipOpened);
+      return () => {
+        document.removeEventListener('click', handleClickOutside);
+        window.removeEventListener('smartTooltipOpened', handleTooltipOpened);
+      };
+    }
+    return undefined;
+  }, [effectiveMode, showTooltip, isDesktop]);
+
+  if (effectiveMode === 'none') {
+    return children;
+  }
+  const trigger = effectiveMode === 'hover' ? ['hover', 'focus'] : ['click'];
+
+  const tooltipOverlay = (
+    <Tooltip className="u-z-index-9020" id={idRef.current}>
+      {title}
+    </Tooltip>
+  );
+
+  // Render for hover trigger using OverlayTrigger (desktop)
+  if (trigger.includes('hover')) {
+    return (
+      <OverlayTrigger
+        placement={placement}
+        overlay={tooltipOverlay}
+        trigger={trigger}
+      >
+        {children}
+      </OverlayTrigger>
+    );
+  }
+
+  // Render for click trigger using OverlayTrigger controlled via `show` (mobile)
+  const handleClick = () => {
+    if (!showTooltip) {
+      window.dispatchEvent(new CustomEvent('smartTooltipOpened', { detail: wrapperRef.current }));
+    }
+    setShowTooltip((prev) => !prev);
+  };
+
+  return (
+    <OverlayTrigger overlay={tooltipOverlay} placement={placement} show={!isDesktop ? showTooltip : undefined}>
+      <span ref={wrapperRef} className="smart-tooltip" onClick={!isDesktop ? handleClick : undefined} style={{ cursor: 'pointer', display: 'inline-block' }}>
+        {children}
+      </span>
+    </OverlayTrigger>
+  );
+};
+
+SmartTooltip.propTypes = {
+  title: PropTypes.node.isRequired,
+  placement: PropTypes.string,
+  triggerType: PropTypes.oneOf(['hover', 'click', 'both']),
+  children: PropTypes.node.isRequired,
+  tooltipId: PropTypes.string,
+};
+
+SmartTooltip.defaultProps = {
+  placement: 'top',
+  triggerType: 'hover',
+  tooltipId: undefined,
+};
+
+export default SmartTooltip;

--- a/src/js/components/Navigation/BallotDecisionsTabs.jsx
+++ b/src/js/components/Navigation/BallotDecisionsTabs.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import BallotActions from '../../actions/BallotActions';
 import { renderLog } from '../../common/utils/logging';
+import SmartTooltip from '../../common/components/Widgets/SmartToolTip';
 
 
 class BallotDecisionsTabs extends Component {
@@ -65,6 +66,10 @@ class BallotDecisionsTabs extends Component {
     const showRemainingDecisions = (remainingDecisionsCountIsDifferentThanAllItems && this.props.ballotLengthRemaining) || false;
     const showDecisionsMade = (remainingDecisionsCountIsDifferentThanAllItems && this.props.ballotLengthRemaining) || false;
     const itemsDecidedCount = this.props.ballotLength - this.props.ballotLengthRemaining || 0;
+    const pluralize = (count) => (count === 1 ? 'office or measure' : 'offices or measures');
+    const allTooltipText = `Show all ${ballotLength} ${pluralize(ballotLength)}`;
+    const remainingTooltipText = `Show ${ballotLengthRemaining} ${pluralize(ballotLengthRemaining)} for which you need to make a choice`;
+    const chosenTooltipText = `Show ${itemsDecidedCount} ${pluralize(itemsDecidedCount)} for which you have made a choice`;
 
     return (
       <Tabs
@@ -86,20 +91,24 @@ class BallotDecisionsTabs extends Component {
           onClick={() => this.goToDifferentCompletionLevelTab('filterAllBallotItems')}
           tabIndex={0}
           label={(
-            <Badge
-              classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 0 ? null : classes.badgeColorPrimary }}
-              color="primary"
-              badgeContent={<BadgeCountWrapper>{ballotLength}</BadgeCountWrapper>}
-              id="ballotDecisionsTabsAllItems"
-              invisible={ballotLength === 0}
-            >
-              <span className="u-show-mobile">
-                All
+            <SmartTooltip title={allTooltipText} triggerType="hover">
+              <span style={{ display: 'inline-block' }}>
+                <Badge
+                  classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 0 ? null : classes.badgeColorPrimary }}
+                  color="primary"
+                  badgeContent={<BadgeCountWrapper>{ballotLength}</BadgeCountWrapper>}
+                  id="ballotDecisionsTabsAllItems"
+                  invisible={ballotLength === 0}
+                >
+                  <span className="u-show-mobile">
+                    All
+                  </span>
+                  <span className="u-show-desktop-tablet">
+                    All
+                  </span>
+                </Badge>
               </span>
-              <span className="u-show-desktop-tablet">
-                All
-              </span>
-            </Badge>
+            </SmartTooltip>
           )}
         />
 
@@ -111,20 +120,24 @@ class BallotDecisionsTabs extends Component {
             tabIndex={0}
             style={{ paddingRight: '26px' }}
             label={(
-              <Badge
-                classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 1 ? null : classes.badgeColorPrimary }}
-                color="primary"
-                badgeContent={<BadgeCountWrapper>{ballotLengthRemaining}</BadgeCountWrapper>}
-                id="ballotDecisionTabsRemainingChoices"
-                invisible={ballotLengthRemaining === 0}
-              >
-                <span className="u-show-mobile">
-                  Choices
+              <SmartTooltip title={remainingTooltipText} triggerType="hover">
+                <span style={{ display: 'inline-block' }}>
+                  <Badge
+                    classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 1 ? null : classes.badgeColorPrimary }}
+                    color="primary"
+                    badgeContent={<BadgeCountWrapper>{ballotLengthRemaining}</BadgeCountWrapper>}
+                    id="ballotDecisionTabsRemainingChoices"
+                    invisible={ballotLengthRemaining === 0}
+                  >
+                    <span className="u-show-mobile">
+                      Choices
+                    </span>
+                    <span className="u-show-desktop-tablet">
+                      Remaining Choices
+                    </span>
+                  </Badge>
                 </span>
-                <span className="u-show-desktop-tablet">
-                  Remaining Choices
-                </span>
-              </Badge>
+              </SmartTooltip>
             )}
           />
         ) : null}
@@ -136,15 +149,19 @@ class BallotDecisionsTabs extends Component {
             onClick={() => this.goToDifferentCompletionLevelTab('filterDecided')}
             tabIndex={0}
             label={(
-              <Badge
-                classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 2 ? null : classes.badgeColorPrimary }}
-                color="primary"
-                badgeContent={<BadgeCountWrapper>{itemsDecidedCount}</BadgeCountWrapper>}
-                id="ballotDecisionsTabsItemsDecided"
-                invisible={itemsDecidedCount === 0}
-              >
-                Chosen
-              </Badge>
+              <SmartTooltip title={chosenTooltipText} triggerType="hover">
+                <span style={{ display: 'inline-block' }}>
+                  <Badge
+                    classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 2 ? null : classes.badgeColorPrimary }}
+                    color="primary"
+                    badgeContent={<BadgeCountWrapper>{itemsDecidedCount}</BadgeCountWrapper>}
+                    id="ballotDecisionsTabsItemsDecided"
+                    invisible={itemsDecidedCount === 0}
+                  >
+                    Chosen
+                  </Badge>
+                </span>
+              </SmartTooltip>
             )}
           />
         ) : null}
@@ -230,4 +247,3 @@ const BadgeCountWrapper = styled('span')(({ theme }) => (`
 `));
 
 export default withStyles(styles)(BallotDecisionsTabs);
-


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-23

### Changes included this pull request?

Added tooltip for Ballot tabs.

Added a tooltip wrapper around React tooltip to help with different tooltip behaviors. Below is some information about what it is and how to use it:

`SmartToolTip.jsx` is a small wrapper around react-bootstrap’s OverlayTrigger that standardizes tooltip behavior across devices. It does two things that the base tooltip doesn’t handle well for us:

- Responsive trigger logic: it chooses hover on desktop and click/tap on mobile, and honors the triggerType prop (hover, click, both) so components can declare the intended behavior.
- Mobile UX cleanup: it closes the tooltip on outside tap and when another tooltip opens, which prevents multiple tooltips lingering on touch devices.
- Usage: wrap the target element with `<SmartTooltip title="..." triggerType="hover|click|both" placement="top|bottom|...">…</SmartTooltip>`

So it exists to give us consistent, predictable tooltip behavior without each component re‑implementing device detection and tap‑to‑close logic.