### PR TITLE
[WV-4255] Edit Opinion Modal: Upgrade

### DIFF
--- a/src/js/common/stores/AppObservableStore.js
+++ b/src/js/common/stores/AppObservableStore.js
@@ -69,6 +69,7 @@ const nonFluxState = {
   showClaimProfileWithEmailModal: false,
   showEditPositionModal: false,
   editPositionModalPoliticianWeVoteId: '',
+  editPositionModalSetPublic: false,
   showClaimProfileWithOtherWaysModal: false,
   showCompleteYourProfileModal: false,
   showNotificationBannerAboveHeader: false,
@@ -210,6 +211,10 @@ export default {
 
   getEditPositionModalPoliticianWeVoteId () {
     return nonFluxState.editPositionModalPoliticianWeVoteId;
+  },
+
+  getEditPositionModalSetPublic () {
+    return nonFluxState.editPositionModalSetPublic;
   },
 
   getShowClaimProfileWithOtherWaysModal () {
@@ -516,9 +521,14 @@ export default {
     messageService.sendMessage('state updated showClaimProfileWithEmailModal');
   },
 
-  setShowEditPositionModal (show, politicianWeVoteId = '') {
+  setEditPositionModalSetPublic (value) {
+    nonFluxState.editPositionModalSetPublic = value;
+  },
+
+  setShowEditPositionModal (show, politicianWeVoteId = '', setPublic = false) {
     nonFluxState.showEditPositionModal = show;
     nonFluxState.editPositionModalPoliticianWeVoteId = show ? politicianWeVoteId : '';
+    nonFluxState.editPositionModalSetPublic = show ? setPublic : false;
     messageService.sendMessage('state updated showEditPositionModal');
   },
 

--- a/src/js/components/More/ConfirmCloseModal.jsx
+++ b/src/js/components/More/ConfirmCloseModal.jsx
@@ -14,6 +14,7 @@ export default function ConfirmCloseModal ({
     <>
       <HideDivider />
       <SoftenCorners />
+      <CenterModal />
       <RemoveTopPadding />
       <ModalDisplayTemplateB
         show={isOpen}
@@ -52,6 +53,15 @@ ConfirmCloseModal.propTypes = {
 };
 
 // Global Styles
+
+const CenterModal = createGlobalStyle`
+  .MuiDialog-paper.MuiDialog-paperScrollPaper[role="dialog"]:has(#closeModalDisplayTemplateBconfirmCloseModal) {
+    margin: 32px auto !important;
+    top: 0 !important;
+    transform: none !important;
+  }
+`;
+
 const HideDivider = createGlobalStyle`
   .MuiDialogTitle-root:has(#closeModalDisplayTemplateBconfirmCloseModal) > hr {
     display: none !important;
@@ -71,9 +81,6 @@ const RemoveTopPadding = createGlobalStyle`
   }
   .MuiDialog-paper:has(#closeModalDisplayTemplateBconfirmCloseModal) .MuiDialogContent-root > div {
     margin-top: 0 !important;
-  }
-  .MuiDialog-paper:has(#closeModalDisplayTemplateBconfirmCloseModal) {
-    overflow: visible !important;
   }
 `;
 

--- a/src/js/components/More/EditInvitationModal.jsx
+++ b/src/js/components/More/EditInvitationModal.jsx
@@ -194,7 +194,6 @@ const HeaderLink = styled.button`
 const HeaderRow = styled.div`
   align-items: center;
   display: flex;
-  justify-content: space-between;
   padding: 0 12px 0 18px;
 `;
 

--- a/src/js/components/More/ImportConfirmModal.jsx
+++ b/src/js/components/More/ImportConfirmModal.jsx
@@ -544,7 +544,6 @@ const Footer = styled.div`
 const HeaderRow = styled.div`
   align-items: center;
   display: flex;
-  justify-content: space-between;
   padding: 0 12px 0 18px;
 
   @media (max-width: 575px) {

--- a/src/js/components/More/InviteSelectedModal.jsx
+++ b/src/js/components/More/InviteSelectedModal.jsx
@@ -98,10 +98,10 @@ export default function InviteSelectedModal ({
       <Count>
         (
         {count}
+        {' '}
         voter
-        {count > 1 ? 's' : ''}
-        selected
-        )
+        {count > 1 ? 's ' : ' '}
+        selected)
       </Count>
     </HeaderRow>
   );
@@ -132,7 +132,9 @@ export default function InviteSelectedModal ({
             {missingEmailOnlyCount > 0 && (
               <li>
                 Email not entered for
+                {' '}
                 {missingEmailOnlyCount}
+                {' '}
                 voter
                 {missingEmailOnlyCount > 1 && 's'}
                 :
@@ -143,7 +145,9 @@ export default function InviteSelectedModal ({
             {missingPhoneOnlyCount > 0 && (
               <li>
                 Mobile phone not entered for
+                {' '}
                 {missingPhoneOnlyCount}
+                {' '}
                 voter
                 {missingPhoneOnlyCount > 1 && 's'}
                 :
@@ -156,8 +160,10 @@ export default function InviteSelectedModal ({
                 <li>
                   <span style={{ color: DesignTokenColors.neutralUI400 }}>
                     {missingBothCount}
+                    {' '}
                     voter
                     {missingBothCount > 1 && 's'}
+                    {' '}
                     cannot be invited (no email or mobile phone entered) -
                   </span>
                 </li>
@@ -181,7 +187,9 @@ export default function InviteSelectedModal ({
         <>
           <SendButton onClick={handleSendBatchEmail}>
             Send email invite to
+            {' '}
             {count}
+            {' '}
             supporter
             {count > 1 && 's'}
           </SendButton>
@@ -371,7 +379,6 @@ const HeaderDivider = styled.div`
 const HeaderRow = styled.div`
   align-items: center;
   display: flex;
-  justify-content: space-between;
   padding: 0 12px 0 18px;
 `;
 

--- a/src/js/components/More/PasteListModal.jsx
+++ b/src/js/components/More/PasteListModal.jsx
@@ -320,7 +320,6 @@ const Footer = styled.div`
 const HeaderRow = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-between;
   padding: 0px 12px 0 18px;
 `;
 

--- a/src/js/components/More/PreviewInvitationModal.jsx
+++ b/src/js/components/More/PreviewInvitationModal.jsx
@@ -153,7 +153,6 @@ const HeaderLink = styled.button`
 const HeaderRow = styled.div`
   align-items: center;
   display: flex;
-  justify-content: space-between;
   padding: 0 12px 0 18px;
 `;
 

--- a/src/js/components/More/UploadCSVModal.jsx
+++ b/src/js/components/More/UploadCSVModal.jsx
@@ -335,7 +335,6 @@ const HeaderLink = styled.button`
 const HeaderRow = styled.div`
   align-items: center;
   display: flex;
-  justify-content: space-between;
   padding: 0 12px 0 18px;
 
   @media (max-width: 575px) {

--- a/src/js/components/PositionItem/VoterPositionEntryAndDisplay.jsx
+++ b/src/js/components/PositionItem/VoterPositionEntryAndDisplay.jsx
@@ -1,10 +1,15 @@
 import { Edit as EditIcon } from '@mui/icons-material';
-import { Box, Button, FormControlLabel, InputBase, Radio, RadioGroup, Skeleton, Tooltip } from '@mui/material';
-import { styled as muiStyled, withStyles } from '@mui/styles';
+import CheckIcon from '@mui/icons-material/Check';
+import BlockIcon from '@mui/icons-material/Block';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import PublicIcon from '@mui/icons-material/Public';
+import { Box, Button, Checkbox, FormControlLabel, InputBase, Skeleton } from '@mui/material';
+import { withStyles } from '@mui/styles';
 import PropTypes from 'prop-types';
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import TagManager from 'react-gtm-module';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 import SupportActions from '../../actions/SupportActions';
 import SpeakerEndorsedOrOpposedSnippet from '../../common/components/Position/SpeakerEndorsedOrOpposedSnippet';
 import VoterPositionEditTripleDot from '../../common/components/Position/VoterPositionEditTripleDot';
@@ -23,9 +28,10 @@ import VoterStore from '../../stores/VoterStore';
 import { avatarGeneric } from '../../utils/applicationUtils';
 import { possibleAppReview } from '../../utils/appReviewFunctions';
 import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
-import ActivityPostPublicDropdown from '../Activity/ActivityPostPublicDropdown';
 import ReviewAppModal from '../ReviewApps/ReviewAppModal';
-import ModalDisplayTemplateB, { CommentContainer, InputBox, templateBStyles, TextFieldDiv, TextFieldForm, TextFieldWrapper, UserInfoText, UserName } from '../Widgets/ModalDisplayTemplateB';
+import VisibilityExplainer from '../Settings/VisibilityExplainer';
+import VisibilityToggleBar from '../Settings/VisibilityToggleBar';
+import ModalDisplayTemplateB, { CommentContainer, InputBox, templateBStyles, TextFieldForm, TextFieldWrapper, UserInfoText, UserName } from '../Widgets/ModalDisplayTemplateB';
 import VoterPositionEditNameAndPhotoModal from './VoterPositionEditNameAndPhotoModal';
 
 /* global $ */
@@ -183,13 +189,14 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
   const [selectedStance, setSelectedStance] = useState('SUPPORT');
   const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
+  const [showLearnMore, setShowLearnMore] = useState(false);
   const [showNegativeModal, setShowNegativeModal] = useState(false);
   const [statementText, setStatementText] = useState('');
   const [draftStatementText, setDraftStatementText] = useState('');
   const [draftSelectedStance, setDraftSelectedStance] = useState('SUPPORT');
-  const [draftVisibilityIsPublic, setDraftVisibilityIsPublic] = useState(false);
   const [supportOrOpposeStanceExists, setSupportOrOpposeStanceExists] = useState(false);
-  const [visibilityIsPublic, setVisibilityIsPublic] = useState(false);
+  const [setAsDefaultVisibility, setSetAsDefaultVisibility] = useState(false);
+  const [visibilitySetting, setVisibilitySetting] = useState('friends'); // 'public', 'friends', 'private'
   const [voterFirstName, setVoterFirstName] = useState('');
   const [voterLastName, setVoterLastName] = useState('');
   const [voterName, setVoterName] = useState('');
@@ -262,10 +269,22 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
     const tokenText = token ? token.text : '';
     const showNegativeModalFromMessage = tokenText.includes('showNegativeFeedbackModal') && tokenText.includes('POSITION');
     const showingNegativeFeedbackModal = AppObservableStore.getShowingNegativeFeedbackModal();
-    if (!showNegativeModal && !showingNegativeFeedbackModal && showNegativeModalFromMessage) {
+    if (!showingNegativeFeedbackModal && showNegativeModalFromMessage) {
       setShowNegativeModal(true);
     }
-  }, [showNegativeModal]);
+    // Listen for "Make public" from ItemActionBar opening this modal
+    if (tokenText.includes('showEditPositionModal')) {
+      const modalWeVoteId = AppObservableStore.getEditPositionModalPoliticianWeVoteId();
+      if (AppObservableStore.getShowEditPositionModal() && modalWeVoteId === effectiveWeVoteId) {
+        if (AppObservableStore.getEditPositionModalSetPublic()) {
+          setTimeout(() => setVisibilitySetting('public'), 300);
+          AppObservableStore.setEditPositionModalSetPublic(false);
+        }
+        setShowEditModal(true);
+        AppObservableStore.setShowEditPositionModal(false);
+      }
+    }
+  }, [effectiveWeVoteId]);
 
   useEffect(() => {
     const appStateSubscription = messageService.getMessage().subscribe(onAppObservableStoreChange);
@@ -314,7 +333,7 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
         setPosition({ ...positionTemp }); // Ensure a new object reference so the component re-renders
         setSelectedStance(stanceTemp);
         setStatementText(voterTextStatement);
-        setVisibilityIsPublic(voterPositionIsPublic);
+        setVisibilitySetting(voterPositionIsPublic ? 'public' : 'friends');
       }
     }
   }, [isMeasure]);
@@ -325,11 +344,6 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
     setVoterFirstName(voter.first_name || 'Anonymous');
     setVoterLastName(voter.last_name || 'Anonymous');
     setVoterName(voter.full_name || 'Anonymous');
-  };
-
-  const handleOpinionChange = (event) => {
-    const newStance = event.target.value;
-    setDraftSelectedStance(newStance);
   };
 
   useEffect(() => {
@@ -398,7 +412,12 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
     if (showEditModal) {
       setDraftStatementText(statementText);
       setDraftSelectedStance(selectedStance);
-      setDraftVisibilityIsPublic(visibilityIsPublic);
+      setShowLearnMore(false);
+      // If opened via "Make public", auto-set visibility to public
+      if (AppObservableStore.getEditPositionModalSetPublic()) {
+        setVisibilitySetting('public');
+        AppObservableStore.setEditPositionModalSetPublic(false);
+      }
     }
   }, [showEditModal]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -412,17 +431,22 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
   const deletePosition = (e) => {
     e.preventDefault();
     const ballotItemWeVoteId = isMeasure ? effectiveWeVoteId : '';
-    const visibilitySetting = 'FRIENDS_ONLY';
+    const deleteVisibility = 'FRIENDS_ONLY';
     const selectedStanceTemp = 'INFO_ONLY';
     const statementTextTemp = '';
-    SupportActions.voterPositionCommentSave(ballotItemWeVoteId, effectiveKindOfBallotItem, effectivePoliticianWeVoteId, statementTextTemp, selectedStanceTemp, visibilitySetting);
+    SupportActions.voterPositionCommentSave(ballotItemWeVoteId, effectiveKindOfBallotItem, effectivePoliticianWeVoteId, statementTextTemp, selectedStanceTemp, deleteVisibility);
     toggleDeleteConfirmationModalLocal();
+  };
+
+  const getVisibilitySettingForApi = () => {
+    if (visibilitySetting === 'public') return 'SHOW_PUBLIC';
+    return 'FRIENDS_ONLY';
   };
 
   const savePosition = (e) => {
     e.preventDefault();
     const ballotItemWeVoteId = isMeasure ? effectiveWeVoteId : '';
-    const visibilitySetting = draftVisibilityIsPublic ? 'SHOW_PUBLIC' : 'FRIENDS_ONLY';
+    const saveVisibility = getVisibilitySettingForApi();
 
     let stanceLabel = 'Not sure yet';
     if (draftSelectedStance === 'SUPPORT') {
@@ -443,7 +467,7 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
       positionDetails: {
         positionStance: stanceLabel,
         hasPositionStatement: draftStatementText.trim() !== '',
-        isPublic: draftVisibilityIsPublic,
+        isPublic: visibilitySetting === 'public',
         positionWeVoteId: position.position_we_vote_id || null,
       },
     };
@@ -452,7 +476,7 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
     }
     TagManager.dataLayer({ dataLayer: dataLayerObject });
 
-    SupportActions.voterPositionCommentSave(ballotItemWeVoteId, effectiveKindOfBallotItem, effectivePoliticianWeVoteId, draftStatementText, draftSelectedStance, visibilitySetting);
+    SupportActions.voterPositionCommentSave(ballotItemWeVoteId, effectiveKindOfBallotItem, effectivePoliticianWeVoteId, draftStatementText, draftSelectedStance, saveVisibility);
     possibleAppReview('POSITION');
     toggleEditModalLocal(false);
   };
@@ -466,30 +490,16 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
   const editPositionModalTitleText = positionExists ? `Edit opinion${ballotItemName && ` about ${ballotItemName}`}` : `Create opinion${ballotItemName && ` about ${ballotItemName}`}`;
   const deleteConfirmationModalTitleText = ballotItemName ? `Delete opinion about ${ballotItemName}?` : 'Delete opinion?';
   const statementPlaceholderText = 'What\'s on your mind?';
-  const rowsToShow = isAndroid() ? 4 : 6;
-
-  const defaultOpinionVisibilityText = (
-    <p>
-      Change your default visibility
-      {' '}
-      <a
-        href="/settings/profile"
-        className={classes.tooltipLink}
-      >
-        in your profile
-      </a>
-      .
-    </p>
-  );
+  const rowsToShow = isAndroid() ? 3 : 4;
 
   const editPositionModalJSX = (
     <TextFieldWrapper>
       <TextFieldForm
         className={classes.formStyles}
-        // onBlur={onBlurInput}
         onFocus={onFocusInput}
         onSubmit={savePosition}
       >
+        {/* Avatar and name row */}
         <VoterAvatarDisplayContainer>
           <VoterAvatarBlock voterPhotoUrlMedium={voterPhotoUrlMedium} voterFirstName={voterFirstName} voterLastName={voterLastName} />
           <EditIcon
@@ -498,50 +508,14 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
           />
           <UserInfoText>
             <UserName>
-              {' '}
               {voterName}
             </UserName>
-            <Tooltip
-              arrow
-              title={defaultOpinionVisibilityText}
-              placement="top"
-              classes={{ tooltip: classes.tooltipPaper, arrow: classes.tooltipArrow }}
-            >
-              <div>
-                <ActivityPostPublicDropdown
-                  visibilityIsPublic={draftVisibilityIsPublic}
-                  onVisibilityChange={(newVisibility) => setDraftVisibilityIsPublic(newVisibility)}
-                />
-              </div>
-            </Tooltip>
           </UserInfoText>
         </VoterAvatarDisplayContainer>
-        <RadioGroup
-          row
-          value={draftSelectedStance}
-          onChange={handleOpinionChange}
-          className={classes.radioGroup}
-        >
-          <FormControlLabel
-            value="SUPPORT"
-            control={<RadioStyled color="primary" />}
-            label={isMeasure ? 'Voting Yes' : 'Supporting'}
-            classes={{ root: classes.radioLabel }}
-          />
-          <FormControlLabel
-            value="OPPOSE"
-            control={<RadioStyled color="primary" />}
-            label={isMeasure ? 'Voting No' : 'Opposing'}
-            classes={{ root: classes.radioLabel }}
-          />
-          <FormControlLabel
-            value="INFO_ONLY"
-            control={<RadioStyled color="primary" />}
-            label="Not sure yet"
-            classes={{ root: classes.radioLabel }}
-          />
-        </RadioGroup>
-        <TextFieldDiv>
+
+        {/* Your opinion text area */}
+        <OpinionSectionLabel>Your opinion:</OpinionSectionLabel>
+        <OpinionTextFieldDiv>
           <InputBase
             classes={{ root: classes.inputStyles, inputMultiline: classes.inputMultiline }}
             id={`activityPostModalStatementText-${effectiveWeVoteId}-${externalUniqueId}`}
@@ -553,17 +527,123 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
             rows={rowsToShow}
             value={draftStatementText || ''}
           />
-        </TextFieldDiv>
-        <Button
-          id={`positionEntrySave-${effectiveWeVoteId}-${externalUniqueId}`}
-          variant="contained"
-          color="primary"
-          classes={{ root: classes.saveButtonRoot }}
-          type="submit"
-          disabled={draftSelectedStance === 'INFO_ONLY' && (!draftStatementText || draftStatementText.trim() === '')}
+        </OpinionTextFieldDiv>
+
+        {/* Choose / Oppose / Undecided toggle buttons */}
+        <OpinionSectionLabel>
+          {isMeasure ? 'What is your position?' : 'Will you choose this candidate?'}
+        </OpinionSectionLabel>
+        <StanceToggleRow>
+          <StanceToggleButton
+            type="button"
+            selected={draftSelectedStance === 'SUPPORT'}
+            stanceType="support"
+            onClick={() => setDraftSelectedStance('SUPPORT')}
+          >
+            <CheckIcon style={{ fontSize: 18, marginRight: 4, color: DesignTokenColors.confirmation500 }} />
+            {isMeasure ? 'Vote Yes' : 'Choose'}
+          </StanceToggleButton>
+          <StanceToggleButton
+            type="button"
+            selected={draftSelectedStance === 'OPPOSE'}
+            stanceType="oppose"
+            onClick={() => setDraftSelectedStance('OPPOSE')}
+          >
+            <BlockIcon style={{ fontSize: 18, marginRight: 4, color: DesignTokenColors.alert800 }} />
+            {isMeasure ? 'Vote No' : 'Oppose'}
+          </StanceToggleButton>
+          <StanceToggleButton
+            type="button"
+            selected={draftSelectedStance === 'INFO_ONLY'}
+            stanceType="undecided"
+            onClick={() => setDraftSelectedStance('INFO_ONLY')}
+          >
+            Undecided
+          </StanceToggleButton>
+        </StanceToggleRow>
+
+        {/* Visibility toggle: Public / WeVote friends / Private */}
+        <OpinionSectionLabel>
+          Visibility of opinion &amp; choice for this
+          {isMeasure ? ' measure' : ' candidate'}
+          :
+        </OpinionSectionLabel>
+        <VisibilityToggleBar value={visibilitySetting} onChange={setVisibilitySetting} />
+
+        {/* "Make public" prompt OR "Set as default" — cross-fade between them */}
+        <VisibilityHintWrapper>
+          <VisibilityHintFade visible={visibilitySetting !== 'public'}>
+            <MakePublicRow>
+              <PublicIcon />
+              <MakePublicLink
+                type="button"
+                onClick={() => setVisibilitySetting('public')}
+              >
+                Make public
+              </MakePublicLink>
+              {' '}
+              to influence more people.
+            </MakePublicRow>
+          </VisibilityHintFade>
+          <VisibilityHintFade visible={visibilitySetting === 'public'}>
+            <SetDefaultVisibilityRow>
+              <FormControlLabel
+                control={(
+                  <Checkbox
+                    checked={setAsDefaultVisibility}
+                    onChange={(e) => setSetAsDefaultVisibility(e.target.checked)}
+                    color="primary"
+                    size="small"
+                  />
+                )}
+                label={(
+                  <SetDefaultLabel>
+                    Set &lsquo;Public&rsquo; as the default visibility for future opinions &amp; choices.
+                    <SetDefaultSubtext>
+                      (Default can be changed in your
+                      {' '}
+                      <a href="/settings/profile">WeVote account page</a>
+                      )
+                    </SetDefaultSubtext>
+                  </SetDefaultLabel>
+                )}
+              />
+            </SetDefaultVisibilityRow>
+          </VisibilityHintFade>
+        </VisibilityHintWrapper>
+
+        {/* Learn more about visibility (expandable) */}
+        <LearnMoreToggle
+          type="button"
+          onClick={() => setShowLearnMore((prev) => !prev)}
         >
-          {positionExists ? 'Save Changes' : 'Add opinion'}
-        </Button>
+          {showLearnMore ? <ExpandLessIcon style={{ fontSize: 20, marginRight: 4 }} /> : <ExpandMoreIcon style={{ fontSize: 20, marginRight: 4 }} />}
+          Learn more about visibility
+        </LearnMoreToggle>
+        <LearnMoreCollapsible expanded={showLearnMore}>
+          <VisibilityExplainer fontSize={13} />
+        </LearnMoreCollapsible>
+
+        {/* Action buttons */}
+        <ModalButtonRow>
+          {positionExists && (
+            <CancelButton
+              type="button"
+              onClick={() => toggleEditModalLocal()}
+            >
+              Cancel
+            </CancelButton>
+          )}
+          <Button
+            id={`positionEntrySave-${effectiveWeVoteId}-${externalUniqueId}`}
+            variant="contained"
+            color="primary"
+            classes={{ root: classes.saveButtonRoot }}
+            type="submit"
+          >
+            {positionExists ? 'Save opinion' : 'Add opinion'}
+          </Button>
+        </ModalButtonRow>
       </TextFieldForm>
     </TextFieldWrapper>
   );
@@ -606,6 +686,7 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
       {showNegativeModal && !showingNegativeFeedbackModal && (
         <ReviewAppModal initialEmail={initialEmail} />
       )}
+      {showEditModal && <EditOpinionModalOverrides />}
       <ModalDisplayTemplateB
         dialogTitleJSX={<>{editPositionModalTitleText}</>}
         show={showEditModal}
@@ -660,15 +741,17 @@ VoterPositionEntryAndDisplay.propTypes = {
   politicianWeVoteId: PropTypes.string,
 };
 
-const CompactEditHint = CompactSecondaryText;
-
-const CompactOwnCommentWrapper = styled('div')`
-  cursor: pointer;
-`;
+// Shared styled components (used by VoterAvatarBlock and VoterPositionBlockComponent above)
 
 const CommentContainerWrapper = styled('div')`
   flex: 1;
   min-width: 0;
+`;
+
+const CompactEditHint = CompactSecondaryText;
+
+const CompactOwnCommentWrapper = styled('div')`
+  cursor: pointer;
 `;
 
 const ItemActionBarContainer = styled('div')`
@@ -679,50 +762,51 @@ const ItemActionBarContainer = styled('div')`
   }
 `;
 
+const SpeakerInfoWrapperB = styled('div')`
+  display: flex;
+  flex-direction: column;
+`;
+
 const SpeakerPositionLikesSourceWrapper = styled('div')`
   align-items: center;
   display: flex;
   justify-content: space-between;
 `;
 
-const SpeakerInfoWrapperB = styled('div')`
+const VoterAvatar = styled('div')`
+  align-items: center;
+  background-color: ${DesignTokenColors.info600};
+  border-radius: 50%;
   display: flex;
-  flex-direction: column;
+  height: 43px;
+  justify-content: center;
+  overflow: hidden;
+  width: 43px;
 `;
 
-const VoterAvatar = styled('div')`
-  height: 43px;
-  width: 43px;
-  border-radius: 50%;
-  background-color: ${DesignTokenColors.info600};
-  display: flex;
-  justify-content: center;
+export const VoterAvatarDisplayContainer = styled('div')`
   align-items: center;
-  overflow: hidden;
+  display: flex;
 `;
 
 const VoterFirstName = styled('p')`
   color: ${DesignTokenColors.whiteUI};
+  font-size: 16px;
   margin: 0;
   padding: 0;
-  font-size: 16px;
+`;
+
+const VoterImage = styled('img')`
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
 `;
 
 const VoterLastName = styled('p')`
   color: ${DesignTokenColors.whiteUI};
+  font-size: 11px;
   margin-bottom: -4px;
   padding: 0;
-  font-size: 11px;
-`;
-
-const VoterImage = styled('img')`
-  object-fit: cover;
-  height: 100%;
-  width: 100%;
-`;
-
-export const VoterAvatarDisplayContainer = styled('div')`
-  display: flex;
 `;
 
 export const VoterPositionContainer = styled('div')`
@@ -737,6 +821,173 @@ export const VoterPositionContainer = styled('div')`
   width: 100%;
 `;
 
-const RadioStyled = muiStyled(Radio)(isMobileScreenSize() ? { padding: '2px' } : {});
+// Edit opinion modal styled components
+
+const CancelButton = styled('button')`
+  align-items: center;
+  background: none;
+  border: none;
+  color: ${DesignTokenColors.neutral900};
+  cursor: pointer;
+  display: flex;
+  font-size: 16px;
+  font-weight: 400;
+  height: 40px;
+  margin-top: 16px;
+  padding: 0 16px;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const EditOpinionModalOverrides = createGlobalStyle`
+  /* Reduce gap between header and content for edit opinion modal */
+  .MuiDialog-paper:has([id^="closeModalDisplayTemplateBeditP"]) .MuiDialogContent-root > div {
+    margin-top: 8px !important;
+  }
+  /* Center the edit opinion modal vertically — override JSS-injected dialogPaper styles */
+  .MuiDialog-paper.MuiDialog-paper.MuiDialog-paperScrollPaper[role="dialog"]:has([id^="closeModalDisplayTemplateBeditP"]) {
+    margin: 32px auto !important;
+    top: 0 !important;
+    transform: none !important;
+  }
+`;
+
+const LearnMoreCollapsible = styled('div')`
+  max-height: ${(props) => (props.expanded ? '200px' : '0')};
+  opacity: ${(props) => (props.expanded ? '1' : '0')};
+  overflow: hidden;
+  transition: max-height 0.3s ease, opacity 0.25s ease;
+`;
+
+const LearnMoreToggle = styled('button')`
+  align-items: center;
+  background: none;
+  border: none;
+  color: ${DesignTokenColors.neutral900};
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  margin: 4px 0;
+  padding: 0;
+`;
+
+const MakePublicLink = styled('button')`
+  background: none;
+  border: none;
+  color: ${DesignTokenColors.primary500};
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  padding: 0;
+
+  &:hover {
+    text-decoration: underline;
+  }
+`;
+
+const MakePublicRow = styled('div')`
+  color: ${DesignTokenColors.neutral900};
+  font-size: 14px;
+  line-height: 1.5;
+  padding-bottom: 4px;
+  padding-top: 6px;
+
+  svg {
+    color: ${DesignTokenColors.primary500};
+    font-size: 18px;
+    margin-right: 6px;
+    vertical-align: middle;
+  }
+`;
+
+const ModalButtonRow = styled('div')`
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+`;
+
+const OpinionSectionLabel = styled('div')`
+  color: ${DesignTokenColors.neutral900};
+  font-size: 14px;
+  font-weight: 600;
+  margin: 8px 0 6px 0;
+`;
+
+const OpinionTextFieldDiv = styled('div')`
+  align-items: flex-start;
+  border: 1px solid ${DesignTokenColors.primary600};
+  border-radius: 16px;
+  display: flex;
+  margin-bottom: 8px;
+  padding: 12px;
+`;
+
+const SetDefaultLabel = styled('span')`
+  font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-size: 13px;
+`;
+
+const SetDefaultSubtext = styled('div')`
+  color: ${DesignTokenColors.neutralUI500};
+  font-size: 12px;
+  margin-top: 4px;
+
+  a {
+    color: ${DesignTokenColors.primary500};
+    font-weight: 600;
+  }
+`;
+
+const SetDefaultVisibilityRow = styled('div')`
+  padding: 4px 0 8px 0;
+
+  .MuiFormControlLabel-label {
+    line-height: 1;
+  }
+`;
+
+const StanceToggleButton = styled('button')`
+  align-items: center;
+  background-color: ${DesignTokenColors.whiteUI};
+  border: 2px solid ${(props) => (props.selected ? DesignTokenColors.info800 : DesignTokenColors.neutralUI300)};
+  border-radius: 20px;
+  color: ${(props) => {
+    if (!props.selected) return DesignTokenColors.neutral900;
+    if (props.stanceType === 'support') return DesignTokenColors.confirmation800;
+    if (props.stanceType === 'oppose') return DesignTokenColors.alert800;
+    return DesignTokenColors.info800;
+  }};
+  cursor: pointer;
+  display: flex;
+  font-size: 14px;
+  font-weight: ${(props) => (props.selected ? '600' : '400')};
+  margin-right: 8px;
+  padding: 4px 16px;
+
+  &:hover {
+    border-color: ${DesignTokenColors.info800};
+  }
+`;
+
+const StanceToggleRow = styled('div')`
+  display: flex;
+  margin-bottom: 6px;
+`;
+
+const VisibilityHintFade = styled('div')`
+  align-self: center;
+  grid-area: 1 / 1;
+  opacity: ${(props) => (props.visible ? '1' : '0')};
+  pointer-events: ${(props) => (props.visible ? 'auto' : 'none')};
+  transition: opacity 0.25s ease;
+  visibility: ${(props) => (props.visible ? 'visible' : 'hidden')};
+`;
+
+const VisibilityHintWrapper = styled('div')`
+  display: grid;
+`;
 
 export default withStyles(templateBStyles)(VoterPositionEntryAndDisplay);

--- a/src/js/components/Settings/DefaultVisibility.jsx
+++ b/src/js/components/Settings/DefaultVisibility.jsx
@@ -1,12 +1,9 @@
 import * as React from 'react';
-import {
-  ToggleButtonGroup as MuiToggleButtonGroup,
-  ToggleButton as MuiToggleButton,
-} from '@mui/material';
 import styled, { keyframes } from 'styled-components';
-import { styled as muiStyled } from '@mui/material/styles';
 import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import webAppConfig from '../../config';
+import VisibilityExplainer from './VisibilityExplainer';
+import VisibilityToggleBar from './VisibilityToggleBar';
 
 const nextReleaseFeaturesEnabled = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES === undefined ? false : webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;
 
@@ -17,11 +14,8 @@ function PrivacyData () {
   const [alignment, setAlignment] = React.useState('public');
   const [animKey, setAnimKey] = React.useState(0);
 
-  const handleAlignment = (event, newAlignment) => {
-    if (newAlignment !== null) {
-      setAlignment(newAlignment);
-    }
-
+  const handleAlignment = (newAlignment) => {
+    setAlignment(newAlignment);
     // Trigger checkmark animation after saving
     setAnimKey((k) => k + 1);
   };
@@ -37,18 +31,7 @@ function PrivacyData () {
       </h4>
 
       <PrivacyToggleButtonGroupContainer>
-        <PrivacyToggleButtonGroup
-          exclusive
-          value={alignment}
-          onChange={handleAlignment}
-          aria-label="Privacy visibility"
-          size="small"
-        >
-          <PrivacyToggleButton value="public">Public</PrivacyToggleButton>
-          <PrivacyToggleButton value="friends">WeVote Friends</PrivacyToggleButton>
-          <PrivacyToggleButton value="private">Private</PrivacyToggleButton>
-
-        </PrivacyToggleButtonGroup>
+        <VisibilityToggleBar value={alignment} onChange={handleAlignment} />
 
         {animKey > 0 && (
           <CheckmarkContainer key={animKey}>
@@ -58,30 +41,11 @@ function PrivacyData () {
       </PrivacyToggleButtonGroupContainer>
 
       <DataSettingText>
-        <font style={{ fontStyle: 'italic' }}>
+        <ItalicNote>
           Changing your default visibility won&apos;t affect past choices or opinions.
           You can still adjust the visibility for each new choice or opinion individually.
-        </font>
-        <ul
-          style={{
-            fontStyle: 'normal',
-            paddingInlineStart: '20px',
-            marginTop: '10px',
-          }}
-        >
-          <li>
-            <font style={{ fontWeight: 'bold', color: DesignTokenColors.neutralUI900 }}>Public (recommended): </font>
-            Expand your reach and influence beyond just your friends.
-          </li>
-          <li>
-            <font style={{ fontWeight: 'bold', color: DesignTokenColors.neutralUI900 }}>Your WeVote friends: </font>
-            People on the platform you&apos;ve added as friends-so you can see and share opinions more easily.
-          </li>
-          <li>
-            <font style={{ fontWeight: 'bold', color: DesignTokenColors.neutralUI900 }}>Private: </font>
-            Ideal for personal reflection or when you&apos;re not ready to share publicly.
-          </li>
-        </ul>
+        </ItalicNote>
+        <VisibilityExplainer fontSize={14} />
       </DataSettingText>
     </div>
   );
@@ -94,25 +58,12 @@ const DataSettingText = styled('div')`
   margin-bottom: 30px;
 `;
 
-const PrivacyToggleButtonGroup = muiStyled(MuiToggleButtonGroup)(({ theme }) => ({
-  marginBottom: theme.spacing(2),
-}));
-
-const PrivacyToggleButton = muiStyled(MuiToggleButton)(({ theme }) => ({
-  border: `2px solid ${theme.palette.divider}`,
-  borderRadius: '15px',
-  borderColor: DesignTokenColors.neutralUI500,
-  color: DesignTokenColors.neutralUI700,
-  minHeight: theme.spacing(4),
-  padding: theme.spacing(0, 1),
-  '&.Mui-selected': {
-    color: DesignTokenColors.info800,
-    fontWeight: 'bold',
-    borderColor: DesignTokenColors.info800,
-    borderTop: `2px solid ${theme.palette.primary.main}`,
-    borderBottom: `2px solid ${theme.palette.primary.main}`,
-  },
-}));
+const ItalicNote = styled('div')`
+  font-size: 14px;
+  font-style: italic;
+  margin-bottom: 4px;
+  margin-top: 4px;
+`;
 
 const PrivacyToggleButtonGroupContainer = styled('div')`
   display: flex;
@@ -143,7 +94,6 @@ const checkmarkFade = keyframes`
 const CheckmarkContainer = styled.div`
   font-size: 16px;
   color: ${DesignTokenColors.confirmation500};
-  padding-bottom: 14px;
   animation: ${checkmarkFade} 1.5s ease-in-out forwards;
 `;
 

--- a/src/js/components/Settings/VisibilityExplainer.jsx
+++ b/src/js/components/Settings/VisibilityExplainer.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+
+
+function VisibilityExplainer ({ fontSize }) {
+  const size = fontSize || 13;
+
+  return (
+    <ExplainerList fontSize={size}>
+      <li>
+        <strong>Public (recommended):</strong>
+        {' '}
+        Expand your reach and influence beyond just your friends.
+      </li>
+      <li>
+        <strong>Your WeVote friends:</strong>
+        {' '}
+        People on the platform you&apos;ve added as friends&mdash;so you can see and share opinions more easily.
+      </li>
+      <li>
+        <strong>Private:</strong>
+        {' '}
+        Ideal for personal reflection or when you&apos;re not ready to share publicly.
+      </li>
+    </ExplainerList>
+  );
+}
+
+VisibilityExplainer.propTypes = {
+  fontSize: PropTypes.number,
+};
+
+const ExplainerList = styled('ul')`
+  color: ${DesignTokenColors.neutralUI500};
+  font-size: ${(props) => props.fontSize}px;
+  line-height: 1.5;
+  margin: 4px 0;
+  padding-left: 20px;
+
+  li {
+    margin-bottom: 4px;
+  }
+
+  strong {
+    color: ${DesignTokenColors.neutralUI900};
+  }
+`;
+
+export default VisibilityExplainer;

--- a/src/js/components/Settings/VisibilityToggleBar.jsx
+++ b/src/js/components/Settings/VisibilityToggleBar.jsx
@@ -1,0 +1,127 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+
+const OPTIONS = [
+  { value: 'public', label: 'Public' },
+  { value: 'friends', label: 'WeVote friends' },
+  { value: 'private', label: 'Private' },
+];
+
+function VisibilityToggleBar ({ value, onChange }) {
+  const containerRef = useRef(null);
+  const buttonRefs = useRef([]);
+  const [indicator, setIndicator] = useState({ left: 0, right: 0 });
+  const hasAnimated = useRef(false);
+
+  const measureIndicator = useCallback(() => {
+    const selectedIndex = OPTIONS.findIndex((opt) => opt.value === value);
+    const button = buttonRefs.current[selectedIndex];
+    const container = containerRef.current;
+    if (button && container) {
+      const containerRect = container.getBoundingClientRect();
+      const buttonRect = button.getBoundingClientRect();
+      setIndicator({
+        left: buttonRect.left - containerRect.left,
+        right: containerRect.right - buttonRect.right,
+      });
+    }
+  }, [value]);
+
+  useEffect(() => {
+    measureIndicator();
+    if (!hasAnimated.current) {
+      requestAnimationFrame(() => { hasAnimated.current = true; });
+    }
+  }, [value, measureIndicator]);
+
+  // Re-measure on window resize
+  useEffect(() => {
+    window.addEventListener('resize', measureIndicator);
+    return () => window.removeEventListener('resize', measureIndicator);
+  }, [measureIndicator]);
+
+  return (
+    <Container ref={containerRef} role="group" aria-label="Visibility setting">
+      <SlidingIndicator
+        style={{
+          left: indicator.left,
+          right: indicator.right,
+        }}
+        animate={hasAnimated.current}
+      />
+      {OPTIONS.map((opt, i) => (
+        <ToggleButton
+          key={opt.value}
+          ref={(el) => { buttonRefs.current[i] = el; }}
+          type="button"
+          selected={value === opt.value}
+          onClick={() => onChange(opt.value)}
+          aria-pressed={value === opt.value}
+          data-label={opt.label}
+        >
+          {opt.label}
+        </ToggleButton>
+      ))}
+    </Container>
+  );
+}
+
+VisibilityToggleBar.propTypes = {
+  value: PropTypes.string.isRequired,
+  onChange: PropTypes.func.isRequired,
+};
+
+const Container = styled('div')`
+  border: 2px solid ${DesignTokenColors.neutralUI300};
+  border-radius: 15px;
+  display: inline-flex;
+  margin-bottom: 1px;
+  overflow: hidden;
+  position: relative;
+  width: fit-content;
+`;
+
+const SlidingIndicator = styled('div')`
+  background-color: ${DesignTokenColors.info100};
+  border-radius: 13px;
+  bottom: 2px;
+  position: absolute;
+  top: 2px;
+  transition: ${(props) => (props.animate ? 'left 0.3s ease, right 0.3s ease' : 'none')};
+  z-index: 0;
+`;
+
+const ToggleButton = styled('button')`
+  background: transparent;
+  border: none;
+  color: ${(props) => (props.selected ? DesignTokenColors.info800 : DesignTokenColors.neutralUI700)};
+  cursor: pointer;
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+  font-size: 14px;
+  font-weight: ${(props) => (props.selected ? '600' : '400')};
+  padding: 4px 12px;
+  position: relative;
+  transition: color 0.2s ease, font-weight 0.2s ease;
+  z-index: 1;
+
+
+  /* Reserve bold width so layout doesn't shift */
+  &::after {
+    content: attr(data-label);
+    font-weight: 600;
+    height: 0;
+    overflow: hidden;
+    visibility: hidden;
+  }
+
+  &:hover {
+    color: ${DesignTokenColors.info800};
+  }
+`;
+
+export default VisibilityToggleBar;

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -376,7 +376,8 @@ class ItemActionBar extends PureComponent {
   };
 
   onClickMakePublic = () => {
-    AppObservableStore.setShowEditPositionModal(true, this.props.politicianWeVoteId);
+    const weVoteId = this.props.politicianWeVoteId || this.props.ballotItemWeVoteId;
+    AppObservableStore.setShowEditPositionModal(true, weVoteId, true);
   };
 
   onClickDotsMenu = () => {
@@ -1073,7 +1074,7 @@ class ItemActionBar extends PureComponent {
                   <VisibilityDivider />
                   <MakePublicVisibilityRow
                     isPublic={voterPositionIsPublic}
-                    onMakePublic={this.togglePositionStatementFunction}
+                    onMakePublic={this.onClickMakePublic}
                     onDotsClick={this.togglePositionStatementFunction}
                   />
                 </VisibilityInlineWrapperDesktop>
@@ -1092,7 +1093,7 @@ class ItemActionBar extends PureComponent {
                 <VisibilityInlineWrapperMobile className="u-show-mobile-tablet">
                   <MakePublicVisibilityRow
                     isPublic={voterPositionIsPublic}
-                    onMakePublic={this.togglePositionStatementFunction}
+                    onMakePublic={this.onClickMakePublic}
                     onDotsClick={this.togglePositionStatementFunction}
                   />
                 </VisibilityInlineWrapperMobile>


### PR DESCRIPTION
UI Changes:
- Pill-style stance toggles replace radio buttons
- Three-way visibility toggle bar (Public/WeVote friends/Private) replaces dropdown
- Crossfade between visibility hints, collapsible "Learn more" section
- "Set as default" checkbox for public visibility
- Opening the modal via "Make public" animates the visibility toggle toward "Public" so users notice before saving

Infra:
- Extract VisibilityToggleBar and VisibilityExplainer into shared components
- Add AppObservableStore support for "Make public" flow from ItemActionBar
- UNRELATED: Fix modal imports across ManageMyCandidates modals (ConfirmCloseModal, InviteSelectedModal, etc.) due to recent TemplateA changes that broke the headers

Some examples (one for Measures, one for Candidates)

| | |
|---|---|
| <img width="459" alt="image" src="https://github.com/user-attachments/assets/1b23abfd-d836-42d7-8729-4d9bdb25dbce" /> | <img width="455" alt="image" src="https://github.com/user-attachments/assets/c93de6a5-ef56-473b-ac69-e13946676e8d" /> |s://github.com/user-attachments/assets/c93de6a5-ef56-473b-ac69-e13946676e8d" />