### PR TITLE
fix(ci): update GitHub Actions Node.js versions and fix package-lock.json for Node v20+ compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['18.x', '20.x']
+        node-version: ['24.x', '25.x']
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: ['24.x', '25.x']
+        node-version: ['20.x', '22.x', '24.x', '25.x']
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14884,6 +14884,21 @@
         }
       }
     },
+    "node_modules/html-encoding-sniffer/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/html-entities": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
@@ -16834,6 +16849,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdom/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/jsdom/node_modules/agent-base": {
@@ -25784,6 +25814,21 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/whatwg-url/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/which": {


### PR DESCRIPTION
## Summary

Updates the Node.js versions tested in GitHub Actions CI workflows and fixes a `package-lock.json` incompatibility that was causing CI failures on older Node versions.

## Problem

A [recent commit](https://github.com/wevote/WebApp/commit/d5f11708fab26c31190d36d63b8dc91e74371a51) updated `package-lock.json` in a way that introduced a dependency on `@noble/hashes` v2.0.1, which requires **Node >= 20.19.0**. This caused the CI build to fail for any Node version below v24 that was listed in the build matrix.

The previous CI matrix was testing `['18.x', '20.x']`, both of which were now broken.

## Changes

### `.github/workflows/build.yml`
- Updated the Node.js version matrix from `['18.x', '20.x']` to `['20.x', '22.x', '24.x', '25.x']`
- Drops Node 18 (EOL) and adds Node 22, 24, and 25 to ensure CI covers currently supported and upcoming LTS versions

### `package-lock.json`
- Added missing nested dependency entries for `@noble/hashes` v2.0.1 in three locations where it is required as a peer/optional dependency:
  - `node_modules/html-encoding-sniffer/node_modules/@noble/hashes`
  - `node_modules/jsdom/node_modules/@noble/hashes`
  - `node_modules/whatwg-url/node_modules/@noble/hashes`
- These entries specify the `>= 20.19.0` engine requirement and ensure the lock file is consistent across Node v20+ environments

## Impact

- CI will now pass on Node 20, 22, 24, and 25
- Drops testing on the EOL Node 18 release
- No application code changes