### PR TITLE
[WV-2443] Add dataLayer events to ManageMyCandidates import/invite and tracking pages

### DIFF
--- a/src/js/components/PositionItem/VoterPositionEntryAndDisplay.jsx
+++ b/src/js/components/PositionItem/VoterPositionEntryAndDisplay.jsx
@@ -80,7 +80,7 @@ function VoterPositionEntryAndDisplay ({ classes, externalUniqueId, politicianWe
         pageDetails: getPageDetails(),
         userDetails: VoterStore.getAnalyticsUserDetails(),
         actionDetails: {
-          action: 'close',
+          actionType: 'close',
           componentName: 'VoterPositionEntryAndDisplay',
           buttonId: closeButtonId,
         },

--- a/src/js/pages/ManageMyCandidates/ManageMyCandidatesLanding.jsx
+++ b/src/js/pages/ManageMyCandidates/ManageMyCandidatesLanding.jsx
@@ -4,17 +4,31 @@ import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } fr
 import { Helmet } from 'react-helmet-async';
 import { useHistory, useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import PoliticianStore from '../../common/stores/PoliticianStore';
 import { ImportInviteIcon } from '../../components/More/ImportInviteIcon';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import VoterStore from '../../stores/VoterStore';
-
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const PoliticiansManagedController = React.lazy(() => import('../../components/PoliticiansManaged/PoliticiansManagedController'));
 const ImportAndInvitePage = React.lazy(() => import('../More/ManageMyCandidates'));
 const TrackingPage = React.lazy(() => import('./SupporterTracking'));
 const AnalyticsPage = React.lazy(() => import('./SupporterAnalytics'));
+
+function pushDataLayer (buttonId = '') {
+  const dataLayerObject = {
+    actionDetails: {
+      actionType: 'navigate',
+      buttonId,
+    },
+    event: 'action',
+    pageDetails: getPageDetails(),
+    userDetails: VoterStore.getAnalyticsUserDetails(),
+  };
+  TagManager.dataLayer({ dataLayer: dataLayerObject });
+}
 
 export default function ManageMyCandidatesLanding () {
   // Left nav active tab
@@ -152,22 +166,22 @@ export default function ManageMyCandidatesLanding () {
           showLeftGradient={showLeftGradient}
           showRightGradient={showRightGradient}
         >
-          <NavPill $mobile $active={active === 'import'} onClick={handleClaimImport}>
+          <NavPill id="importInviteNavButton-mobile" $mobile $active={active === 'import'} onClick={() => { pushDataLayer('importInviteNavButton-mobile'); handleClaimImport(); }}>
             <PillIcon><ImportInviteIcon fontSize="small" /></PillIcon>
             Import &amp; invite
           </NavPill>
 
-          <NavPill $mobile $active={active === 'tracking'} onClick={handleClaimTracking}>
+          <NavPill id="trackingNavButton-mobile" $mobile $active={active === 'tracking'} onClick={() => { pushDataLayer('trackingNavButton-mobile'); handleClaimTracking(); }}>
             <PillIcon><TrackingIcon fontSize="small" /></PillIcon>
             Tracking
           </NavPill>
 
-          <NavPill $mobile $active={active === 'analytics'} onClick={handleClaimAnalytics}>
+          <NavPill id="analyticsNavButton-mobile" $mobile $active={active === 'analytics'} onClick={() => { pushDataLayer('analyticsNavButton-mobile'); handleClaimAnalytics(); }}>
             <PillIcon><AnalyticsIcon fontSize="small" /></PillIcon>
             Analytics
           </NavPill>
 
-          <NavPill $mobile as="button" $active={false} onClick={handleClaimEdit}>
+          <NavPill id="editCandidateProfileNavButton-mobile" $mobile as="button" $active={false} onClick={() => { pushDataLayer('editCandidateProfileNavButton-mobile'); handleClaimEdit(); }}>
             <PillIcon><EditIcon fontSize="small" /></PillIcon>
             Edit
           </NavPill>
@@ -175,24 +189,24 @@ export default function ManageMyCandidatesLanding () {
 
         {/* Desktop and tablet navigation bar */}
         <NavBar className="u-show-desktop" aria-label="Manage navigation">
-          <NavPill $active={active === 'import'} onClick={handleClaimImport}>
+          <NavPill id="importInviteNavButton-desktop" $active={active === 'import'} onClick={() => { pushDataLayer('importInviteNavButton-desktop'); handleClaimImport(); }}>
             <PillIcon><ImportInviteIcon fontSize="small" /></PillIcon>
             Import &amp; invite voters
           </NavPill>
 
-          <NavPill $active={active === 'tracking'} onClick={handleClaimTracking}>
+          <NavPill id="trackingNavButton-desktop" $active={active === 'tracking'} onClick={() => { pushDataLayer('trackingNavButton-desktop'); handleClaimTracking(); }}>
             <PillIcon><TrackingIcon fontSize="small" /></PillIcon>
             Tracking
           </NavPill>
 
-          <NavPill $active={active === 'analytics'} onClick={handleClaimAnalytics}>
+          <NavPill id="analyticsNavButton-desktop" $active={active === 'analytics'} onClick={() => { pushDataLayer('analyticsNavButton-desktop'); handleClaimAnalytics(); }}>
             <PillIcon><AnalyticsIcon fontSize="small" /></PillIcon>
             Analytics
           </NavPill>
 
           <SideDivider />
 
-          <NavPill as="button" $active={false} onClick={handleClaimEdit}>
+          <NavPill id="editCandidateProfileNavButton-desktop" as="button" $active={false} onClick={() => { pushDataLayer('editCandidateProfileNavButton-desktop'); handleClaimEdit(); }}>
             <PillIcon><EditIcon fontSize="small" /></PillIcon>
             Edit candidate profile
           </NavPill>

--- a/src/js/pages/ManageMyCandidates/ManageMyCandidatesLanding.jsx
+++ b/src/js/pages/ManageMyCandidates/ManageMyCandidatesLanding.jsx
@@ -10,14 +10,14 @@ import PoliticianStore from '../../common/stores/PoliticianStore';
 import { ImportInviteIcon } from '../../components/More/ImportInviteIcon';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import VoterStore from '../../stores/VoterStore';
-import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const PoliticiansManagedController = React.lazy(() => import('../../components/PoliticiansManaged/PoliticiansManagedController'));
 const ImportAndInvitePage = React.lazy(() => import('../More/ManageMyCandidates'));
 const TrackingPage = React.lazy(() => import('./SupporterTracking'));
 const AnalyticsPage = React.lazy(() => import('./SupporterAnalytics'));
 
-function pushDataLayer (buttonId = '') {
+function pushDataLayer (buttonId = '', politicianWeVoteId = null) {
   const dataLayerObject = {
     actionDetails: {
       actionType: 'navigate',
@@ -27,6 +27,9 @@ function pushDataLayer (buttonId = '') {
     pageDetails: getPageDetails(),
     userDetails: VoterStore.getAnalyticsUserDetails(),
   };
+  if (politicianWeVoteId) {
+    dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+  }
   TagManager.dataLayer({ dataLayer: dataLayerObject });
 }
 
@@ -166,22 +169,22 @@ export default function ManageMyCandidatesLanding () {
           showLeftGradient={showLeftGradient}
           showRightGradient={showRightGradient}
         >
-          <NavPill id="importInviteNavButton-mobile" $mobile $active={active === 'import'} onClick={() => { pushDataLayer('importInviteNavButton-mobile'); handleClaimImport(); }}>
+          <NavPill id="importInviteNavButton-mobile" $mobile $active={active === 'import'} onClick={() => { pushDataLayer('importInviteNavButton-mobile', selectedPoliticianWeVoteId); handleClaimImport(); }}>
             <PillIcon><ImportInviteIcon fontSize="small" /></PillIcon>
             Import &amp; invite
           </NavPill>
 
-          <NavPill id="trackingNavButton-mobile" $mobile $active={active === 'tracking'} onClick={() => { pushDataLayer('trackingNavButton-mobile'); handleClaimTracking(); }}>
+          <NavPill id="trackingNavButton-mobile" $mobile $active={active === 'tracking'} onClick={() => { pushDataLayer('trackingNavButton-mobile', selectedPoliticianWeVoteId); handleClaimTracking(); }}>
             <PillIcon><TrackingIcon fontSize="small" /></PillIcon>
             Tracking
           </NavPill>
 
-          <NavPill id="analyticsNavButton-mobile" $mobile $active={active === 'analytics'} onClick={() => { pushDataLayer('analyticsNavButton-mobile'); handleClaimAnalytics(); }}>
+          <NavPill id="analyticsNavButton-mobile" $mobile $active={active === 'analytics'} onClick={() => { pushDataLayer('analyticsNavButton-mobile', selectedPoliticianWeVoteId); handleClaimAnalytics(); }}>
             <PillIcon><AnalyticsIcon fontSize="small" /></PillIcon>
             Analytics
           </NavPill>
 
-          <NavPill id="editCandidateProfileNavButton-mobile" $mobile as="button" $active={false} onClick={() => { pushDataLayer('editCandidateProfileNavButton-mobile'); handleClaimEdit(); }}>
+          <NavPill id="editCandidateProfileNavButton-mobile" $mobile as="button" $active={false} onClick={() => { pushDataLayer('editCandidateProfileNavButton-mobile', selectedPoliticianWeVoteId); handleClaimEdit(); }}>
             <PillIcon><EditIcon fontSize="small" /></PillIcon>
             Edit
           </NavPill>
@@ -189,24 +192,24 @@ export default function ManageMyCandidatesLanding () {
 
         {/* Desktop and tablet navigation bar */}
         <NavBar className="u-show-desktop" aria-label="Manage navigation">
-          <NavPill id="importInviteNavButton-desktop" $active={active === 'import'} onClick={() => { pushDataLayer('importInviteNavButton-desktop'); handleClaimImport(); }}>
+          <NavPill id="importInviteNavButton-desktop" $active={active === 'import'} onClick={() => { pushDataLayer('importInviteNavButton-desktop', selectedPoliticianWeVoteId); handleClaimImport(); }}>
             <PillIcon><ImportInviteIcon fontSize="small" /></PillIcon>
             Import &amp; invite voters
           </NavPill>
 
-          <NavPill id="trackingNavButton-desktop" $active={active === 'tracking'} onClick={() => { pushDataLayer('trackingNavButton-desktop'); handleClaimTracking(); }}>
+          <NavPill id="trackingNavButton-desktop" $active={active === 'tracking'} onClick={() => { pushDataLayer('trackingNavButton-desktop', selectedPoliticianWeVoteId); handleClaimTracking(); }}>
             <PillIcon><TrackingIcon fontSize="small" /></PillIcon>
             Tracking
           </NavPill>
 
-          <NavPill id="analyticsNavButton-desktop" $active={active === 'analytics'} onClick={() => { pushDataLayer('analyticsNavButton-desktop'); handleClaimAnalytics(); }}>
+          <NavPill id="analyticsNavButton-desktop" $active={active === 'analytics'} onClick={() => { pushDataLayer('analyticsNavButton-desktop', selectedPoliticianWeVoteId); handleClaimAnalytics(); }}>
             <PillIcon><AnalyticsIcon fontSize="small" /></PillIcon>
             Analytics
           </NavPill>
 
           <SideDivider />
 
-          <NavPill id="editCandidateProfileNavButton-desktop" as="button" $active={false} onClick={() => { pushDataLayer('editCandidateProfileNavButton-desktop'); handleClaimEdit(); }}>
+          <NavPill id="editCandidateProfileNavButton-desktop" as="button" $active={false} onClick={() => { pushDataLayer('editCandidateProfileNavButton-desktop', selectedPoliticianWeVoteId); handleClaimEdit(); }}>
             <PillIcon><EditIcon fontSize="small" /></PillIcon>
             Edit candidate profile
           </NavPill>
@@ -221,7 +224,7 @@ export default function ManageMyCandidatesLanding () {
                 selectedPoliticianWeVoteId={selectedPoliticianWeVoteId}
               />
             )}
-            {active === 'tracking' && <TrackingPage />}
+            {active === 'tracking' && <TrackingPage selectedPoliticianWeVoteId={selectedPoliticianWeVoteId} />}
             {active === 'analytics' && <AnalyticsPage />}
           </Suspense>
         </RightPanel>

--- a/src/js/pages/ManageMyCandidates/SupporterTracking.jsx
+++ b/src/js/pages/ManageMyCandidates/SupporterTracking.jsx
@@ -9,25 +9,29 @@ import TagManager from 'react-gtm-module';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import VoterStore from '../../stores/VoterStore';
 import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import PoliticianStore from '../../common/stores/PoliticianStore';
 
 import SupportersJoined from './SupportersJoined';
 import SupportersInvited from './SupportersInvited';
 import SupportersToRemind from './SupportersToRemind';
 
-function pushDataLayer (buttonId = '') {
+function pushDataLayer (buttonId = '', politicianWeVoteId = null) {
   const dataLayerObject = {
     actionDetails: {
-      actionType: 'filter',
+      actionType: 'navigate',
       buttonId,
     },
     event: 'action',
     pageDetails: getPageDetails(),
     userDetails: VoterStore.getAnalyticsUserDetails(),
   };
+  if (politicianWeVoteId) {
+    dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+  }
   TagManager.dataLayer({ dataLayer: dataLayerObject });
 }
 
-export default function SupporterTracking () {
+export default function SupporterTracking ({ selectedPoliticianWeVoteId = null }) {
   const [activeTab, setActiveTab] = useState('joined');
 
   /**
@@ -190,7 +194,7 @@ export default function SupporterTracking () {
         <Tab
           id="trackingJoinedWeVoteTab"
           active={activeTab === 'joined'}
-          onClick={() => { pushDataLayer('trackingJoinedWeVoteTab'); setActiveTab('joined'); }}
+          onClick={() => { pushDataLayer('trackingJoinedWeVoteTab', selectedPoliticianWeVoteId); setActiveTab('joined'); }}
           data-hidden-bold-text={`Joined WeVote (${counts['joined']})`}
         >
           Joined WeVote
@@ -201,7 +205,7 @@ export default function SupporterTracking () {
         <Tab
           id="trackingInvitedTab"
           active={activeTab === 'invited'}
-          onClick={() => { pushDataLayer('trackingInvitedTab'); setActiveTab('invited'); }}
+          onClick={() => { pushDataLayer('trackingInvitedTab', selectedPoliticianWeVoteId); setActiveTab('invited'); }}
           data-hidden-bold-text={`Invited (${counts['invited']})`}
         >
           Invited
@@ -212,7 +216,7 @@ export default function SupporterTracking () {
         <Tab
           id="trackingReminderNeededTab"
           active={activeTab === 'remind'}
-          onClick={() => { pushDataLayer('trackingReminderNeededTab'); setActiveTab('remind'); }}
+          onClick={() => { pushDataLayer('trackingReminderNeededTab', selectedPoliticianWeVoteId); setActiveTab('remind'); }}
           data-hidden-bold-text={`Reminder needed (${counts['remind']})`}
         >
           Reminder needed

--- a/src/js/pages/ManageMyCandidates/SupporterTracking.jsx
+++ b/src/js/pages/ManageMyCandidates/SupporterTracking.jsx
@@ -5,11 +5,27 @@ import IconButton from "@mui/material/IconButton";
 import Popover from "@mui/material/Popover";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import CloseIcon from "@mui/icons-material/Close";
+import TagManager from 'react-gtm-module';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 import SupportersJoined from './SupportersJoined';
 import SupportersInvited from './SupportersInvited';
 import SupportersToRemind from './SupportersToRemind';
+
+function pushDataLayer (buttonId = '') {
+  const dataLayerObject = {
+    actionDetails: {
+      actionType: 'filter',
+      buttonId,
+    },
+    event: 'action',
+    pageDetails: getPageDetails(),
+    userDetails: VoterStore.getAnalyticsUserDetails(),
+  };
+  TagManager.dataLayer({ dataLayer: dataLayerObject });
+}
 
 export default function SupporterTracking () {
   const [activeTab, setActiveTab] = useState('joined');
@@ -172,8 +188,9 @@ export default function SupporterTracking () {
       </Popover>
       <TabRow>
         <Tab
+          id="trackingJoinedWeVoteTab"
           active={activeTab === 'joined'}
-          onClick={() => setActiveTab('joined')}
+          onClick={() => { pushDataLayer('trackingJoinedWeVoteTab'); setActiveTab('joined'); }}
           data-hidden-bold-text={`Joined WeVote (${counts['joined']})`}
         >
           Joined WeVote
@@ -182,8 +199,9 @@ export default function SupporterTracking () {
           )
         </Tab>
         <Tab
+          id="trackingInvitedTab"
           active={activeTab === 'invited'}
-          onClick={() => setActiveTab('invited')}
+          onClick={() => { pushDataLayer('trackingInvitedTab'); setActiveTab('invited'); }}
           data-hidden-bold-text={`Invited (${counts['invited']})`}
         >
           Invited
@@ -192,8 +210,9 @@ export default function SupporterTracking () {
           )
         </Tab>
         <Tab
+          id="trackingReminderNeededTab"
           active={activeTab === 'remind'}
-          onClick={() => setActiveTab('remind')}
+          onClick={() => { pushDataLayer('trackingReminderNeededTab'); setActiveTab('remind'); }}
           data-hidden-bold-text={`Reminder needed (${counts['remind']})`}
         >
           Reminder needed

--- a/src/js/pages/More/ManageMyCandidates.jsx
+++ b/src/js/pages/More/ManageMyCandidates.jsx
@@ -2,6 +2,7 @@ import { CheckCircle as CheckIcon, Close as CloseIcon, ContentCopy as CopyIcon, 
 import React, { Suspense, useCallback, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import styled from 'styled-components';
+import TagManager from 'react-gtm-module';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import EditInvitationModal from '../../components/More/EditInvitationModal';
 import EnterOneByOneModal from '../../components/More/EnterOneByOneModal';
@@ -9,8 +10,30 @@ import { StyledImportInviteIcon } from '../../components/More/ImportInviteIcon';
 import PasteListModal from '../../components/More/PasteListModal';
 import PreviewInvitationModal from '../../components/More/PreviewInvitationModal';
 import UploadCSVModal from '../../components/More/UploadCSVModal';
+import VoterStore from '../../stores/VoterStore';
+import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const ImportedVotersList = React.lazy(() => import('../../components/PoliticiansManaged/ImportedVotersList'));
+
+function pushDataLayer (event, actionType, buttonId = '', destinationPath = null) {
+  const destinationPage = destinationPath && lookupPageNameAndPageTypeDict(destinationPath);
+  const dataLayerObject = {
+    actionDetails: {
+      actionType,
+      buttonId,
+    },
+    event,
+    pageDetails: getPageDetails(),
+    userDetails: VoterStore.getAnalyticsUserDetails(),
+    ...(destinationPage && { destinationDetails: {
+      destinationPageName: destinationPage.pageName,
+      destinationPageType: destinationPage.pageType,
+      destinationPathname: destinationPath,
+    },
+    }),
+  };
+  TagManager.dataLayer({ dataLayer: dataLayerObject });
+}
 
 export default function ManageMyCandidates ({ selectedPolitician, selectedPoliticianWeVoteId }) {
   const [invitationBody, setInvitationBody] = useState(`Hello friend,
@@ -149,20 +172,20 @@ Thanks for your help!`);
         <InviteDivider className="u-show-desktop" />
         <InviteQuickLinks>
           <InviteLabel>Invitation:</InviteLabel>
-          <IconButton type="button" title="Copy invitation" onClick={handleCopyInviteBody}>
+          <IconButton id="copyInvitationButton-desktop" type="button" title="Copy invitation" onClick={() => { pushDataLayer('action', 'share', 'copyInvitationButton-desktop'); handleCopyInviteBody(); }}>
             <CopyIcon fontSize="small" />
           </IconButton>
-          <IconButton type="button" title="Preview invitation" onClick={handlePreviewOpen}>
+          <IconButton id="previewInvitationButton-desktop" type="button" title="Preview invitation" onClick={() => { pushDataLayer('action', 'openModal', 'previewInvitationButton-desktop'); handlePreviewOpen(); }}>
             <EyeIcon fontSize="small" />
           </IconButton>
-          <IconButton type="button" title="Edit invitation" onClick={openEditModal}>
+          <IconButton id="editInvitationButton-desktop" type="button" title="Edit invitation" onClick={() => { pushDataLayer('action', 'openModal', 'editInvitationButton-desktop'); openEditModal(); }}>
             <EditIcon fontSize="small" />
           </IconButton>
           <InviteLabel>Post to:</InviteLabel>
-          <SocialIconButton type="button" aria-label="Post to Facebook">
+          <SocialIconButton id="postToFacebookButton-desktop" type="button" aria-label="Post to Facebook" onClick={() => pushDataLayer('click', 'share', 'postToFacebookButton-desktop')}>
             <FacebookIcon fontSize="small" />
           </SocialIconButton>
-          <SocialIconButton type="button" aria-label="Post to X">
+          <SocialIconButton id="postToXButton-desktop" type="button" aria-label="Post to X" onClick={() => pushDataLayer('click', 'share', 'postToXButton-desktop')}>
             <XIcon fontSize="small" />
           </SocialIconButton>
         </InviteQuickLinks>
@@ -174,13 +197,13 @@ Thanks for your help!`);
         <MobileInviteActions>
           <LeftGroup>
             <InviteLabel>Invitation:</InviteLabel>
-            <IconButton type="button" title="Copy invitation" onClick={handleCopyInviteBody}>
+            <IconButton id="copyInvitationButton-mobile" type="button" title="Copy invitation" onClick={() => { pushDataLayer('action', 'share', 'copyInvitationButton-mobile'); handleCopyInviteBody(); }}>
               <CopyIcon fontSize="small" />
             </IconButton>
-            <IconButton type="button" title="Preview invitation" onClick={handlePreviewOpen}>
+            <IconButton id="previewInvitationButton-mobile" type="button" title="Preview invitation" onClick={() => { pushDataLayer('action', 'openModal', 'previewInvitationButton-mobile'); handlePreviewOpen(); }}>
               <EyeIcon fontSize="small" />
             </IconButton>
-            <IconButton type="button" title="Edit invitation" onClick={openEditModal}>
+            <IconButton id="editInvitationButton-mobile" type="button" title="Edit invitation" onClick={() => { pushDataLayer('action', 'openModal', 'editInvitationButton-mobile'); openEditModal(); }}>
               <EditIcon fontSize="small" />
             </IconButton>
           </LeftGroup>
@@ -189,10 +212,10 @@ Thanks for your help!`);
 
           <RightGroup>
             <InviteLabel>Post to:</InviteLabel>
-            <SocialIconButton type="button" aria-label="Post to Facebook">
+            <SocialIconButton id="postToFacebookButton-mobile" type="button" aria-label="Post to Facebook" onClick={() => pushDataLayer('click', 'share', 'postToFacebookButton-mobile')}>
               <FacebookIcon fontSize="small" />
             </SocialIconButton>
-            <SocialIconButton type="button" aria-label="Post to X">
+            <SocialIconButton id="postToXButton-mobile" type="button" aria-label="Post to X" onClick={() => pushDataLayer('click', 'share', 'postToXButton-mobile')}>
               <XIcon fontSize="small" />
             </SocialIconButton>
           </RightGroup>
@@ -211,7 +234,7 @@ Thanks for your help!`);
         )}
 
         {!mobileImportDropdown ? (
-          <CollapsedButton type="button" onClick={() => setMobileImportDropdown(true)}>
+          <CollapsedButton id="importVotersExpandButton" type="button" onClick={() => { pushDataLayer('action', 'showMore', 'importVotersExpandButton'); setMobileImportDropdown(true); }}>
             <StyledImportInviteIcon />
             Import voters
           </CollapsedButton>
@@ -222,26 +245,34 @@ Thanks for your help!`);
                 <StyledImportInviteIcon />
                 Import voters
               </ImportVotersTitle>
-              <CloseButton type="button" onClick={() => setMobileImportDropdown(false)}>
+              <CloseButton id="importVotersCloseButton" type="button" onClick={() => { pushDataLayer('action', 'showLess', 'importVotersCloseButton'); setMobileImportDropdown(false); }}>
                 <CloseIcon fontSize="small" />
               </CloseButton>
             </ImportVotersHeader>
 
             <ImportOptionsGrid>
               <ImportOptionWrapper>
-                <ImportOptionButton type="button" onClick={() => setShowUpload(true)}>
+                <ImportOptionButton id="uploadCSVFileButton-mobile" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'uploadCSVFileButton-mobile'); setShowUpload(true); }}>
                   <UploadIcon />
                 </ImportOptionButton>
                 <ImportOptionLabel>Upload CSV file</ImportOptionLabel>
               </ImportOptionWrapper>
               <ImportOptionWrapper>
-                <ImportOptionButton type="button" onClick={() => setShowPaste(true)}>
+                <ImportOptionButton id="pasteListButton-mobile" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'pasteListButton-mobile'); setShowPaste(true); }}>
                   <PasteListIcon />
                 </ImportOptionButton>
                 <ImportOptionLabel>Paste list</ImportOptionLabel>
               </ImportOptionWrapper>
               <ImportOptionWrapper>
-                <ImportOptionButton type="button" onClick={() => setShowEnterOne(true)}>
+                <ImportOptionButton
+                  id="enterOneByOneButton"
+                  type="button"
+                  onClick={() => {
+                    pushDataLayer('action', 'openModal', 'enterOneByOneButton');
+                    setShowEnterOne(true);
+                    setMobileImportDropdown(false);
+                  }}
+                >
                   <PersonIcon />
                 </ImportOptionButton>
                 <ImportOptionLabel>Enter one-by-one</ImportOptionLabel>
@@ -258,8 +289,9 @@ Thanks for your help!`);
           <Input placeholder="Email" value={oneEmail} onChange={(e) => setOneEmail(e.target.value)} />
           <Input placeholder="Mobile phone" value={onePhone} onChange={(e) => setOnePhone(e.target.value)} />
           <PrimaryButton
+            id="importVoterButton"
             type="button"
-            onClick={handleImportOne}
+            onClick={() => { pushDataLayer('action', 'save', 'importVoterButton'); handleImportOne(); }}
             disabled={!oneName.trim() || !emailRE.test(oneEmail)}
           >
             Import voter
@@ -270,12 +302,12 @@ Thanks for your help!`);
       <Section className="u-show-desktop-tablet">
         <H3>Upload voters from a file or paste a list</H3>
         <Row>
-          <PillButton type="button" onClick={() => setShowUpload(true)}>
+          <PillButton id="uploadCSVFileButton-desktop" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'uploadCSVFileButton-desktop'); setShowUpload(true); }}>
             <UploadIcon fontSize="small" />
             Upload CSV file
           </PillButton>
           <Or>OR</Or>
-          <PillButton type="button" onClick={() => setShowPaste(true)}>
+          <PillButton id="pasteListButton-desktop" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'pasteListButton-desktop'); setShowPaste(true); }}>
             <PasteListIcon size={22} />
             Paste list
           </PillButton>

--- a/src/js/pages/More/ManageMyCandidates.jsx
+++ b/src/js/pages/More/ManageMyCandidates.jsx
@@ -12,10 +12,11 @@ import PreviewInvitationModal from '../../components/More/PreviewInvitationModal
 import UploadCSVModal from '../../components/More/UploadCSVModal';
 import VoterStore from '../../stores/VoterStore';
 import lookupPageNameAndPageTypeDict, { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
+import PoliticianStore from '../../common/stores/PoliticianStore';
 
 const ImportedVotersList = React.lazy(() => import('../../components/PoliticiansManaged/ImportedVotersList'));
 
-function pushDataLayer (event, actionType, buttonId = '', destinationPath = null) {
+function pushDataLayer (event, actionType, buttonId = '', destinationPath = null, politicianWeVoteId = null) {
   const destinationPage = destinationPath && lookupPageNameAndPageTypeDict(destinationPath);
   const dataLayerObject = {
     actionDetails: {
@@ -32,6 +33,9 @@ function pushDataLayer (event, actionType, buttonId = '', destinationPath = null
     },
     }),
   };
+  if (politicianWeVoteId) {
+    dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);
+  }
   TagManager.dataLayer({ dataLayer: dataLayerObject });
 }
 
@@ -172,20 +176,20 @@ Thanks for your help!`);
         <InviteDivider className="u-show-desktop" />
         <InviteQuickLinks>
           <InviteLabel>Invitation:</InviteLabel>
-          <IconButton id="copyInvitationButton-desktop" type="button" title="Copy invitation" onClick={() => { pushDataLayer('action', 'share', 'copyInvitationButton-desktop'); handleCopyInviteBody(); }}>
+          <IconButton id="copyInvitationButton-desktop" type="button" title="Copy invitation" onClick={() => { pushDataLayer('action', 'share', 'copyInvitationButton-desktop', null, selectedPoliticianWeVoteId); handleCopyInviteBody(); }}>
             <CopyIcon fontSize="small" />
           </IconButton>
-          <IconButton id="previewInvitationButton-desktop" type="button" title="Preview invitation" onClick={() => { pushDataLayer('action', 'openModal', 'previewInvitationButton-desktop'); handlePreviewOpen(); }}>
+          <IconButton id="previewInvitationButton-desktop" type="button" title="Preview invitation" onClick={() => { pushDataLayer('action', 'openModal', 'previewInvitationButton-desktop', null, selectedPoliticianWeVoteId); handlePreviewOpen(); }}>
             <EyeIcon fontSize="small" />
           </IconButton>
-          <IconButton id="editInvitationButton-desktop" type="button" title="Edit invitation" onClick={() => { pushDataLayer('action', 'openModal', 'editInvitationButton-desktop'); openEditModal(); }}>
+          <IconButton id="editInvitationButton-desktop" type="button" title="Edit invitation" onClick={() => { pushDataLayer('action', 'openModal', 'editInvitationButton-desktop', null, selectedPoliticianWeVoteId); openEditModal(); }}>
             <EditIcon fontSize="small" />
           </IconButton>
           <InviteLabel>Post to:</InviteLabel>
-          <SocialIconButton id="postToFacebookButton-desktop" type="button" aria-label="Post to Facebook" onClick={() => pushDataLayer('click', 'share', 'postToFacebookButton-desktop')}>
+          <SocialIconButton id="postToFacebookButton-desktop" type="button" aria-label="Post to Facebook" onClick={() => pushDataLayer('click', 'share', 'postToFacebookButton-desktop', null, selectedPoliticianWeVoteId)}>
             <FacebookIcon fontSize="small" />
           </SocialIconButton>
-          <SocialIconButton id="postToXButton-desktop" type="button" aria-label="Post to X" onClick={() => pushDataLayer('click', 'share', 'postToXButton-desktop')}>
+          <SocialIconButton id="postToXButton-desktop" type="button" aria-label="Post to X" onClick={() => pushDataLayer('click', 'share', 'postToXButton-desktop', null, selectedPoliticianWeVoteId)}>
             <XIcon fontSize="small" />
           </SocialIconButton>
         </InviteQuickLinks>
@@ -197,13 +201,13 @@ Thanks for your help!`);
         <MobileInviteActions>
           <LeftGroup>
             <InviteLabel>Invitation:</InviteLabel>
-            <IconButton id="copyInvitationButton-mobile" type="button" title="Copy invitation" onClick={() => { pushDataLayer('action', 'share', 'copyInvitationButton-mobile'); handleCopyInviteBody(); }}>
+            <IconButton id="copyInvitationButton-mobile" type="button" title="Copy invitation" onClick={() => { pushDataLayer('action', 'share', 'copyInvitationButton-mobile', null, selectedPoliticianWeVoteId); handleCopyInviteBody(); }}>
               <CopyIcon fontSize="small" />
             </IconButton>
-            <IconButton id="previewInvitationButton-mobile" type="button" title="Preview invitation" onClick={() => { pushDataLayer('action', 'openModal', 'previewInvitationButton-mobile'); handlePreviewOpen(); }}>
+            <IconButton id="previewInvitationButton-mobile" type="button" title="Preview invitation" onClick={() => { pushDataLayer('action', 'openModal', 'previewInvitationButton-mobile', null, selectedPoliticianWeVoteId); handlePreviewOpen(); }}>
               <EyeIcon fontSize="small" />
             </IconButton>
-            <IconButton id="editInvitationButton-mobile" type="button" title="Edit invitation" onClick={() => { pushDataLayer('action', 'openModal', 'editInvitationButton-mobile'); openEditModal(); }}>
+            <IconButton id="editInvitationButton-mobile" type="button" title="Edit invitation" onClick={() => { pushDataLayer('action', 'openModal', 'editInvitationButton-mobile', null, selectedPoliticianWeVoteId); openEditModal(); }}>
               <EditIcon fontSize="small" />
             </IconButton>
           </LeftGroup>
@@ -212,10 +216,10 @@ Thanks for your help!`);
 
           <RightGroup>
             <InviteLabel>Post to:</InviteLabel>
-            <SocialIconButton id="postToFacebookButton-mobile" type="button" aria-label="Post to Facebook" onClick={() => pushDataLayer('click', 'share', 'postToFacebookButton-mobile')}>
+            <SocialIconButton id="postToFacebookButton-mobile" type="button" aria-label="Post to Facebook" onClick={() => pushDataLayer('click', 'share', 'postToFacebookButton-mobile', null, selectedPoliticianWeVoteId)}>
               <FacebookIcon fontSize="small" />
             </SocialIconButton>
-            <SocialIconButton id="postToXButton-mobile" type="button" aria-label="Post to X" onClick={() => pushDataLayer('click', 'share', 'postToXButton-mobile')}>
+            <SocialIconButton id="postToXButton-mobile" type="button" aria-label="Post to X" onClick={() => pushDataLayer('click', 'share', 'postToXButton-mobile', null, selectedPoliticianWeVoteId)}>
               <XIcon fontSize="small" />
             </SocialIconButton>
           </RightGroup>
@@ -234,7 +238,7 @@ Thanks for your help!`);
         )}
 
         {!mobileImportDropdown ? (
-          <CollapsedButton id="importVotersExpandButton" type="button" onClick={() => { pushDataLayer('action', 'showMore', 'importVotersExpandButton'); setMobileImportDropdown(true); }}>
+          <CollapsedButton id="importVotersExpandButton" type="button" onClick={() => { pushDataLayer('action', 'showMore', 'importVotersExpandButton', null, selectedPoliticianWeVoteId); setMobileImportDropdown(true); }}>
             <StyledImportInviteIcon />
             Import voters
           </CollapsedButton>
@@ -245,20 +249,20 @@ Thanks for your help!`);
                 <StyledImportInviteIcon />
                 Import voters
               </ImportVotersTitle>
-              <CloseButton id="importVotersCloseButton" type="button" onClick={() => { pushDataLayer('action', 'showLess', 'importVotersCloseButton'); setMobileImportDropdown(false); }}>
+              <CloseButton id="importVotersCloseButton" type="button" onClick={() => { pushDataLayer('action', 'showLess', 'importVotersCloseButton', null, selectedPoliticianWeVoteId); setMobileImportDropdown(false); }}>
                 <CloseIcon fontSize="small" />
               </CloseButton>
             </ImportVotersHeader>
 
             <ImportOptionsGrid>
               <ImportOptionWrapper>
-                <ImportOptionButton id="uploadCSVFileButton-mobile" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'uploadCSVFileButton-mobile'); setShowUpload(true); }}>
+                <ImportOptionButton id="uploadCSVFileButton-mobile" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'uploadCSVFileButton-mobile', null, selectedPoliticianWeVoteId); setShowUpload(true); }}>
                   <UploadIcon />
                 </ImportOptionButton>
                 <ImportOptionLabel>Upload CSV file</ImportOptionLabel>
               </ImportOptionWrapper>
               <ImportOptionWrapper>
-                <ImportOptionButton id="pasteListButton-mobile" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'pasteListButton-mobile'); setShowPaste(true); }}>
+                <ImportOptionButton id="pasteListButton-mobile" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'pasteListButton-mobile', null, selectedPoliticianWeVoteId); setShowPaste(true); }}>
                   <PasteListIcon />
                 </ImportOptionButton>
                 <ImportOptionLabel>Paste list</ImportOptionLabel>
@@ -268,7 +272,7 @@ Thanks for your help!`);
                   id="enterOneByOneButton"
                   type="button"
                   onClick={() => {
-                    pushDataLayer('action', 'openModal', 'enterOneByOneButton');
+                    pushDataLayer('action', 'openModal', 'enterOneByOneButton', null, selectedPoliticianWeVoteId);
                     setShowEnterOne(true);
                     setMobileImportDropdown(false);
                   }}
@@ -291,7 +295,7 @@ Thanks for your help!`);
           <PrimaryButton
             id="importVoterButton"
             type="button"
-            onClick={() => { pushDataLayer('action', 'save', 'importVoterButton'); handleImportOne(); }}
+            onClick={() => { pushDataLayer('action', 'save', 'importVoterButton', null, selectedPoliticianWeVoteId); handleImportOne(); }}
             disabled={!oneName.trim() || !emailRE.test(oneEmail)}
           >
             Import voter
@@ -302,12 +306,12 @@ Thanks for your help!`);
       <Section className="u-show-desktop-tablet">
         <H3>Upload voters from a file or paste a list</H3>
         <Row>
-          <PillButton id="uploadCSVFileButton-desktop" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'uploadCSVFileButton-desktop'); setShowUpload(true); }}>
+          <PillButton id="uploadCSVFileButton-desktop" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'uploadCSVFileButton-desktop', null, selectedPoliticianWeVoteId); setShowUpload(true); }}>
             <UploadIcon fontSize="small" />
             Upload CSV file
           </PillButton>
           <Or>OR</Or>
-          <PillButton id="pasteListButton-desktop" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'pasteListButton-desktop'); setShowPaste(true); }}>
+          <PillButton id="pasteListButton-desktop" type="button" onClick={() => { pushDataLayer('action', 'openModal', 'pasteListButton-desktop', null, selectedPoliticianWeVoteId); setShowPaste(true); }}>
             <PasteListIcon size={22} />
             Paste list
           </PillButton>

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -90,6 +90,18 @@ const pageNameAndTypeSimpleDict = {
     pageName: 'Credits',
     pageType: 'credits',
   },
+  '/managecandidates': {
+    pageName: 'ManageMyCandidates',
+    pageType: 'account',
+  },
+  '/managecandidates/tracking': {
+    pageName: 'SupporterTracking',
+    pageType: 'account',
+  },
+  '/managecandidates/analytics': {
+    pageName: 'SupporterAnalytics',
+    pageType: 'account',
+  },
 };
 
 function calculatePageNameAndPageTypeDict (path) {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-2443
WV-2087

### Changes included this pull request?
* ManageMyCandidates.jsx: add dataLayer events for all import/invite buttons (copy link, preview, edit, Facebook, X, upload CSV, paste list, enter one-by-one) with desktop and mobile variants
* ManageMyCandidatesLanding.jsx: add dataLayer events for nav pill buttons (import/invite, tracking, analytics, edit candidate profile) with desktop and mobile variants
* SupporterTracking.jsx: add dataLayer events for tracking subtab buttons (joinedWeVote, invited, reminderNeeded)
* lookupPageNameAndPageTypeDict.js: add /managecandidates, /managecandidates/tracking, and /managecandidates/analytics to pageNameAndTypeSimpleDict
* [WV-2087] VoterPositionEntryAndDisplay.jsx: fix pre-existing bug where actionDetails field was named 'action' instead of 'actionType'

[WV-2087]: https://wevoteusa.atlassian.net/browse/WV-2087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ