### PR TITLE
WV-4665: Add candidate search to Election Finder list pages with grouped results and loading states

### DIFF
--- a/src/js/actions/CandidateActions.js
+++ b/src/js/actions/CandidateActions.js
@@ -10,11 +10,11 @@ export default {
     );
   },
 
-  candidatesQuery (electionDay = '', raceOfficeLevelList = '', stateCode = '', searchText = '') {
-    Dispatcher.loadEndpoint(
+  candidatesQuery (electionDay = '', raceOfficeLevelList = '', stateCode = '', searchText = '', numberRequested = 24) {
+    return Dispatcher.loadEndpoint(
       'candidatesQuery',
       {
-        numberRequested: 24,
+        numberRequested,
         electionDay,
         raceOfficeLevelList,
         searchText,

--- a/src/js/pages/ElectionFinder/ElectionFinderForElection.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderForElection.jsx
@@ -20,34 +20,20 @@ import CopyChip from './CopyChip';
 import copyAndToast from './copyAndToast';
 import formatDateLong from './dateHelpers';
 import ElectionFinderHeader from './ElectionFinderHeader';
+import highlightMatch from './highlightMatch';
 import RowKebabMenu from './RowKebabMenu';
 import {
   ActionDivider, DarkTooltip,
   CandidateActions as CandidateActionsRow, CandidateInfo, CandidateList, CandidateName,
   CandidateParty, CandidateRow, DetailTitle, ElectionDetailDate, ElectionTitleRow,
   ExpandCollapseButton, ExpandCollapseRow, ExpandMoreIcon,
-  HighlightSpan, InlineSearchField, NoResults,
+  InlineSearchField, NoResults,
   OfficeHeader, OfficeHeaderActions, OfficeHeaderLeft, OfficeName, OfficePrimaryPartySpan,
   OfficeSection, SearchIconButton, SearchResultCount, ShowMoreButton,
 } from './electionFinderStyles';
 import webAppConfig from '../../config';
 
 const nextReleaseFeaturesEnabled = webAppConfig.ENABLE_NEXT_RELEASE_FEATURES === undefined ? false : webAppConfig.ENABLE_NEXT_RELEASE_FEATURES;
-
-function highlightMatch (text, query) {
-  if (!query) return text;
-  const words = query.trim().split(/\s+/).filter(Boolean);
-  if (words.length === 0) return text;
-  const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-  const regex = new RegExp(`(${escaped.join('|')})`, 'gi');
-  const lowerWords = words.map((w) => w.toLowerCase());
-  return text.split(regex).map((part, idx) => {
-    if (lowerWords.includes(part.toLowerCase())) {
-      return <HighlightSpan key={`hl-${idx}-${part}`}>{part}</HighlightSpan>; // eslint-disable-line react/no-array-index-key
-    }
-    return part;
-  });
-}
 
 function ElectionFinderForElection () {
   renderLog('ElectionFinderForElection');

--- a/src/js/pages/ElectionFinder/ElectionFinderForState.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderForState.jsx
@@ -3,6 +3,7 @@ import { IconButton, InputAdornment } from '@mui/material';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { useParams } from 'react-router-dom';
+import CandidateActions from '../../actions/CandidateActions';
 import ElectionActions from '../../actions/ElectionActions';
 import { renderLog } from '../../common/utils/logging';
 import { stateCodeMap, convertStateCodeToStateText } from '../../common/utils/addressFunctions';
@@ -10,16 +11,20 @@ import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import historyPush from '../../common/utils/historyPush';
 import SnackNotifier from '../../common/components/Widgets/SnackNotifier';
+import CandidateStore from '../../stores/CandidateStore';
 import ElectionStore from '../../stores/ElectionStore';
+import buildCandidateSearchResults from './buildCandidateSearchResults';
 import CopyChip from './CopyChip';
 import copyAndToast from './copyAndToast';
 import formatDateLong from './dateHelpers';
 import ElectionFinderHeader from './ElectionFinderHeader';
+import highlightMatch from './highlightMatch';
 import RowKebabMenu from './RowKebabMenu';
 import {
-  ActionDivider, DarkTooltip,
+  ActionDivider, CandidateInfo, CandidateList, CandidateName, CandidateParty, CandidateRow, DarkTooltip,
   ElectionDateText, ElectionLink, ElectionList, ElectionRow, ElectionRowActions, ElectionRowText,
   FilterTab, FilterTabsRow, InlineSearchField, NoResults,
+  OfficeName, OfficeSection,
   SearchIconButton, SectionTitle, SectionTitleRow, ShowMoreButton,
   StateSelectWrapper, StateSelectNative, StateSelectLabel, StateSelectCaret,
 } from './electionFinderStyles';
@@ -67,8 +72,11 @@ function ElectionFinderForState () {
   const [visibleCount, setVisibleCount] = useState(50);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
+  const [candidateList, setCandidateList] = useState([]);
+  const [candidateSearchLoading, setCandidateSearchLoading] = useState(false);
   const searchInputRef = useRef(null);
   const searchDebounceRef = useRef(null);
+  const pendingCandidateSearchRef = useRef('');
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -76,10 +84,15 @@ function ElectionFinderForState () {
       const list = ElectionStore.getElectionList();
       setElectionList(list);
     });
+    const candidateListener = CandidateStore.addListener(() => {
+      setCandidateList(CandidateStore.getCandidateList());
+    });
     ElectionActions.electionsRetrieve();
     return () => {
       listener.remove();
+      candidateListener.remove();
       clearTimeout(searchDebounceRef.current);
+      pendingCandidateSearchRef.current = null;
     };
   }, []);
 
@@ -112,19 +125,17 @@ function ElectionFinderForState () {
     historyPush(`/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`);
   }, [selectedStateCode]);
 
-  let stateElections = electionList.filter((el) => matchesStateCode(el, selectedStateCode));
+  const stateElections = electionList.filter((el) => matchesStateCode(el, selectedStateCode));
 
-  // Apply search filter before splitting upcoming/past so counts reflect the search
-  if (searchText) {
-    const lowerSearch = searchText.toLowerCase();
-    stateElections = stateElections.filter(
-      (el) => (el.election_name || '').toLowerCase().includes(lowerSearch) ||
-              (el.election_day_text || '').toLowerCase().includes(lowerSearch),
-    );
-  }
+  // When searching, union election-name matches with candidate-name matches
+  // (grouped Election -> Office -> Candidate) before splitting upcoming/past, so
+  // the tab counts reflect the search.
+  const workingList = searchText ?
+    buildCandidateSearchResults(stateElections, candidateList, searchText, selectedStateCode) :
+    stateElections;
 
-  const upcomingElections = stateElections.filter((el) => el.election_is_upcoming).sort(sortByDateAsc);
-  const pastElections = stateElections.filter((el) => !el.election_is_upcoming);
+  const upcomingElections = workingList.filter((el) => el.election_is_upcoming).sort(sortByDateAsc);
+  const pastElections = workingList.filter((el) => !el.election_is_upcoming);
   const upcomingCount = upcomingElections.length;
   const pastCount = pastElections.length;
 
@@ -149,6 +160,37 @@ function ElectionFinderForState () {
   } else {
     sectionDownloadLabel = 'Download data for all upcoming elections';
   }
+
+  const emptyListMessage = (() => {
+    if (electionList.length === 0) return 'Loading...';
+    if (searchText) {
+      if (candidateSearchLoading) return 'Fetching data...';
+      return 'Your search did not return any results. Try another search.';
+    }
+    return 'No elections found.';
+  })();
+
+  const runCandidateSearch = useCallback((value) => {
+    setSearchText(value);
+    if (!value) {
+      pendingCandidateSearchRef.current = '';
+      setCandidateSearchLoading(false);
+      return;
+    }
+    pendingCandidateSearchRef.current = value;
+    setCandidateSearchLoading(true);
+    const request = CandidateActions.candidatesQuery('', [], selectedStateCode, value, 100);
+    const finishSearch = () => {
+      if (pendingCandidateSearchRef.current === value) {
+        setCandidateSearchLoading(false);
+      }
+    };
+    if (request && typeof request.always === 'function') {
+      request.always(finishSearch);
+    } else {
+      finishSearch();
+    }
+  }, [selectedStateCode]);
 
   return (
     <>
@@ -191,8 +233,11 @@ function ElectionFinderForState () {
               inputRef={searchInputRef}
               defaultValue=""
               onChange={(e) => {
+                const { value } = e.target;
                 clearTimeout(searchDebounceRef.current);
-                searchDebounceRef.current = setTimeout(() => setSearchText(e.target.value), 300);
+                searchDebounceRef.current = setTimeout(() => {
+                  runCandidateSearch(value);
+                }, 300);
               }}
               autoFocus
               InputProps={{
@@ -206,6 +251,8 @@ function ElectionFinderForState () {
                       onClick={() => {
                         if (searchInputRef.current) searchInputRef.current.value = '';
                         setSearchOpen(false);
+                        pendingCandidateSearchRef.current = '';
+                        setCandidateSearchLoading(false);
                         setSearchText('');
                       }}
                     >
@@ -235,42 +282,65 @@ function ElectionFinderForState () {
           {(searchText ? displayElections : displayElections.slice(0, visibleCount)).map((election) => {
             const googleCivicElectionId = election.google_civic_election_id;
             return (
-              <ElectionRow
-                key={googleCivicElectionId}
-                onClick={() => onElectionSelect(googleCivicElectionId)}
-              >
-                <ElectionRowText>
-                  <ElectionLink>{election.election_name || ''}</ElectionLink>
-                  {election.election_day_text && (
-                    <ElectionDateText>{formatDateLong(election.election_day_text)}</ElectionDateText>
-                  )}
-                </ElectionRowText>
-                <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-                  <CopyChip
-                    defaultLabel="Copy link"
-                    getText={() => `${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`}
-                  />
-                  <ActionDivider />
-                  {nextReleaseFeaturesEnabled && (
-                    <DarkTooltip title="Download election data">
-                      <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
+              <React.Fragment key={googleCivicElectionId}>
+                <ElectionRow onClick={() => onElectionSelect(googleCivicElectionId)}>
+                  <ElectionRowText>
+                    <ElectionLink>{election.election_name || ''}</ElectionLink>
+                    {election.election_day_text && (
+                      <ElectionDateText>{formatDateLong(election.election_day_text)}</ElectionDateText>
+                    )}
+                  </ElectionRowText>
+                  <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
+                    <CopyChip
+                      defaultLabel="Copy link"
+                      getText={() => `${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`}
+                    />
+                    <ActionDivider />
+                    {nextReleaseFeaturesEnabled && (
+                      <DarkTooltip title="Download election data">
+                        <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
+                      </DarkTooltip>
+                    )}
+                    <DarkTooltip title="Open in new tab">
+                      <IconButton size="small" onClick={() => window.open(`/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`, '_blank')}>
+                        <Launch fontSize="small" />
+                      </IconButton>
                     </DarkTooltip>
-                  )}
-                  <DarkTooltip title="Open in new tab">
-                    <IconButton size="small" onClick={() => window.open(`/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`, '_blank')}>
-                      <Launch fontSize="small" />
-                    </IconButton>
-                  </DarkTooltip>
-                </ElectionRowActions>
-                <RowKebabMenu
-                  ariaLabel="More options for this election"
-                  items={[
-                    { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`) },
-                    ...(nextReleaseFeaturesEnabled ? [{ key: 'download', icon: FileDownloadOutlined, label: 'Download election data', onClick: () => {} }] : []),
-                    { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(`/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`, '_blank') },
-                  ]}
-                />
-              </ElectionRow>
+                  </ElectionRowActions>
+                  <RowKebabMenu
+                    ariaLabel="More options for this election"
+                    items={[
+                      { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`) },
+                      ...(nextReleaseFeaturesEnabled ? [{ key: 'download', icon: FileDownloadOutlined, label: 'Download election data', onClick: () => {} }] : []),
+                      { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(`/election-finder/${selectedStateCode.toLowerCase()}/${googleCivicElectionId}`, '_blank') },
+                    ]}
+                  />
+                </ElectionRow>
+                {searchText && election.matchedOffices && election.matchedOffices.map((office) => (
+                  <OfficeSection key={office.officeWeVoteId || office.officeName}>
+                    <OfficeName style={{ display: 'block', padding: '7px 16px 7px 32px' }}>
+                      {highlightMatch(office.officeName, searchText)}
+                      {` (${office.candidates.length})`}
+                    </OfficeName>
+                    <CandidateList>
+                      {office.candidates.map((candidate) => (
+                        <CandidateRow
+                          key={candidate.we_vote_id}
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => onElectionSelect(googleCivicElectionId)}
+                        >
+                          <CandidateInfo>
+                            <CandidateName>
+                              {highlightMatch(candidate.ballot_item_display_name || candidate.candidate_name || '', searchText)}
+                            </CandidateName>
+                            <CandidateParty>{candidate.party || ''}</CandidateParty>
+                          </CandidateInfo>
+                        </CandidateRow>
+                      ))}
+                    </CandidateList>
+                  </OfficeSection>
+                ))}
+              </React.Fragment>
             );
           })}
           {!searchText && displayElections.length > visibleCount && (
@@ -279,7 +349,7 @@ function ElectionFinderForState () {
             </ShowMoreButton>
           )}
           {displayElections.length === 0 && (
-            <NoResults>{electionList.length === 0 ? 'Loading...' : 'No elections found.'}</NoResults>
+            <NoResults>{emptyListMessage}</NoResults>
           )}
         </ElectionList>
       </PageContentContainer>

--- a/src/js/pages/ElectionFinder/ElectionFinderHome.jsx
+++ b/src/js/pages/ElectionFinder/ElectionFinderHome.jsx
@@ -2,6 +2,7 @@ import { ContentCopy, ExpandMore, FileDownloadOutlined, Launch, Search, Close } 
 import { IconButton, InputAdornment } from '@mui/material';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Helmet } from 'react-helmet-async';
+import CandidateActions from '../../actions/CandidateActions';
 import ElectionActions from '../../actions/ElectionActions';
 import { renderLog } from '../../common/utils/logging';
 import { stateCodeMap, convertStateCodeToStateText } from '../../common/utils/addressFunctions';
@@ -9,16 +10,20 @@ import isMobileScreenSize from '../../common/utils/isMobileScreenSize';
 import { PageContentContainer } from '../../components/Style/pageLayoutStyles';
 import historyPush from '../../common/utils/historyPush';
 import SnackNotifier from '../../common/components/Widgets/SnackNotifier';
+import CandidateStore from '../../stores/CandidateStore';
 import ElectionStore from '../../stores/ElectionStore';
+import buildCandidateSearchResults from './buildCandidateSearchResults';
 import CopyChip from './CopyChip';
 import copyAndToast from './copyAndToast';
 import formatDateLong from './dateHelpers';
 import ElectionFinderHeader from './ElectionFinderHeader';
+import highlightMatch from './highlightMatch';
 import RowKebabMenu from './RowKebabMenu';
 import {
-  ActionDivider, DarkTooltip,
+  ActionDivider, CandidateInfo, CandidateList, CandidateName, CandidateParty, CandidateRow, DarkTooltip,
   ElectionDateText, ElectionLink, ElectionList, ElectionRow, ElectionRowActions, ElectionRowText,
   FilterTab, FilterTabsRow, InlineSearchField, NoResults,
+  OfficeName, OfficeSection,
   SearchIconButton, SectionTitle, SectionTitleRow, ShowMoreButton,
   StateSelectWrapper, StateSelectNative, StateSelectLabel, StateSelectCaret,
 } from './electionFinderStyles';
@@ -42,8 +47,11 @@ function ElectionFinderHome () {
   const [visibleCount, setVisibleCount] = useState(50);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchText, setSearchText] = useState('');
+  const [candidateList, setCandidateList] = useState([]);
+  const [candidateSearchLoading, setCandidateSearchLoading] = useState(false);
   const searchInputRef = useRef(null);
   const searchDebounceRef = useRef(null);
+  const pendingCandidateSearchRef = useRef('');
 
   useEffect(() => {
     window.scrollTo(0, 0);
@@ -56,10 +64,15 @@ function ElectionFinderHome () {
         return prev;
       });
     });
+    const candidateListener = CandidateStore.addListener(() => {
+      setCandidateList(CandidateStore.getCandidateList());
+    });
     ElectionActions.electionsRetrieve();
     return () => {
       listener.remove();
+      candidateListener.remove();
       clearTimeout(searchDebounceRef.current);
+      pendingCandidateSearchRef.current = null;
     };
   }, []);
 
@@ -92,17 +105,15 @@ function ElectionFinderHome () {
     );
   }
 
-  // Apply search filter before splitting upcoming/past so counts reflect the search
-  if (searchText) {
-    const lowerSearch = searchText.toLowerCase();
-    filteredByState = filteredByState.filter(
-      (el) => (el.election_name || '').toLowerCase().includes(lowerSearch) ||
-              (el.election_day_text || '').toLowerCase().includes(lowerSearch),
-    );
-  }
+  // When searching, union election-name matches with candidate-name matches
+  // (grouped Election -> Office -> Candidate) before splitting upcoming/past, so
+  // the tab counts reflect the search.
+  const workingList = searchText ?
+    buildCandidateSearchResults(filteredByState, candidateList, searchText, '') :
+    filteredByState;
 
-  const upcomingElections = filteredByState.filter((el) => el.election_is_upcoming).sort(sortByDateAsc);
-  const pastElections = filteredByState.filter((el) => !el.election_is_upcoming);
+  const upcomingElections = workingList.filter((el) => el.election_is_upcoming).sort(sortByDateAsc);
+  const pastElections = workingList.filter((el) => !el.election_is_upcoming);
   const upcomingCount = upcomingElections.length;
   const pastCount = pastElections.length;
 
@@ -123,6 +134,37 @@ function ElectionFinderHome () {
   const sectionDownloadLabel = filterTab === 'past' ?
     'Download data for all past elections' :
     'Download data for all upcoming elections';
+
+  const emptyListMessage = (() => {
+    if (electionList.length === 0) return 'Loading...';
+    if (searchText) {
+      if (candidateSearchLoading) return 'Fetching data...';
+      return 'Your search did not return any results. Try another search.';
+    }
+    return 'No elections found.';
+  })();
+
+  const runCandidateSearch = useCallback((value) => {
+    setSearchText(value);
+    if (!value) {
+      pendingCandidateSearchRef.current = '';
+      setCandidateSearchLoading(false);
+      return;
+    }
+    pendingCandidateSearchRef.current = value;
+    setCandidateSearchLoading(true);
+    const request = CandidateActions.candidatesQuery('', [], '', value, 100);
+    const finishSearch = () => {
+      if (pendingCandidateSearchRef.current === value) {
+        setCandidateSearchLoading(false);
+      }
+    };
+    if (request && typeof request.always === 'function') {
+      request.always(finishSearch);
+    } else {
+      finishSearch();
+    }
+  }, []);
 
   return (
     <>
@@ -157,8 +199,11 @@ function ElectionFinderHome () {
               inputRef={searchInputRef}
               defaultValue=""
               onChange={(e) => {
+                const { value } = e.target;
                 clearTimeout(searchDebounceRef.current);
-                searchDebounceRef.current = setTimeout(() => setSearchText(e.target.value), 300);
+                searchDebounceRef.current = setTimeout(() => {
+                  runCandidateSearch(value);
+                }, 300);
               }}
               autoFocus
               InputProps={{
@@ -172,6 +217,8 @@ function ElectionFinderHome () {
                       onClick={() => {
                         if (searchInputRef.current) searchInputRef.current.value = '';
                         setSearchOpen(false);
+                        pendingCandidateSearchRef.current = '';
+                        setCandidateSearchLoading(false);
                         setSearchText('');
                       }}
                     >
@@ -205,43 +252,66 @@ function ElectionFinderHome () {
               'na';
             const electionUrl = `/election-finder/${sc}/${googleCivicElectionId}`;
             return (
-              <ElectionRow
-                key={googleCivicElectionId}
-                onClick={() => onElectionSelect(election)}
-              >
-                <ElectionRowText>
-                  <ElectionLink>
-                    {election.state_code && election.state_code !== 'NA' ?
-                      `${convertStateCodeToStateText(election.state_code)} – ${election.election_name || ''}` :
-                      (election.election_name || '')}
-                  </ElectionLink>
-                  {election.election_day_text && (
-                    <ElectionDateText>{formatDateLong(election.election_day_text)}</ElectionDateText>
-                  )}
-                </ElectionRowText>
-                <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
-                  <CopyChip defaultLabel="Copy link" getText={() => `${window.location.origin}${electionUrl}`} />
-                  <ActionDivider />
-                  {nextReleaseFeaturesEnabled && (
-                    <DarkTooltip title="Download election data">
-                      <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
+              <React.Fragment key={googleCivicElectionId}>
+                <ElectionRow onClick={() => onElectionSelect(election)}>
+                  <ElectionRowText>
+                    <ElectionLink>
+                      {election.state_code && election.state_code !== 'NA' ?
+                        `${convertStateCodeToStateText(election.state_code)} – ${election.election_name || ''}` :
+                        (election.election_name || '')}
+                    </ElectionLink>
+                    {election.election_day_text && (
+                      <ElectionDateText>{formatDateLong(election.election_day_text)}</ElectionDateText>
+                    )}
+                  </ElectionRowText>
+                  <ElectionRowActions className="u-show-desktop-tablet" onClick={(e) => e.stopPropagation()}>
+                    <CopyChip defaultLabel="Copy link" getText={() => `${window.location.origin}${electionUrl}`} />
+                    <ActionDivider />
+                    {nextReleaseFeaturesEnabled && (
+                      <DarkTooltip title="Download election data">
+                        <IconButton size="small"><FileDownloadOutlined fontSize="small" /></IconButton>
+                      </DarkTooltip>
+                    )}
+                    <DarkTooltip title="Open in new tab">
+                      <IconButton size="small" onClick={() => window.open(electionUrl, '_blank')}>
+                        <Launch fontSize="small" />
+                      </IconButton>
                     </DarkTooltip>
-                  )}
-                  <DarkTooltip title="Open in new tab">
-                    <IconButton size="small" onClick={() => window.open(electionUrl, '_blank')}>
-                      <Launch fontSize="small" />
-                    </IconButton>
-                  </DarkTooltip>
-                </ElectionRowActions>
-                <RowKebabMenu
-                  ariaLabel="More options for this election"
-                  items={[
-                    { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}${electionUrl}`) },
-                    ...(nextReleaseFeaturesEnabled ? [{ key: 'download', icon: FileDownloadOutlined, label: 'Download election data', onClick: () => {} }] : []),
-                    { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(electionUrl, '_blank') },
-                  ]}
-                />
-              </ElectionRow>
+                  </ElectionRowActions>
+                  <RowKebabMenu
+                    ariaLabel="More options for this election"
+                    items={[
+                      { key: 'copy-link', icon: ContentCopy, label: 'Copy link', onClick: () => copyAndToast(`${window.location.origin}${electionUrl}`) },
+                      ...(nextReleaseFeaturesEnabled ? [{ key: 'download', icon: FileDownloadOutlined, label: 'Download election data', onClick: () => {} }] : []),
+                      { key: 'open', icon: Launch, label: 'Open in new tab', onClick: () => window.open(electionUrl, '_blank') },
+                    ]}
+                  />
+                </ElectionRow>
+                {searchText && election.matchedOffices && election.matchedOffices.map((office) => (
+                  <OfficeSection key={office.officeWeVoteId || office.officeName}>
+                    <OfficeName style={{ display: 'block', padding: '7px 16px 7px 32px' }}>
+                      {highlightMatch(office.officeName, searchText)}
+                      {` (${office.candidates.length})`}
+                    </OfficeName>
+                    <CandidateList>
+                      {office.candidates.map((candidate) => (
+                        <CandidateRow
+                          key={candidate.we_vote_id}
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => onElectionSelect(election)}
+                        >
+                          <CandidateInfo>
+                            <CandidateName>
+                              {highlightMatch(candidate.ballot_item_display_name || candidate.candidate_name || '', searchText)}
+                            </CandidateName>
+                            <CandidateParty>{candidate.party || ''}</CandidateParty>
+                          </CandidateInfo>
+                        </CandidateRow>
+                      ))}
+                    </CandidateList>
+                  </OfficeSection>
+                ))}
+              </React.Fragment>
             );
           })}
           {!searchText && displayElections.length > visibleCount && (
@@ -250,7 +320,7 @@ function ElectionFinderHome () {
             </ShowMoreButton>
           )}
           {displayElections.length === 0 && (
-            <NoResults>{electionList.length === 0 ? 'Loading...' : 'No elections found.'}</NoResults>
+            <NoResults>{emptyListMessage}</NoResults>
           )}
         </ElectionList>
       </PageContentContainer>

--- a/src/js/pages/ElectionFinder/buildCandidateSearchResults.js
+++ b/src/js/pages/ElectionFinder/buildCandidateSearchResults.js
@@ -1,0 +1,82 @@
+// Pure helper for Election Finder search. Given the already state-scoped election
+// list, the cached candidate list (from CandidateStore.getCandidateList()), the
+// current search text, and the selected state code, returns the unioned, deduped
+// set of "result elections". Each result is the original election object augmented
+// with a `matchedOffices` array describing which offices/candidates matched.
+//
+// An election is included when its name/date matches the query (existing behavior)
+// OR when it contains a candidate whose name matches. Results are deduped by
+// google_civic_election_id, and candidates whose election is not present in
+// scopedElectionList are dropped (we have no election row to attach them to).
+//
+// matchedOffices shape: [{ officeWeVoteId, officeName, candidates: [candidate, ...] }]
+// Elections that matched only by name carry an empty matchedOffices array.
+
+import { convertStateCodeToStateText } from '../../common/utils/addressFunctions';
+
+function getCandidateName (candidate) {
+  return candidate.ballot_item_display_name || candidate.candidate_name || '';
+}
+
+function getElectionSearchText (election) {
+  const parts = [
+    election.election_name,
+    election.election_day_text,
+  ];
+
+  if (election.state_code && election.state_code !== 'NA') {
+    parts.push(convertStateCodeToStateText(election.state_code));
+    parts.push(election.state_code); // optional: match "AL" as well as "Alabama"
+  }
+
+  return parts.filter(Boolean).join(' ').toLowerCase();
+}
+
+export default function buildCandidateSearchResults (scopedElectionList, candidateList, searchText, selectedStateCode) {
+  const lowerSearch = (searchText || '').toLowerCase().trim();
+  if (!lowerSearch) return scopedElectionList;
+
+  const electionById = {};
+  scopedElectionList.forEach((election) => {
+    electionById[parseInt(election.google_civic_election_id, 10)] = election;
+  });
+
+  // Elections matched by name or date
+  const matchedElectionIds = new Set();
+  scopedElectionList.forEach((election) => {
+    const nameHit = getElectionSearchText(election).includes(lowerSearch);
+    if (nameHit) matchedElectionIds.add(parseInt(election.google_civic_election_id, 10));
+  });
+
+  // Candidate matches grouped by election -> office
+  const stateFilter = (selectedStateCode || '').toUpperCase();
+  const officesByElectionId = {};
+  (candidateList || []).forEach((candidate) => {
+    if (!getCandidateName(candidate).toLowerCase().includes(lowerSearch)) return;
+    if (stateFilter && candidate.state_code && candidate.state_code.toUpperCase() !== stateFilter) return;
+    const electionId = parseInt(candidate.google_civic_election_id, 10);
+    if (!electionId || !(electionId in electionById)) return;
+
+    if (!(electionId in officesByElectionId)) officesByElectionId[electionId] = {};
+    const officeKey = candidate.contest_office_we_vote_id || candidate.contest_office_name || 'unknown';
+    if (!(officeKey in officesByElectionId[electionId])) {
+      officesByElectionId[electionId][officeKey] = {
+        officeWeVoteId: candidate.contest_office_we_vote_id || '',
+        officeName: candidate.contest_office_name || '',
+        candidates: [],
+      };
+    }
+    officesByElectionId[electionId][officeKey].candidates.push(candidate);
+    matchedElectionIds.add(electionId);
+  });
+
+  // Build augmented results, preserving the scopedElectionList ordering
+  const results = [];
+  scopedElectionList.forEach((election) => {
+    const electionId = parseInt(election.google_civic_election_id, 10);
+    if (!matchedElectionIds.has(electionId)) return;
+    const officeMap = officesByElectionId[electionId] || {};
+    results.push({ ...election, matchedOffices: Object.values(officeMap) });
+  });
+  return results;
+}

--- a/src/js/pages/ElectionFinder/highlightMatch.jsx
+++ b/src/js/pages/ElectionFinder/highlightMatch.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { HighlightSpan } from './electionFinderStyles';
+
+// Wraps each occurrence of any word in `query` found within `text` in a
+// <HighlightSpan>, so matched search terms render highlighted. Returns the
+// original text unchanged when there is no query.
+export default function highlightMatch (text, query) {
+  if (!query) return text;
+  const words = query.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return text;
+  const escaped = words.map((w) => w.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const regex = new RegExp(`(${escaped.join('|')})`, 'gi');
+  const lowerWords = words.map((w) => w.toLowerCase());
+  return text.split(regex).map((part, idx) => {
+    if (lowerWords.includes(part.toLowerCase())) {
+      return <HighlightSpan key={`hl-${idx}-${part}`}>{part}</HighlightSpan>; // eslint-disable-line react/no-array-index-key
+    }
+    return part;
+  });
+}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
### WV-4665

### Changes included this pull request?
## Summary

Implements WV-4665: voters can search for candidates on the Election Finder **Home** and **State** list pages to see which election(s) a person is running in. Search returns election-centric results grouped as **Election → Office → Candidate**, with matched terms highlighted. Also improves empty-state messaging while candidate data is loading, and extends election-name search to include resolved state names from `state_code`.

## What changed

### New modules
- **`buildCandidateSearchResults.js`** — Pure helper that unions election-name matches with candidate-name matches (deduped by `google_civic_election_id`). Candidate matches are grouped under offices via `matchedOffices`. Re-filters the shared `CandidateStore` cache by current search text.
- **`highlightMatch.jsx`** — Shared term-highlighting helper (extracted from the election detail page).

### List pages (`ElectionFinderHome`, `ElectionFinderForState`)
- Debounced search calls `CandidateActions.candidatesQuery` (100 results) and subscribes to `CandidateStore`.
- When searching, renders office/candidate sub-rows under matching elections; clicking a row navigates to the election detail page.
- Tab counts (Upcoming/Past/All) reflect active search results.
- Empty states: **"Fetching data…"** while `candidatesQuery` is in flight; **"Your search did not return any results…"** after fetch completes with no matches.

### Other
- **`CandidateActions.candidatesQuery`** — Backward-compatible 5th param `numberRequested` (default 24); returns the AJAX promise so pages can track loading. List pages pass `100`.
- **`ElectionFinderForElection`** — Uses shared `highlightMatch`; no behavior change.
- **`_election_finder_docs/candidate-search-flow.md`** — Sequence diagram and code cheatsheet for team walkthrough.

## How it works

1. User types a query → debounced `candidatesQuery` populates the shared candidate cache.
2. `buildCandidateSearchResults` unions:
   - Elections matching name, date, or resolved `state_code` / state name
   - Elections containing candidates whose names match (re-filtered from cache)
3. Results preserve list ordering; candidates whose election isn't in the scoped list are dropped.