### PR TITLE
'Make public' in ItemActionBar saves visibility directly instead of opening "edit opinion" modal

### DIFF
--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -376,8 +376,11 @@ class ItemActionBar extends PureComponent {
   };
 
   onClickMakePublic = () => {
-    const weVoteId = this.props.politicianWeVoteId || this.props.ballotItemWeVoteId;
-    AppObservableStore.setShowEditPositionModal(true, weVoteId, true);
+    const { ballotItemType, ballotItemWeVoteId } = this.state;
+    const { politicianWeVoteId } = this.props;
+    SupportActions.voterPositionVisibilitySave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId, 'SHOW_PUBLIC');
+    this.setState({ voterPositionIsPublic: true });
+    openSnackbar({ message: 'Your choice & opinion is now visible to anyone!' });
   };
 
   onClickDotsMenu = () => {


### PR DESCRIPTION
Wire candidates and measures to save SHOW_PUBLIC via voterPositionVisibilitySave, update snackbar copy to cover oppose/no votes.

After clicking "Make public":
<img width="622" height="175" alt="image" src="https://github.com/user-attachments/assets/5fbd600f-6da0-4485-bc59-89796bedd94e" />
