### PR TITLE
[WV-2305]Candidates Detail Page - the ellipsis for 'View source of opinion' overlap the Like/Dislike Section for groups[TEAM REVIEW]

### DIFF
--- a/src/js/common/components/Position/PositionForBallotItem.jsx
+++ b/src/js/common/components/Position/PositionForBallotItem.jsx
@@ -266,7 +266,7 @@ const ThumbsUpAndSourceWrapper = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-evenly;
-  margin-top: -15px;
+  margin-top: 0px;
 `;
 
 export default withStyles(styles)(PositionForBallotItem);


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-2305]Candidates Detail Page - the ellipsis for 'View source of opinion' overlap the Like/Dislike Section for groups
### Changes included this pull request?
src/js/common/components/Position/PositionForBallotItem.jsx
Fixed margin of ThumbsUpAndSourceWrapper to avoid overlap with other elements

[WV-2305]: https://wevoteusa.atlassian.net/browse/WV-2305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ