### PR TITLE
[WV-2444] Add dataLayer for Profile Sections on Candidate Profile Setting Page with button id[TEAM_REVIEW]

### DIFF
--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -147,7 +147,7 @@ const SettingsPoliticalParty = ({ politicianWeVoteId }) => {
         <CustomWrapper>
           <Input
             id="politicalPartyCustom"
-            name="customPartyInput"
+            name="politicalPartyCustom"
             type="text"
             value={customParty}
             placeholder="Type your party name..."

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -146,8 +146,8 @@ const SettingsPoliticalParty = ({ politicianWeVoteId }) => {
       {selectedParty === enterYourOwnPartyText && (
         <CustomWrapper>
           <Input
-            id="customPartyInput"
-            name="politicalPartyCustom"
+            id="politicalPartyCustom"
+            name="customPartyInput"
             type="text"
             value={customParty}
             placeholder="Type your party name..."

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
@@ -145,7 +145,7 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
                   id={campaignWebsiteID}
                   name="campaignWebsite"
                   placeholder="Campaign Website"
-                  onKeyDown={this.handleKeyPressCampaignWebsite(campaignWebsiteID)}
+                  onKeyDown={() => this.handleKeyPressCampaignWebsite(campaignWebsiteID)}
                   onChange={this.updateCampaignWebsite}
                   value={campaignWebsite}
                 />

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
@@ -49,7 +49,7 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
     }
   }
 
-  handleKeyPressCampaignWebsite () {
+  handleKeyPressCampaignWebsite (buttonId) {
     const { politicianWeVoteId } = this.props;
     if (this.campaignWebsiteTimer) clearTimeout(this.campaignWebsiteTimer);
     if (this.props.voterHasMadeChangesFunction) {
@@ -66,7 +66,7 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
           event: 'action',
           actionDetails: {
             actionType: 'save',
-            buttonId: 'SaveCampaignWebsite',
+            buttonId,
           },
           userDetails: VoterStore.getAnalyticsUserDetails(),
           pageDetails: getPageDetails(),
@@ -124,13 +124,14 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
     if (!politician) {
       return LoadingWheel;
     }
-
+    const campaignWebsiteID = `linkCampaignWebsite-${externalUniqueId}`;
     return (
       <form
         onSubmit={(e) => {
           e.preventDefault();
         }}
       >
+
         <span>
           <Row>
             <ColumnFullWidth>
@@ -141,10 +142,10 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
                   label="Campaign Website"
                   margin="dense"
                   variant="outlined"
-                  id={`linkCampaignWebsite-${externalUniqueId}`}
+                  id={campaignWebsiteID}
                   name="campaignWebsite"
                   placeholder="Campaign Website"
-                  onKeyDown={this.handleKeyPressCampaignWebsite}
+                  onKeyDown={this.handleKeyPressCampaignWebsite(campaignWebsiteID)}
                   onChange={this.updateCampaignWebsite}
                   value={campaignWebsite}
                 />

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
@@ -49,7 +49,7 @@ class SettingsWidgetPoliticianName extends Component {
     }
   }
 
-  handleKeyPressPoliticianName () {
+  handleKeyPressPoliticianName (buttonId) {
     const { politicianWeVoteId } = this.props;
     if (this.politicianNameTimer) clearTimeout(this.politicianNameTimer);
     if (this.props.voterHasMadeChangesFunction) {
@@ -66,7 +66,7 @@ class SettingsWidgetPoliticianName extends Component {
           event: 'action',
           actionDetails: {
             actionType: 'save',
-            buttonId: 'SavePoliticianName',
+            buttonId,
           },
           userDetails: VoterStore.getAnalyticsUserDetails(),
           pageDetails: getPageDetails(),
@@ -124,7 +124,7 @@ class SettingsWidgetPoliticianName extends Component {
     if (!politician) {
       return LoadingWheel;
     }
-
+    const politicianNameID = `politicianName-${externalUniqueId}`;
     return (
       <form
         onSubmit={(e) => {
@@ -142,10 +142,10 @@ class SettingsWidgetPoliticianName extends Component {
                   margin="dense"
                   variant="outlined"
                   autoComplete="given-name"
-                  id={`politicianName-${externalUniqueId}`}
+                  id={politicianNameID}
                   name="politicianName"
                   placeholder="Candidate Name for Ballot"
-                  onKeyDown={this.handleKeyPressPoliticianName}
+                  onKeyDown={this.handleKeyPressPoliticianName(politicianNameID)}
                   onChange={this.updatePoliticianName}
                   value={politicianName}
                 />

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
@@ -145,7 +145,7 @@ class SettingsWidgetPoliticianName extends Component {
                   id={politicianNameID}
                   name="politicianName"
                   placeholder="Candidate Name for Ballot"
-                  onKeyDown={this.handleKeyPressPoliticianName(politicianNameID)}
+                  onKeyDown={() => this.handleKeyPressPoliticianName(politicianNameID)}
                   onChange={this.updatePoliticianName}
                   value={politicianName}
                 />

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
@@ -47,8 +47,7 @@ class SettingsWidgetPoliticianStatement extends Component {
     }
   }
 
-  handleSavePoliticianStatement (e) {
-    e.preventDefault();
+  handleSavePoliticianStatement (buttonId) {
     const { politicianWeVoteId } = this.props;
     const { politicianStatement } = this.state;
 
@@ -63,7 +62,7 @@ class SettingsWidgetPoliticianStatement extends Component {
         event: 'action',
         actionDetails: {
           actionType: 'save',
-          buttonId: 'SavePoliticianStatement',
+          buttonId,
         },
         userDetails: VoterStore.getAnalyticsUserDetails(),
         pageDetails: getPageDetails(),
@@ -122,9 +121,13 @@ class SettingsWidgetPoliticianStatement extends Component {
     if (!politician) {
       return LoadingWheel;
     }
-
+    const politicianStatementID = `official-statement-${externalUniqueId}`;
     return (
-      <form onSubmit={this.handleSavePoliticianStatement}>
+      <form
+      onSubmit={(e) => {
+        e.preventDefault();
+      }}
+      >
         <span>
           <Row>
             <ColumnFullWidth>
@@ -133,7 +136,7 @@ class SettingsWidgetPoliticianStatement extends Component {
                   autoComplete="given-name"
                   // className={classes.input}
                   fullWidth
-                  id={`official-statement-${externalUniqueId}`}
+                  id={politicianStatementID}
                   label="Official Statement"
                   margin="dense"
                   multiline
@@ -155,6 +158,7 @@ class SettingsWidgetPoliticianStatement extends Component {
                   variant="contained"
                   color="primary"
                   type="submit"
+                  onClick={() => this.handleSavePoliticianStatement(politicianStatementID)}
                   disabled={!hasUnsavedChanges}
                   className={classes.saveButton}
                 >


### PR DESCRIPTION
What github.com/wevote/WebApp/issues does this fix?
[WV-2444]Add dataLayer for Profile Sections on Candidate Profile Setting Page with button id values

Changes included this pull request?
Updated datalayer objects with button id vlaues for following components when each of them saved

Political Party : src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
Your Website: src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
Official Statement: src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
Name & Photo: src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx

[WV-2444]: https://wevoteusa.atlassian.net/browse/WV-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ