### PR TITLE
Add drawerName to dataLayer pageDetails [WV-4234]

### DIFF
--- a/src/js/components/Activity/ActivityTidbitDrawer.jsx
+++ b/src/js/components/Activity/ActivityTidbitDrawer.jsx
@@ -5,11 +5,14 @@ import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import historyPush from '../../common/utils/historyPush';
 import { isCordova } from '../../common/utils/isCordovaOrWebApp';
 import { renderLog } from '../../common/utils/logging';
 import ActivityStore from '../../stores/ActivityStore';
+import VoterStore from '../../stores/VoterStore';
 import { cordovaDrawerTopMargin } from '../../utils/cordovaOffsets';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const ActivityCommentAdd = React.lazy(() => import(/* webpackChunkName: 'ActivityCommentAdd' */ './ActivityCommentAdd'));
 const ActivityTidbitAddReaction = React.lazy(() => import(/* webpackChunkName: 'ActivityTidbitAddReaction' */ './ActivityTidbitAddReaction'));
@@ -30,6 +33,7 @@ class ActivityTidbitDrawer extends Component {
   componentDidMount () {
     this.onActivityStoreChange();
     this.activityStoreListener = ActivityStore.addListener(this.onActivityStoreChange.bind(this));
+    this.sendGTMDataLayer();
   }
 
   componentWillUnmount () {
@@ -64,6 +68,16 @@ class ActivityTidbitDrawer extends Component {
     if (typeof pathname !== 'undefined' && pathname && pathname.startsWith('/news/a/')) {
       historyPush(`/news#${activityTidbitWeVoteId}`);
     }
+  };
+
+  sendGTMDataLayer = () => {
+    const dataLayerObject = {
+      event: 'action',
+      actionDetails: { actionType: 'open' },
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+      pageDetails: getPageDetails(null, 'ActivityTidbitDrawer'),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
   };
 
   render () {

--- a/src/js/components/Ballot/PositionDrawer.jsx
+++ b/src/js/components/Ballot/PositionDrawer.jsx
@@ -4,6 +4,7 @@ import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 import PropTypes from 'prop-types';
 import React, { Component, Suspense } from 'react';
+import TagManager from 'react-gtm-module';
 import AnalyticsActions from '../../actions/AnalyticsActions';
 import CandidateActions from '../../actions/CandidateActions';
 import IssueActions from '../../actions/IssueActions';
@@ -23,6 +24,7 @@ import IssueStore from '../../stores/IssueStore';
 import MeasureStore from '../../stores/MeasureStore';
 import VoterGuideStore from '../../stores/VoterGuideStore';
 import VoterStore from '../../stores/VoterStore';
+import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 
 const DelayedLoad = React.lazy(() => import(/* webpackChunkName: 'DelayedLoad' */ '../../common/components/Widgets/DelayedLoad'));
 const PositionItem = React.lazy(() => import(/* webpackChunkName: 'PositionItem' */ './PositionItem'));
@@ -139,6 +141,7 @@ class PositionDrawer extends Component {
     this.setState({
       modalOpen: this.props.modalOpen,
     });
+    this.sendGTMDataLayer();
   }
 
   componentWillUnmount () {
@@ -197,6 +200,16 @@ class PositionDrawer extends Component {
       });
     }
   }
+
+  sendGTMDataLayer = () => {
+    const dataLayerObject = {
+      event: 'action',
+      actionDetails: { actionType: 'open' },
+      userDetails: VoterStore.getAnalyticsUserDetails(),
+      pageDetails: getPageDetails(null, 'PositionDrawer'),
+    };
+    TagManager.dataLayer({ dataLayer: dataLayerObject });
+  };
 
   localPositionListHasBeenRetrievedOnce (ballotItemWeVoteId) {
     if (ballotItemWeVoteId) {

--- a/src/js/components/Drawers/HeaderProfileDrawer.jsx
+++ b/src/js/components/Drawers/HeaderProfileDrawer.jsx
@@ -145,7 +145,7 @@ function HeaderProfileDrawer () {
         buttonId,
       },
       userDetails: VoterStore.getAnalyticsUserDetails(),
-      pageDetails: getPageDetails(),
+      pageDetails: getPageDetails(null, 'HeaderProfileDrawer'),
       destinationDetails: {
         destinationPageName: destinationPage.pageName || '',
         destinationPageType: destinationPage.pageType || '',

--- a/src/js/components/Drawers/PoliticianSelfEditDrawer.jsx
+++ b/src/js/components/Drawers/PoliticianSelfEditDrawer.jsx
@@ -152,7 +152,7 @@ function PoliticianSelfEditDrawer () {
         buttonId,
       },
       userDetails: VoterStore.getAnalyticsUserDetails(),
-      pageDetails: getPageDetails(),
+      pageDetails: getPageDetails(null, 'PoliticianSelfEditDrawer'),
       destinationDetails: {
         destinationPageName: destinationPage.pageName || '',
         destinationPageType: destinationPage.pageType || '',

--- a/src/js/utils/lookupPageNameAndPageTypeDict.js
+++ b/src/js/utils/lookupPageNameAndPageTypeDict.js
@@ -175,22 +175,18 @@ export default function lookupPageNameAndPageTypeDict (path) {
   }
 }
 
-export function getPageDetails (stateCode = null) {
+export function getPageDetails (stateCode = null, drawerName = null) {
   const { location: { pathname } } = window;
   const currentPage = lookupPageNameAndPageTypeDict(pathname);
-  // console.log(currentPage);
 
-  if (stateCode) {
-    return {
-      pageType: currentPage.pageType,
-      pageName: currentPage.pageName,
-      pathname,
-      stateCode,
-    };
-  }
-  return {
+  const pageDetails = {
     pageType: currentPage.pageType,
     pageName: currentPage.pageName,
     pathname,
   };
+
+  if (stateCode) pageDetails.stateCode = stateCode;
+  if (drawerName) pageDetails.drawerName = drawerName;
+
+  return pageDetails;
 }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-4234

### Changes included this pull request?
* Add drawerName parameter to getPageDetails()
* Update HeaderProfileDrawer and PoliticianSelfEditDrawer to pass drawerName when calling getPageDetails()
* Implement dataLayer events in ActivityTidbitDrawer and PositionDrawer, capturing drawerName in pageDetails

### Testing
* HeaderProfileDrawer – confirmed working, drawerName appears in dataLayer
* PoliticianSelfEditDrawer – unable to verify locally; requires a politician/candidate account
* ActivityTidbitDrawer – unable to verify locally; onClickShowActivityTidbitDrawer is commented out in [ActivityTidbitItem.jsx](https://github.com/wevote/WebApp/blob/6cac591d8a338835c6e6b8cee0763be405412820/src/js/components/Activity/ActivityTidbitItem.jsx#L177) so the drawer cannot be opened via UI
* PositionDrawer – unable to verify locally; could not find a UI trigger that opens this drawer in the available test environment