### PR TITLE
Reduce CLS on politician details page with endorsements skeleton and conditional min-height

### DIFF
--- a/src/js/common/pages/Politician/PoliticianDetailsEndorsementsSkeleton.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsEndorsementsSkeleton.jsx
@@ -1,0 +1,179 @@
+import { Box, Skeleton } from '@mui/material';
+import PropTypes from 'prop-types';
+import React from 'react';
+import styled from 'styled-components';
+import DesignTokenColors from '../../components/Style/DesignTokenColors';
+import { CampaignSubSectionTitleWrapper, CommentsListWrapper } from '../../components/Style/CampaignDetailsStyles';
+import { renderLog } from '../../utils/logging';
+
+// Keep in sync with PoliticianDetailsPage PoliticianEndorsementsList startingNumberOfPositionsToDisplay
+const ENDORSEMENT_SKELETON_CARD_COUNT = 5;
+
+//  Reserve vertical space so the loaded endorsements area (title + composer + up to five endorsements)
+//  is less likely to be shorter than this placeholder, reducing CLS when real content mounts. 
+const EndorsementsSkeletonRoot = styled('div')(({ theme }) => ({
+  minHeight: '480px',
+  [theme.breakpoints.up('md')]: {
+    minHeight: '680px',
+  },
+}));
+
+const ComposerOuter = styled('div')`
+  align-items: flex-start;
+  background-color: ${DesignTokenColors.caution50};
+  display: flex;
+  gap: 10px;
+  margin: 12px 0 26px 0;
+  padding: 6px;
+`;
+
+const ComposerMain = styled('div')`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  width: 100%;
+`;
+
+const CardRow = styled('div')`
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid ${DesignTokenColors.neutralUI200};
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+`;
+
+const CardCol = styled('div')`
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+`;
+
+const TopRow = styled('div')`
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: space-between;
+`;
+
+const NameAndActions = styled('div')`
+  align-items: center;
+  display: flex;
+  flex: 1;
+  gap: 8px;
+  min-width: 0;
+`;
+
+const FooterRow = styled('div')`
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 4px;
+`;
+
+function TitleSkeleton () {
+  return (
+    <CampaignSubSectionTitleWrapper>
+      <Skeleton component="div" variant="text" width="82%" height={36} sx={{ maxWidth: 480 }} />
+    </CampaignSubSectionTitleWrapper>
+  );
+}
+
+function ComposerSkeleton () {
+  return (
+    <ComposerOuter>
+      <Skeleton variant="circular" width={43} height={43} />
+      <ComposerMain>
+        {/* ModalDisplayTemplateB CommentContainer + InputBox: ~56–64px tall on desktop */}
+        <Skeleton variant="rounded" height={56} sx={{ borderRadius: 2, width: '100%' }} />
+        <Box display="flex" gap={1} sx={{ mt: 0.25 }}>
+          <Skeleton variant="rounded" width={100} height={36} sx={{ borderRadius: 2 }} />
+          <Skeleton variant="rounded" width={100} height={36} sx={{ borderRadius: 2 }} />
+        </Box>
+      </ComposerMain>
+    </ComposerOuter>
+  );
+}
+
+function EndorsementCardSkeleton () {
+  return (
+    <CardRow>
+      <Skeleton variant="circular" width={40} height={40} />
+      <CardCol>
+        <TopRow>
+          <NameAndActions>
+            <Skeleton variant="text" width={160} height={24} />
+          </NameAndActions>
+          <Box display="flex" gap={0.5}>
+            <Skeleton variant="rounded" width={32} height={32} sx={{ borderRadius: 1 }} />
+            <Skeleton variant="rounded" width={32} height={32} sx={{ borderRadius: 1 }} />
+          </Box>
+        </TopRow>
+        <Skeleton variant="text" width="100%" height={18} />
+        <Skeleton variant="text" width="96%" height={18} />
+        <Skeleton variant="text" width="88%" height={18} />
+        <Skeleton variant="text" width="72%" height={18} />
+        <Skeleton variant="text" width="58%" height={18} />
+        <FooterRow>
+          <Skeleton variant="text" width="55%" height={16} />
+          <Skeleton variant="rounded" width={28} height={28} sx={{ borderRadius: 1 }} />
+        </FooterRow>
+      </CardCol>
+    </CardRow>
+  );
+}
+
+function FeedSkeletonList () {
+  return (
+    <>
+      {Array.from({ length: ENDORSEMENT_SKELETON_CARD_COUNT }, (_, index) => (
+        <EndorsementCardSkeleton key={`endorsement-skeleton-${index}`} />
+      ))}
+    </>
+  );
+}
+
+
+//  Loading placeholders for "What people are saying", opinion composer, endorsements feed.
+//  variant "full": title + composer + feed (before politician id is available).
+//  variant "feedOnly": endorsement cards only (positions hydrating or lazy chunk loading).
+ 
+export default function PoliticianDetailsEndorsementsSkeleton ({ variant = 'full' }) {
+  renderLog('PoliticianDetailsEndorsementsSkeleton');
+
+  if (variant === 'feedOnly') {
+    return (
+      <Box
+        sx={{
+          minHeight: { xs: 420, md: 560 },
+        }}
+      >
+        <FeedSkeletonList />
+      </Box>
+    );
+  }
+
+  return (
+    <EndorsementsSkeletonRoot>
+      <TitleSkeleton />
+      <ComposerSkeleton />
+      <CommentsListWrapper>
+        <FeedSkeletonList />
+      </CommentsListWrapper>
+    </EndorsementsSkeletonRoot>
+  );
+}
+
+PoliticianDetailsEndorsementsSkeleton.propTypes = {
+  variant: PropTypes.oneOf(['full', 'feedOnly']),
+};

--- a/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
+++ b/src/js/common/pages/Politician/PoliticianDetailsPage.jsx
@@ -50,6 +50,7 @@ import normalizedImagePath from '../../utils/normalizedImagePath';
 import { getPoliticianValuesFromIdentifiers, politicianRetrieveFromIdentifiersIfNeeded } from '../../utils/politicianUtils';
 import returnFirstXWords from '../../utils/returnFirstXWords';
 import saveCampaignSupportAndGoToNextPage from '../../utils/saveCampaignSupportAndGoToNextPage';
+import PoliticianDetailsEndorsementsSkeleton from './PoliticianDetailsEndorsementsSkeleton';
 
 const CampaignRetrieveController = React.lazy(() => import(/* webpackChunkName: 'CampaignRetrieveController' */ '../../components/Campaign/CampaignRetrieveController'));
 const CampaignSupportThermometer = React.lazy(() => import(/* webpackChunkName: 'CampaignSupportThermometer' */ '../../components/CampaignSupport/CampaignSupportThermometer'));
@@ -98,6 +99,8 @@ class PoliticianDetailsPage extends Component {
       politicianStateParsedFromURLBeforeLoad: '',
       politicianNameParsedFromURLBeforeLoad: '',
       dataLayerSent: false, // instance flag for GTM
+      allCachedPositionsForThisPolitician: undefined,
+      positionRetrieveCompleted: false,
       // youtubeUrl: '',
     };
     // this.onScroll = this.onScroll.bind(this);
@@ -375,8 +378,22 @@ class PoliticianDetailsPage extends Component {
     // console.log('onCandidateStoreChange politicianWeVoteId: ', politicianWeVoteId);
     if (politicianWeVoteId) {
       const allCachedPositionsForThisPolitician = CandidateStore.getAllCachedPositionsByPoliticianWeVoteId(politicianWeVoteId);
+      const candidateList = CandidateStore.getCandidateListByPoliticianWeVoteId(politicianWeVoteId);
+      let positionRetrieveCompleted = false;
+      if (candidateList && candidateList.length > 0) {
+        // positionRetrieveCompleted = CandidateStore.positionListRetrieveHasCompletedForCandidate(candidateList[0].we_vote_id);
+        positionRetrieveCompleted = candidateList.some(
+          (candidate) => CandidateStore.positionListRetrieveHasCompletedForCandidate(candidate.we_vote_id),
+        );
+      }
       this.setState({
         allCachedPositionsForThisPolitician,
+        positionRetrieveCompleted,
+      });
+    } else {
+      this.setState({
+        allCachedPositionsForThisPolitician: undefined,
+        positionRetrieveCompleted: false,
       });
     }
   }
@@ -559,6 +576,8 @@ class PoliticianDetailsPage extends Component {
       twitterHandle2: '',
       wikipediaUrl: '',
       youtubeUrl: '',
+      allCachedPositionsForThisPolitician: undefined,
+      positionRetrieveCompleted: false,
     });
     AppObservableStore.setCampaignXWeVoteIdBeingViewed('');
     AppObservableStore.setPoliticianWeVoteIdBeingViewed('');
@@ -658,7 +677,7 @@ class PoliticianDetailsPage extends Component {
       scrolledDown, showMobileViewUpcomingBallot,
       stateText, twitterHandle, twitterHandle2,
       voterCanEditThisPolitician, voterSupportsThisPolitician,
-      wikipediaUrl, youtubeUrl,
+      wikipediaUrl, youtubeUrl, positionRetrieveCompleted,
     } = this.state;
     let { contestOfficeName } = this.state;
     // console.log('PoliticianDetailsPage render this.state.politicianWeVoteId:', politicianWeVoteId, ', this.state.politicianWeVoteIdForDisplay:', politicianWeVoteIdForDisplay);
@@ -906,7 +925,7 @@ class PoliticianDetailsPage extends Component {
       positionListTeaserHtml = (
         <CommentsListWrapper>
           <DelayedLoad waitBeforeShow={loadSlow ? 1000 : 0}>
-            <Suspense fallback={<span>&nbsp;</span>}>
+            <Suspense fallback={<PoliticianDetailsEndorsementsSkeleton variant="feedOnly" />}>
               <PoliticianEndorsementsList
                 hideEncouragementToEndorse
                 politicianWeVoteId={politicianWeVoteIdForDisplay}
@@ -917,6 +936,33 @@ class PoliticianDetailsPage extends Component {
         </CommentsListWrapper>
       );
     }
+
+    const hasPoliticianId = !!(politicianWeVoteIdForDisplay || politicianWeVoteId);
+    const positionsHydrated = allCachedPositionsForThisPolitician !== undefined;
+    // const hasPositions = allCachedPositionsForThisPolitician && allCachedPositionsForThisPolitician.length > 0;
+    const showFullEndorsementsSkeleton = !hasPoliticianId;
+    const keepEndorsementsMinHeight = !positionRetrieveCompleted;;
+    let feedLoadingHtml = <></>;
+    if (hasPoliticianId && !positionsHydrated) {
+      feedLoadingHtml = (
+        <CommentsListWrapper>
+          <PoliticianDetailsEndorsementsSkeleton variant="feedOnly" />
+        </CommentsListWrapper>
+      );
+    }
+    const endorsementsContent = showFullEndorsementsSkeleton ? (
+      <PoliticianDetailsEndorsementsSkeleton variant="full" />
+    ) : (
+      <EndorsementsContentWrapper useMinHeight={keepEndorsementsMinHeight}>
+        {listTitleHtml}
+        <VoterPositionEntryAndDisplay
+          politicianWeVoteId={politicianWeVoteIdForDisplay || politicianWeVoteId}
+          politicianName={politicianName}
+        />
+        {feedLoadingHtml}
+        {positionListTeaserHtml}
+      </EndorsementsContentWrapper>
+    );
 
     // let commentListTeaserHtml = <></>;
     // if (supporterEndorsementsWithText && supporterEndorsementsWithText.length > 0) {
@@ -1082,18 +1128,7 @@ class PoliticianDetailsPage extends Component {
                 </IndicatorRow>
               )}
             </CampaignDescriptionWrapper>
-            {listTitleHtml}
-            <VoterPositionEntryAndDisplay
-              politicianWeVoteId={politicianWeVoteIdForDisplay || politicianWeVoteId}
-              politicianName={politicianName}
-            />
-            {/*
-            <VoterPositionEntryAndDisplayMook
-              politicianWeVoteId={politicianWeVoteId}
-              politicianName={politicianName}
-            />
-            */}
-            {positionListTeaserHtml}
+            {endorsementsContent}
             <SpacerAfterPositions />
             {(opponentCandidateList && opponentCandidateList.length > 0) && (
               <CandidateCampaignListMobile>
@@ -1255,18 +1290,7 @@ class PoliticianDetailsPage extends Component {
                 />
               </ColumnOneThird>
               <ColumnTwoThirds>
-                {listTitleHtml}
-                <VoterPositionEntryAndDisplay
-                  politicianWeVoteId={politicianWeVoteIdForDisplay || politicianWeVoteId}
-                  politicianName={politicianName}
-                />
-                {/*
-                <VoterPositionEntryAndDisplayMook
-                  politicianWeVoteId={politicianWeVoteId}
-                  politicianName={politicianName}
-                />
-                */}
-                {positionListTeaserHtml}
+                {endorsementsContent}
                 <SpacerAfterPositions />
                 {(opponentCandidateList && opponentCandidateList.length > 0) && (
                   <CandidateCampaignListDesktop>
@@ -1547,6 +1571,17 @@ const PoliticianLinksWrapper = styled('div')`
     margin: 0;
   }
 `;
+
+const EndorsementsContentWrapper = styled('div', {
+  shouldForwardProp: (prop) => prop !== 'useMinHeight',
+})(({ theme, useMinHeight }) => ({
+  ...(useMinHeight && {
+    minHeight: '480px',
+    [theme.breakpoints.up('md')]: {
+      minHeight: '680px',
+    },
+  }),
+}));
 
 const SpacerAfterPositions = styled('div')`
   margin-bottom: 60px;

--- a/src/js/stores/CandidateStore.js
+++ b/src/js/stores/CandidateStore.js
@@ -102,7 +102,13 @@ class CandidateStore extends ReduceStore {
       candidateListsByPoliticianWeVoteId: {}, // Dictionary with politician_we_vote_id as key and list of candidates linked to the politician as value
       candidateWeVoteIdInFutureByPoliticianWeVoteId: {}, // Dictionary with politician_we_vote_id as key and the candidate_we_vote_id as value
       numberOfCandidatesRetrievedByOffice: {}, // Dictionary with office_we_vote_id as key and number of candidates as value
+      positionListRetrieveCompleteByBallotItem: {}, // Dictionary with candidate_we_vote_id as key and list of positions as value
     };
+  }
+
+
+  positionListRetrieveHasCompletedForCandidate (candidateWeVoteId) {
+    return this.getState().positionListRetrieveCompleteByBallotItem[candidateWeVoteId] || false;
   }
 
   getAllCachedPositionsDictByCandidateWeVoteId (candidateWeVoteId) {
@@ -333,6 +339,7 @@ class CandidateStore extends ReduceStore {
     const {
       allCachedCandidates, allCachedCandidateWeVoteIdsByCampaignXWeVoteId, allCachedPositionsAboutCandidates,
       candidateWeVoteIdInFutureByPoliticianWeVoteId, numberOfCandidatesRetrievedByOffice,
+      positionListRetrieveCompleteByBallotItem,
     } = state;
     let {
       candidateListsByOfficeWeVoteId, candidateListsByPoliticianWeVoteId,
@@ -564,7 +571,15 @@ class CandidateStore extends ReduceStore {
       case 'positionListForBallotItem':
       case 'positionListForBallotItemFromFriends':
         // console.log('positionListForBallotItem action.res:', action.res);
-        if (action.res.count === 0) return state;
+
+        positionListRetrieveCompleteByBallotItem[action.res.ballot_item_we_vote_id] = true;
+
+        if (action.res.count === 0) {
+          return {
+            ...state,
+            positionListRetrieveCompleteByBallotItem,
+          };
+        }
 
         if (action.res.kind_of_ballot_item === 'CANDIDATE') {
           newPositionList = action.res.position_list || [];
@@ -587,6 +602,7 @@ class CandidateStore extends ReduceStore {
           return {
             ...state,
             allCachedPositionsAboutCandidates,
+            positionListRetrieveCompleteByBallotItem,
           };
         } else if (action.res.kind_of_ballot_item === 'OFFICE') {
           officePositionList = action.res.position_list || [];
@@ -610,6 +626,7 @@ class CandidateStore extends ReduceStore {
           return {
             ...state,
             allCachedPositionsAboutCandidates,
+            positionListRetrieveCompleteByBallotItem,
           };
         } else {
           return state;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix? CLS on politician details page 

## Changes included this pull request?

### Summary
- Added `PoliticianDetailsEndorsementsSkeleton` component with two variants (`full` and `feedOnly`) that placeholder the "What people are saying" endorsements area while data loads, preventing content below (e.g. "Other candidates, same office") from shifting upward.
- Wrapped the real endorsements content in `EndorsementsContentWrapper` with a conditional `minHeight` that holds vertical space during loading and releases it once the position retrieval API has responded; whether the response contains endorsements or not.
- Added `positionListRetrieveCompleteByBallotItem` flag to `CandidateStore` so the store emits a change even when the positions API returns zero results. Previously, a zero-count response was silently discarded (`return state`), making it impossible for the page to distinguish "still loading" from "confirmed no endorsements."
- `PoliticianDetailsPage.onCandidateStoreChange` now checks this flag to set `positionRetrieveCompleted`, which controls whether the min-height wrapper stays active.

### How it works
1. While waiting for the politician ID, a `full` skeleton (title + composer + 5 card placeholders) reserves space.
2. Once the ID arrives, real title and composer render inside `EndorsementsContentWrapper` with `minHeight` active, and a `feedOnly` skeleton shows while positions hydrate.
3. When the positions API responds, `CandidateStore` sets the completion flag and emits; even for zero-count responses.
4. The page sees `positionRetrieveCompleted: true` and drops the `minHeight`. If endorsements exist, they fill the space naturally. If not, the area collapses to its real height with no wasted space.

## Files changed
- `src/js/common/pages/Politician/PoliticianDetailsEndorsementsSkeleton.jsx` : New skeleton component with `full` and `feedOnly` variants
- `src/js/common/pages/Politician/PoliticianDetailsPage.jsx` : Endorsements content wrapper with conditional min-height, position retrieval completion check
- `src/js/stores/CandidateStore.js` : `positionListRetrieveCompleteByBallotItem` dictionary, getter, and updated reducer to emit on zero-count responses

## Testing done
- Loaded a politician with many endorsements (Kamala Harris) : no CLS during load, endorsements render normally, no blank gap after loading
- Loaded a politician with no endorsements (Adrian Smith) : skeleton shows during load, blank gap disappears once API confirms empty
- Loaded a politician with few endorsements (Marianne Williamson) : no persistent blank gap below the endorsement cards
- Navigated between politicians : skeleton resets and shows for the new politician