### PR TITLE
Add ability to run WebApp in a local docker environment

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,17 @@
+name: wevote
+
+services:
+  webapp:
+    build:
+      dockerfile: docker/Dockerfile.dev
+    volumes:
+      - .:/app
+    ports:
+      - "127.0.0.1:3000:3000" # this allows access to the WeVote WebApp at localhost:3000  
+    networks:
+      - wevote
+
+networks:
+  wevote:
+    name: wevote
+    external: true

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,0 +1,11 @@
+FROM public.ecr.aws/docker/library/node:25
+WORKDIR /app
+
+# add node_modules/.bin to PATH so that we can run storybook and webpack from the command line
+ENV PATH="${PATH}:/app/node_modules/.bin"
+
+COPY package*.json ./
+RUN npm install
+RUN which storybook
+CMD ["npm", "run", "dev"]
+

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -6,6 +6,5 @@ ENV PATH="${PATH}:/app/node_modules/.bin"
 
 COPY package*.json ./
 RUN npm install
-RUN which storybook
 CMD ["npm", "run", "dev"]
 

--- a/docker/Dockerfile.prod
+++ b/docker/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/node:22 AS builder
+FROM public.ecr.aws/docker/library/node:25 AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm install

--- a/docs/installing/DOCKER.md
+++ b/docs/installing/DOCKER.md
@@ -28,7 +28,7 @@ Only [Docker Desktop](https://docs.docker.com/get-docker/) is required.
   ```
 
 ### 3. Create Docker network
-We will run all WeVote docker containers in an isolated docker network. Since the backend (WeVoteServer) and frontend (WebApp) both use docker compose (which typically manage docker networks for us), we must manually create this shared network to avoid conflicts. Even if you are not planning on running your own backend, this step must still be completed.
+We will run all WeVote docker containers in an isolated docker network. Since the backend (WeVoteServer) and frontend (WebApp) both use docker compose (which typically manages docker networks for us), we must manually create this shared network to avoid conflicts. Even if you are not planning on running your own backend, this step must still be completed.
 ```
 docker network create wevote
 ```

--- a/docs/installing/DOCKER.md
+++ b/docs/installing/DOCKER.md
@@ -1,0 +1,69 @@
+# README for Installation with Docker
+[Back to root README](../../README.md)
+
+Only [Docker Desktop](https://docs.docker.com/get-docker/) is required.
+
+[WSL 2](https://learn.microsoft.com/en-us/windows/wsl/compare-versions#comparing-wsl-1-and-wsl-2) users should follow [this guide](https://docs.docker.com/desktop/wsl/) as well.
+
+## Installation
+
+### 1. Clone your WebApp fork (replace wevote with your github username)
+
+  ```
+  git clone https://github.com/wevote/WebApp.git
+  cd WebApp
+  ```
+
+### 2. Create configuration by copying the default template
+
+  ```
+  cp src/js/config-template.js src/js/config.js
+  ```
+  If you are running your own API server (WeVoteServer) locally, change the new config file to point to your local API container (instead of the live API server):
+  ```
+  WE_VOTE_SERVER_ROOT_URL: 'http://localhost:8000/',
+  WE_VOTE_SERVER_ADMIN_ROOT_URL: 'http://localhost:8000/admin/',
+  WE_VOTE_SERVER_API_ROOT_URL: 'http://localhost:8000/apis/v1/',
+  WE_VOTE_SERVER_API_CDN_ROOT_URL: 'http://localhost:8000/apis/v1/',
+  ```
+
+### 3. Create Docker network
+We will run all WeVote docker containers in an isolated docker network. Since the backend (WeVoteServer) and frontend (WebApp) both use docker compose (which typically manage docker networks for us), we must manually create this shared network to avoid conflicts. Even if you are not planning on running your own backend, this step must still be completed.
+```
+docker network create wevote
+```
+
+### 4. Starting the container
+
+To start the WeVote WebApp service, use one of these commands. You should already be running the WeVoteServer API service. If you are just getting started, we recommend using the first (foreground) method below. These commands assume you are in the `WebApp` folder created in Step 1 above.
+
+#### 1. Start in the foreground (for debugging/logs):
+```
+docker compose up
+```
+This command builds, (re)creates, and starts the service, and shows the logs in your terminal. **Press `Ctrl+C` to stop the container gracefully.**
+
+#### 2. Start in the background (detached mode):
+```
+docker compose up -d
+```
+The `-d` (detached) flag runs the container in the background, leaving it running after you exit the terminal. Once started in detached state, use this command to stop the container:
+```
+docker compose down
+```
+
+Once the container is running, you can now access the WebApp at [http://localhost:3000/](http://localhost:3000/)
+
+## Resources
+
+1. Docker Compose
+    
+    - [CLI](https://docs.docker.com/compose/reference/)
+
+    - [Networking](https://docs.docker.com/compose/networking/)
+
+2. PostgreSQL
+
+    - [Official Docker Image](https://hub.docker.com/_/postgres)
+
+[Back to root README](../README.md)

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lintCordova": "eslint --format stylish --ext .jsx --ext .js srcCordova/js",
     "prod": "npm run build",
     "run-prod-local": "node server-prod-local.js",
+    "dev": "node node/initialSteps && npm run build-storybook && PROTOCOL=HTTP webpack serve --mode development --host 0.0.0.0",
     "start": "node node/initialSteps && npm run build-storybook && PROTOCOL=HTTP webpack serve --mode development",
     "start-win": "node node/initialSteps && webpack serve --mode development",
     "start-https": "node node/initialSteps && PROTOCOL=HTTPS webpack serve --mode development",


### PR DESCRIPTION
This PR gives the ability for developers to run the WebApp locally in a docker container, to avoid installing all the dependencies globally on their local machine.

1. Create compose.yaml to define docker container config.
2. Add actual Dockerfile.dev for running in local development environment
3. Update new production Dockerfile to use node v25 (instead of v22)
4. Add DOCKER.md instructions for setting up local Docker-based dev environment
5. Add new dev target in package.json which sets host parameter to 0.0.0.0 (instead of localhost) since we will be running in a container.

