### PR TITLE
[WV-2444] Add dataLayer for Profile Sections on Candidate Profile Setting Page[TEAM_REVIEW]

### DIFF
--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -48,6 +48,9 @@ const SettingsPoliticalParty = ({ politicianWeVoteId }) => {
       pageDetails: getPageDetails(),
 
     };
+    if (politicianWeVoteId) {
+      dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+    }
     TagManager.dataLayer({ dataLayer: dataLayerObject });
   };
 

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import PoliticianActions from '../../common/actions/PoliticianActions';
 import PoliticianStore from '../../common/stores/PoliticianStore';
+import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const delayBeforeSavingToAPI = 1500;
 const delayBeforeShowingSavedStatus = 3000;
@@ -33,6 +36,22 @@ const SettingsPoliticalParty = ({ politicianWeVoteId }) => {
   const clearStatusTimer = useRef(null);
   const savingStatusTimer = useRef(null);
 
+  const sendGTMDataLayer = ({ buttonId, actionType = 'save' }) => {
+    // const destinationPage = lookupPageNameAndPageTypeDict(destinationPath);
+    const dataLayerObject = {
+      event: 'action',
+      actionDetails: {
+        actionType,
+        buttonId,
+      },
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+      pageDetails: getPageDetails(),
+
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+  };
+
+
   const updatePoliticalPartyCustom = (event) => {
     const politicalPartyValue = event.target.value;
     if (event.target.name === 'politicalPartyCustom') {
@@ -49,6 +68,7 @@ const SettingsPoliticalParty = ({ politicianWeVoteId }) => {
       clearStatusTimer.current = setTimeout(() => {
         // After some time, show that the data was saved
         setSavedStatus('Saved');
+        sendGTMDataLayer({ buttonId: 'politicalPartyCustom' });
       }, delayBeforeShowingSavedStatus);
     }
   };
@@ -67,6 +87,7 @@ const SettingsPoliticalParty = ({ politicianWeVoteId }) => {
         // After some time, show that the data was saved
         clearStatusTimer.current = setTimeout(() => {
           setSavedStatus('Saved');
+          sendGTMDataLayer({ buttonId: 'politicalPartySelect' });
         }, delayBeforeShowingSavedStatus);
       }
     }

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticianPicture.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticianPicture.jsx
@@ -95,6 +95,9 @@ class SettingsPoliticianPicture extends Component {
         userDetails: VoterStore.getAnalyticsUserDetails(),
         pageDetails: getPageDetails(),
       };
+      if (politicianWeVoteId) {
+        dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+      }
       TagManager.dataLayer({ dataLayer: dataLayerObject });
     }
 

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
@@ -2,12 +2,15 @@ import { FormControl, TextField } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import PoliticianActions from '../../common/actions/PoliticianActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../common/utils/cordovaUtils';
 import { renderLog } from '../../common/utils/logging';
 import PoliticianStore from '../../common/stores/PoliticianStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import VoterStore from '../../stores/VoterStore';
 
 const delayBeforeApiUpdateCall = 2000;
 const delayBeforeRemovingSavedStatus = 4000;
@@ -58,7 +61,18 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
       const { campaignWebsite } = this.state;
       // console.log('SettingsWidgetLinkCampaignWebsite handleKeyPressCampaignWebsite campaignWebsite:', campaignWebsite, ', politicianWeVoteId:', politicianWeVoteId);
       PoliticianActions.politicianCampaignWebsiteSave(politicianWeVoteId, campaignWebsite);
-      this.setState({ campaignWebsiteSavedStatus: 'Saved' });
+      this.setState({ campaignWebsiteSavedStatus: 'Saved' }, () => {
+        const dataLayerObject = {
+          event: 'action',
+          actionDetails: {
+            actionType: 'save',
+            buttonId: 'SaveCampaignWebsite',
+          },
+          userDetails: VoterStore.getAnalyticsUserDetails(),
+          pageDetails: getPageDetails(),
+        };
+        TagManager.dataLayer({ dataLayer: dataLayerObject });
+      });
     }, delayBeforeApiUpdateCall);
   }
 

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
@@ -71,6 +71,9 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
           userDetails: VoterStore.getAnalyticsUserDetails(),
           pageDetails: getPageDetails(),
         };
+        if (politicianWeVoteId) {
+          dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+        }
         TagManager.dataLayer({ dataLayer: dataLayerObject });
       });
     }, delayBeforeApiUpdateCall);

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
@@ -71,6 +71,9 @@ class SettingsWidgetPoliticianName extends Component {
           userDetails: VoterStore.getAnalyticsUserDetails(),
           pageDetails: getPageDetails(),
         };
+        if (politicianWeVoteId) {
+          dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+        }
         TagManager.dataLayer({ dataLayer: dataLayerObject });
       });
     }, delayBeforeApiUpdateCall);

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
@@ -2,12 +2,15 @@ import { FormControl, TextField } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import PoliticianActions from '../../common/actions/PoliticianActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../common/utils/cordovaUtils';
 import { renderLog } from '../../common/utils/logging';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import PoliticianStore from '../../common/stores/PoliticianStore';
+import VoterStore from '../../stores/VoterStore';
 
 const delayBeforeApiUpdateCall = 2000;
 const delayBeforeRemovingSavedStatus = 4000;
@@ -58,7 +61,18 @@ class SettingsWidgetPoliticianName extends Component {
       const { politicianName } = this.state;
       // console.log('SettingsWidgetPoliticianName handleKeyPressPoliticianName politicianName:', politicianName, ', politicianWeVoteId:', politicianWeVoteId);
       PoliticianActions.politicianNameSave(politicianWeVoteId, politicianName);
-      this.setState({ politicianNameSavedStatus: 'Saved' });
+      this.setState({ politicianNameSavedStatus: 'Saved' }, () => {
+        const dataLayerObject = {
+          event: 'action',
+          actionDetails: {
+            actionType: 'save',
+            buttonId: 'SavePoliticianName',
+          },
+          userDetails: VoterStore.getAnalyticsUserDetails(),
+          pageDetails: getPageDetails(),
+        };
+        TagManager.dataLayer({ dataLayer: dataLayerObject });
+      });
     }, delayBeforeApiUpdateCall);
   }
 

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
@@ -68,6 +68,9 @@ class SettingsWidgetPoliticianStatement extends Component {
         userDetails: VoterStore.getAnalyticsUserDetails(),
         pageDetails: getPageDetails(),
       };
+      if (politicianWeVoteId) {
+        dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+      }
       TagManager.dataLayer({ dataLayer: dataLayerObject });
     });
 

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
@@ -2,12 +2,15 @@ import { Button, FormControl, TextField } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import PoliticianActions from '../../common/actions/PoliticianActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../common/utils/cordovaUtils';
 import { renderLog } from '../../common/utils/logging';
 import PoliticianStore from '../../common/stores/PoliticianStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import VoterStore from '../../stores/VoterStore';
 
 const delayBeforeRemovingSavedStatus = 4000;
 
@@ -55,6 +58,17 @@ class SettingsWidgetPoliticianStatement extends Component {
     this.setState({
       politicianStatementSavedStatus: 'Saved',
       hasUnsavedChanges: false,
+    }, () => {
+      const dataLayerObject = {
+        event: 'action',
+        actionDetails: {
+          actionType: 'save',
+          buttonId: 'SavePoliticianStatement',
+        },
+        userDetails: VoterStore.getAnalyticsUserDetails(),
+        pageDetails: getPageDetails(),
+      };
+      TagManager.dataLayer({ dataLayer: dataLayerObject });
     });
 
     // Clear saved message after delay


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-2444]Add dataLayer for Profile Sections on Candidate Profile Setting Page
### Changes included this pull request?
Added datalayer objects for following components when each of them saved

Political Party : src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
Your Website: src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
Official Statement: src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
Name & Photo: src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx

[WV-2444]: https://wevoteusa.atlassian.net/browse/WV-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ