### PR TITLE
Fix verification modal getting stuck on Verifying after a correct code (WV-4229)

### DIFF
--- a/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
+++ b/src/js/common/components/Settings/SettingsVerifySecretCode.jsx
@@ -508,6 +508,11 @@ class SettingsVerifySecretCode extends Component {
     // console.log('voterVerifySecretCode this.props.closeVerifyModal:', this.props.closeVerifyModal);
     if (this.props.closeSignInModal) {
       this.props.closeSignInModal();
+    } else if (this.props.closeVerifyModal) {
+      // WV-4229: Some entry points (WelcomeForVoters, CompleteYourProfile, SetUpAccountEditName)
+      // only pass closeVerifyModal, not closeSignInModal. Without this fallback, a successful
+      // code verification leaves the modal stuck on "Verifying...".
+      this.props.closeVerifyModal();
     }
   };
 


### PR DESCRIPTION
When you signed up with your name and email on the For Voters page and then entered the emailed 6-digit code, the modal would get stuck on Verifying forever instead of finishing. On a successful verification the component tried to close the modal by calling closeSignInModalLocal, but that function only does something if a closeSignInModal prop was passed in. A few of the places that use this modal, namely WelcomeForVoters, CompleteYourProfile, and SetUpAccountEditName, only pass closeVerifyModal instead, so on success nothing actually closed the modal and it just sat there saying Verifying. Entering a wrong code still worked fine since that path uses closeVerifyModal, so only the success case was broken. The fix just adds a fallback so that when closeSignInModal isn't there it uses closeVerifyModal instead, which gets those three flows working again without changing any of the flows that already passed closeSignInModal. I reproduced the stuck state first, then confirmed the modal now closes on a correct code, and checked that a wrong code still shows the error and lets you try again.