### PR TITLE
[WV-2660] Election Finder: tweaks, date pills, tooltips, search, header, copy link

### DIFF
--- a/src/js/pages/ElectionFinder/ElectionFinderForElection.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderForElection.jsx
@@ -1,5 +1,5 @@
 import { ContentCopy, FileDownloadOutlined, InfoOutlined, Launch, Search, Close, ExpandMore, UnfoldMore, UnfoldLess } from '@mui/icons-material';
-import { IconButton, InputAdornment, Tooltip } from '@mui/material';
+import { IconButton, InputAdornment } from '@mui/material';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
@@ -11,14 +11,13 @@ import SupportActions from '../../actions/SupportActions';
 import { renderLog } from '../../common/utils/logging';
 import { convertStateCodeToStateText } from '../../common/utils/addressFunctions';
 import AppObservableStore from '../../common/stores/AppObservableStore';
-import { ElectionStateLabel } from '../../components/Style/BallotTitleHeaderStyles';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import BallotStore from '../../stores/BallotStore';
 import CandidateStore from '../../stores/CandidateStore';
 import ElectionStore from '../../stores/ElectionStore';
 import ElectionFinderHeader from './ElectionFinderHeader';
 import {
-  ActionChip, ActionDivider,
+  ActionChip, ActionDivider, DarkTooltip,
   CandidateActions as CandidateActionsRow, CandidateInfo, CandidateList, CandidateName,
   CandidateParty, CandidateRow, DetailTitle, ElectionTitleRow,
   ExpandCollapseButton, ExpandCollapseRow, ExpandMoreIcon,
@@ -201,14 +200,14 @@ function ElectionFinderForElection () {
             { label: `${stateName} ${isUpcoming ? 'Upcoming' : 'Past'} Elections (${isUpcoming ? upcomingCount : pastCount})`, href: `/election-finder/${selectedStateCode.toLowerCase()}` },
             { label: electionName },
           ]}
+          stateLabel={stateName}
         />
-        <ElectionStateLabel style={{ marginBottom: 12 }}>{stateName}</ElectionStateLabel>
 
         <ElectionTitleRow>
           <DetailTitle>{electionName}</DetailTitle>
-          <Tooltip title="Download election data">
+          <DarkTooltip title="Download election data">
             <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
-          </Tooltip>
+          </DarkTooltip>
           {electionSearchOpen ? (
             <InlineSearchField
               variant="outlined"
@@ -263,9 +262,9 @@ function ElectionFinderForElection () {
         {totalResults !== null && (
           <SearchResultCount>
             {`${totalResults} results for \u201C${electionSearchText}\u201D`}
-            <Tooltip title="Download search results">
+            <DarkTooltip title="Download search results">
               <IconButton size="small" style={{ marginLeft: 8 }}><FileDownloadOutlined fontSize="small" /></IconButton>
-            </Tooltip>
+            </DarkTooltip>
           </SearchResultCount>
         )}
 
@@ -323,27 +322,27 @@ function OfficeSectionItemInner ({ // eslint-disable-line react/no-multi-comp
           </OfficeName>
         </OfficeHeaderLeft>
         <OfficeHeaderActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-          <Tooltip title="Copy office name">
+          <DarkTooltip title="Copy office name">
             <ActionChip onClick={() => copyToClipboard(officeName)}>
               <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
               Copy office name
             </ActionChip>
-          </Tooltip>
-          <Tooltip title="Copy link">
+          </DarkTooltip>
+          <DarkTooltip title="Copy link">
             <ActionChip onClick={() => copyToClipboard(`${window.location.origin}/office/${officeWeVoteId}`)}>
               <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
               Copy link
             </ActionChip>
-          </Tooltip>
+          </DarkTooltip>
           <ActionDivider />
-          <Tooltip title="Info">
+          <DarkTooltip title="Info">
             <IconButton size="small"><InfoOutlined fontSize="small" /></IconButton>
-          </Tooltip>
-          <Tooltip title="Open in new tab">
+          </DarkTooltip>
+          <DarkTooltip title="Open in new tab">
             <IconButton size="small" onClick={() => window.open(`/office/${officeWeVoteId}`, '_blank')}>
               <Launch fontSize="small" />
             </IconButton>
-          </Tooltip>
+          </DarkTooltip>
         </OfficeHeaderActions>
       </OfficeHeader>
       {isExpanded && (
@@ -361,24 +360,24 @@ function OfficeSectionItemInner ({ // eslint-disable-line react/no-multi-comp
                   <CandidateParty>{candidateParty}</CandidateParty>
                 </CandidateInfo>
                 <CandidateActionsRow className="u-show-desktop-tablet">
-                  <Tooltip title="Copy candidate name">
+                  <DarkTooltip title="Copy candidate name">
                     <ActionChip onClick={() => copyToClipboard(candidateName)}>
                       <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
                       Copy candidate name
                     </ActionChip>
-                  </Tooltip>
-                  <Tooltip title="Copy link">
+                  </DarkTooltip>
+                  <DarkTooltip title="Copy link">
                     <ActionChip onClick={() => copyToClipboard(`${window.location.origin}${getCandidatePath(candidate)}`)}>
                       <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
                       Copy link
                     </ActionChip>
-                  </Tooltip>
+                  </DarkTooltip>
                   <ActionDivider />
-                  <Tooltip title="Open in new tab">
+                  <DarkTooltip title="Open in new tab">
                     <IconButton size="small" onClick={() => window.open(getCandidatePath(candidate), '_blank')}>
                       <Launch fontSize="small" />
                     </IconButton>
-                  </Tooltip>
+                  </DarkTooltip>
                 </CandidateActionsRow>
               </CandidateRow>
             );

--- a/src/js/pages/ElectionFinder/ElectionFinderForState.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderForState.jsx
@@ -1,17 +1,19 @@
-import { ExpandMore, FileDownloadOutlined, Launch, Search, Close } from '@mui/icons-material';
-import { IconButton, InputAdornment, Tooltip } from '@mui/material';
+import { ContentCopy, ExpandMore, FileDownloadOutlined, Launch, Search, Close } from '@mui/icons-material';
+import { IconButton, InputAdornment } from '@mui/material';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import ElectionActions from '../../actions/ElectionActions';
 import { renderLog } from '../../common/utils/logging';
 import { stateCodeMap, convertStateCodeToStateText } from '../../common/utils/addressFunctions';
+import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import historyPush from '../../common/utils/historyPush';
 import ElectionStore from '../../stores/ElectionStore';
 import ElectionFinderHeader from './ElectionFinderHeader';
 import {
-  ElectionLink, ElectionList, ElectionRow, ElectionRowActions,
+  ActionChip, ActionDivider, DarkTooltip,
+  ElectionDatePill, ElectionLink, ElectionList, ElectionRow, ElectionRowActions,
   FilterTab, FilterTabsRow, InlineSearchField, NoResults,
   SearchIconButton, SectionTitle, SectionTitleRow, ShowMoreButton,
   StateSelectWrapper, StateSelectNative, StateSelectLabel, StateSelectCaret,
@@ -20,6 +22,16 @@ import {
 const SORTED_STATES = Object.entries(stateCodeMap)
   .filter(([code]) => code !== 'NA')
   .sort((a, b) => a[1].localeCompare(b[1]));
+
+function formatDateUS (dateString) {
+  if (!dateString) return '';
+  const [y, m, d] = dateString.split('-');
+  return `${m}-${d}-${y}`;
+}
+
+function sortByDateAsc (a, b) {
+  return (a.election_day_text || '').localeCompare(b.election_day_text || '');
+}
 
 function getBreadcrumbTabLabel (filterTab) {
   if (filterTab === 'all') return 'All';
@@ -105,7 +117,7 @@ function ElectionFinderForState () {
     );
   }
 
-  const upcomingElections = stateElections.filter((el) => el.election_is_upcoming);
+  const upcomingElections = stateElections.filter((el) => el.election_is_upcoming).sort(sortByDateAsc);
   const pastElections = stateElections.filter((el) => !el.election_is_upcoming);
   const upcomingCount = upcomingElections.length;
   const pastCount = pastElections.length;
@@ -123,9 +135,14 @@ function ElectionFinderForState () {
     sectionTitle = `${stateName} \u2013 Past Elections`;
   }
 
-  const sectionDownloadLabel = filterTab === 'past' ?
-    'Download data for all past elections' :
-    'Download data for all upcoming elections';
+  let sectionDownloadLabel;
+  if (filterTab === 'all') {
+    sectionDownloadLabel = `Download data for all ${stateName} elections`;
+  } else if (filterTab === 'past') {
+    sectionDownloadLabel = 'Download data for all past elections';
+  } else {
+    sectionDownloadLabel = 'Download data for all upcoming elections';
+  }
 
   return (
     <>
@@ -162,7 +179,7 @@ function ElectionFinderForState () {
             <InlineSearchField
               variant="outlined"
               size="small"
-              placeholder="Search elections..."
+              placeholder={isMobileScreenSize() ? 'Search...' : 'Search elections...'}
               inputRef={searchInputRef}
               defaultValue=""
               onChange={(e) => {
@@ -199,32 +216,43 @@ function ElectionFinderForState () {
 
         <SectionTitleRow>
           <SectionTitle>{sectionTitle}</SectionTitle>
-          <Tooltip title={sectionDownloadLabel}>
+          <DarkTooltip title={sectionDownloadLabel}>
             <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
-          </Tooltip>
+          </DarkTooltip>
         </SectionTitleRow>
 
         <ElectionList>
           {(searchText ? displayElections : displayElections.slice(0, visibleCount)).map((election) => {
             const googleCivicElectionId = election.google_civic_election_id;
-            const electionLabel = `${election.election_name || ''} \u2013 ${election.election_day_text || ''}`;
             return (
               <ElectionRow
                 key={googleCivicElectionId}
                 onClick={() => onElectionSelect(googleCivicElectionId)}
               >
                 <ElectionLink>
-                  {electionLabel}
+                  {election.election_day_text && (
+                    <ElectionDatePill>{formatDateUS(election.election_day_text)}</ElectionDatePill>
+                  )}
+                  {election.election_name || ''}
                 </ElectionLink>
                 <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-                  <Tooltip title="Download election data">
+                  <DarkTooltip title="Copy link">
+                    <ActionChip
+                      onClick={() => navigator.clipboard.writeText(`${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`)}
+                    >
+                      <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
+                      Copy link
+                    </ActionChip>
+                  </DarkTooltip>
+                  <ActionDivider />
+                  <DarkTooltip title="Download election data">
                     <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
-                  </Tooltip>
-                  <Tooltip title="Open in new tab">
+                  </DarkTooltip>
+                  <DarkTooltip title="Open in new tab">
                     <IconButton size="small" onClick={() => window.open(`/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`, '_blank')}>
                       <Launch fontSize="small" />
                     </IconButton>
-                  </Tooltip>
+                  </DarkTooltip>
                 </ElectionRowActions>
               </ElectionRow>
             );

--- a/src/js/pages/ElectionFinder/ElectionFinderHeader.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderHeader.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ElectionNameH1 } from '../../components/Style/BallotTitleHeaderStyles';
-import { Breadcrumb, BreadcrumbAnchor, TitleWrapper } from './electionFinderStyles';
+import { ElectionNameH1, ElectionStateLabel } from '../../components/Style/BallotTitleHeaderStyles';
+import { Breadcrumb, BreadcrumbAnchor } from './electionFinderStyles';
 
-function ElectionFinderHeader ({ breadcrumbs, subtitle }) {
+function ElectionFinderHeader ({ breadcrumbs, stateLabel, subtitle }) {
   return (
     <>
-      <TitleWrapper>
-        <ElectionNameH1 style={{ paddingBottom: 4 }}>Election Finder</ElectionNameH1>
-      </TitleWrapper>
+      {stateLabel && <ElectionStateLabel>{stateLabel}</ElectionStateLabel>}
+      <ElectionNameH1>Election Finder</ElectionNameH1>
       {breadcrumbs && breadcrumbs.length > 0 && (
         <Breadcrumb>
           {breadcrumbs.map((crumb, idx) => {
@@ -38,6 +37,7 @@ ElectionFinderHeader.propTypes = {
     label: PropTypes.string.isRequired,
     href: PropTypes.string,
   })),
+  stateLabel: PropTypes.string,
   subtitle: PropTypes.string,
 };
 

--- a/src/js/pages/ElectionFinder/ElectionFinderHome.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderHome.jsx
@@ -1,20 +1,32 @@
-import { ExpandMore, FileDownloadOutlined, Launch, Search, Close } from '@mui/icons-material';
-import { IconButton, InputAdornment, Tooltip } from '@mui/material';
+import { ContentCopy, ExpandMore, FileDownloadOutlined, Launch, Search, Close } from '@mui/icons-material';
+import { IconButton, InputAdornment } from '@mui/material';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import ElectionActions from '../../actions/ElectionActions';
 import { renderLog } from '../../common/utils/logging';
 import { stateCodeMap } from '../../common/utils/addressFunctions';
+import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import historyPush from '../../common/utils/historyPush';
 import ElectionStore from '../../stores/ElectionStore';
 import ElectionFinderHeader from './ElectionFinderHeader';
 import {
-  ElectionLink, ElectionList, ElectionRow, ElectionRowActions,
+  ActionChip, ActionDivider, DarkTooltip,
+  ElectionDatePill, ElectionLink, ElectionList, ElectionRow, ElectionRowActions,
   FilterTab, FilterTabsRow, InlineSearchField, NoResults,
   SearchIconButton, SectionTitle, SectionTitleRow, ShowMoreButton,
   StateSelectWrapper, StateSelectNative, StateSelectLabel, StateSelectCaret,
 } from './electionFinderStyles';
+
+function formatDateUS (dateString) {
+  if (!dateString) return '';
+  const [y, m, d] = dateString.split('-');
+  return `${m}-${d}-${y}`;
+}
+
+function sortByDateAsc (a, b) {
+  return (a.election_day_text || '').localeCompare(b.election_day_text || '');
+}
 
 const SORTED_STATES = Object.entries(stateCodeMap)
   .filter(([code]) => code !== 'NA')
@@ -87,7 +99,7 @@ function ElectionFinderHome () {
     );
   }
 
-  const upcomingElections = filteredByState.filter((el) => el.election_is_upcoming);
+  const upcomingElections = filteredByState.filter((el) => el.election_is_upcoming).sort(sortByDateAsc);
   const pastElections = filteredByState.filter((el) => !el.election_is_upcoming);
   const upcomingCount = upcomingElections.length;
   const pastCount = pastElections.length;
@@ -137,7 +149,7 @@ function ElectionFinderHome () {
             <InlineSearchField
               variant="outlined"
               size="small"
-              placeholder="Search elections..."
+              placeholder={isMobileScreenSize() ? 'Search...' : 'Search elections...'}
               inputRef={searchInputRef}
               defaultValue=""
               onChange={(e) => {
@@ -174,28 +186,43 @@ function ElectionFinderHome () {
 
         <SectionTitleRow>
           <SectionTitle>{sectionTitle}</SectionTitle>
-          <Tooltip title={sectionDownloadLabel}>
+          <DarkTooltip title={sectionDownloadLabel}>
             <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
-          </Tooltip>
+          </DarkTooltip>
         </SectionTitleRow>
 
         <ElectionList>
           {(searchText ? displayElections : displayElections.slice(0, visibleCount)).map((election) => {
             const googleCivicElectionId = election.google_civic_election_id;
-            const electionLabel = `${election.election_name || ''} \u2013 ${election.election_day_text || ''}`;
             return (
               <ElectionRow
                 key={googleCivicElectionId}
                 onClick={() => onElectionSelect(election)}
               >
                 <ElectionLink>
-                  {electionLabel}
+                  {election.election_day_text && (
+                    <ElectionDatePill>{formatDateUS(election.election_day_text)}</ElectionDatePill>
+                  )}
+                  {election.election_name || ''}
                 </ElectionLink>
                 <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-                  <Tooltip title="Download election data">
+                  <DarkTooltip title="Copy link">
+                    <ActionChip onClick={() => {
+                      const sc = (election.state_code_list && election.state_code_list.length > 0) ?
+                        election.state_code_list[0].toLowerCase() :
+                        'na';
+                      navigator.clipboard.writeText(`${window.location.origin}/election-finder/${sc}/${googleCivicElectionId}`);
+                    }}
+                    >
+                      <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
+                      Copy link
+                    </ActionChip>
+                  </DarkTooltip>
+                  <ActionDivider />
+                  <DarkTooltip title="Download election data">
                     <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
-                  </Tooltip>
-                  <Tooltip title="Open in new tab">
+                  </DarkTooltip>
+                  <DarkTooltip title="Open in new tab">
                     <IconButton
                       size="small"
                       onClick={() => {
@@ -207,7 +234,7 @@ function ElectionFinderHome () {
                     >
                       <Launch fontSize="small" />
                     </IconButton>
-                  </Tooltip>
+                  </DarkTooltip>
                 </ElectionRowActions>
               </ElectionRow>
             );

--- a/src/js/pages/ElectionFinder/electionFinderStyles.js
+++ b/src/js/pages/ElectionFinder/electionFinderStyles.js
@@ -1,5 +1,24 @@
-import { TextField } from '@mui/material';
+import { TextField, Tooltip, tooltipClasses } from '@mui/material';
+import React from 'react'; // eslint-disable-line no-unused-vars
 import styled from 'styled-components';
+
+// eslint-disable-next-line react/jsx-props-no-spreading, react/react-in-jsx-scope
+export const DarkTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} /> // eslint-disable-line react/jsx-props-no-spreading
+))`
+  & .${tooltipClasses.tooltip} {
+    background-color: rgba(0, 0, 0, 0.9);
+    color: #fff;
+    font-family: "Poppins", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0.15px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    max-width: 200px;
+    text-align: center;
+  }
+`;
 
 export const ActionChip = styled('button')`
   display: inline-flex;
@@ -27,7 +46,8 @@ export const ActionDivider = styled('span')`
 export const Breadcrumb = styled('div')`
   font-size: 14px;
   color: #555;
-  margin-bottom: 4px;
+  margin-top: -14px;
+  margin-bottom: 8px;
 `;
 
 export const BreadcrumbAnchor = styled('a')`
@@ -93,6 +113,16 @@ export const DetailTitle = styled('h2')`
   font-weight: 700;
   color: #333;
   margin: 0;
+`;
+
+export const ElectionDatePill = styled('span')`
+  display: inline-block;
+  color: #848484;
+  font-size: 13px;
+  font-weight: 500;
+  margin-right: 8px;
+  vertical-align: middle;
+  white-space: nowrap;
 `;
 
 export const ElectionLink = styled('span')`
@@ -199,7 +229,7 @@ export const HighlightSpan = styled('span')`
 `;
 
 export const InlineSearchField = styled(TextField)`
-  flex: 1;
+  flex: 1 1 150px;
   max-width: 280px;
   & .MuiOutlinedInput-root {
     height: 26px;
@@ -347,9 +377,4 @@ export const StateSelectCaret = styled('span')`
   align-items: center;
   color: #555;
   font-size: 18px;
-`;
-
-
-export const TitleWrapper = styled('div')`
-  margin-top: 20px;
 `;


### PR DESCRIPTION
- Date pill before election name (MM-DD-YYYY format, grey label)
- Upcoming elections sorted chronologically (soonest first)
- Copy link action added to election row hover actions (Home + State)
- DarkTooltip styled component matching bootstrap tooltip style
- ElectionFinderHeader: stateLabel prop, removed TitleWrapper, breadcrumb spacing to be consistent w/ other headers across the site
- State dropdown "All" tab shows state-specific download tooltip
- Search placeholder: "Search..." on mobile, "Search elections..." on desktop
- Search field flex-wrap for mobile responsiveness
- Removed unused TitleWrapper export from styles
- Functional components with isMobileScreenSize for responsive placeholder