### PR TITLE
[WV-2665] Auto-detect BrowserStack endpoint for browser vs app-automate sessions

### DIFF
--- a/tests/browserstack_automation/utils/uploadVideosToDriveFromBrowserStack.js
+++ b/tests/browserstack_automation/utils/uploadVideosToDriveFromBrowserStack.js
@@ -15,8 +15,27 @@ async function getDriveClient() {
   return getAuthenticatedDriveClient();
 }
 
+const AUTOMATE_ENDPOINTS = [
+  'https://api.browserstack.com/automate/sessions',
+  'https://api.browserstack.com/app-automate/sessions',
+];
+
+async function resolveSessionEndpoint(sessionId, auth) {
+  for (const base of AUTOMATE_ENDPOINTS) {
+    try {
+      const response = await axios.get(`${base}/${sessionId}.json`, { auth });
+      if (response.data?.automation_session) {
+        console.log(`Session found at: ${base}`);
+        return { base, data: response.data };
+      }
+    } catch (err) {
+      if (err.response?.status !== 404) throw err;
+    }
+  }
+  throw new Error(`Session ${sessionId} not found on any BrowserStack endpoint`);
+}
+
 async function getVideoUrl(sessionId) {
-  const url = `https://api.browserstack.com/app-automate/sessions/${sessionId}.json`;
   const auth = {
     username: browserStackConfig.BROWSERSTACK_USER,
     password: browserStackConfig.BROWSERSTACK_KEY,
@@ -27,11 +46,11 @@ async function getVideoUrl(sessionId) {
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const response = await axios.get(url, { auth });
-      const videoUrl = response.data?.automation_session?.video_url;
+      const { base, data } = await resolveSessionEndpoint(sessionId, auth);
+      const videoUrl = data?.automation_session?.video_url;
 
       if (videoUrl) {
-        console.log(`Video URL fetched: ${videoUrl}`);
+        console.log(`Video URL fetched from ${base}: ${videoUrl}`);
         return videoUrl;
       }
 


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

Linear ticket WV-2665: Create a utility to automatically download Cordova Apps from the Google Drive folder and upload on developer's machine. Also to check if the utility can be reused for uploading items to Google Drive.

### Changes included this pull request?

- Fixed `uploadVideosToDriveFromBrowserStack.js` to auto-detect the correct BrowserStack API endpoint (`automate` vs `app-automate`) rather than hardcoding one — the utility now works for both browser automation (ProductDemo) and native app (Cordova) sessions without any configuration change.
