### PR TITLE
[WV-2475] Extend the itemActionBar to include "make public" interface [TEAM REVIEW]

### DIFF
--- a/src/js/components/Ballot/BallotScrollingContainer.jsx
+++ b/src/js/components/Ballot/BallotScrollingContainer.jsx
@@ -93,10 +93,7 @@ class BallotScrollingContainer extends Component {
     const { oneCandidate } = this.props;
     const politicianWeVoteId = oneCandidate ? oneCandidate.politician_we_vote_id : null;
     const dataLayerObject = {
-      actionDetails: {
-        actionType: 'openModal',
-        buttonId,
-      },
+      actionDetails: { actionType: 'openModal', buttonId },
       event: 'action',
       pageDetails: getPageDetails(),
       destinationDetails: {
@@ -158,9 +155,7 @@ class BallotScrollingContainer extends Component {
   };
 
   checkCandidateHasEndorsements = (value) => {
-    this.setState({
-      hasEndorsements: value,
-    });
+    this.setState({ hasEndorsements: value });
   };
 
   render () {
@@ -198,6 +193,7 @@ class BallotScrollingContainer extends Component {
           showRightGradient={!this.state.hideRightArrow}
           hasEndorsements={this.state.hasEndorsements}
           onClick={(e) => this.handleContainerClick(e, oneCandidate.we_vote_id, `ballotItemScrollingArea-${oneCandidate.we_vote_id}`)}
+          style={{ flexDirection: 'column' }}
         >
           <CandidateContainer
             data-modal-trigger
@@ -221,9 +217,7 @@ class BallotScrollingContainer extends Component {
                         />
                       </Suspense>
                       {pigsCanFly && (
-                        <BallotMatchIndicator
-                          oneCandidate={oneCandidate}
-                        />
+                        <BallotMatchIndicator oneCandidate={oneCandidate} />
                       )}
                     </CandidateImageAndMatchWrapper>
                     {/* Candidate Name */}
@@ -258,24 +252,6 @@ class BallotScrollingContainer extends Component {
                       />
                     </Suspense>
                   )}
-                  {!hideItemActionBar && (
-                    <ItemActionBarOutsideWrapper data-modal-trigger>
-                      <Suspense fallback={<></>}>
-                        <ItemActionBar
-                          ballotItemWeVoteId={oneCandidate.we_vote_id}
-                          ballotItemDisplayName={oneCandidate.ballot_item_display_name}
-                          commentButtonHide
-                          // commentButtonHide={!futureFeaturesDisabled && nextReleaseFeaturesEnabled}
-                          externalUniqueId={`OfficeItemCompressed-ItemActionBar-${oneCandidate.we_vote_id}-${externalUniqueId}`}
-                          hidePositionPublicToggle={!futureFeaturesDisabled && nextReleaseFeaturesEnabled}
-                          politicianWeVoteId={oneCandidate.politician_we_vote_id}
-                          positionPublicToggleWrapAllowed
-                          shareButtonHide
-                          useHelpDefeatOrHelpWin={useHelpDefeatOrHelpWin}
-                        />
-                      </Suspense>
-                    </ItemActionBarOutsideWrapper>
-                  )}
                 </CandidateBottomRow>
               </CandidateInfo>
             </CandidateWrapper>
@@ -305,6 +281,26 @@ class BallotScrollingContainer extends Component {
               </PositionRowListInnerWrapper>
             </PositionRowListOuterWrapper>
           </CandidateContainer>
+
+          {/* ItemActionBar, last child in the column, always below everything */}
+          {!hideItemActionBar && (
+            <ItemActionBarOutsideWrapper>
+              <Suspense fallback={<></>}>
+                <ItemActionBar
+                  ballotItemWeVoteId={oneCandidate.we_vote_id}
+                  ballotItemDisplayName={oneCandidate.ballot_item_display_name}
+                  commentButtonHide
+                  externalUniqueId={`OfficeItemCompressed-ItemActionBar-${oneCandidate.we_vote_id}-${externalUniqueId}`}
+                  hidePositionPublicToggle={!futureFeaturesDisabled && nextReleaseFeaturesEnabled}
+                  politicianWeVoteId={oneCandidate.politician_we_vote_id}
+                  positionPublicToggleWrapAllowed
+                  shareButtonHide
+                  showCandidateStaffAndChat
+                  useHelpDefeatOrHelpWin={useHelpDefeatOrHelpWin}
+                />
+              </Suspense>
+            </ItemActionBarOutsideWrapper>
+          )}
         </BallotHorizontallyScrollingContainer>
         {/* {((candidateCount < candidatesToRenderLength) && (candidateCount < limitNumberOfCandidatesShownToThisNumber)) && ( */}
         {(candidateCount < limitNumberOfCandidatesShownToThisNumber) && (
@@ -321,6 +317,7 @@ class BallotScrollingContainer extends Component {
     );
   }
 }
+
 BallotScrollingContainer.propTypes = {
   externalUniqueId: PropTypes.string,
   isFirstBallotItem: PropTypes.bool,
@@ -342,11 +339,13 @@ const HrSeparator = styled('hr')`
 
 const ItemActionBarOutsideWrapper = styled('div')`
   display: flex;
-  cursor: pointer;
   flex-direction: row;
-  justify-content: flex-start;
-  margin-top: 12px;
+  align-items: center;
   width: 100%;
+  margin-top: 12px;
+  padding-left: 8px;
+  padding-bottom: 12px;
+  box-sizing: border-box;
 `;
 
 export default BallotScrollingContainer;

--- a/src/js/components/Ballot/PositionRowListCompressed.jsx
+++ b/src/js/components/Ballot/PositionRowListCompressed.jsx
@@ -611,17 +611,18 @@ const CandidateEndorsementText = styled('div')`
   cursor: pointer;
   font-family: "Poppins", sans-serif;
   font-size: 14px;
-  height: 54px;
   letter-spacing: 0.5%;
   line-height: 17.92px;
   margin-top: 12px;
+  overflow: hidden;
   overflow-wrap: break-word;
-  // text-decoration: underline;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
   width: 100%;
 `;
 
 const CandidateEndorsementsWrapper = styled('div')`
-  height: 102px;
   max-width: 100%;
   white-space: wrap;
   width: 275px;

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable import/newline-after-import */
 /* eslint-disable import/order */
 /* eslint-disable react/jsx-indent */
-import { Comment, Done, NotInterested, ThumbDown, ThumbUp } from '@mui/icons-material';
+import { ChatBubbleOutline, Comment, Done, EditOutlined, NotInterested, ThumbDown, ThumbUp } from '@mui/icons-material';
 import { Button } from '@mui/material';
 import withStyles from '@mui/styles/withStyles';
 import PropTypes from 'prop-types';
@@ -34,6 +34,7 @@ import PositionPublicToggle from '../../PositionItem/PositionPublicToggle';
 import ReviewAppModal from '../../ReviewApps/ReviewAppModal';
 import PositionStatementModal from '../PositionStatementModal'; // eslint-disable-line import/no-cycle
 import ShareButtonDropDown from '../ShareButtonDropdown';
+import MakePublicVisibilityRow from './MakePublicVisibilityRow'; // NEW
 
 const HelpWinOrDefeatModal = React.lazy(() => import(/* webpackChunkName: 'HelpWinOrDefeatModal' */ '../../../common/components/CampaignSupport/HelpWinOrDefeatModal')); // eslint-disable-line import/no-cycle
 
@@ -55,6 +56,7 @@ class ItemActionBar extends PureComponent {
       numberOfSupportPositionsForScore: 0,
       showNegativeModal: false,
       transitioning: false,
+      visibilityRowOpen: false,
       voterTextStatement: undefined,
       voterTextStatementOpened: false, // TODO Setting this to true crashes the app
       helpWinOrDefeatModalOpen: false,
@@ -257,13 +259,9 @@ class ItemActionBar extends PureComponent {
           });
         }
         if (voterTextStatement) {
-          this.setState({
-            voterTextStatement,
-          });
+          this.setState({ voterTextStatement });
         }
-        this.setState({
-          voterPositionIsPublic,
-        });
+        this.setState({ voterPositionIsPublic });
       }
     }
   }
@@ -274,9 +272,7 @@ class ItemActionBar extends PureComponent {
     const showingNegativeFeedbackModal = AppObservableStore.getShowingNegativeFeedbackModal();
     const { showNegativeModal } = this.state;
     if (!showNegativeModal && !showingNegativeFeedbackModal && showNegativeModalFromMessage) {
-      this.setState({
-        showNegativeModal: true,
-      });
+      this.setState({ showNegativeModal: true });
     }
   }
 
@@ -356,6 +352,26 @@ class ItemActionBar extends PureComponent {
     if (this.props.togglePositionStatementFunction) {
       this.props.togglePositionStatementFunction();
     }
+  };
+
+  //  NEW; Dale will make the conversation bubble and “Claim & edit profile” link active
+
+  // NOTE: The old PositionPublicToggle only appeared after the voter made a choice
+  // (isAnyEndorsementCalculated). MakePublicVisibilityRow currently shows whenever
+  // the chat bubble is clicked, regardless of endorsement state. When wiring up the
+  // API (onClickMakePublic → SupportActions.voterPositionVisibilitySave), revisit
+  // whether the visibility row should be gated on isAnyEndorsementCalculated().
+  onClickChatBubble = () => {
+    this.setState((prev) => ({ visibilityRowOpen: !prev.visibilityRowOpen }));
+  };
+
+  onClickMakePublic = () => {
+    // Wire up to API
+    this.setState({ voterPositionIsPublic: true });
+  };
+
+  onClickDotsMenu = () => {
+    console.log('ItemActionBar: dots menu clicked'); // eslint-disable-line no-console
   };
 
   helpThemWinButton = (localUniqueId) => {
@@ -476,27 +492,11 @@ class ItemActionBar extends PureComponent {
         <Done classes={this.isSupportCalculated() ? { root: classes.buttonIconDoneSelected } : { root: classes.buttonIconDone }} />
         {this.isSupportCalculated() ? (
           <ChooseButtonLabelSelected>
-            {useSupportWording ? (
-              <>
-                Supporting
-              </>
-            ) : (
-              <>
-                Chosen
-              </>
-            )}
+            {useSupportWording ? <>Supporting</> : <>Chosen</>}
           </ChooseButtonLabelSelected>
         ) : (
           <ChooseButtonLabel isAtState={!shareButtonHide}>
-            {useSupportWording ? (
-              <>
-                Support
-              </>
-            ) : (
-              <>
-                Choose
-              </>
-            )}
+            {useSupportWording ? <>Support</> : <>Choose</>}
           </ChooseButtonLabel>
         )}
       </Button>
@@ -529,14 +529,10 @@ class ItemActionBar extends PureComponent {
         variant={this.isSupportCalculated() ? 'contained' : 'outlined'}
       >
         <Done classes={{ root: classes.buttonIconDone }} />
-        { this.isSupportCalculated() ? (
-          <ChooseButtonLabelSelected className="u-no-break">
-            Voting Yes
-          </ChooseButtonLabelSelected>
+        {this.isSupportCalculated() ? (
+          <ChooseButtonLabelSelected className="u-no-break">Voting Yes</ChooseButtonLabelSelected>
         ) : (
-          <ChooseButtonLabel isAtState={!shareButtonHide} className="u-no-break">
-            Vote Yes
-          </ChooseButtonLabel>
+          <ChooseButtonLabel isAtState={!shareButtonHide} className="u-no-break">Vote Yes</ChooseButtonLabel>
         )}
       </Button>
     );
@@ -568,14 +564,10 @@ class ItemActionBar extends PureComponent {
         classes={{ root: classes.buttonMeasureRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
       >
         <NotInterested classes={{ root: classes.buttonIconNotInterested }} />
-        { this.isOpposeCalculated() ? (
-          <ChooseButtonLabelSelected className="u-no-break">
-            Voting No
-          </ChooseButtonLabelSelected>
+        {this.isOpposeCalculated() ? (
+          <ChooseButtonLabelSelected className="u-no-break">Voting No</ChooseButtonLabelSelected>
         ) : (
-          <ChooseButtonLabel isAtState={!shareButtonHide} className="u-no-break">
-            Vote No
-          </ChooseButtonLabel>
+          <ChooseButtonLabel isAtState={!shareButtonHide} className="u-no-break">Vote No</ChooseButtonLabel>
         )}
       </Button>
     );
@@ -607,9 +599,7 @@ class ItemActionBar extends PureComponent {
         classes={{ root: classes.buttonRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
       >
         <Comment classes={{ root: classes.buttonIcon }} />
-        <ChooseButtonLabel isAtState={!shareButtonHide}>
-          Comment
-        </ChooseButtonLabel>
+        <ChooseButtonLabel isAtState={!shareButtonHide}>Comment</ChooseButtonLabel>
       </Button>
     );
   };
@@ -623,10 +613,7 @@ class ItemActionBar extends PureComponent {
           variant="contained"
           className={`${commentButtonHideInMobile ? 'd-none d-sm-block ' : null} btn-default`}
           onClick={this.togglePositionStatementFunction}
-          classes={{
-            root: classes.buttonNoTextRoot,
-            outlinedPrimary: classes.buttonOutlinedPrimary,
-          }}
+          classes={{ root: classes.buttonNoTextRoot, outlinedPrimary: classes.buttonOutlinedPrimary }}
         >
           <Comment classes={{ root: classes.buttonIcon }} />
         </Button>
@@ -691,18 +678,13 @@ class ItemActionBar extends PureComponent {
     this.sendGTMDataLayer({ buttonId });
     const isSignedIn = VoterStore.getVoterIsSignedIn();
     const dataLayerObject = {
-      actionDetails: {
-        actionType: isSignedIn ? 'favorite' : 'favoriteSignedOut',
-      },
+      actionDetails: { actionType: isSignedIn ? 'favorite' : 'favoriteSignedOut' },
       event: 'action',
       userDetails: VoterStore.getAnalyticsUserDetails(),
       pageDetails: getPageDetails(),
     };
-
-    if (ballotItemWeVoteId) {
-      if (ballotItemWeVoteId.includes('cand')) {
-        dataLayerObject.candidateDetails = CandidateStore.getAnalyticsCandidateDetails(ballotItemWeVoteId);
-      }
+    if (ballotItemWeVoteId && ballotItemWeVoteId.includes('cand')) {
+      dataLayerObject.candidateDetails = CandidateStore.getAnalyticsCandidateDetails(ballotItemWeVoteId);
     }
     if (politicianWeVoteId) {
       dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
@@ -710,29 +692,19 @@ class ItemActionBar extends PureComponent {
     TagManager.dataLayer({ dataLayer: dataLayerObject });
 
     SupportActions.voterSupportingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
-    this.setState({
-      transitioning: true,
-    });
+    this.setState({ transitioning: true });
     openSnackbar({ message: 'Support added!' });
   }
 
   stopSupportingItem (buttonId) {
     const { politicianWeVoteId } = this.props;
     const { ballotItemType, ballotItemWeVoteId, transitioning } = this.state;
-    this.setState({
-      isOpposeLocalState: false,
-      isSupportLocalState: false,
-    });
-    if (transitioning) {
-      return;
-    }
-
+    this.setState({ isOpposeLocalState: false, isSupportLocalState: false });
+    if (transitioning) { return; }
     this.sendGTMDataLayer({ buttonId });
     possibleAppReview('ITEM');
     SupportActions.voterStopSupportingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
-    this.setState({
-      transitioning: true,
-    });
+    this.setState({ transitioning: true });
     openSnackbar({ message: 'Support removed!' });
   }
 
@@ -748,45 +720,26 @@ class ItemActionBar extends PureComponent {
       this.stopOpposingItem(buttonId);
       return;
     }
-
-    // console.log('opposeItem setState');
-    this.setState({
-      isOpposeLocalState: true,
-      isSupportLocalState: false,
-    });
-    if (transitioning) {
-      return;
-    }
-
-    // If the logic in this function decides to, show the "Sign in to save your choices" modal
+    this.setState({ isOpposeLocalState: true, isSupportLocalState: false });
+    if (transitioning) { return; }
     this.showChooseOrOpposeIntroModalDecision();
     this.sendGTMDataLayer({ buttonId });
 
     possibleAppReview('ITEM');
     SupportActions.voterOpposingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
-    this.setState({
-      transitioning: true,
-    });
+    this.setState({ transitioning: true });
     openSnackbar({ message: 'Opposition added!', severity: 'error' });
   }
 
   stopOpposingItem (buttonId) {
     const { politicianWeVoteId } = this.props;
     const { ballotItemType, ballotItemWeVoteId, transitioning } = this.state;
-    // console.log('ItemActionBar, stopOpposingItem, transitioning:', this.state.transitioning);
-    this.setState({
-      isOpposeLocalState: false,
-      isSupportLocalState: false,
-    });
-    if (transitioning) {
-      return;
-    }
+    this.setState({ isOpposeLocalState: false, isSupportLocalState: false });
+    if (transitioning) { return; }
     this.sendGTMDataLayer({ buttonId });
     possibleAppReview('ITEM');
     SupportActions.voterStopOpposingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
-    this.setState({
-      transitioning: true,
-    });
+    this.setState({ transitioning: true });
     openSnackbar({ message: 'Opposition removed!', severity: 'error' });
   }
 
@@ -814,7 +767,7 @@ class ItemActionBar extends PureComponent {
     const {
       ballotItemType, ballotItemWeVoteId, helpWinOrDefeatModalOpen, isOpposeAPIState, isSupportAPIState,
       numberOfOpposePositionsForScore, numberOfSupportPositionsForScore, showNegativeModal,
-      voterPositionIsPublic, voterTextStatementOpened,
+      voterPositionIsPublic, voterTextStatementOpened, visibilityRowOpen,
     } = this.state;
 
     if (
@@ -884,10 +837,7 @@ class ItemActionBar extends PureComponent {
     }
     helpWinButtonPopOverText += ' win by chipping in $1.';
 
-    let supportButtonSelectedPopOverText = 'Click to choose';
-    if (useSupportWording) {
-      supportButtonSelectedPopOverText = 'Click to support';
-    }
+    let supportButtonSelectedPopOverText = useSupportWording ? 'Click to support' : 'Click to choose';
     if (ballotItemDisplayName.length > 0) {
       supportButtonSelectedPopOverText += ` ${ballotItemDisplayName}.`;
     } else {
@@ -948,7 +898,7 @@ class ItemActionBar extends PureComponent {
 
     const supportButtonPopoverTooltip = isMobileScreenSize() ? (<></>) : (
       <Tooltip className="u-z-index-9020" id="supportButtonTooltip">
-        {this.isSupportCalculated() ? supportButtonUnselectedPopOverText : supportButtonSelectedPopOverText }
+        {this.isSupportCalculated() ? supportButtonUnselectedPopOverText : supportButtonSelectedPopOverText}
       </Tooltip>
     );
 
@@ -966,17 +916,22 @@ class ItemActionBar extends PureComponent {
 
     return (
       <ItemActionBarWrapper
-          // inModal={this.props.inModal}
-          displayInline={buttonsOnly || this.props.shareButtonHide}
-          onMouseOver={handleEnterHoverLocalArea}
-          onFocus={handleEnterHoverLocalArea}
-          onMouseOut={handleLeaveHoverLocalArea}
-          onBlur={handleLeaveHoverLocalArea}
-          positionPublicToggleWrapAllowed={this.props.positionPublicToggleWrapAllowed}
+        displayInline={buttonsOnly || this.props.shareButtonHide}
+        onMouseOver={handleEnterHoverLocalArea}
+        onFocus={handleEnterHoverLocalArea}
+        onMouseOut={handleLeaveHoverLocalArea}
+        onBlur={handleLeaveHoverLocalArea}
+        positionPublicToggleWrapAllowed={this.props.positionPublicToggleWrapAllowed}
       >
-          {showNegativeModal && !showingNegativeFeedbackModal && (
-            <ReviewAppModal initialEmail={initialEmail} />
-          )}
+        {showNegativeModal && !showingNegativeFeedbackModal && (
+          <ReviewAppModal initialEmail={initialEmail} />
+        )}
+
+        {/* Row: buttons + [chat bubble] + [candidate staff]
+            On desktop: all inline. Chat bubble toggles visibility row in place.
+            On mobile: visibility row wraps to its own row below buttons + staff. */}
+        <ActionBarRow>
+          {/* Section 1: Choose / Oppose / Comment / Share buttons */}
           <ButtonGroup
             className={`${!this.props.shareButtonHide ? ' u-push--sm' : ''}`}
             positionPublicToggleWrapAllowed={this.props.positionPublicToggleWrapAllowed}
@@ -991,10 +946,7 @@ class ItemActionBar extends PureComponent {
                     {(ballotItemType === 'MEASURE') && this.measureYesButtonNoText(`desktopVersion-${ballotItemWeVoteId}${politicianWeVoteId}`)}
                   </StackedButton>
                 ) : (
-                  <ButtonWrapper
-                    className="u-push--xs d-none d-lg-block"
-                    data-modal-trigger
-                  >
+                  <ButtonWrapper className="u-push--xs d-none d-lg-block" data-modal-trigger>
                     <OverlayTrigger
                       overlay={(useHelpDefeatOrHelpWin && this.isOpposeCalculated()) ? helpDefeatButtonPopoverTooltip : supportButtonPopoverTooltip}
                       placement="top"
@@ -1014,7 +966,7 @@ class ItemActionBar extends PureComponent {
                     {ballotItemType === 'MEASURE' && this.measureYesButtonNoText(`mobileVersion-${ballotItemWeVoteId}${politicianWeVoteId}`)}
                   </StackedButton>
                 ) : (
-                  <ButtonWrapper className="u-push--xs u-push--xs d-lg-none">
+                  <ButtonWrapper className="u-push--xs d-lg-none">
                     {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && ((useHelpDefeatOrHelpWin && this.isOpposeCalculated()) ? <></> : this.supportButton(`mobileVersion-${ballotItemWeVoteId}${politicianWeVoteId}`))}
                     {ballotItemType === 'MEASURE' && this.measureYesButton(`mobileVersion-${ballotItemWeVoteId}${politicianWeVoteId}`)}
                   </ButtonWrapper>
@@ -1071,11 +1023,7 @@ class ItemActionBar extends PureComponent {
                   </StackedButton>
                 ) : (
                   <ButtonWrapperFarRight className="d-none d-lg-block">
-                    <OverlayTrigger
-                      overlay={helpDefeatButtonPopoverTooltip}
-                      placement="top"
-                      rootClose
-                    >
+                    <OverlayTrigger overlay={helpDefeatButtonPopoverTooltip} placement="top" rootClose>
                       <div>
                         {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && (useHelpDefeatOrHelpWin && this.isOpposeCalculated()) && this.helpDefeatThemButton(`desktopVersion-${ballotItemWeVoteId}${politicianWeVoteId}`)}
                       </div>
@@ -1095,56 +1043,95 @@ class ItemActionBar extends PureComponent {
                 )}
               </>
             )}
-            { this.props.commentButtonHide || this.props.inModal ?
-              null : (
-                <span>
-                  {buttonsOnly ? (
-                    <CommentFlex>
-                      {this.commentButtonNoText(`${ballotItemWeVoteId}${politicianWeVoteId}`)}
-                    </CommentFlex>
-                  ) : (
-                    <CommentFlex>
-                      {this.commentButton(`${ballotItemWeVoteId}${politicianWeVoteId}`)}
-                    </CommentFlex>
-                  )}
-                </span>
+
+            {/* Comment Button */}
+            {this.props.commentButtonHide || this.props.inModal ? null : (
+              <span>
+                {buttonsOnly ? (
+                  <CommentFlex>{this.commentButtonNoText(`${ballotItemWeVoteId}${politicianWeVoteId}`)}</CommentFlex>
+                ) : (
+                  <CommentFlex>{this.commentButton(`${ballotItemWeVoteId}${politicianWeVoteId}`)}</CommentFlex>
+                )}
+              </span>
+            )}
+
+            {/* Share Button */}
+            {this.props.shareButtonHide || this.props.inModal ? null : (
+              <ShareButtonDropDown showMoreId="itemActionBarShowMoreFooter" urlBeingShared={urlBeingShared} shareIcon={shareIcon} shareText="Share" />
+            )}
+          </ButtonGroup>
+
+          {/* Chat bubble + "For candidate staff", candidates/politicians only.
+              Pass showCandidateStaffAndChat prop to enable (e.g. in BallotScrollingContainer). */}
+          {(ballotItemType === 'CANDIDATE' || ballotItemType === 'POLITICIAN') && this.props.showCandidateStaffAndChat && (
+            <>
+              {/* When visibilityRowOpen: hide bubble, show divider + visibility text inline */}
+              {visibilityRowOpen ? (
+                <VisibilityInlineWrapperDesktop className="u-show-desktop">
+                  <VisibilityDivider />
+                  <MakePublicVisibilityRow
+                    isPublic={voterPositionIsPublic}
+                    onMakePublic={this.onClickMakePublic}
+                    onDotsClick={this.onClickDotsMenu}
+                  />
+                </VisibilityInlineWrapperDesktop>
+              ) : (
+                <ChatBubbleButton
+                  aria-label="Comments"
+                  onClick={this.onClickChatBubble}
+                  type="button"
+                >
+                  <ChatBubbleOutline style={{ fontSize: 22, color: '#1976d2' }} />
+                </ChatBubbleButton>
               )}
 
-            { this.props.shareButtonHide || this.props.inModal ?
-              null :
-              <ShareButtonDropDown showMoreId="itemActionBarShowMoreFooter" urlBeingShared={urlBeingShared} shareIcon={shareIcon} shareText="Share" /> }
-          </ButtonGroup>
-          {showPositionPublicToggle && (
-            <PositionPublicToggle
-              ballotItemType={ballotItemType}
-              ballotItemWeVoteId={ballotItemWeVoteId}
-              className="null"
-              externalUniqueId={`itemActionBar-${this.props.externalUniqueId}`}
-              politicianWeVoteId={politicianWeVoteId}
-            />
+              {!this.props.inModal && (
+                <CandidateStaffWrapper visibilityRowOpen={visibilityRowOpen}>
+                  <CandidateStaffText>For candidate staff:</CandidateStaffText>
+                  <CandidateStaffLink href="#">
+                    <EditOutlined style={{ fontSize: 14, verticalAlign: 'middle', marginRight: 2 }} />
+                    Claim &amp; edit profile
+                  </CandidateStaffLink>
+                </CandidateStaffWrapper>
+              )}
+
+              {/* Mobile: full-width visibility row wraps below buttons + candidate staff */}
+              {visibilityRowOpen && (
+                <VisibilityInlineWrapperMobile className="u-show-mobile-tablet">
+                  <MakePublicVisibilityRow
+                    isPublic={voterPositionIsPublic}
+                    onMakePublic={this.onClickMakePublic}
+                    onDotsClick={this.onClickDotsMenu}
+                  />
+                </VisibilityInlineWrapperMobile>
+              )}
+            </>
           )}
-          <Suspense fallback={<></>}>
-            <HelpWinOrDefeatModal
-              ballotItemWeVoteId={ballotItemWeVoteId}
-              // externalUniqueId={externalUniqueId}
-              politicianWeVoteId={politicianWeVoteId}
-              show={helpWinOrDefeatModalOpen}
-              toggleModal={this.toggleHelpWinOrDefeatFunction}
-            />
-          </Suspense>
-          {voterTextStatementOpened && (
-            <PositionStatementModal
-              ballotItemWeVoteId={ballotItemWeVoteId}
-              // externalUniqueId={externalUniqueId}
-              politicianWeVoteId={politicianWeVoteId}
-              show={voterTextStatementOpened}
-              toggleModal={this.togglePositionStatementFunction}
-            />
-          )}
+        </ActionBarRow>
+
+        <Suspense fallback={<></>}>
+          <HelpWinOrDefeatModal
+            ballotItemWeVoteId={ballotItemWeVoteId}
+            // externalUniqueId={externalUniqueId}
+            politicianWeVoteId={politicianWeVoteId}
+            show={helpWinOrDefeatModalOpen}
+            toggleModal={this.toggleHelpWinOrDefeatFunction}
+          />
+        </Suspense>
+        {voterTextStatementOpened && (
+          <PositionStatementModal
+            ballotItemWeVoteId={ballotItemWeVoteId}
+            // externalUniqueId={externalUniqueId}
+            politicianWeVoteId={politicianWeVoteId}
+            show={voterTextStatementOpened}
+            toggleModal={this.togglePositionStatementFunction}
+          />
+        )}
       </ItemActionBarWrapper>
     );
   }
 }
+
 ItemActionBar.propTypes = {
   ballotItemDisplayName: PropTypes.string,
   ballotItemWeVoteId: PropTypes.string,
@@ -1166,6 +1153,7 @@ ItemActionBar.propTypes = {
   positionPublicToggleWrapAllowed: PropTypes.bool,
   shareButtonHide: PropTypes.bool,
   supportOrOpposeHasBeenClicked: PropTypes.func,
+  showCandidateStaffAndChat: PropTypes.bool,
   togglePositionStatementFunction: PropTypes.func,
   useHelpDefeatOrHelpWin: PropTypes.bool,
   useSupportWording: PropTypes.bool,
@@ -1178,31 +1166,18 @@ const styles = (theme) => ({
     padding: 4,
     width: 'fit-content',
     height: 32,
-    [theme.breakpoints.down('md')]: {
-      width: 'fit-content',
-      height: 30,
-    },
-    [theme.breakpoints.down('sm')]: {
-      width: 'fit-content',
-      minWidth: 80,
-      height: 28,
-      padding: '0 8px',
-    },
+    [theme.breakpoints.down('md')]: { width: 'fit-content', height: 30 },
+    [theme.breakpoints.down('sm')]: { width: 'fit-content', minWidth: 80, height: 28, padding: '0 8px' },
   },
   buttonIcon: {
     fontSize: 18,
     marginRight: '.3rem',
     fontWeight: 'bold',
-    [theme.breakpoints.down('md')]: {
-      fontSize: 16,
-    },
-    [theme.breakpoints.down('sm')]: {
-      fontSize: 14,
-      marginTop: -2,
-    },
+    [theme.breakpoints.down('md')]: { fontSize: 16 },
+    [theme.breakpoints.down('sm')]: { fontSize: 14, marginTop: -2 },
   },
   buttonIconDone: {
-    color: `${DesignTokenColors.confirmation300}`, /* green color before selection */
+    color: `${DesignTokenColors.confirmation300}`,
     fontSize: 22,
     fontWeight: 'bold',
     marginRight: '.3rem',
@@ -1216,7 +1191,7 @@ const styles = (theme) => ({
     marginTop: '-2px',
   },
   buttonIconNotInterested: {
-    color: `${DesignTokenColors.alert500}`, /* red color before selection */
+    color: `${DesignTokenColors.alert500}`,
     fontSize: 18,
     fontWeight: 'bold',
     marginRight: '.3rem',
@@ -1229,49 +1204,23 @@ const styles = (theme) => ({
     marginRight: '.3rem',
     marginTop: '-2px',
   },
-  dialogPaper: {
-    minHeight: 282,
-    margin: '0 8px',
-  },
+  dialogPaper: { minHeight: 282, margin: '0 8px' },
   buttonMeasureRoot: {
     padding: 4,
     width: 130,
     height: 32,
-    [theme.breakpoints.down('sm')]: {
-      width: 'fit-content',
-      minWidth: 80,
-      height: 28,
-      padding: '0 8px',
-    },
+    [theme.breakpoints.down('sm')]: { width: 'fit-content', minWidth: 80, height: 28, padding: '0 8px' },
   },
   buttonRoot: {
     borderRadius: '15px',
     padding: 4,
     width: 120,
     height: 32,
-    [theme.breakpoints.down('md')]: {
-      width: 100,
-      height: 30,
-    },
-    [theme.breakpoints.down('sm')]: {
-      width: 'fit-content',
-      minWidth: 80,
-      height: 28,
-      padding: '0 8px',
-    },
+    [theme.breakpoints.down('md')]: { width: 100, height: 30 },
+    [theme.breakpoints.down('sm')]: { width: 'fit-content', minWidth: 80, height: 28, padding: '0 8px' },
   },
-  buttonRootForCard: {
-    borderRadius: '15px',
-    padding: 4,
-    width: 138,
-    height: 32,
-  },
-  buttonRootForCardAfterChoice: {
-    borderRadius: '15px',
-    padding: 4,
-    width: 110,
-    height: 32,
-  },
+  buttonRootForCard: { borderRadius: '15px', padding: 4, width: 138, height: 32 },
+  buttonRootForCardAfterChoice: { borderRadius: '15px', padding: 4, width: 110, height: 32 },
   buttonNoTextRoot: {
     padding: 4,
     fontSize: 12,
@@ -1280,38 +1229,22 @@ const styles = (theme) => ({
     marginLeft: '.1rem',
     marginTop: '.3rem',
     marginBottom: 4,
-    [theme.breakpoints.down('md')]: {
-      width: 30,
-      height: 30,
-    },
-    [theme.breakpoints.down('sm')]: {
-      width: 'fit-content',
-      minWidth: 28,
-      height: 28,
-      padding: '0 8px',
-      fontSize: 10,
-    },
+    [theme.breakpoints.down('md')]: { width: 30, height: 30 },
+    [theme.breakpoints.down('sm')]: { width: 'fit-content', minWidth: 28, height: 28, padding: '0 8px', fontSize: 10 },
   },
-  buttonOutlinedPrimary: {
-    background: 'white',
-  },
-  closeButton: {
-    position: 'absolute',
-    right: theme.spacing(1),
-    top: theme.spacing(1),
-  },
-  dialogTitle: {
-    paddingTop: 22,
-    paddingBottom: 5,
-  },
+  buttonOutlinedPrimary: { background: 'white' },
+  closeButton: { position: 'absolute', right: theme.spacing(1), top: theme.spacing(1) },
+  dialogTitle: { paddingTop: 22, paddingBottom: 5 },
 });
+
+// Styled Components
 
 const ItemActionBarWrapper = styled('div', {
   shouldForwardProp: (prop) => !['positionPublicToggleWrapAllowed', 'displayInline'].includes(prop),
 })(({ positionPublicToggleWrapAllowed, displayInline, theme }) => (`
-  display: ${positionPublicToggleWrapAllowed ? '' :  'flex'};
-  justify-content: ${positionPublicToggleWrapAllowed ? '' :  'flex-start'};
-  width: ${positionPublicToggleWrapAllowed ? '' :  '100%'};
+  display: ${positionPublicToggleWrapAllowed ? '' : 'flex'};
+  justify-content: ${positionPublicToggleWrapAllowed ? '' : 'flex-start'};
+  width: ${positionPublicToggleWrapAllowed ? '' : '100%'};
   align-items: center;
   border-top: ${displayInline ? '' : '1px solid #eee !default'};
   margin-top: ${displayInline ? '' : '16px'};
@@ -1321,32 +1254,37 @@ const ItemActionBarWrapper = styled('div', {
   padding-top: ${displayInline ? '0' : '8px'};
   ${theme.breakpoints.down('sm')} {
     flex-wrap: wrap;
+  }
 `));
+
+// NEW: single row that holds all three sections — buttons | visibility | candidate staff
+// flex-wrap lets MakePublicVisibilityRow drop to the next line on mobile
+const ActionBarRow = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 0;
+`;
 
 const ButtonGroup = styled('div', {
   shouldForwardProp: (prop) => !['positionPublicToggleWrapAllowed'].includes(prop),
 })(({ positionPublicToggleWrapAllowed }) => (`
   display: flex;
-  // border-color: red;
-  // border-style: solid;
-  // border-width: 1 px;
   flex-wrap: nowrap;
-  height: fit-content;
   height: 40px;
-  justify-content: center;
+  justify-content: flex-start;
   margin-left: 0;
-  margin-right: 8px;
-  ${positionPublicToggleWrapAllowed ? 'width: 100%;' : ''};
+  margin-right: 0;
+  flex-shrink: 0;
 `));
 
 const ButtonWrapper = styled('div')`
-  &:last-child {
-    margin-right: 0;
-  }
+  &:last-child { margin-right: 0; }
   margin-right: 8px;
   display: flex;
   align-items: center;
-  // {({ onlyTwoButtons }) => (onlyTwoButtons ? 'width: 50% !important;' : '')}
 `;
 
 const ButtonWrapperFarRight = styled('div')`
@@ -1359,21 +1297,17 @@ const ButtonWrapperRight = styled('div')`
   margin-right: 0;
   display: flex;
   align-items: center;
-  // {({ onlyTwoButtons }) => (onlyTwoButtons ? 'width: 50% !important;' : '')}
 `;
 
 const ChooseButtonLabel = styled('span', {
   shouldForwardProp: (prop) => !['isAtState'].includes(prop),
 })(({ isAtState }) => (`
-  color: #000;
-  // ${isAtState ? 'font-weight: bold;' : ''};
+  color: #1976d2;
 `));
 
 const ChooseButtonLabelSelected = styled('span', {
   shouldForwardProp: (prop) => !['isAtState'].includes(prop),
-})(({ isAtState }) => (`
-  ${isAtState ? '' : ''};
-`));
+})(({ isAtState }) => (''));
 
 const CommentFlex = styled('div')`
   display: flex;
@@ -1388,15 +1322,13 @@ const HelpButtonLabel = styled('span')`
 const OpposeButtonLabel = styled('span', {
   shouldForwardProp: (prop) => !['isAtState'].includes(prop),
 })(({ isAtState }) => (`
-  color: #000;
+  color: #1976d2;
   ${isAtState ? 'font-weight: bold;' : ''};
 `));
 
 const OpposeButtonLabelSelected = styled('span', {
   shouldForwardProp: (prop) => !['isAtState'].includes(prop),
-})(({ isAtState }) => (`
-  ${isAtState ? '' : ''};
-`));
+})(({ isAtState }) => (''));
 
 const StackedButton = styled('div', {
   shouldForwardProp: (prop) => prop !== 'onlyTwoButtons',
@@ -1404,5 +1336,78 @@ const StackedButton = styled('div', {
   marginLeft: '3px',
   width: onlyTwoButtons ? '50% !important' : '33% !important',
 }));
+
+const ChatBubbleButton = styled('button')`
+  background: none;
+  border: none;
+  padding: 0 16px;
+  margin: 0;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  line-height: 1;
+
+  &:hover svg { color: #1565c0 !important; }
+  &:focus-visible {
+    outline: 2px solid #1976d2;
+    border-radius: 4px;
+  }
+`;
+
+// Inline wrapper for the visibility row when chat bubble is clicked —
+// sits in the flex row alongside buttons and candidate staff.
+const VisibilityInlineWrapperDesktop = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-shrink: 0;
+`;
+
+const VisibilityInlineWrapperMobile = styled('div')`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  margin-top: 8px;
+`;
+
+const VisibilityDivider = styled('div')`
+  width: 1.5px;
+  height: 32px;
+  background: #e0e0e0;
+  margin-left: 12px;
+  margin-right: 12px;
+  flex-shrink: 0;
+`;
+
+// Section 3: "For candidate staff" — always in the row, never wraps, pushed to the right
+const CandidateStaffWrapper = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'visibilityRowOpen',
+})(({ visibilityRowOpen }) => (`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding-left: 12px;
+  border-left: 1.5px solid #e0e0e0;
+  font-size: 13px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  @media (max-width: 991px) {
+    margin-left: ${visibilityRowOpen ? '16px' : '0'};
+  }
+`));
+
+const CandidateStaffText = styled('span')`
+  color: #555;
+  line-height: 1.3;
+`;
+
+const CandidateStaffLink = styled('a')`
+  color: #0075b8;
+  text-decoration: none;
+  line-height: 1.3;
+  &:hover { text-decoration: underline; }
+`;
 
 export default withStyles(styles)(ItemActionBar);

--- a/src/js/components/Widgets/ItemActionBar/MakePublicVisibilityRow.jsx
+++ b/src/js/components/Widgets/ItemActionBar/MakePublicVisibilityRow.jsx
@@ -1,0 +1,142 @@
+import { Language, MoreHoriz } from '@mui/icons-material';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+
+/**
+ * MakePublicVisibilityRow
+ *
+ * Shown inline after clicking the chat bubble.
+ * Parent (VisibilityInlineWrapper) handles the left divider and spacing.
+ *
+ * isPublic=false  →  "Choice & opinion visible to WeVote friends only. ···"
+ *                    "🌐 Make public to influence more people."
+ *
+ * isPublic=true   →  "Choice & opinion visible to public. ···"
+ */
+
+export default function MakePublicVisibilityRow ({ isPublic, onMakePublic, onDotsClick }) {
+  return (
+    <Wrapper>
+      <TopRow>
+        <VisibilityText isPublic={isPublic}>
+          {isPublic ?
+            'Choice & opinion visible to public.' :
+            'Choice & opinion visible to WeVote friends only.'}
+        </VisibilityText>
+        <DotsButton aria-label="More options" onClick={onDotsClick} type="button">
+          <MoreHoriz style={{ fontSize: 18 }} />
+        </DotsButton>
+      </TopRow>
+
+      {!isPublic && (
+        <MakePublicRow>
+          <MakePublicButton
+            onClick={onMakePublic}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onMakePublic();
+              }
+            }}
+          >
+            <Language style={{ fontSize: 16, color: '#0075b8', marginRight: 4 }} />
+            <MakePublicText>Make public</MakePublicText>
+          </MakePublicButton>
+          <MakePublicSuffix>&nbsp;to influence more people.</MakePublicSuffix>
+        </MakePublicRow>
+      )}
+    </Wrapper>
+  );
+}
+
+MakePublicVisibilityRow.propTypes = {
+  isPublic: PropTypes.bool,
+  onMakePublic: PropTypes.func,
+  onDotsClick: PropTypes.func,
+};
+
+MakePublicVisibilityRow.defaultProps = {
+  isPublic: false,
+  onMakePublic: () => {},
+  onDotsClick: () => {},
+};
+
+// Styled Components
+
+const DotsButton = styled('button')`
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  color: #555;
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  line-height: 1;
+
+  &:hover { color: #111; }
+  &:focus-visible {
+    outline: 2px solid #0075b8;
+    border-radius: 2px;
+  }
+`;
+
+const MakePublicButton = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid #0075b8;
+    border-radius: 2px;
+  }
+`;
+
+const MakePublicRow = styled('div')`
+  display: flex;
+  align-items: center;
+`;
+
+const MakePublicSuffix = styled('span')`
+  color: #555;
+  font-size: 13px;
+  white-space: nowrap;
+`;
+
+const MakePublicText = styled('span')`
+  color: #0075b8;
+  font-size: 13px;
+  white-space: nowrap;
+
+  &:hover { color: #005a8e; }
+`;
+
+const TopRow = styled('div')`
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  gap: 8px;
+`;
+
+const VisibilityText = styled('span', {
+  shouldForwardProp: (prop) => prop !== 'isPublic',
+})(({ isPublic }) => (`
+  color: #555;
+  white-space: nowrap;
+  font-weight: ${isPublic ? 'normal' : '600'};
+  font-style: ${isPublic ? 'normal' : 'italic'};
+`));
+
+const Wrapper = styled('div')`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 2px;
+  font-size: 13px;
+  line-height: 1.4;
+  padding-right: 12px;
+`;

--- a/src/js/components/Widgets/ModalDisplayTemplateA.jsx
+++ b/src/js/components/Widgets/ModalDisplayTemplateA.jsx
@@ -14,7 +14,16 @@ class ModalDisplayTemplateA extends Component {
   constructor (props) {
     super(props);
     this.state = {
+      isContentScrolled: false,
     };
+    this.handleContentScroll = this.handleContentScroll.bind(this);
+  }
+
+  handleContentScroll (e) {
+    const scrolled = e.target.scrollTop > 0;
+    if (scrolled !== this.state.isContentScrolled) {
+      this.setState({ isContentScrolled: scrolled });
+    }
   }
 
   render () {
@@ -22,6 +31,7 @@ class ModalDisplayTemplateA extends Component {
     const {
       classes, dialogTitleJSX, externalUniqueId, show, tallMode, textFieldJSX,
     } = this.props;
+    const { isContentScrolled } = this.state;
     let dialogPaperCombined;
     if (tallMode) {
       dialogPaperCombined = `${classes.dialogPaper} ${classes.dialogPaperAdditionTall}`;
@@ -36,7 +46,14 @@ class ModalDisplayTemplateA extends Component {
         open={show}
         style={{ paddingTop: `${isCordova() ? '75px' : 'undefined'}` }}
       >
-        <DialogTitle classes={{ root: classes.dialogTitle }}>
+        <DialogTitle
+          classes={{ root: classes.dialogTitle }}
+          style={{
+            borderBottom: isContentScrolled ? '1.5px solid #e8e8e8' : '1.5px solid transparent',
+            transition: 'border-bottom-color 0.2s ease',
+            zIndex: 1,
+          }}
+        >
           <DialogTitleInnerWrapper>
             <Title>
               {dialogTitleJSX || <>&nbsp;</>}
@@ -53,7 +70,10 @@ class ModalDisplayTemplateA extends Component {
           </DialogTitleInnerWrapper>
           <Divider />
         </DialogTitle>
-        <DialogContent classes={{ root: classes.dialogContent }}>
+        <DialogContent
+          classes={{ root: classes.dialogContent }}
+          onScroll={this.handleContentScroll}
+        >
           <DialogContentInnerWrapper>
             {textFieldJSX}
           </DialogContentInnerWrapper>


### PR DESCRIPTION
Added visibility row + candidate staff section to item action bar

Wired up the chat bubble to toggle the make public row inline, added the "for candidate staff" claim & edit section, and gated everything behind a showCandidateStaffAndChat prop so it only shows in the ballot container for now. API calls are stubbed out for later

Mobile/tablet: 
<img width="401" height="343" alt="image" src="https://github.com/user-attachments/assets/877bbeb8-01ea-4d55-9fe3-30d915bdb6d5" />


Desktop: 
<img width="662" height="394" alt="image" src="https://github.com/user-attachments/assets/b98c0f72-96e4-4e04-a79c-e32df7f307d7" />


Other uses of ItemActionBar are unaffected: 
<img width="398" height="528" alt="image" src="https://github.com/user-attachments/assets/01c1294a-0e75-4f8e-b8c2-11695a334e9b" />

To enable chat bubble + "For candidate staff" (candidates/politicians only), pass showCandidateStaffAndChat prop to anywhere `<ItemActionBar />` is used


Also added a border under ModalTemplateA's header that only appears on scroll

<img width="374" height="119" alt="image" src="https://github.com/user-attachments/assets/9ce17afe-0152-4432-b818-1fbf7b6eef5e" />