### PR TITLE
[WV-4250] Privacy module- Open replay privacy page link not working

### DIFF
--- a/src/js/common/components/PrivacyBody.jsx
+++ b/src/js/common/components/PrivacyBody.jsx
@@ -284,9 +284,9 @@ export default class PrivacyBody extends Component {
             <Suspense fallback={<></>}>
               <OpenExternalWebSite
                 linkIdAttribute="openReplayPrivacy"
-                url="https://openreplay.com/legal/privacy.html"
+                url="https://openreplay.com/legal/privacy"
                 target="_blank"
-                body={<span>https://openreplay.com/legal/privacy.html</span>}
+                body={<span>https://openreplay.com/legal/privacy</span>}
               />
             </Suspense>
             ).

--- a/tests/browserstack_automation/specs/PrivacyPage.browser.js
+++ b/tests/browserstack_automation/specs/PrivacyPage.browser.js
@@ -108,9 +108,9 @@ describe('Privacy PageBrowser', () => {
     await driver.pause(waitTime);
     await driver.waitUntil(async () => {
       // Add condition to check for the expected URL
-      await driver.switchWindow('https://openreplay.com/legal/privacy.html');
+      await driver.switchWindow('https://openreplay.com/legal/privacy');
       const currentUrl = await driver.getUrl();
-      return currentUrl === 'https://openreplay.com/legal/privacy.html';
+      return currentUrl === 'https://openreplay.com/legal/privacy';
     }, {
       timeout: 10000,
       timeoutMsg: 'Expected URL not found, timeout after 10000ms',

--- a/tests/browserstack_automation/specs/PrivacyPageMobileBrowser.browser.js
+++ b/tests/browserstack_automation/specs/PrivacyPageMobileBrowser.browser.js
@@ -151,9 +151,9 @@ describe('Privacy PageBrowser', () => {
     });
     await driver.pause(waitTime);
     await driver.waitUntil(async () => {
-      await driver.switchWindow('https://openreplay.com/legal/privacy.html');
+      await driver.switchWindow('https://openreplay.com/legal/privacy');
       const currentUrl = await driver.getUrl();
-      return currentUrl === 'https://openreplay.com/legal/privacy.html';
+      return currentUrl === 'https://openreplay.com/legal/privacy';
     }, {
       timeout: 10000,
       timeoutMsg: 'Expected URL not found, timeout after 10000ms',


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

[WV-4250](https://wevoteusa.atlassian.net/browse/WV-4250) Privacy module- Open replay privacy page link not working

### Changes included this pull request?

Updated URL

[WV-4250]: https://wevoteusa.atlassian.net/browse/WV-4250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ