### PR TITLE
changes to <SmartTooltip> - now includes a hover area prop

### DIFF
--- a/src/js/common/components/Widgets/SmartToolTip.jsx
+++ b/src/js/common/components/Widgets/SmartToolTip.jsx
@@ -4,7 +4,7 @@ import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 
-const SmartTooltip = ({ title, placement, triggerType, children, tooltipId }) => {
+const SmartTooltip = ({ title, placement, triggerType, children, tooltipId, fillContainer }) => {
   const theme = useTheme();
   const isDesktop = useMediaQuery(theme.breakpoints.up('md'));
 
@@ -52,8 +52,14 @@ const SmartTooltip = ({ title, placement, triggerType, children, tooltipId }) =>
     return undefined;
   }, [effectiveMode, showTooltip, isDesktop]);
 
+  const wrappedChildren = fillContainer ? (
+    <span className="smart-tooltip__fill" style={{ display: 'flex', width: '100%', height: '100%', alignItems: 'center', justifyContent: 'center' }}>
+      {children}
+    </span>
+  ) : children;
+
   if (effectiveMode === 'none') {
-    return children;
+    return wrappedChildren;
   }
   const trigger = effectiveMode === 'hover' ? ['hover', 'focus'] : ['click'];
 
@@ -71,7 +77,7 @@ const SmartTooltip = ({ title, placement, triggerType, children, tooltipId }) =>
         overlay={tooltipOverlay}
         trigger={trigger}
       >
-        {children}
+        {wrappedChildren}
       </OverlayTrigger>
     );
   }
@@ -86,8 +92,20 @@ const SmartTooltip = ({ title, placement, triggerType, children, tooltipId }) =>
 
   return (
     <OverlayTrigger overlay={tooltipOverlay} placement={placement} show={!isDesktop ? showTooltip : undefined}>
-      <span ref={wrapperRef} className="smart-tooltip" onClick={!isDesktop ? handleClick : undefined} style={{ cursor: 'pointer', display: 'inline-block' }}>
-        {children}
+      <span
+        ref={wrapperRef}
+        className="smart-tooltip"
+        onClick={!isDesktop ? handleClick : undefined}
+        style={{
+          cursor: 'pointer',
+          display: fillContainer ? 'flex' : 'inline-block',
+          width: fillContainer ? '100%' : undefined,
+          height: fillContainer ? '100%' : undefined,
+          alignItems: fillContainer ? 'center' : undefined,
+          justifyContent: fillContainer ? 'center' : undefined,
+        }}
+      >
+        {wrappedChildren}
       </span>
     </OverlayTrigger>
   );
@@ -99,12 +117,14 @@ SmartTooltip.propTypes = {
   triggerType: PropTypes.oneOf(['hover', 'click', 'both']),
   children: PropTypes.node.isRequired,
   tooltipId: PropTypes.string,
+  fillContainer: PropTypes.bool,
 };
 
 SmartTooltip.defaultProps = {
   placement: 'top',
   triggerType: 'hover',
   tooltipId: undefined,
+  fillContainer: false,
 };
 
 export default SmartTooltip;

--- a/src/js/components/Navigation/BallotDecisionsTabs.jsx
+++ b/src/js/components/Navigation/BallotDecisionsTabs.jsx
@@ -91,23 +91,21 @@ class BallotDecisionsTabs extends Component {
           onClick={() => this.goToDifferentCompletionLevelTab('filterAllBallotItems')}
           tabIndex={0}
           label={(
-            <SmartTooltip title={allTooltipText} triggerType="hover">
-              <span style={{ display: 'inline-block' }}>
-                <Badge
-                  classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 0 ? null : classes.badgeColorPrimary }}
-                  color="primary"
-                  badgeContent={<BadgeCountWrapper>{ballotLength}</BadgeCountWrapper>}
-                  id="ballotDecisionsTabsAllItems"
-                  invisible={ballotLength === 0}
-                >
-                  <span className="u-show-mobile">
-                    All
-                  </span>
-                  <span className="u-show-desktop-tablet">
-                    All
-                  </span>
-                </Badge>
-              </span>
+            <SmartTooltip title={allTooltipText} triggerType="hover" fillContainer>
+              <Badge
+                classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 0 ? null : classes.badgeColorPrimary }}
+                color="primary"
+                badgeContent={<BadgeCountWrapper>{ballotLength}</BadgeCountWrapper>}
+                id="ballotDecisionsTabsAllItems"
+                invisible={ballotLength === 0}
+              >
+                <span className="u-show-mobile">
+                  All
+                </span>
+                <span className="u-show-desktop-tablet">
+                  All
+                </span>
+              </Badge>
             </SmartTooltip>
           )}
         />
@@ -120,23 +118,21 @@ class BallotDecisionsTabs extends Component {
             tabIndex={0}
             style={{ paddingRight: '26px' }}
             label={(
-              <SmartTooltip title={remainingTooltipText} triggerType="hover">
-                <span style={{ display: 'inline-block' }}>
-                  <Badge
-                    classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 1 ? null : classes.badgeColorPrimary }}
-                    color="primary"
-                    badgeContent={<BadgeCountWrapper>{ballotLengthRemaining}</BadgeCountWrapper>}
-                    id="ballotDecisionTabsRemainingChoices"
-                    invisible={ballotLengthRemaining === 0}
-                  >
-                    <span className="u-show-mobile">
-                      Choices
-                    </span>
-                    <span className="u-show-desktop-tablet">
-                      Remaining Choices
-                    </span>
-                  </Badge>
-                </span>
+              <SmartTooltip title={remainingTooltipText} triggerType="hover" fillContainer>
+                <Badge
+                  classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 1 ? null : classes.badgeColorPrimary }}
+                  color="primary"
+                  badgeContent={<BadgeCountWrapper>{ballotLengthRemaining}</BadgeCountWrapper>}
+                  id="ballotDecisionTabsRemainingChoices"
+                  invisible={ballotLengthRemaining === 0}
+                >
+                  <span className="u-show-mobile">
+                    Choices
+                  </span>
+                  <span className="u-show-desktop-tablet">
+                    Remaining Choices
+                  </span>
+                </Badge>
               </SmartTooltip>
             )}
           />
@@ -149,18 +145,16 @@ class BallotDecisionsTabs extends Component {
             onClick={() => this.goToDifferentCompletionLevelTab('filterDecided')}
             tabIndex={0}
             label={(
-              <SmartTooltip title={chosenTooltipText} triggerType="hover">
-                <span style={{ display: 'inline-block' }}>
-                  <Badge
-                    classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 2 ? null : classes.badgeColorPrimary }}
-                    color="primary"
-                    badgeContent={<BadgeCountWrapper>{itemsDecidedCount}</BadgeCountWrapper>}
-                    id="ballotDecisionsTabsItemsDecided"
-                    invisible={itemsDecidedCount === 0}
-                  >
-                    Chosen
-                  </Badge>
-                </span>
+              <SmartTooltip title={chosenTooltipText} triggerType="hover" fillContainer>
+                <Badge
+                  classes={{ badge: classes.badge, colorPrimary: this.getSelectedTab() === 2 ? null : classes.badgeColorPrimary }}
+                  color="primary"
+                  badgeContent={<BadgeCountWrapper>{itemsDecidedCount}</BadgeCountWrapper>}
+                  id="ballotDecisionsTabsItemsDecided"
+                  invisible={itemsDecidedCount === 0}
+                >
+                  Chosen
+                </Badge>
               </SmartTooltip>
             )}
           />


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix? WV-23

### Changes included this pull request?

- Expanded `SmartTooltip` hover target with new fillContainer option.
- Updated BallotDecisionsTabs to use fillContainer so tab tooltips cover the full tab without breaking MUI Tab selection styling.
