### PR TITLE
modify dockerfile.dev and compose.yaml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,10 +6,7 @@ services:
       dockerfile: docker/Dockerfile.dev
     volumes:
       - .:/app
-      # Create an anonymous volume for node_modules inside the container
-      # This prevents the host's (potentially empty or incompatible) node_modules
-      # from shadowing the container's installed node_modules
-      - /app/node_modules
+      - webapp_node_modules:/app/node_modules
     ports:
       - "127.0.0.1:3000:3000" # this allows access to the WeVote WebApp at localhost:3000  
     networks:
@@ -19,3 +16,6 @@ networks:
   wevote:
     name: wevote
     external: true
+
+volumes:
+  webapp_node_modules:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,6 +1,14 @@
-FROM public.ecr.aws/docker/library/node:25
-WORKDIR /app
-COPY package*.json ./
-RUN npm install
-CMD ["npm", "run", "dev"]
+# --- builder: root, full install ---
+  FROM public.ecr.aws/docker/library/node:25 AS builder
+  WORKDIR /app
+  COPY package.json package-lock.json ./
+  RUN npm install
 
+  # --- runtime: non-root, copy artifacts from builder ---
+  FROM public.ecr.aws/docker/library/node:25
+  WORKDIR /app
+  COPY package.json package-lock.json ./
+  COPY --from=builder /app/node_modules ./node_modules
+  RUN chown -R node:node /app
+  USER node
+  CMD ["npm", "run", "dev"]


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Epic: https://wevoteusa.atlassian.net/browse/WV-4285
Child: https://wevoteusa.atlassian.net/browse/WV-4286

### Changes included this pull request?

- Run containers as a non-root user. This reduces the potential impact of any malicious scripts by limiting system-level access.
- Use a named volume for node_modules. This prevents leftover or “dangling” dependencies from persisting across builds and causing inconsistencies. (Addendum, anonymous volumes persist after docker compose down, and on relaunching the container a new volume is created. This leaves a dangling volume of ~750mb)
- Adopt multi-stage Docker builds. Dependencies will be installed during the image build process rather than at runtime, ensuring a more controlled and reproducible environment.