### PR TITLE
[WV-2660] Election Finder: mobile kebab menu, multi-word search, fix search crash

### DIFF
--- a/src/js/pages/ElectionFinder/CopyChip.jsx
+++ b/src/js/pages/ElectionFinder/CopyChip.jsx
@@ -1,0 +1,53 @@
+import { ContentCopy } from '@mui/icons-material';
+import PropTypes from 'prop-types';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { ActionChip, DarkTooltip } from './electionFinderStyles';
+
+const COPIED_DURATION_MS = 3000;
+
+// Only one CopyChip on the page should show "Copied!" at a time. Each instance
+// registers its reset; clicking a chip calls every other chip's reset first.
+const resetCallbacks = new Set();
+
+// getText is a function (not a string) so callers with side effects in the
+// path computation (e.g. CandidateActions fetch) only run them on click.
+export default function CopyChip ({ defaultLabel, getText }) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef(null);
+
+  const reset = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    setCopied(false);
+  }, []);
+
+  useEffect(() => {
+    resetCallbacks.add(reset);
+    return () => {
+      resetCallbacks.delete(reset);
+      clearTimeout(timeoutRef.current);
+    };
+  }, [reset]);
+
+  const onClick = () => {
+    resetCallbacks.forEach((r) => { if (r !== reset) r(); });
+    navigator.clipboard.writeText(getText());
+    setCopied(true);
+    clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(() => setCopied(false), COPIED_DURATION_MS);
+  };
+
+  const label = copied ? 'Copied!' : defaultLabel;
+  return (
+    <DarkTooltip title={label}>
+      <ActionChip onClick={onClick}>
+        <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
+        {label}
+      </ActionChip>
+    </DarkTooltip>
+  );
+}
+
+CopyChip.propTypes = {
+  defaultLabel: PropTypes.string.isRequired,
+  getText: PropTypes.func.isRequired,
+};

--- a/src/js/pages/ElectionFinder/ElectionFinderForElection.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderForElection.jsx
@@ -1,7 +1,7 @@
 import { ContentCopy, FileDownloadOutlined, InfoOutlined, Launch, Search, Close, ExpandMore, UnfoldMore, UnfoldLess } from '@mui/icons-material';
 import { IconButton, InputAdornment } from '@mui/material';
 import PropTypes from 'prop-types';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useReducer, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
 import BallotActions from '../../actions/BallotActions';
@@ -14,10 +14,14 @@ import AppObservableStore from '../../common/stores/AppObservableStore';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import BallotStore from '../../stores/BallotStore';
 import CandidateStore from '../../stores/CandidateStore';
+import SnackNotifier from '../../common/components/Widgets/SnackNotifier';
 import ElectionStore from '../../stores/ElectionStore';
+import CopyChip from './CopyChip';
+import copyAndToast from './copyAndToast';
 import ElectionFinderHeader from './ElectionFinderHeader';
+import RowKebabMenu from './RowKebabMenu';
 import {
-  ActionChip, ActionDivider, DarkTooltip,
+  ActionDivider, DarkTooltip,
   CandidateActions as CandidateActionsRow, CandidateInfo, CandidateList, CandidateName,
   CandidateParty, CandidateRow, DetailTitle, ElectionTitleRow,
   ExpandCollapseButton, ExpandCollapseRow, ExpandMoreIcon,
@@ -28,6 +32,21 @@ import {
 import webAppConfig from '../../config';
 
 const nextReleaseFeaturesEnabled = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES === undefined ? false : webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;
+
+function highlightMatch (text, query) {
+  if (!query) return text;
+  const words = query.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return text;
+  const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const regex = new RegExp(`(${escaped.join('|')})`, 'gi');
+  const lowerWords = words.map((w) => w.toLowerCase());
+  return text.split(regex).map((part, idx) => {
+    if (lowerWords.includes(part.toLowerCase())) {
+      return <HighlightSpan key={`hl-${idx}-${part}`}>{part}</HighlightSpan>; // eslint-disable-line react/no-array-index-key
+    }
+    return part;
+  });
+}
 
 function ElectionFinderForElection () {
   renderLog('ElectionFinderForElection');
@@ -59,13 +78,14 @@ function ElectionFinderForElection () {
   const upcomingCount = stateElections.filter((el) => el.election_is_upcoming).length;
   const pastCount = stateElections.filter((el) => !el.election_is_upcoming).length;
 
+  // ElectionStore changes affect derived values (electionName, isUpcoming, counts)
+  // computed inline above — bump a counter to re-render without reallocating ballotItems.
+  const [, forceTick] = useReducer((n) => n + 1, 0);
+
   // Mount: subscribe to stores, fetch data
   useEffect(() => {
     window.scrollTo(0, 0);
-    const electionListener = ElectionStore.addListener(() => {
-      // Force re-render to pick up derived values above
-      setBallotItems((prev) => [...prev]);
-    });
+    const electionListener = ElectionStore.addListener(forceTick);
     const ballotListener = BallotStore.addListener(() => {
       const allItems = BallotStore.getAllBallotItemsFlattened(googleCivicElectionId);
       const offices = allItems.filter((item) => item.kind_of_ballot_item === 'OFFICE');
@@ -119,10 +139,6 @@ function ElectionFinderForElection () {
     setExpandedOffices({});
   }, []);
 
-  const copyToClipboard = useCallback((text) => {
-    navigator.clipboard.writeText(text);
-  }, []);
-
   const getCandidatePath = useCallback((candidate) => {
     const candidateWeVoteId = candidate.we_vote_id;
     const fullCandidate = CandidateStore.getCandidateByWeVoteId(candidateWeVoteId);
@@ -153,36 +169,25 @@ function ElectionFinderForElection () {
     AppObservableStore.setShowOrganizationModal(true);
   }, []);
 
-  const highlightMatch = useCallback((text, query) => {
-    if (!query) return text;
-    const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp(`(${escaped})`, 'gi');
-    const parts = text.split(regex);
-    return parts.map((part, idx) => {
-      if (part.toLowerCase() === query.toLowerCase()) {
-        return <HighlightSpan key={`hl-${idx}-${part}`}>{part}</HighlightSpan>; // eslint-disable-line react/no-array-index-key
-      }
-      return part;
-    });
-  }, []);
-
-  // Filter offices/candidates by search
+  // Filter offices/candidates by search — every word must appear somewhere in the office text,
+  // or be split across office text + a candidate's text (e.g. "attorney kwame" matches the
+  // Attorney General office showing Kwame Raoul)
   let filteredOffices = ballotItems;
-  if (electionSearchText) {
-    const lowerSearch = electionSearchText.toLowerCase();
+  const searchWords = electionSearchText.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (searchWords.length > 0) {
     filteredOffices = ballotItems
       .map((office) => {
-        const officeNameMatches = office.ballot_item_display_name.toLowerCase().includes(lowerSearch);
+        const officeText = `${office.ballot_item_display_name} ${office.primary_party || ''}`.toLowerCase();
         const candidates = office.candidate_list || [];
-        const matchingCandidates = candidates.filter(
-          (c) => c.ballot_item_display_name.toLowerCase().includes(lowerSearch) ||
-                 (c.party || '').toLowerCase().includes(lowerSearch),
-        );
-        if (officeNameMatches || matchingCandidates.length > 0) {
-          return {
-            ...office,
-            candidate_list: officeNameMatches ? candidates : matchingCandidates,
-          };
+        if (searchWords.every((w) => officeText.includes(w))) {
+          return { ...office, candidate_list: candidates };
+        }
+        const matchingCandidates = candidates.filter((c) => {
+          const combinedText = `${officeText} ${c.ballot_item_display_name} ${c.party || ''}`.toLowerCase();
+          return searchWords.every((w) => combinedText.includes(w));
+        });
+        if (matchingCandidates.length > 0) {
+          return { ...office, candidate_list: matchingCandidates };
         }
         return null;
       })
@@ -196,11 +201,11 @@ function ElectionFinderForElection () {
   return (
     <>
       <Helmet><title>{`${electionName} - Election Finder - We Vote`}</title></Helmet>
+      <SnackNotifier />
       <PageContentContainer>
         <ElectionFinderHeader
           breadcrumbs={[
-            { label: '\u2190 Election Finder Home', href: '/election-finder' },
-            { label: `${stateName} ${isUpcoming ? 'Upcoming' : 'Past'} Elections (${isUpcoming ? upcomingCount : pastCount})`, href: `/election-finder/${selectedStateCode.toLowerCase()}` },
+            { label: `\u2190 ${stateName} ${isUpcoming ? 'Upcoming' : 'Past'} Elections (${isUpcoming ? upcomingCount : pastCount})`, href: `/election-finder/${selectedStateCode.toLowerCase()}` },
             { label: electionName },
           ]}
           stateLabel={stateName}
@@ -253,16 +258,18 @@ function ElectionFinderForElection () {
           )}
         </ElectionTitleRow>
 
-        <ExpandCollapseRow>
-          <ExpandCollapseButton onClick={expandAll}>
-            <UnfoldMore fontSize="small" />
-            {' Expand all'}
-          </ExpandCollapseButton>
-          <ExpandCollapseButton onClick={collapseAll}>
-            <UnfoldLess fontSize="small" />
-            {' Collapse all'}
-          </ExpandCollapseButton>
-        </ExpandCollapseRow>
+        {filteredOffices.length > 0 && (
+          <ExpandCollapseRow>
+            <ExpandCollapseButton onClick={expandAll}>
+              <UnfoldMore fontSize="small" />
+              {' Expand all'}
+            </ExpandCollapseButton>
+            <ExpandCollapseButton onClick={collapseAll}>
+              <UnfoldLess fontSize="small" />
+              {' Collapse all'}
+            </ExpandCollapseButton>
+          </ExpandCollapseRow>
+        )}
 
         {totalResults !== null && (
           <SearchResultCount>
@@ -286,8 +293,6 @@ function ElectionFinderForElection () {
               onToggle={toggleOfficeExpanded}
               onCandidateClick={onCandidateClick}
               getCandidatePath={getCandidatePath}
-              copyToClipboard={copyToClipboard}
-              highlightMatch={highlightMatch}
             />
           );
         })}
@@ -309,27 +314,13 @@ function ElectionFinderForElection () {
 // Memoized office section — only re-renders when its own props change
 function OfficeSectionItemInner ({ // eslint-disable-line react/no-multi-comp
   office, isExpanded, searchText,
-  onToggle, onCandidateClick, getCandidatePath, copyToClipboard, highlightMatch,
+  onToggle, onCandidateClick, getCandidatePath,
 }) {
-  // console.log('OfficeSectionItemInner render office: ', office);
   const officeWeVoteId = office.we_vote_id;
   const officeName = office.ballot_item_display_name;
   const primaryParty = office.primary_party || '';
   const candidates = office.candidate_list || [];
-  const officeNameWithPrimaryParty = (
-    <span>
-      {officeName}
-      {primaryParty && (
-        <OfficePrimaryPartySpan>
-          ,
-          {' '}
-          {primaryParty}
-          {' '}
-          Primary
-        </OfficePrimaryPartySpan>
-      )}
-    </span>
-  );
+  const primaryPartySuffix = primaryParty ? `, ${primaryParty} Primary` : '';
   return (
     <OfficeSection>
       <OfficeHeader onClick={() => onToggle(officeWeVoteId)}>
@@ -338,23 +329,18 @@ function OfficeSectionItemInner ({ // eslint-disable-line react/no-multi-comp
             <ExpandMore fontSize="small" />
           </ExpandMoreIcon>
           <OfficeName>
-            {searchText ? highlightMatch(officeNameWithPrimaryParty, searchText) : officeNameWithPrimaryParty}
+            {searchText ? highlightMatch(officeName, searchText) : officeName}
+            {primaryParty && (
+              <OfficePrimaryPartySpan>
+                {searchText ? highlightMatch(primaryPartySuffix, searchText) : primaryPartySuffix}
+              </OfficePrimaryPartySpan>
+            )}
             {` (${candidates.length})`}
           </OfficeName>
         </OfficeHeaderLeft>
         <OfficeHeaderActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-          <DarkTooltip title="Copy office name">
-            <ActionChip onClick={() => copyToClipboard(officeName)}>
-              <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
-              Copy office name
-            </ActionChip>
-          </DarkTooltip>
-          <DarkTooltip title="Copy link">
-            <ActionChip onClick={() => copyToClipboard(`${window.location.origin}/office/${officeWeVoteId}`)}>
-              <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
-              Copy link
-            </ActionChip>
-          </DarkTooltip>
+          <CopyChip defaultLabel="Copy office name" getText={() => officeName} />
+          <CopyChip defaultLabel="Copy link" getText={() => `${window.location.origin}/office/${officeWeVoteId}`} />
           <ActionDivider />
           {nextReleaseFeaturesEnabled && (
             <DarkTooltip title="Info">
@@ -367,6 +353,15 @@ function OfficeSectionItemInner ({ // eslint-disable-line react/no-multi-comp
             </IconButton>
           </DarkTooltip>
         </OfficeHeaderActions>
+        <RowKebabMenu
+          ariaLabel="More options for this office"
+          items={[
+            { key: 'copy-name', icon: ContentCopy, label: 'Copy office name', onClick: () => copyAndToast(officeName) },
+            { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}/office/${officeWeVoteId}`) },
+            ...(nextReleaseFeaturesEnabled ? [{ key: 'about', icon: InfoOutlined, label: 'About office', onClick: () => {} }] : []),
+            { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(`/office/${officeWeVoteId}`, '_blank') },
+          ]}
+        />
       </OfficeHeader>
       {isExpanded && (
         <CandidateList>
@@ -383,18 +378,8 @@ function OfficeSectionItemInner ({ // eslint-disable-line react/no-multi-comp
                   <CandidateParty>{candidateParty}</CandidateParty>
                 </CandidateInfo>
                 <CandidateActionsRow className="u-show-desktop-tablet">
-                  <DarkTooltip title="Copy candidate name">
-                    <ActionChip onClick={() => copyToClipboard(candidateName)}>
-                      <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
-                      Copy candidate name
-                    </ActionChip>
-                  </DarkTooltip>
-                  <DarkTooltip title="Copy link">
-                    <ActionChip onClick={() => copyToClipboard(`${window.location.origin}${getCandidatePath(candidate)}`)}>
-                      <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
-                      Copy link
-                    </ActionChip>
-                  </DarkTooltip>
+                  <CopyChip defaultLabel="Copy candidate name" getText={() => candidateName} />
+                  <CopyChip defaultLabel="Copy link" getText={() => `${window.location.origin}${getCandidatePath(candidate)}`} />
                   <ActionDivider />
                   <DarkTooltip title="Open in new tab">
                     <IconButton size="small" onClick={() => window.open(getCandidatePath(candidate), '_blank')}>
@@ -402,6 +387,14 @@ function OfficeSectionItemInner ({ // eslint-disable-line react/no-multi-comp
                     </IconButton>
                   </DarkTooltip>
                 </CandidateActionsRow>
+                <RowKebabMenu
+                  ariaLabel="More options for this candidate"
+                  items={[
+                    { key: 'copy-name', icon: ContentCopy, label: 'Copy candidate name', onClick: () => copyAndToast(candidateName) },
+                    { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}${getCandidatePath(candidate)}`) },
+                    { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(getCandidatePath(candidate), '_blank') },
+                  ]}
+                />
               </CandidateRow>
             );
           })}
@@ -418,8 +411,6 @@ OfficeSectionItemInner.propTypes = {
   onToggle: PropTypes.func.isRequired,
   onCandidateClick: PropTypes.func.isRequired,
   getCandidatePath: PropTypes.func.isRequired,
-  copyToClipboard: PropTypes.func.isRequired,
-  highlightMatch: PropTypes.func.isRequired,
 };
 
 const OfficeSectionItem = React.memo(OfficeSectionItemInner);

--- a/src/js/pages/ElectionFinder/ElectionFinderForState.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderForState.jsx
@@ -9,10 +9,14 @@ import { stateCodeMap, convertStateCodeToStateText } from '../../common/utils/ad
 import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import historyPush from '../../common/utils/historyPush';
+import SnackNotifier from '../../common/components/Widgets/SnackNotifier';
 import ElectionStore from '../../stores/ElectionStore';
+import CopyChip from './CopyChip';
+import copyAndToast from './copyAndToast';
 import ElectionFinderHeader from './ElectionFinderHeader';
+import RowKebabMenu from './RowKebabMenu';
 import {
-  ActionChip, ActionDivider, DarkTooltip,
+  ActionDivider, DarkTooltip,
   ElectionDatePill, ElectionLink, ElectionList, ElectionRow, ElectionRowActions,
   FilterTab, FilterTabsRow, InlineSearchField, NoResults,
   SearchIconButton, SectionTitle, SectionTitleRow, ShowMoreButton,
@@ -150,6 +154,7 @@ function ElectionFinderForState () {
   return (
     <>
       <Helmet><title>{`${stateName} Elections - Election Finder - We Vote`}</title></Helmet>
+      <SnackNotifier />
       <PageContentContainer>
         <ElectionFinderHeader
           breadcrumbs={[
@@ -241,14 +246,10 @@ function ElectionFinderForState () {
                   {election.election_name || ''}
                 </ElectionLink>
                 <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-                  <DarkTooltip title="Copy link">
-                    <ActionChip
-                      onClick={() => navigator.clipboard.writeText(`${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`)}
-                    >
-                      <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
-                      Copy link
-                    </ActionChip>
-                  </DarkTooltip>
+                  <CopyChip
+                    defaultLabel="Copy link"
+                    getText={() => `${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`}
+                  />
                   <ActionDivider />
                   {nextReleaseFeaturesEnabled && (
                     <DarkTooltip title="Download election data">
@@ -261,6 +262,14 @@ function ElectionFinderForState () {
                     </IconButton>
                   </DarkTooltip>
                 </ElectionRowActions>
+                <RowKebabMenu
+                  ariaLabel="More options for this election"
+                  items={[
+                    { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`) },
+                    ...(nextReleaseFeaturesEnabled ? [{ key: 'download', icon: FileDownloadOutlined, label: 'Download election data', onClick: () => {} }] : []),
+                    { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(`/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`, '_blank') },
+                  ]}
+                />
               </ElectionRow>
             );
           })}

--- a/src/js/pages/ElectionFinder/ElectionFinderHome.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderHome.jsx
@@ -8,10 +8,14 @@ import { stateCodeMap } from '../../common/utils/addressFunctions';
 import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import historyPush from '../../common/utils/historyPush';
+import SnackNotifier from '../../common/components/Widgets/SnackNotifier';
 import ElectionStore from '../../stores/ElectionStore';
+import CopyChip from './CopyChip';
+import copyAndToast from './copyAndToast';
 import ElectionFinderHeader from './ElectionFinderHeader';
+import RowKebabMenu from './RowKebabMenu';
 import {
-  ActionChip, ActionDivider, DarkTooltip,
+  ActionDivider, DarkTooltip,
   ElectionDatePill, ElectionLink, ElectionList, ElectionRow, ElectionRowActions,
   FilterTab, FilterTabsRow, InlineSearchField, NoResults,
   SearchIconButton, SectionTitle, SectionTitleRow, ShowMoreButton,
@@ -37,23 +41,14 @@ const SORTED_STATES = Object.entries(stateCodeMap)
 
 function ElectionFinderHome () {
   renderLog('ElectionFinderHome');
-  const [copyLinkText, setCopyLinkText] = useState('Copy link');
   const [electionList, setElectionList] = useState([]);
   const [selectedStateCode, setSelectedStateCode] = useState('all');
   const [filterTab, setFilterTab] = useState('upcoming');
   const [visibleCount, setVisibleCount] = useState(50);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
-  const copyLinkTimeoutRef = useRef(null);
   const searchInputRef = useRef(null);
   const searchDebounceRef = useRef(null);
-
-  useEffect(() => () => {
-    // Clear timeout when component unmounts
-    if (copyLinkTimeoutRef.current) {
-      clearTimeout(copyLinkTimeoutRef.current);
-    }
-  }, []);
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -137,6 +132,7 @@ function ElectionFinderHome () {
   return (
     <>
       <Helmet><title>Election Finder - We Vote</title></Helmet>
+      <SnackNotifier />
       <PageContentContainer>
         <ElectionFinderHeader subtitle="Find past or upcoming elections." />
         <StateSelectWrapper>
@@ -208,6 +204,10 @@ function ElectionFinderHome () {
         <ElectionList>
           {(searchText ? displayElections : displayElections.slice(0, visibleCount)).map((election) => {
             const googleCivicElectionId = election.google_civic_election_id;
+            const sc = (election.state_code_list && election.state_code_list.length > 0) ?
+              election.state_code_list[0].toLowerCase() :
+              'na';
+            const electionUrl = `/election-finder/${sc}/${googleCivicElectionId}`;
             return (
               <ElectionRow
                 key={googleCivicElectionId}
@@ -220,22 +220,7 @@ function ElectionFinderHome () {
                   {election.election_name || ''}
                 </ElectionLink>
                 <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-                  <DarkTooltip title={copyLinkText}>
-                    <ActionChip onClick={() => {
-                      setCopyLinkText('Copied!');
-                      copyLinkTimeoutRef.current = setTimeout(() => {
-                        setCopyLinkText('Copy link');
-                      }, 3000);
-                      const sc = (election.state_code_list && election.state_code_list.length > 0) ?
-                        election.state_code_list[0].toLowerCase() :
-                        'na';
-                      navigator.clipboard.writeText(`${window.location.origin}/election-finder/${sc}/${googleCivicElectionId}`);
-                    }}
-                    >
-                      <ContentCopy sx={{ fontSize: 14, mr: 0.5 }} />
-                      {copyLinkText}
-                    </ActionChip>
-                  </DarkTooltip>
+                  <CopyChip defaultLabel="Copy link" getText={() => `${window.location.origin}${electionUrl}`} />
                   <ActionDivider />
                   {nextReleaseFeaturesEnabled && (
                     <DarkTooltip title="Download election data">
@@ -243,19 +228,19 @@ function ElectionFinderHome () {
                     </DarkTooltip>
                   )}
                   <DarkTooltip title="Open in new tab">
-                    <IconButton
-                      size="small"
-                      onClick={() => {
-                        const sc = (election.state_code_list && election.state_code_list.length > 0) ?
-                          election.state_code_list[0].toLowerCase() :
-                          'na';
-                        window.open(`/election-finder/${sc}/${googleCivicElectionId}`, '_blank');
-                      }}
-                    >
+                    <IconButton size="small" onClick={() => window.open(electionUrl, '_blank')}>
                       <Launch fontSize="small" />
                     </IconButton>
                   </DarkTooltip>
                 </ElectionRowActions>
+                <RowKebabMenu
+                  ariaLabel="More options for this election"
+                  items={[
+                    { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}${electionUrl}`) },
+                    ...(nextReleaseFeaturesEnabled ? [{ key: 'download', icon: FileDownloadOutlined, label: 'Download election data', onClick: () => {} }] : []),
+                    { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(electionUrl, '_blank') },
+                  ]}
+                />
               </ElectionRow>
             );
           })}

--- a/src/js/pages/ElectionFinder/RowKebabMenu.jsx
+++ b/src/js/pages/ElectionFinder/RowKebabMenu.jsx
@@ -1,0 +1,136 @@
+import { MoreVert } from '@mui/icons-material';
+import PropTypes from 'prop-types';
+import React, { useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+const ESTIMATED_MENU_HEIGHT = 220;
+
+export default function RowKebabMenu ({ ariaLabel, items }) {
+  const [open, setOpen] = useState(false);
+  const [openAbove, setOpenAbove] = useState(false);
+  const wrapRef = useRef(null);
+  const buttonRef = useRef(null);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const onDocClick = (e) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  const handleToggle = (e) => {
+    e.stopPropagation();
+    if (!open && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setOpenAbove(rect.bottom + ESTIMATED_MENU_HEIGHT > window.innerHeight);
+    }
+    setOpen((prev) => !prev);
+  };
+
+  const handleItemClick = (handler) => (e) => {
+    e.stopPropagation();
+    handler();
+    setOpen(false);
+  };
+
+  return (
+    <Wrap ref={wrapRef} className="u-show-mobile">
+      <KebabButton
+        ref={buttonRef}
+        type="button"
+        aria-label={ariaLabel}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={handleToggle}
+      >
+        <MoreVert fontSize="small" />
+      </KebabButton>
+      {open && (
+        <MenuCard role="menu" $openAbove={openAbove}>
+          {items.map((item) => {
+            const Icon = item.icon;
+            return (
+              <MenuItem key={item.key} role="menuitem" onClick={handleItemClick(item.onClick)}>
+                <Icon fontSize="small" />
+                <span>{item.label}</span>
+              </MenuItem>
+            );
+          })}
+        </MenuCard>
+      )}
+    </Wrap>
+  );
+}
+
+RowKebabMenu.propTypes = {
+  ariaLabel: PropTypes.string.isRequired,
+  items: PropTypes.arrayOf(PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    icon: PropTypes.elementType.isRequired,
+    label: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+  })).isRequired,
+};
+
+const KebabButton = styled('button')`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: none;
+  border: none;
+  border-radius: 999px;
+  color: #555;
+  cursor: pointer;
+  padding: 0;
+  &:hover {
+    background: #f0f0f0;
+  }
+`;
+
+const MenuCard = styled('div').withConfig({
+  shouldForwardProp: (prop) => prop !== '$openAbove',
+})`
+  position: absolute;
+  right: 0;
+  top: calc(100% + 6px);
+  min-width: 200px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(16, 24, 40, 0.08);
+  padding: 6px;
+  z-index: 1000;
+  ${({ $openAbove }) => $openAbove && `
+    top: auto;
+    bottom: calc(100% + 6px);
+  `}
+`;
+
+const MenuItem = styled('button')`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 10px 12px;
+  font-size: 14px;
+  color: #333;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 6px;
+  white-space: nowrap;
+  &:hover {
+    background: #f5f5f5;
+  }
+`;
+
+const Wrap = styled('div')`
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+`;

--- a/src/js/pages/ElectionFinder/copyAndToast.js
+++ b/src/js/pages/ElectionFinder/copyAndToast.js
@@ -1,0 +1,6 @@
+import { openSnackbar } from '../../common/components/Widgets/SnackNotifier';
+
+export default function copyAndToast (text) {
+  navigator.clipboard.writeText(text);
+  openSnackbar({ message: 'Copied!' });
+}

--- a/src/js/pages/ElectionFinder/electionFinderStyles.js
+++ b/src/js/pages/ElectionFinder/electionFinderStyles.js
@@ -3,24 +3,6 @@ import React from 'react'; // eslint-disable-line no-unused-vars
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
-// eslint-disable-next-line react/jsx-props-no-spreading, react/react-in-jsx-scope
-export const DarkTooltip = styled(({ className, ...props }) => (
-  <Tooltip {...props} classes={{ popper: className }} /> // eslint-disable-line react/jsx-props-no-spreading
-))`
-  & .${tooltipClasses.tooltip} {
-    background-color: rgba(0, 0, 0, 0.9);
-    color: #fff;
-    font-family: "Poppins", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-    font-size: 14px;
-    font-weight: 400;
-    letter-spacing: 0.15px;
-    padding: 4px 8px;
-    border-radius: 4px;
-    max-width: 200px;
-    text-align: center;
-  }
-`;
-
 export const ActionChip = styled('button')`
   display: inline-flex;
   align-items: center;
@@ -59,7 +41,6 @@ export const BreadcrumbAnchor = styled(Link)`
     text-decoration: underline;
   }
 `;
-
 
 export const CandidateActions = styled('div')`
   display: flex;
@@ -109,6 +90,26 @@ export const CandidateRow = styled('div')`
   }
 `;
 
+// disableFocusListener + disableInteractive: tooltip closes the moment the
+// mouse leaves the trigger — doesn't stick around on focus or popper hover.
+// eslint-disable-next-line react/jsx-props-no-spreading, react/react-in-jsx-scope
+export const DarkTooltip = styled(({ className, ...props }) => (
+  <Tooltip disableFocusListener disableInteractive {...props} classes={{ popper: className }} /> // eslint-disable-line react/jsx-props-no-spreading
+))`
+  & .${tooltipClasses.tooltip} {
+    background-color: rgba(0, 0, 0, 0.9);
+    color: #fff;
+    font-family: "Poppins", "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    letter-spacing: 0.15px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    max-width: 200px;
+    text-align: center;
+  }
+`;
+
 export const DetailTitle = styled('h2')`
   font-size: 22px;
   font-weight: 700;
@@ -140,6 +141,9 @@ export const ElectionList = styled('div')`
   flex-direction: column;
 `;
 
+// ElectionRowActions must precede ElectionRow because ElectionRow's hover
+// selector references it via ${ElectionRowActions} (template-literal interpolation
+// is evaluated at module-load time).
 export const ElectionRowActions = styled('div')`
   display: flex;
   align-items: center;
@@ -251,11 +255,12 @@ export const NoResults = styled('p')`
   padding: 16px 0;
 `;
 
+// OfficeHeaderActions must precede OfficeHeader because OfficeHeader's hover
+// selector references it via ${OfficeHeaderActions}.
 export const OfficeHeaderActions = styled('div')`
   display: flex;
   align-items: center;
   gap: 4px;
-  margin-right: 16px;
   visibility: hidden;
 `;
 
@@ -263,7 +268,7 @@ export const OfficeHeader = styled('div')`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 7px 0;
+  padding: 7px 16px 7px 0;
   border-bottom: 1.5px solid #ccc;
   cursor: pointer;
   &:hover {
@@ -311,22 +316,6 @@ export const SearchIconButton = styled('button')`
   }
 `;
 
-export const ShowMoreButton = styled('button')`
-  display: block;
-  margin: 16px 0;
-  padding: 8px 16px;
-  font-size: 14px;
-  color: #555;
-  background: none;
-  border: 1px solid #ccc;
-  border-radius: 14px;
-  cursor: pointer;
-  &:hover {
-    border-color: #2e3c5d;
-    color: #333;
-  }
-`;
-
 export const SearchResultCount = styled('p')`
   font-size: 18px;
   color: #555;
@@ -347,13 +336,35 @@ export const SectionTitleRow = styled('div')`
   margin-bottom: 8px;
 `;
 
-export const StateSelectWrapper = styled('div')`
+export const ShowMoreButton = styled('button')`
+  display: block;
+  margin: 16px 0;
+  padding: 8px 16px;
+  font-size: 14px;
+  color: #555;
+  background: none;
+  border: 1px solid #ccc;
+  border-radius: 14px;
+  cursor: pointer;
+  &:hover {
+    border-color: #2e3c5d;
+    color: #333;
+  }
+`;
+
+export const StateSelectCaret = styled('span')`
+  flex-shrink: 0;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
-  margin-bottom: 10px;
-  cursor: pointer;
-  position: relative;
+  color: #555;
+  font-size: 18px;
+`;
+
+export const StateSelectLabel = styled('span')`
+  font-size: 15px;
+  font-weight: 400;
+  color: #333;
+  white-space: nowrap;
 `;
 
 export const StateSelectNative = styled('select')`
@@ -368,18 +379,11 @@ export const StateSelectNative = styled('select')`
   z-index: 1;
 `;
 
-export const StateSelectLabel = styled('span')`
-  font-size: 15px;
-  font-weight: 400;
-  color: #333;
-  white-space: nowrap;
-`;
-
-
-export const StateSelectCaret = styled('span')`
-  flex-shrink: 0;
+export const StateSelectWrapper = styled('div')`
   display: inline-flex;
   align-items: center;
-  color: #555;
-  font-size: 18px;
+  gap: 4px;
+  margin-bottom: 10px;
+  cursor: pointer;
+  position: relative;
 `;


### PR DESCRIPTION
## What's new

- **Mobile kebab (⋮) menu on every row** — Copy link, Copy office/candidate name, Open in new tab. Mirrors the desktop hover buttons. Indentation consistent across all four row types.
- **Multi-word search.** Typing `attorney kwame` finds Kwame Raoul under Attorney General; words can split across an office and one of its candidates. Each word highlights independently.
- **Copy feedback.** Desktop chip flips to "Copied!" for 3s; mobile menu shows a "Copied!" toast. Only one chip ever shows "Copied!" at a time.

## Fixes

- **Search refresh bug.** Typing in the search bar on the office-detail page no longer triggers a page refresh (`highlightMatch` was crashing on every keystroke).

## Cleanup

- Tooltips disappear the moment your cursor leaves the button — no more sticking around when hovering the popper or after a click.
- Hide *Expand all* / *Collapse all* when there are no results.
- Detail-page breadcrumb shows only the immediate previous page (drops the redundant "Election Finder Home" link).

## Screenshots

<img width="748" alt="Search + breadcrumb" src="https://github.com/user-attachments/assets/73a3cfec-b9f2-498e-b70e-372a2f889c65" />

<img width="419" alt="Mobile kebab menu" src="https://github.com/user-attachments/assets/c344c3ae-5326-491e-b589-6ed1e8991749" />