### PR TITLE
[WV-1734]When the "Share" button on Ballot Page is clicked, change the URL in address bar to include "/modal/share" at end [TEAM REVIEW]

### DIFF
--- a/src/js/components/Share/ShareButtonDesktopTablet.jsx
+++ b/src/js/components/Share/ShareButtonDesktopTablet.jsx
@@ -177,7 +177,7 @@ class ShareButtonDesktopTablet extends Component {
     AppObservableStore.setShowShareModal(true);
     AppObservableStore.setWhatAndHowMuchToShare(whatAndHowMuchToShare);
     if (!stringContains('/modal/share', pathname) && isWebApp()) {
-    //  console.log('Navigation ShareButtonDesktopTablet openShareModal ', pathnameWithModalShare);
+      // console.log('Navigation ShareButtonDesktopTablet openShareModal ', pathnameWithModalShare);
       historyPush(pathnameWithModalShare, false, false);
     }
   }

--- a/src/js/components/Share/ShareButtonDesktopTablet.jsx
+++ b/src/js/components/Share/ShareButtonDesktopTablet.jsx
@@ -177,8 +177,8 @@ class ShareButtonDesktopTablet extends Component {
     AppObservableStore.setShowShareModal(true);
     AppObservableStore.setWhatAndHowMuchToShare(whatAndHowMuchToShare);
     if (!stringContains('/modal/share', pathname) && isWebApp()) {
-      // console.log('Navigation ShareButtonDesktopTablet openShareModal ', pathnameWithModalShare)
-      historyPush(pathnameWithModalShare, false, true);
+    //  console.log('Navigation ShareButtonDesktopTablet openShareModal ', pathnameWithModalShare);
+      historyPush(pathnameWithModalShare, false, false);
     }
   }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-1734]When the "Share" button on Ballot Page is clicked, change the URL in address bar to include "/modal/share" at end 
### Changes included this pull request?
src/js/components/Share/ShareButtonDesktopTablet.jsx
Update historyPush call to update history so that the url in address bar reflect /modal/share at end.

[WV-1734]: https://wevoteusa.atlassian.net/browse/WV-1734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ