### PR TITLE
[WV-4226] Remove OpenPeople from Credits Page

### DIFF
--- a/src/js/common/constants/people.js
+++ b/src/js/common/constants/people.js
@@ -319,13 +319,16 @@ export const organizationalDonors = [{
   title: 'For supporting Code for San Francisco',
   link: 'https://www.microsoft.com/',
   logo: `${logoPath}microsoft-logo.png`,
-}, {
+},
+// Commented to Remove OpenPeople from Credits Page to fix issue: WV-4226
+/* {
   alt: 'Open People Search',
   name: '',
   title: 'Contact Data Augmentation',
   link: 'https://www.openpeoplesearch.com/',
   logo: `${logoPath}open-people-search-logo.png`,
-}, {
+}, */
+{
   alt: 'TurboVote, Democracy Works',
   name: '',
   title: 'Data',


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

[WV-4226] Remove the OpenPeople Search from the Credits page whose profile link is currently broken.

### Changes included this pull request?

Commented the OpenPeople Search entry from Organizational Donors list

[WV-4226]: https://wevoteusa.atlassian.net/browse/WV-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ