### PR TITLE
Hide Opinions header when candidate has no other content and no opinions

### DIFF
--- a/src/js/components/Ballot/BallotScrollingContainer.jsx
+++ b/src/js/components/Ballot/BallotScrollingContainer.jsx
@@ -216,6 +216,7 @@ class BallotScrollingContainer extends Component {
     const positionCounts = CandidateStore.getNumberOfPositionsByCandidateWeVoteId(oneCandidate.we_vote_id);
     const hasSupport = positionCounts.numberOfAllSupportPositions > 0;
     const hasOppose = positionCounts.numberOfAllOpposePositions > 0;
+    const hasContentBeforeOpinions = this.state.hasIssues || hasSupport || hasOppose;
     const endorsementColWidth = (hasSupport && hasOppose) ? ENDORSEMENT_BOTH : ENDORSEMENT_SINGLE;
 
     return (
@@ -334,10 +335,11 @@ class BallotScrollingContainer extends Component {
               )}
 
               {/* Right column: Opinions */}
-              <CandidateOpinionsColumnWrapper $hasContentBefore={this.state.hasIssues || hasSupport || hasOppose}>
+              <CandidateOpinionsColumnWrapper $hasContentBefore={hasContentBeforeOpinions}>
                 <Suspense fallback={<></>}>
                   <CandidateOpinionsColumn
                     candidateWeVoteId={oneCandidate.we_vote_id}
+                    hasOtherColumns={hasContentBeforeOpinions}
                     politicianWeVoteId={oneCandidate.politician_we_vote_id}
                   />
                 </Suspense>

--- a/src/js/components/Ballot/CandidateOpinionsColumn.jsx
+++ b/src/js/components/Ballot/CandidateOpinionsColumn.jsx
@@ -54,22 +54,21 @@ class CandidateOpinionsColumn extends Component {
 
   render () {
     renderLog('CandidateOpinionsColumn');
-    const { candidateWeVoteId, politicianWeVoteId } = this.props;
+    const { candidateWeVoteId, hasOtherColumns, politicianWeVoteId } = this.props;
     const { opinions, opinionsCount } = this.state;
+    const hideHeader = !hasOtherColumns && opinionsCount === 0;
+    const headerText = opinionsCount > 0 ? `${opinionsCount} ${opinionsCount === 1 ? 'Opinion' : 'Opinions'}` : 'Opinions';
 
     return (
       <OpinionsWrapper>
-        {opinionsCount > 0 ? (
-          <OpinionsCountHeader>{`${opinionsCount} ${opinionsCount === 1 ? 'Opinion' : 'Opinions'}`}</OpinionsCountHeader>
-        ) : (
-          <OpinionsCountHeader>Opinions</OpinionsCountHeader>
-        )}
+        {!hideHeader && <OpinionsCountHeader>{headerText}</OpinionsCountHeader>}
 
         <Suspense fallback={<span />}>
           <VoterPositionEntryAndDisplay
             ballotItemWeVoteId={candidateWeVoteId}
             compactMode
             externalUniqueId={`CandidateOpinionsColumn-${candidateWeVoteId}`}
+            noBottomMargin={opinionsCount === 0}
             politicianWeVoteId={politicianWeVoteId}
           />
         </Suspense>
@@ -90,6 +89,7 @@ class CandidateOpinionsColumn extends Component {
 
 CandidateOpinionsColumn.propTypes = {
   candidateWeVoteId: PropTypes.string.isRequired,
+  hasOtherColumns: PropTypes.bool,
   politicianWeVoteId: PropTypes.string,
 };
 

--- a/src/js/components/PositionItem/VoterPositionEntryAndDisplay.jsx
+++ b/src/js/components/PositionItem/VoterPositionEntryAndDisplay.jsx
@@ -63,12 +63,12 @@ VoterAvatarBlock.propTypes = {
 
 function VoterPositionBlockComponent ({
   classes, compactMode, effectiveWeVoteId, effectivePoliticianWeVoteId, externalUniqueId,
-  handleEditModalOpen, isMeasure, onClick, openDeleteConfirmationModal, openEditModal,
+  handleEditModalOpen, isMeasure, noBottomMargin, onClick, openDeleteConfirmationModal, openEditModal,
   position, positionExists, statementText, supportOrOpposeStanceExists,
   voterFirstName, voterLastName, voterName, voterPhotoUrlMedium,
 }) {
   return (
-    <VoterPositionContainer>
+    <VoterPositionContainer $noBottomMargin={noBottomMargin}>
       <VoterAvatarDisplayContainer>
         <VoterAvatarBlock
           voterPhotoUrlMedium={voterPhotoUrlMedium}
@@ -154,6 +154,7 @@ VoterPositionBlockComponent.propTypes = {
   externalUniqueId: PropTypes.string,
   handleEditModalOpen: PropTypes.func,
   isMeasure: PropTypes.bool,
+  noBottomMargin: PropTypes.bool,
   onClick: PropTypes.func.isRequired,
   openDeleteConfirmationModal: PropTypes.func,
   openEditModal: PropTypes.func,
@@ -167,7 +168,7 @@ VoterPositionBlockComponent.propTypes = {
   voterPhotoUrlMedium: PropTypes.string,
 };
 
-function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdProp, classes, compactMode, externalUniqueId, onModalClose, openEditModalOnLoad, politicianWeVoteId }) {
+function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdProp, classes, compactMode, externalUniqueId, noBottomMargin, onModalClose, openEditModalOnLoad, politicianWeVoteId }) {
   const isMeasure = stringContains('meas', ballotItemWeVoteIdProp);
   const effectiveWeVoteId = isMeasure ? ballotItemWeVoteIdProp : politicianWeVoteId;
   const effectiveKindOfBallotItem = isMeasure ? 'MEASURE' : 'CANDIDATE';
@@ -634,6 +635,7 @@ function VoterPositionEntryAndDisplay ({ ballotItemWeVoteId: ballotItemWeVoteIdP
           externalUniqueId={externalUniqueId}
           handleEditModalOpen={handleEditModalOpen}
           isMeasure={isMeasure}
+          noBottomMargin={noBottomMargin}
           onClick={openEditModal}
           openDeleteConfirmationModal={openDeleteConfirmationModal}
           openEditModal={openEditModal}
@@ -655,6 +657,7 @@ VoterPositionEntryAndDisplay.propTypes = {
   classes: PropTypes.object,
   compactMode: PropTypes.bool,
   externalUniqueId: PropTypes.string,
+  noBottomMargin: PropTypes.bool,
   onModalClose: PropTypes.func,
   openEditModalOnLoad: PropTypes.bool,
   politicianWeVoteId: PropTypes.string,
@@ -725,14 +728,16 @@ export const VoterAvatarDisplayContainer = styled('div')`
   display: flex;
 `;
 
-export const VoterPositionContainer = styled('div')`
+export const VoterPositionContainer = styled('div', {
+  shouldForwardProp: (prop) => prop !== '$noBottomMargin',
+})`
   align-items: flex-start;
   background-color: ${DesignTokenColors.caution50};
   border-radius: 8px;
   box-sizing: border-box;
   display: flex;
   gap: 10px;
-  margin: 0 0 12px 0;
+  margin: ${({ $noBottomMargin }) => ($noBottomMargin ? '0' : '0 0 12px 0')};
   padding: 8px;
   width: 100%;
 `;


### PR DESCRIPTION
- CandidateOpinionsColumn hides OpinionsCountHeader when no issues/support/oppose column exists and opinionsCount is 0
- QOL change: VoterPositionEntryAndDisplay accepts noBottomMargin to suppress the 12px bottom margin on VoterPositionContainer to avoid awkward trailing spacing; passed from CandidateOpinionsColumn when there are no opinions below
- DRY: Hoist shared hasContentBeforeOpinions in BallotScrollingContainer to avoid re-evaluating the same expression twice per candidate

Examples:
<img width="735" height="350" alt="image" src="https://github.com/user-attachments/assets/7277c8e3-5b3e-471d-a5ca-3df8ecf8ddf6" />