### PR TITLE
[WV-2444] Add timeStampOfChange to dataLayer for save events on profile sections

### DIFF
--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticalParty.jsx
@@ -46,6 +46,7 @@ function SettingsPoliticalParty ({ politicianWeVoteId }) {
       },
       userDetails: VoterStore.getAnalyticsUserDetails(),
       pageDetails: getPageDetails(),
+      timeStampOfChange: Date.now(),
 
     };
     if (politicianWeVoteId) {

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetLinkCampaignWebsite.jsx
@@ -70,6 +70,7 @@ class SettingsWidgetLinkCampaignWebsite extends Component {
           },
           userDetails: VoterStore.getAnalyticsUserDetails(),
           pageDetails: getPageDetails(),
+          timeStampOfChange: Date.now(),
         };
         if (politicianWeVoteId) {
           dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianName.jsx
@@ -70,6 +70,7 @@ class SettingsWidgetPoliticianName extends Component {
           },
           userDetails: VoterStore.getAnalyticsUserDetails(),
           pageDetails: getPageDetails(),
+          timeStampOfChange: Date.now(),
         };
         if (politicianWeVoteId) {
           dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);

--- a/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsWidgetPoliticianStatement.jsx
@@ -66,6 +66,7 @@ class SettingsWidgetPoliticianStatement extends Component {
         },
         userDetails: VoterStore.getAnalyticsUserDetails(),
         pageDetails: getPageDetails(),
+        timeStampOfChange: Date.now(),
       };
       if (politicianWeVoteId) {
         dataLayerObject.politicianDetails = PoliticianStore.getAnalyticsPoliticianDetails(politicianWeVoteId);


### PR DESCRIPTION
## Summary
Adds `timeStampOfChange` to the dataLayer for save events on the candidate profile settings page.

## Changes
- **SettingsPoliticalParty.jsx** – Added timestamp when political party is saved
- **SettingsWidgetLinkCampaignWebsite.jsx** – Added timestamp when campaign website is saved
- **SettingsWidgetPoliticianName.jsx** – Added timestamp when politician name is saved
- **SettingsWidgetPoliticianStatement.jsx** – Added timestamp when official statement is saved

## Details
- Uses `Date.now()` for the timestamp (milliseconds since epoch)
- Matches the `timeStampOfChange` pattern used elsewhere in the codebase
