### PR TITLE
[WV-1464]Add dataLayer when saving new address in modal on Ballot Page [Team Review]

### DIFF
--- a/src/js/components/AddressBox.jsx
+++ b/src/js/components/AddressBox.jsx
@@ -141,6 +141,7 @@ class AddressBox extends Component {
       actionDetails: {
         actionType: 'save',
         buttonId,
+        searchKeyword: textForMapSearch,
       },
       event: 'action',
       pageDetails: getPageDetails(),


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-1464]Add dataLayer when saving new address in modal on Ballot Page
### Changes included this pull request?
src/js/components/AddressBox.jsx : Added search keyword in datalayer object

[WV-1464]: https://wevoteusa.atlassian.net/browse/WV-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ