### PR TITLE
[WV-4253] Add ballot election header to Office page

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -2944,6 +2944,13 @@ h1,h2,h3,h4,h5,h6 {
   position:absolute
 }
 
+.office-header-divider {
+  margin:20;
+  width:200%;
+  left:-300px;
+  position:relative
+}
+
 @media print {
   .BallotList {
     column-count:1

--- a/src/js/components/Ballot/BallotTitleHeader.jsx
+++ b/src/js/components/Ballot/BallotTitleHeader.jsx
@@ -18,6 +18,10 @@ import VoterStore from '../../stores/VoterStore';
 import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
 import { BallotAddress, ClickBlockWrapper, ContentWrapper, ElectionDateBelow, ElectionDateRight, ElectionNameBlock, ElectionNameH1, ElectionNameScrollContent, ElectionStateLabel, OverflowContainer, OverflowContent, VoteByBelowLabel, VoteByBelowWrapper, VoteByRightLabel, VoteByRightWrapper } from '../Style/BallotTitleHeaderStyles';
 import BallotTitleHeaderNationalPlaceholder from './BallotTitleHeaderNationalPlaceholder';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 
 const ShareButtonDesktopTablet = React.lazy(() => import(/* webpackChunkName: 'ShareButtonDesktopTablet' */ '../Share/ShareButtonDesktopTablet'));
 
@@ -134,7 +138,7 @@ class BallotTitleHeader extends Component {
 
   render () {
     renderLog('BallotTitleHeader');  // Set LOG_RENDER_EVENTS to log all renders
-    const { allowTextWrap, centerText, linksOff, shareButtonText, showBallotCaveat, showShareButton, turnOffVoteByBelow } = this.props;
+    const { allowTextWrap, centerText, linksOff, shareButtonText, showBallotCaveat, showShareButton, turnOffVoteByBelow, officeName, onViewBallotClick, } = this.props;
     const {
       ballotCaveat, daysUntilElection, electionDayTextObject,
       electionName, nextNationalElectionDateMDY, originalTextAddress, originalTextState,
@@ -144,6 +148,43 @@ class BallotTitleHeader extends Component {
     const electionNameContainsWordElection = stringContains('election', electionName.toLowerCase());
     const stateTextUsed = substitutedState || originalTextState || '';
     const electionNameContainsState = stringContains(stateTextUsed.toLowerCase(), electionName.toLowerCase());
+
+    const fromOfficePage = officeName && officeName.trim() !== '';
+    console.log("Button onViewBallotClick:", onViewBallotClick);
+
+    const electionNameTooltip = isMobileScreenSize() ? (<></>) : (
+      <Tooltip className="u-z-index-9020" id="election-name-tooltip">
+        {electionName}
+      </Tooltip>
+    );
+
+    const BallotOfficeHeader = ({
+      officeName,
+      onViewBallotClick,
+    }) => {
+      return (
+        <InlineOfficeHeader>
+          <span>
+            <span className="u-show-mobile">
+              Ballot Section for
+            </span>
+            <span className="u-show-desktop-tablet">
+              Ballot section for office of
+            </span>
+
+            {' '}
+
+            <strong style={{ fontWeight: 500 }}>
+              {officeName}
+            </strong>
+          </span>
+
+          <ViewBallotButton onClick={onViewBallotClick}>
+            View full ballot
+          </ViewBallotButton>
+        </InlineOfficeHeader>
+      );
+    };
 
     const editIconStyled = <Edit style={{ fontSize: 16, margin: '-6px 0 0 2px', color: '#69A7FF' }} />;
     // console.log('BallotTitleHeader allowTextWrap:', allowTextWrap);
@@ -195,21 +236,31 @@ class BallotTitleHeader extends Component {
                           )}
                         </ElectionStateLabel>
                       )}
-                      <ElectionNameH1
-                        tabIndex={0}
-                        centerText={centerText}
-                        className={linksOff ? '' : 'u-cursor--pointer'}
-                        id="ballotTitleHeaderElectionName"
-                        onClick={this.showSelectBallotModalChooseElection}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            this.showSelectBallotModalChooseElection();
-                          }
-                        }}
-                      >
-                        {electionName}
-                      </ElectionNameH1>
+                      <OverlayTrigger placement="bottom-end" overlay={electionNameTooltip}>
+                        <ElectionNameH1
+                          tabIndex={0}
+                          centerText={centerText}
+                          className={linksOff ? '' : 'u-cursor--pointer'}
+                          id="ballotTitleHeaderElectionName"
+                          onClick={this.showSelectBallotModalChooseElection}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              this.showSelectBallotModalChooseElection();
+                            }
+                          }}
+                        >
+                          {electionName}
+                        </ElectionNameH1>
+                      </OverlayTrigger>
+                      {
+                        fromOfficePage ? (
+                              <BallotOfficeHeader
+                                  officeName={officeName}
+                                  onViewBallotClick={onViewBallotClick}
+                              />
+                        ) : (
+                      <>
                       {(showBallotCaveat && ballotCaveat) ? (
                         <BallotAddress tabIndex={-1}
                           allowTextWrap={allowTextWrap}
@@ -232,12 +283,12 @@ class BallotTitleHeader extends Component {
                               id="ballotTitleBallotAddress"
                               onClick={() => this.showSelectBallotModalEditAddress('ballotTitleBallotAddress')}
                             >
-                              Ballot for
+                                    Ballot for
                               {' '}
                               <span tabIndex={0}
                                 className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}
                               >
-                                <span>
+                               <span>
                                   {(textForMapSearch && textForMapSearch !== '') ? textForMapSearch : originalTextAddress}
                                 </span>
                                 {linksOff ? <></> : editIconStyled}
@@ -253,10 +304,10 @@ class BallotTitleHeader extends Component {
                                   id="ballotTitleBallotAddressSubstituted"
                                   onClick={() => this.showSelectBallotModalEditAddress('ballotTitleBallotAddressSubstituted')}
                                 >
-                                  Ballot for
+                                          Ballot for
                                   {' '}
                                   <span tabIndex={0} className={linksOff ? '' : 'u-link-color u-link-underline-on-hover'}>
-                                    {substitutedAddress}
+                                        {substitutedAddress}
                                   </span>
                                   {linksOff ? <></> : editIconStyled}
                                 </BallotAddress>
@@ -278,6 +329,8 @@ class BallotTitleHeader extends Component {
                           )}
                         </>
                       )}
+                      </>
+                    )}
                       {(!turnOffVoteByBelow && electionDayTextObject) && (
                         <VoteByBelowWrapper centerText={centerText}>
                           <VoteByBelowLabel>
@@ -364,6 +417,8 @@ BallotTitleHeader.propTypes = {
   showShareButton: PropTypes.bool,
   // toggleSelectBallotModal: PropTypes.func,
   turnOffVoteByBelow: PropTypes.bool,
+  officeName: PropTypes.string,
+  onViewBallotClick: PropTypes.func,
 };
 
 const styles = {
@@ -387,7 +442,27 @@ const BallotShareWrapper = styled('div')`
 `;
 
 const BallotTitleHeaderWrapper = styled('div')`
-  height: ${isAndroid() ? '110px' : '90px'};
+  min-height: ${isAndroid() ? '110px' : '90px'};
+  height: auto;
+`;
+
+const ViewBallotButton = styled.button`
+  background: ${DesignTokenColors.primary700};
+  color:${DesignTokenColors.whiteUI};
+  border: 1px solid #ddd;
+  border-radius: 20px;
+  cursor: pointer;
+  padding: 6px 6px;
+  font-weight: 400;
+  &:hover {
+    background: ${DesignTokenColors.primary800};
+  }
+`;
+
+const InlineOfficeHeader = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;   /* controls spacing properly */
 `;
 
 export default withTheme(withStyles(styles)(BallotTitleHeader));

--- a/src/js/components/Style/BallotTitleHeaderStyles.jsx
+++ b/src/js/components/Style/BallotTitleHeaderStyles.jsx
@@ -64,14 +64,16 @@ export const ElectionNameH1 = styled('h1', {
   padding-bottom: 18px;
   ${theme.breakpoints.down('sm')} {
     padding-top: 5px;
-    padding-bottom: 12px;
+    padding-bottom: 10px;
+    white-space: normal;
   }
   ${() => (isIOs6p1OrSmaller() ? 'font-weight: 600;' : '')}
   line-height: 1;
   margin: 0px;
   ${centerText ? 'text-align: center;' : ''}
-  word-wrap: break-word;    // e.g 'District of Columbia General Election' in mobile/Cordova
-  white-space: normal;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 `));
 
 export const ElectionNameScrollContent = styled('div')`

--- a/src/js/pages/Ballot/Office.jsx
+++ b/src/js/pages/Ballot/Office.jsx
@@ -10,6 +10,7 @@ import OfficeActions from '../../actions/OfficeActions';
 import LoadingWheel from '../../common/components/Widgets/LoadingWheel';
 import toTitleCase from '../../common/utils/toTitleCase';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
+import { DualHeaderContainer, getTopOffsetDueToHeadroomWrapper, HeaderContentContainer, HeaderContentOuterContainer } from '../../components/Style/pageLayoutStyles';
 import AppObservableStore, { messageService } from '../../common/stores/AppObservableStore';
 import BallotStore from '../../stores/BallotStore';
 import CandidateStore from '../../stores/CandidateStore';
@@ -20,6 +21,11 @@ import { renderLog } from '../../common/utils/logging';
 import apiCalming from '../../common/utils/apiCalming';
 import { sortCandidateList } from '../../utils/positionFunctions';
 import BallotItemCompressed from '../../components/Ballot/BallotItemCompressed';
+import BallotTitleHeader from '../../components/Ballot/BallotTitleHeader';
+import { isCordova, isWebApp } from '../../common/utils/isCordovaOrWebApp';
+import BallotActions from '../../actions/BallotActions';
+import { useHistory } from 'react-router-dom';
+
 
 
 // This is related to pages/VoterGuide/OrganizationVoterGuideOffice
@@ -32,6 +38,13 @@ function Office () {
   const [officeWeVoteId, setOfficeWeVoteId] = useState('');
   const [positionListFromFriendsHasBeenRetrievedOnce, setPositionListFromFriendsHasBeenRetrievedOnce] = useState({});
   const [positionListHasBeenRetrievedOnce, setPositionListHasBeenRetrievedOnce] = useState({});
+  const scrolledDown = false;
+
+  const history = useHistory();
+  const handleViewBallotClick = () => {
+  //window.close();
+  history.push('/ballot');
+  };
 
   const localPositionListHasBeenRetrievedOnce = (weVoteId) => {
     if (weVoteId) {
@@ -51,6 +64,7 @@ function Office () {
     // We update dummyVariable so we can force a re-render of the component,
     //  which is necessary to pick up an AppObservableStore update that changes
     //  getPaddingTop in PageContentContainer
+    scrolledDown: AppObservableStore.getScrolledDown()
     const now = new Date();
     const hours = now.getHours().toString().padStart(2, '0');
     const minutes = now.getMinutes().toString().padStart(2, '0');
@@ -224,6 +238,11 @@ function Office () {
     if (apiCalming('activityNoticeListRetrieve', 10000)) {
       ActivityActions.activityNoticeListRetrieve();
     }
+
+    if (apiCalming('voterBallotItemsRetrieve', 600000)) {
+      BallotActions.voterBallotItemsRetrieve(0, '', '');
+    }
+
     AnalyticsActions.saveActionOffice(VoterStore.electionId(), params.office_we_vote_id);
 
     const candidateStoreListener = CandidateStore.addListener(onCandidateStoreChange);
@@ -283,38 +302,71 @@ function Office () {
   const descriptionText = `Choose who you support for ${officeName} in this election`;
 
   return (
-    <PageContentContainer>
+    <>
       <Helmet
         title={titleText}
         meta={[{ name: 'description', content: descriptionText }]}
       />
-      <OfficeWrapper>
-        <Suspense fallback={<></>}>
-          <BallotItemCompressed
-            ballotItemDisplayName={office.ballot_item_display_name}
-            candidateList={candidateList}
-            // candidatesToShowForSearchResults={item.candidatesToShowForSearchResults}
-            // foundInSearchWords={item.foundInSearchWords}
-            // id={chipLabelText(item.ballot_item_display_name)}
-            // isFirstBallotItem={isFirstBallotItem}
-            // isMeasure={item.kind_of_ballot_item === TYPES.MEASURE}
-            // primaryParty={item.primary_party}
-            // totalNumberOfBallotItems={totalNumberOfBallotItems}
-            useHelpDefeatOrHelpWin
-            weVoteId={office.we_vote_id}
-            // key={key}
-          />
-        </Suspense>
-      </OfficeWrapper>
-    </PageContentContainer>
+      <DualHeaderContainer id="ballot" scrolledDown={scrolledDown} topOffset={getTopOffsetDueToHeadroomWrapper()}>
+        <HeaderContentOuterContainer>
+          <HeaderContentContainer>
+                <div className="col-md-12">
+                  <header className="ballot__header__group">
+                    <BallotTitleHeaderContainer>
+                      <BallotTitleHeader
+                        showShareButton={false}
+                        officeName={officeName}
+                        linksOff={true}
+                        allowTextWrap={true}
+                        onViewBallotClick={handleViewBallotClick}
+                      />
+                    </BallotTitleHeaderContainer>
+                  </header>
+                </div>
+          </HeaderContentContainer>
+        </HeaderContentOuterContainer>
+        <hr className="office-header-divider" />
+      </DualHeaderContainer>
+      <PageContentContainer>
+        <div className="container-fluid">
+          <OfficeWrapper>
+            <Suspense fallback={<></>}>
+              <BallotItemCompressed
+                ballotItemDisplayName={office.ballot_item_display_name}
+                candidateList={candidateList}
+                // candidatesToShowForSearchResults={item.candidatesToShowForSearchResults}
+                // foundInSearchWords={item.foundInSearchWords}
+                // id={chipLabelText(item.ballot_item_display_name)}
+                // isFirstBallotItem={isFirstBallotItem}
+                // isMeasure={item.kind_of_ballot_item === TYPES.MEASURE}
+                // primaryParty={item.primary_party}
+                // totalNumberOfBallotItems={totalNumberOfBallotItems}
+                useHelpDefeatOrHelpWin
+                weVoteId={office.we_vote_id}
+              // key={key}
+              />
+            </Suspense>
+          </OfficeWrapper>
+        </div>
+      </PageContentContainer>
+    </>
   );
 }
 Office.propTypes = {
   // match: PropTypes.object.isRequired,
 };
 
-const OfficeWrapper = styled('div')`
+const OfficeWrapper = styled('div')(({ theme }) => (`
+  padding-top: 100px;
   margin: 0 15px;
+  ${theme.breakpoints.down('sm')} {
+    padding-top: 160px;
+  }
+`));
+
+const BallotTitleHeaderContainer = styled('div')`
+  margin-top: 50px;
+  transition: ${isWebApp() ? 'all 150ms ease-in' : ''};
 `;
 
 export default Office;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

[WV-4253] Add ballot election header to Office page

### Changes included this pull request?

New Changes:

- Added a ballot header to the office page
- Reused the same Ballot Header component with prop-based switches to support office page specific adjustments and  maintain component consistency

Bug Fixes:

- Added truncation for long election names when they exceed a single line, with an ellipsis (...) displayed at the end
- Added a black background Popover to display the full election name on hover/focus

[WV-4253]: https://wevoteusa.atlassian.net/browse/WV-4253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ