### PR TITLE
[WV-1100]Add “utm_medium=shared_link” to the unique links generated in WeVote share dialog box[TEAM REVIEW]

### DIFF
--- a/src/js/components/Friends/ShareWithFriendsModalTitleWithController.jsx
+++ b/src/js/components/Friends/ShareWithFriendsModalTitleWithController.jsx
@@ -161,6 +161,7 @@ class ShareWithFriendsModalTitleWithController extends Component {
   render () {
     renderLog('ShareWithFriendsModalTitleWithController');  // Set LOG_RENDER_EVENTS to log all renders
     const { friendsModalTitle, urlToShare } = this.props;
+    const urlToSharewithutm = urlToShare ? `${urlToShare}${urlToShare.includes('?') ? '&' : '?'}utm_medium=shared_link` : '';
     const { copyLinkCopied, messageToFriendType } = this.state;
 
     return (
@@ -177,12 +178,12 @@ class ShareWithFriendsModalTitleWithController extends Component {
             <Suspense fallback={<></>}>
               <MessageToFriendInputField messageToFriendType={messageToFriendType} />
             </Suspense>
-            {(urlToShare) && (
+            {(urlToSharewithutm) && (
               <UrlToShareWrapper>
-                <CopyToClipboard text={urlToShare} onCopy={this.copyLink}>
+                <CopyToClipboard text={urlToSharewithutm} onCopy={this.copyLink}>
                   <CopyToClipboardInnerWrapper>
                     <UrlToShareInnerWrapper>
-                      {urlToShare}
+                      {urlToSharewithutm}
                     </UrlToShareInnerWrapper>
                     <ContentCopyWrapper>
                       <ContentCopy style={{ fontSize: 18, margin: '-3px 0 0 3px', color: '#999' }} />

--- a/src/js/components/Share/shareButtonCommon.jsx
+++ b/src/js/components/Share/shareButtonCommon.jsx
@@ -282,13 +282,14 @@ function pushDataLayer (buttonId, destinationPageName, destinationPageType, shar
 // React functional component example
 export function CopyLink (props) {
   const { saveActionShareButtonCopy, linkToBeSharedCopy } = props;
+  const linkWithUtm = linkToBeSharedCopy ? `${linkToBeSharedCopy}${linkToBeSharedCopy.includes('?') ? '&' : '?'}utm_medium=shared_link` : '';
   return (
     <ShareWrapper>
       <ShareModalOption
           backgroundColor="#2E3C5D"
           copyLink
           icon={<FileCopyOutlined />}
-          urlToShare={linkToBeSharedCopy}
+          urlToShare={linkWithUtm}
           onClickFunction={saveActionShareButtonCopy}
           title="Copy link"
           uniqueExternalId="shareButtonFooter-CopyLink"


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-1100]Add “utm_medium=shared_link” to the unique links generated in WeVote share dialog box
### Changes included this pull request?
src/js/components/Friends/ShareWithFriendsModalTitleWithController.jsx
src/js/components/Share/shareButtonCommon.jsx

Added utm_medium=shared_link to the generated Copy Link URL so Google Analytics can identify traffic coming from voter-shared links instead of direct website visits.

[WV-1100]: https://wevoteusa.atlassian.net/browse/WV-1100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ