### PR TITLE
[WV-1726]Add dataLayer saving changes to "Name","Website", or "Description" on Profile/Setting Page [TEAM REVIEW]

### DIFF
--- a/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
+++ b/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
@@ -2,6 +2,7 @@ import { FormControl, TextField } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import FriendActions from '../../actions/FriendActions';
 import OrganizationActions from '../../actions/OrganizationActions';
@@ -13,6 +14,7 @@ import { renderLog } from '../../common/utils/logging';
 import OrganizationStore from '../../stores/OrganizationStore';
 import VoterStore from '../../stores/VoterStore';
 import { isSpeakerTypeOrganization } from '../../utils/organization-functions';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const delayBeforeApiUpdateCall = 2000;
 const delayBeforeRemovingSavedStatus = 4000;
@@ -84,7 +86,7 @@ class SettingsWidgetFirstLastName extends Component {
     }, delayBeforeApiUpdateCall);
   }
 
-  handleKeyPressVoterName () {
+  handleKeyPressVoterName (buttonID) {
     if (this.voterNameTimer) clearTimeout(this.voterNameTimer);
     if (this.props.voterHasMadeChangesFunction) {
       this.props.voterHasMadeChangesFunction();
@@ -93,7 +95,18 @@ class SettingsWidgetFirstLastName extends Component {
     if (this.voterNameTimer) clearTimeout(this.voterNameTimer);
     this.voterNameTimer = setTimeout(() => {
       VoterActions.voterNameSave(this.state.firstName, this.state.lastName);
-      this.setState({ voterNameSavedStatus: 'Saved' });
+      this.setState({ voterNameSavedStatus: 'Saved' }, () => {
+        const dataLayerObject = {
+          event: 'action',
+          actionDetails: {
+            actionType: 'save',
+            buttonID,
+          },
+          userDetails: VoterStore.getAnalyticsUserDetails(),
+          pageDetails: getPageDetails(),
+        };
+        TagManager.dataLayer({ dataLayer: dataLayerObject });
+      });
     }, delayBeforeApiUpdateCall);
   }
 
@@ -216,6 +229,8 @@ class SettingsWidgetFirstLastName extends Component {
       voterNameSavedStatus,
     } = this.state;
     const { classes, displayOnly = false, externalUniqueId } = this.props;
+    const fistNameID = `first-name-${externalUniqueId}`;
+    const lastNameID = `last-name-${externalUniqueId}`;
 
     return (
       <div className="">
@@ -283,10 +298,10 @@ class SettingsWidgetFirstLastName extends Component {
                               margin="dense"
                               variant="outlined"
                               autoComplete="given-name"
-                              id={`first-name-${externalUniqueId}`}
+                              id={fistNameID}
                               name="firstName"
                               placeholder="First Name"
-                              onKeyDown={this.handleKeyPressVoterName}
+                              onKeyDown={() => this.handleKeyPressVoterName(fistNameID)}
                               onChange={this.updateVoterName}
                               value={firstName}
                             />
@@ -300,10 +315,10 @@ class SettingsWidgetFirstLastName extends Component {
                               margin="dense"
                               variant="outlined"
                               autoComplete="family-name"
-                              id={`last-name-${externalUniqueId}`}
+                              id={lastNameID}
                               name="lastName"
                               placeholder="Last Name"
-                              onKeyDown={this.handleKeyPressVoterName}
+                              onKeyDown={() => this.handleKeyPressVoterName(lastNameID)}
                               onChange={this.updateVoterName}
                               value={lastName}
                             />

--- a/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
+++ b/src/js/components/Settings/SettingsWidgetFirstLastName.jsx
@@ -229,7 +229,7 @@ class SettingsWidgetFirstLastName extends Component {
       voterNameSavedStatus,
     } = this.state;
     const { classes, displayOnly = false, externalUniqueId } = this.props;
-    const fistNameID = `first-name-${externalUniqueId}`;
+    const firstNameID = `first-name-${externalUniqueId}`;
     const lastNameID = `last-name-${externalUniqueId}`;
 
     return (
@@ -298,10 +298,10 @@ class SettingsWidgetFirstLastName extends Component {
                               margin="dense"
                               variant="outlined"
                               autoComplete="given-name"
-                              id={fistNameID}
+                              id={firstNameID}
                               name="firstName"
                               placeholder="First Name"
-                              onKeyDown={() => this.handleKeyPressVoterName(fistNameID)}
+                              onKeyDown={() => this.handleKeyPressVoterName(firstNameID)}
                               onChange={this.updateVoterName}
                               value={firstName}
                             />

--- a/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import TagManager from 'react-gtm-module';
 import OrganizationActions from '../../actions/OrganizationActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../common/utils/cordovaUtils';
@@ -10,6 +11,7 @@ import { renderLog } from '../../common/utils/logging';
 import OrganizationStore from '../../stores/OrganizationStore';
 import VoterStore from '../../stores/VoterStore';
 import { isSpeakerTypeOrganization } from '../../utils/organization-functions';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 // import Textarea from 'react-textarea-autosize';
 
 const delayBeforeApiUpdateCall = 1200;
@@ -48,14 +50,25 @@ class SettingsWidgetOrganizationDescription extends Component {
     restoreStylesAfterCordovaKeyboard('SettingsWidgetOrganizationDescription');
   }
 
-  handleKeyPress () {
+  handleKeyPress (buttonId) {
     if (this.timer) clearTimeout(this.timer);
     if (this.props.voterHasMadeChangesFunction) {
       this.props.voterHasMadeChangesFunction();
     }
     this.timer = setTimeout(() => {
       OrganizationActions.organizationDescriptionSave(this.state.linkedOrganizationWeVoteId, this.state.organizationDescription);
-      this.setState({ organizationDescriptionSavedStatus: 'Saved' });
+      this.setState({ organizationDescriptionSavedStatus: 'Saved' }, () => {
+        const dataLayerObject = {
+          event: 'action',
+          actionDetails: {
+            actionType: 'save',
+            buttonId,
+          },
+          userDetails: VoterStore.getAnalyticsUserDetails(),
+          pageDetails: getPageDetails(),
+        };
+        TagManager.dataLayer({ dataLayer: dataLayerObject });
+      });
     }, delayBeforeApiUpdateCall);
   }
 
@@ -114,7 +127,7 @@ class SettingsWidgetOrganizationDescription extends Component {
 
     const { classes, externalUniqueId } = this.props;
     const { isOrganization, organizationDescription, organizationDescriptionSavedStatus } = this.state;
-
+    const organizationDescriptionID = `organizationDescriptionTextArea-${externalUniqueId}`;
     return (
       <div className="">
         <form onSubmit={(e) => { e.preventDefault(); }}>
@@ -122,7 +135,7 @@ class SettingsWidgetOrganizationDescription extends Component {
             <Column>
               <FormControl classes={{ root: classes.formControl }}>
                 <TextField
-                  id={`organizationDescriptionTextArea-${externalUniqueId}`}
+                  id={organizationDescriptionID}
                   label={isOrganization ? 'Description Shown with Endorsements' : 'Description Shown with Endorsements'}
                   name="organizationDescription"
                   rows={4}
@@ -132,7 +145,7 @@ class SettingsWidgetOrganizationDescription extends Component {
                   variant="outlined"
                   placeholder={isOrganization ? 'Type Organization Description...' : 'Type Description of Yourself...'}
                   value={organizationDescription}
-                  onKeyDown={this.handleKeyPress}
+                  onKeyDown={() => this.handleKeyPress(organizationDescriptionID)}
                   onChange={this.updateOrganizationDescription}
                 />
               </FormControl>

--- a/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
+++ b/src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import TagManager from 'react-gtm-module';
 import OrganizationActions from '../../actions/OrganizationActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import { prepareForCordovaKeyboard, restoreStylesAfterCordovaKeyboard } from '../../common/utils/cordovaUtils';
@@ -10,6 +11,7 @@ import { renderLog } from '../../common/utils/logging';
 import OrganizationStore from '../../stores/OrganizationStore';
 import VoterStore from '../../stores/VoterStore';
 import { isSpeakerTypeOrganization } from '../../utils/organization-functions';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const delayBeforeApiUpdateCall = 1200;
 const delayBeforeRemovingSavedStatus = 4000;
@@ -47,14 +49,25 @@ class SettingsWidgetOrganizationWebsite extends Component {
     restoreStylesAfterCordovaKeyboard('SettingsWidgetOrganizationWebsite');
   }
 
-  handleKeyPress () {
+  handleKeyPress (buttonId) {
     clearTimeout(this.timer);
     if (this.props.voterHasMadeChangesFunction) {
       this.props.voterHasMadeChangesFunction();
     }
     this.timer = setTimeout(() => {
       OrganizationActions.organizationWebsiteSave(this.state.linkedOrganizationWeVoteId, this.state.organizationWebsite);
-      this.setState({ organizationWebsiteSavedStatus: 'Saved' });
+      this.setState({ organizationWebsiteSavedStatus: 'Saved' }, () => {
+        const dataLayerObject = {
+          event: 'action',
+          actionDetails: {
+            actionType: 'save',
+            buttonId,
+          },
+          userDetails: VoterStore.getAnalyticsUserDetails(),
+          pageDetails: getPageDetails(),
+        };
+        TagManager.dataLayer({ dataLayer: dataLayerObject });
+      });
     }, delayBeforeApiUpdateCall);
   }
 
@@ -114,7 +127,7 @@ class SettingsWidgetOrganizationWebsite extends Component {
 
     const { classes, externalUniqueId } = this.props;
     const { isOrganization, organizationWebsite, organizationWebsiteSavedStatus } = this.state;
-
+    const organizationWebsiteID = `organizationWebsiteTextArea-${externalUniqueId}`;
     return (
       <div className="">
         <form onSubmit={(e) => { e.preventDefault(); }}>
@@ -122,14 +135,14 @@ class SettingsWidgetOrganizationWebsite extends Component {
             <ColumnFullWidth>
               <FormControl classes={{ root: classes.formControl }}>
                 <TextField
-                  id={`organizationWebsiteTextArea-${externalUniqueId}`}
+                  id={organizationWebsiteID}
                   label={isOrganization ? 'Organization Website' : 'Your Website'}
                   name="organizationWebsite"
                   margin="dense"
                   variant="outlined"
                   placeholder={isOrganization ? 'Type Organization\'s Website, www...' : 'Type Your Website Address, www...'}
                   value={organizationWebsite}
-                  onKeyDown={this.handleKeyPress}
+                  onKeyDown={() => this.handleKeyPress(organizationWebsiteID)}
                   onChange={this.updateOrganizationWebsite}
                 />
               </FormControl>


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-1726]Add dataLayer saving changes to "Name","Website", or "Description" on Profile/Setting Page 
### Changes included this pull request?
Added datalayer objects for following components when each of them saved
src/js/components/Settings/SettingsWidgetFirstLastName.jsx
src/js/components/Settings/SettingsWidgetOrganizationDescription.jsx
src/js/components/Settings/SettingsWidgetOrganizationWebsite.jsx

[WV-1726]: https://wevoteusa.atlassian.net/browse/WV-1726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ