### PR TITLE
[WV-2679]Search on Candidates Landing Page - party name matching text is not highlighted [Team Review]

### DIFF
--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -157,7 +157,7 @@ function CardForListBody (props) {
                       <SvgImageWrapper>
                         <SvgImage imageName={politicalPartySvgNameWithPath} stylesTextIncoming="width: 18px;" />
                       </SvgImageWrapper>
-                      <PoliticalPartyDiv>{politicalParty}</PoliticalPartyDiv>
+                      <PoliticalPartyDiv>{highlightSearchText(politicalParty, searchText)}</PoliticalPartyDiv>
                     </FlexDivLeft>
                   </CardForListRow>
                 )}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-2679]Search on Candidates Landing Page - party name matching text is not highlighted
### Changes included this pull request?
added highserachtext to political party name

src/js/common/components/CardForListBody.jsx

<img width="1044" height="445" alt="search_highlight_party" src="https://github.com/user-attachments/assets/6b565b04-9e03-4355-ae71-6ba664ea8fd8" />



[WV-2679]: https://wevoteusa.atlassian.net/browse/WV-2679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ