### PR TITLE
[WV-2306] Fix 'Complete your profile' prompt when toggling heart

### DIFF
--- a/src/js/common/components/Settings/CompleteYourProfileModal.jsx
+++ b/src/js/common/components/Settings/CompleteYourProfileModal.jsx
@@ -60,7 +60,12 @@ class CompleteYourProfileModal extends Component {
   render () {
     renderLog('CompleteYourProfileModal');  // Set LOG_RENDER_EVENTS to log all renders
     const {
-      becomeMember, campaignXWeVoteId, classes, startCampaign, supportCampaign,
+      becomeMember,
+      campaignXWeVoteId,
+      classes,
+      startCampaign,
+      supportCampaign,
+      supportPolitician,
     } = this.props;
 
     const { voter } = this.state;
@@ -74,7 +79,7 @@ class CompleteYourProfileModal extends Component {
       completeProfileTitle = <span>becomeMember</span>;
     } else if (startCampaign) {
       completeProfileTitle = <span>Complete your profile</span>;
-    } else if (supportCampaign) {
+    } else if (supportCampaign || supportPolitician) {
       completeProfileTitle = <span>Complete your support</span>;
     }
     return (
@@ -135,7 +140,6 @@ const styles = () => ({
   },
   dialogRoot: {
     height: '100%',
-    top: '-15%',
     left: '0% !important',
     right: 'unset !important',
     bottom: 'unset !important',

--- a/src/js/common/components/Settings/CompleteYourProfileModalController.jsx
+++ b/src/js/common/components/Settings/CompleteYourProfileModalController.jsx
@@ -39,7 +39,7 @@ class CompleteYourProfileModalController extends Component {
   render () {
     renderLog('CompleteYourProfileModalController');  // Set LOG_RENDER_EVENTS to log all renders
 
-    const { becomeMember, campaignXWeVoteId, startCampaign, supportCampaign } = this.props;
+    const { becomeMember, campaignXWeVoteId, startCampaign, supportCampaign, supportPolitician } = this.props;
     const { showCompleteYourProfileModal } = this.state;
     return (
       <div>
@@ -52,6 +52,7 @@ class CompleteYourProfileModalController extends Component {
             show={showCompleteYourProfileModal}
             startCampaign={startCampaign}
             supportCampaign={supportCampaign}
+            supportPolitician={supportPolitician}
           />
         )}
       </div>


### PR DESCRIPTION
[WV-2306] Fix 'Complete your profile' prompt when toggling heart/favorite on politician page

### What github.com/wevote/WebApp/issues does this fix?

https://wevoteusa.atlassian.net/browse/WV-2306

### Changes included this pull request?

* add supportPolitician keyword to CompleteYourProfileModal, based on its presence in src/js/common/pages/Politician/PoliticianDetailsPage.jsx:1398
* Remove negative space from Modal root to ensure visibility

### Notes on testing

Unable to directly verify this behavior, as the Modal does not pop up as intended using a profile with [null] first name or [null] last name, using code on WebApp/HEAD (9b9bfc82e).

[WV-2306]: https://wevoteusa.atlassian.net/browse/WV-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ