### PR TITLE
[WV-2254] Convert WebDriverIO configs to ESM for v8 compatibility

### DIFF
--- a/tests/browserstack_automation/buildMobileCapabilities.js
+++ b/tests/browserstack_automation/buildMobileCapabilities.js
@@ -1,7 +1,6 @@
-const axios = require('axios');
-const { writeFileSync } = require('fs');
-const browserStackConfig = require('./config/browserstack.config');
-
+import axios from 'axios';
+import { writeFileSync } from 'fs';
+import { browserStackConfig } from './config/browserstack.config.js';
 /*
 
 https://www.browserstack.com/test-on-the-right-mobile-devices

--- a/tests/browserstack_automation/config/wdio.config.js
+++ b/tests/browserstack_automation/config/wdio.config.js
@@ -2,8 +2,14 @@
 import { driver } from '@wdio/globals';
 import { readFileSync } from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
 import { browserStackConfig } from './browserstack.config.js';
 import { uploadAppsToBrowserStack } from '../utils/uploadAndConfigureApps.js';
+
+// ESM equivalent
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 //import data files
 import cordovaData from '../capabilities/cordova_mobile_devices.json' with { type: 'json' };

--- a/tests/browserstack_automation/config/wdio.config.local.js
+++ b/tests/browserstack_automation/config/wdio.config.local.js
@@ -1,7 +1,7 @@
-const { driver } = require('@wdio/globals');
-const { readFileSync } = require('fs');
-const browserStackConfig = require('./browserstack.config');
-const browserCapabilities = require('../capabilities/browser.json');
+import { driver } from '@wdio/globals';
+import { readFileSync } from 'fs';
+import { browserStackConfig } from './browserstack.config.js';
+import browserCapabilities from '../capabilities/browser.json' with { type: 'json' };
 
 let mobileCapabilities = [];
 
@@ -22,7 +22,7 @@ const buildName = `${browserStackConfig.NAME}: ${dateForDisplay}`;
 
 // https://webdriver.io/docs/configurationfile
 
-module.exports.config = {
+export const config = {
   user: browserStackConfig.BROWSERSTACK_USER,
   key: browserStackConfig.BROWSERSTACK_KEY,
   injectGlobals: false,
@@ -81,14 +81,14 @@ module.exports.config = {
   },
 };
 
-module.exports.config.capabilities.forEach((capability) => {
+config.capabilities.forEach((capability) => {
   const device = capability;
   const keys = Object.keys(device);
   keys.forEach((key) => {
-    if (key in module.exports.config.commonCapabilities) {
+    if (key in config.commonCapabilities) {
       device[key] = {
         ...device[key],
-        ...module.exports.config.commonCapabilities[key],
+        ...config.commonCapabilities[key],
       };
     }
   });

--- a/tests/browserstack_automation/config/wdio.config.productdemo.js
+++ b/tests/browserstack_automation/config/wdio.config.productdemo.js
@@ -1,9 +1,10 @@
-const { browser, driver } = require('@wdio/globals');
-const { readFileSync } = require('fs');
-const browserStackConfig = require('./browserstack.config');
-const browserCapabilities = require('../capabilities/browser_bvt.json');
-const { exec } = require('child_process');
-const { promisify } = require('util');
+import { browser, driver } from '@wdio/globals';
+import { readFileSync } from 'fs';
+import { browserStackConfig } from './browserstack.config.js';
+import browserCapabilities from '../capabilities/browser_bvt.json' with { type: 'json' };
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { resolve } from 'path';
 const execAsync = promisify(exec);
 
 let mobileCapabilities = [];
@@ -23,7 +24,7 @@ const dateForDisplay = date.toDateString();
 
 const buildName = `${browserStackConfig.NAME}: ${dateForDisplay}`;
 
-module.exports.config = {
+export const config = {
   user: browserStackConfig.BROWSERSTACK_USER,
   key: browserStackConfig.BROWSERSTACK_KEY,
   injectGlobals: false,
@@ -86,7 +87,7 @@ module.exports.config = {
     console.warn('No session ID found, skipping video upload');
     return;
   }
-  const scriptPath = require('path').resolve('./tests/browserstack_automation/specs/', 'DownloadVideo.browser.js');
+  const scriptPath = resolve('./tests/browserstack_automation/specs/', 'DownloadVideo.browser.js');
   console.log('Running helper script:', scriptPath);
   try {
     const { stdout, stderr } = await execAsync(`node ${scriptPath} ${sessionId}`);
@@ -97,17 +98,16 @@ module.exports.config = {
   }
 }
 };
-module.exports.config.capabilities.forEach((capability) => {
+config.capabilities.forEach((capability) => {
   const device = capability;
   const keys = Object.keys(device);
   keys.forEach((key) => {
-    if (key in module.exports.config.commonCapabilities) {
+    if (key in config.commonCapabilities) {
       device[key] = {
         ...device[key],
-        ...module.exports.config.commonCapabilities[key],
+        ...config.commonCapabilities[key],
       };
     }
   });
 });
-
 

--- a/tests/browserstack_automation/config/wdio.local.config.js
+++ b/tests/browserstack_automation/config/wdio.local.config.js
@@ -1,4 +1,4 @@
-const { config } = require('./wdio.config.js'); 
+import { config } from './wdio.config.js';
 
 config.capabilities = [{
   maxInstances: 5,
@@ -13,5 +13,5 @@ delete config.user;
 delete config.key;
 config.services = [];
 
-module.exports = { config };
+export { config };
 

--- a/tests/browserstack_automation/specs/DiscussPage.browser.js
+++ b/tests/browserstack_automation/specs/DiscussPage.browser.js
@@ -2,8 +2,6 @@
 import { browser, driver, expect } from '@wdio/globals';
 import DiscussPage from '../page_objects/discuss.browser';
 
-const { describe, it } = require('mocha');
-
 const waitTime = 5000;
 const email = 'wevote@wevote.us';
 const errorMessage = 'Enter valid email 6 to 254 characters long';

--- a/tests/browserstack_automation/specs/DownloadVideo.browser.js
+++ b/tests/browserstack_automation/specs/DownloadVideo.browser.js
@@ -1,9 +1,9 @@
-const fs = require('fs');
-const path = require('path');
-const axios = require('axios');
-const readline = require('readline');
-const { google } = require('googleapis');
-const browserStackConfig = require('../config/browserstack.config');
+import fs from 'fs';
+import path from 'path';
+import axios from 'axios';
+import readline from 'readline';
+import { google } from 'googleapis';
+import { browserStackConfig } from '../config/browserstack.config.js';
 
 const BROWSERSTACK_USERNAME = browserStackConfig.BROWSERSTACK_USER;
 const BROWSERSTACK_ACCESS_KEY = browserStackConfig.BROWSERSTACK_KEY;

--- a/tests/browserstack_automation/specs/PrivacyPageMobileBrowser.browser.js
+++ b/tests/browserstack_automation/specs/PrivacyPageMobileBrowser.browser.js
@@ -1,9 +1,7 @@
 import { driver, expect } from '@wdio/globals';
 import ReadyPage from '../page_objects/ready.browser';
 import PrivacyPage from '../page_objects/privacy.browser';
-
-const assert = require('assert');
-const { describe, it } = require('mocha');
+import assert from 'node:assert';
 
 const waitTime = 10000;
 

--- a/tests/browserstack_automation/specs/WhosRunningForOfficeMobileBrowser.browser.js
+++ b/tests/browserstack_automation/specs/WhosRunningForOfficeMobileBrowser.browser.js
@@ -1,9 +1,7 @@
 import { $, driver, expect, browser } from '@wdio/globals';
 import ReadyPage from '../page_objects/ready.browser';
 import PopulateData from '../testDataForScripts/populateStateandCandidateData.js';
-
-const assert = require('assert');
-const { describe, it } = require('mocha');
+import assert from 'node:assert';
 
 const waitTime = 8000;
 


### PR DESCRIPTION
## Summary
Converted WebDriverIO configuration files from CommonJS to ESM syntax for WebDriverIO 8 compatibility.

## Changes Made
- Updated browserstack.config.js to use export syntax
- Updated wdio.config.local.js to use import/export
- Updated wdio.config.productdemo.js to use import/export  
- Updated wdio.local.config.js to use import/export
- Updated DiscussPage.browser.js to use import/export
- Updated all spec files to ESM syntax

https://automate.browserstack.com/projects/Default+Project/builds/Tarun+Ramireddy:/3?tab=tests&status=failed&testListView=spec&match=%7B%22status%22%3A%22OR%22%7D
