### PR TITLE
Introduce a quarantine period for dependency updates

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 init-author-name="We Vote Dev Team"
 init-author-email="info@wevote.us"
+
+min-release-age=3

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -2,6 +2,7 @@
   FROM public.ecr.aws/docker/library/node:25 AS builder
   WORKDIR /app
   COPY package.json package-lock.json ./
+  COPY .npmrc ./
   # TO DEVELOPERS:
   # If `npm ci` causes issues, try `npm install` instead
   # and notify Marcel Jacquot on Slack of your error


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
Adding in `min-release-age=3` limits the updates of packages to older than 3 days. This helps prevent supply chain attacks.

Also set to copy the config file into the docker container.

### Changes included this pull request?
https://wevoteusa.atlassian.net/browse/WV-4650

## Testing
<img width="1008" height="634" alt="image" src="https://github.com/user-attachments/assets/4f3b041f-24cd-4f52-ac03-c5ac7226bab5" />
