### PR TITLE
WV-2664: Persist heart like/dislike icon and keep support tally in sync

### DIFF
--- a/src/js/common/components/CampaignSupport/CampaignSupportThermometer.jsx
+++ b/src/js/common/components/CampaignSupport/CampaignSupportThermometer.jsx
@@ -9,7 +9,7 @@ import { renderLog } from '../../utils/logging';
 import DesignTokenColors from '../Style/DesignTokenColors';
 import numberWithCommas from '../../utils/numberWithCommas';
 import CampaignStore from '../../stores/CampaignStore';
-import OrganizationStore from '../../../stores/OrganizationStore';
+import SupportStore from '../../../stores/SupportStore';
 
 class CampaignSupportThermometer extends React.Component {
   constructor (props) {
@@ -28,8 +28,8 @@ class CampaignSupportThermometer extends React.Component {
   componentDidMount () {
     this.onCampaignStoreChange();
     this.campaignStoreListener = CampaignStore.addListener(this.onCampaignStoreChange.bind(this));
-    this.onOrganizationStoreChange();
-    this.organizationStoreListener = OrganizationStore.addListener(this.onOrganizationStoreChange.bind(this));
+    this.onSupportStoreChange();
+    this.supportStoreListener = SupportStore.addListener(this.onSupportStoreChange.bind(this));
   }
 
   componentDidUpdate (prevProps, prevState) {
@@ -74,7 +74,7 @@ class CampaignSupportThermometer extends React.Component {
       clearTimeout(this.campaignTimer);
     }
     this.campaignTimer = null;
-    this.organizationStoreListener.remove();
+    this.supportStoreListener.remove();
   }
 
   onCampaignStoreChange () {
@@ -111,7 +111,7 @@ class CampaignSupportThermometer extends React.Component {
             politicianWeVoteId,
             supportersCount,
             supportersCountNextGoal: supportersCountNextGoalWithFloor,
-          }, () => this.onOrganizationStoreChange());
+          }, () => this.onSupportStoreChange());
         }
       } else if (campaignXWeVoteIdFromDict && !politicianWeVoteId) {
         this.setState({
@@ -124,17 +124,16 @@ class CampaignSupportThermometer extends React.Component {
     }
   }
 
-  onOrganizationStoreChange () {
-    // Lookup Organization data by politicianWeVoteId, so we can get the number of followers
-    const { politicianWeVoteId } = this.state;
-    // console.log('HeartFavoriteToggleLive onOrganizationStoreChange politicianWeVoteId:', politicianWeVoteId);
-    if (politicianWeVoteId) {
-      // console.log('voterOpposesCampaignX: ', OrganizationStore.isVoterDislikingThisPolitician(politicianWeVoteId));
-      // console.log('voterSupportsCampaignX: ', OrganizationStore.isVoterFollowingThisPolitician(politicianWeVoteId));
-      this.setState({
-        voterOpposesCampaignX: OrganizationStore.isVoterDislikingThisPolitician(politicianWeVoteId),
-        // voterSupportsCampaignX: OrganizationStore.isVoterFollowingThisPolitician(politicianWeVoteId),  // A variation on isVoterFollowingThisOrganization
-      });
+  onSupportStoreChange () {
+    // WV-4247 / WV-2664: The progress bar reflects the voter's CURRENT stance, not their
+    // sticky "first action" heart state. SupportStore tracks current Choose/Oppose status,
+    // so Edit-opinion → Save (or any switch back to Support) correctly re-shows the bar.
+    const { politicianWeVoteId, voterOpposesCampaignX: voterOpposesPrev } = this.state;
+    if (!politicianWeVoteId) return;
+    const statSheet = SupportStore.getBallotItemStatSheet('', politicianWeVoteId);
+    const voterOpposesCampaignX = !!(statSheet && statSheet.voterOpposesBallotItem);
+    if (voterOpposesCampaignX !== voterOpposesPrev) {
+      this.setState({ voterOpposesCampaignX });
     }
   }
 

--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -319,6 +319,7 @@ function CardForListBody (props) {
                     <ItemActionBar
                       ballotItemWeVoteId={candidateWeVoteId}
                       ballotItemDisplayName={ballotItemDisplayName}
+                      campaignXWeVoteId={linkedCampaignXWeVoteId}
                       commentButtonHide
                       // externalUniqueId={`${idBaseName}ForList-ItemActionBar-${politicianWeVoteId}-${externalUniqueId}`}
                       hidePositionPublicToggle
@@ -333,6 +334,7 @@ function CardForListBody (props) {
                     <ItemActionBar
                       ballotItemWeVoteId={candidateWeVoteId}
                       ballotItemDisplayName={ballotItemDisplayName}
+                      campaignXWeVoteId={linkedCampaignXWeVoteId}
                       commentButtonHide
                       // externalUniqueId={`${idBaseName}ForList-ItemActionBar-${politicianWeVoteId}-${externalUniqueId}`}
                       hidePositionPublicToggle

--- a/src/js/common/components/Widgets/HeartFavoriteToggle/HeartFavoriteToggleLive.jsx
+++ b/src/js/common/components/Widgets/HeartFavoriteToggle/HeartFavoriteToggleLive.jsx
@@ -89,7 +89,11 @@ class HeartFavoriteToggleLive extends React.Component {
       const supportersCountNextGoalWithFloor = supportersCountNextGoal || CampaignStore.getCampaignXSupportersCountNextGoalDefault();
       if (campaignXWeVoteIdFromDict && politicianWeVoteId) {
         //
-        const { politicianWeVoteId: politicianWeVoteIdPrevious } = this.state;
+        const {
+          politicianWeVoteId: politicianWeVoteIdPrevious,
+          opposersCount: opposersCountPrevious,
+          supportersCount: supportersCountPrevious,
+        } = this.state;
         if (politicianWeVoteId !== politicianWeVoteIdPrevious) {
           this.setState({
             opposersCount,
@@ -97,6 +101,15 @@ class HeartFavoriteToggleLive extends React.Component {
             supportersCount,
             supportersCountNextGoal: supportersCountNextGoalWithFloor,
           }, () => this.onOrganizationStoreChange());
+        } else if (opposersCount !== opposersCountPrevious || supportersCount !== supportersCountPrevious) {
+          // WV-2664: Same politician, but the counts changed (e.g. the optimistic
+          // campaignLocalAttributesUpdate fired by a heart/Choose action). Sync them so the
+          // tally updates live instead of waiting for a page refresh.
+          this.setState({
+            opposersCount,
+            supportersCount,
+            supportersCountNextGoal: supportersCountNextGoalWithFloor,
+          });
         }
       } else if (campaignXWeVoteIdFromDict && !politicianWeVoteId) {
         // console.log('HeartFavoriteToggleLive onCampaignStoreChange voterCampaignXSupporter:', voterCampaignXSupporter);
@@ -172,12 +185,14 @@ class HeartFavoriteToggleLive extends React.Component {
     const { politicianWeVoteId } = this.state;
     // console.log('HeartFavoriteToggleLive onOrganizationStoreChange organizationWeVoteId:', organizationWeVoteId, ', politicianWeVoteId:', politicianWeVoteId);
     if (politicianWeVoteId) {
-      // console.log('voterOpposes: ', OrganizationStore.isVoterDislikingThisPolitician(politicianWeVoteId));
-      // console.log('voterSupports: ', OrganizationStore.isVoterFollowingThisPolitician(politicianWeVoteId));
-      this.setState({
-        voterOpposes: OrganizationStore.isVoterDislikingThisPolitician(politicianWeVoteId),
-        voterSupports: OrganizationStore.isVoterFollowingThisPolitician(politicianWeVoteId),  // A variation on isVoterFollowingThisOrganization
-      });
+      const { voterSupports, voterOpposes } = this.calculateVoterPositionForPolitician(politicianWeVoteId);
+      const { voterSupports: voterSupportsPrev, voterOpposes: voterOpposesPrev } = this.state;
+      if (voterSupports !== voterSupportsPrev || voterOpposes !== voterOpposesPrev) {
+        this.setState({
+          voterOpposes,
+          voterSupports,
+        });
+      }
     } else if (organizationWeVoteId) {
       // console.log('voterOpposes: ', OrganizationStore.isVoterDislikingThisOrganization(organizationWeVoteId));
       // console.log('voterSupports: ', OrganizationStore.isVoterFollowingThisOrganization(organizationWeVoteId));
@@ -208,6 +223,17 @@ class HeartFavoriteToggleLive extends React.Component {
         // }
       }
     });
+  }
+
+  calculateVoterPositionForPolitician (politicianWeVoteId) {
+    // WV-2664: OrgStore is the source of truth, hydrated from the server's
+    // organizationsFollowedRetrieve. The WeVoteServer (WV-2664HeartFollowDecouple) stores the
+    // heart (FollowOrganization FOLLOWING / FOLLOW_DISLIKE) independently of the voter's
+    // support/oppose stance, so this no longer snaps back on refresh — no client-side cache needed.
+    return {
+      voterSupports: OrganizationStore.isVoterFollowingThisPolitician(politicianWeVoteId),
+      voterOpposes: OrganizationStore.isVoterDislikingThisPolitician(politicianWeVoteId),
+    };
   }
 
   functionToUseWhenProfileComplete (support = true, oppose = false, stopSupporting = false, stopOpposing = false) {
@@ -280,7 +306,10 @@ class HeartFavoriteToggleLive extends React.Component {
   }
 
   submitOpposeClick () {
-    const { voterFirstName, voterIsSignedIn, voterLastName } = this.state;
+    const { voterFirstName, voterIsSignedIn, voterLastName, voterOpposes } = this.state;
+    // WV-2664: No-op if voter is already opposing — prevents accidental double-increment
+    // if a downstream caller fires the action while local state was already in this state.
+    if (voterOpposes) return;
     if (!voterIsSignedIn || !voterFirstName || !voterLastName) {
       this.submitActionClick(false, true, false, false);
       return;
@@ -293,43 +322,46 @@ class HeartFavoriteToggleLive extends React.Component {
     this.setState({
       opposersCount: opposersCount + 1,
       supportersCount,
-      // supportersCountNextGoal: supportersCountNextGoalWithFloor,
       voterOpposes: true,
       voterSupports: false,
     }, () => this.submitActionClick(false, true, false, false));
   }
 
   submitStopOpposingClick () {
-    const { opposersCount } = this.state;
+    const { opposersCount, voterOpposes } = this.state;
+    // WV-2664: No-op if voter wasn't opposing to begin with — nothing to roll back.
+    if (!voterOpposes) return;
     const oppose = false;
     const support = false;
     const stopOpposing = true;
     const stopSupporting = false;
     this.setState({
-      opposersCount: opposersCount - 1,
-      // supportersCountNextGoal: supportersCountNextGoalWithFloor,
+      opposersCount: Math.max(0, opposersCount - 1),
       voterOpposes: false,
       voterSupports: false,
     }, () => this.submitActionClick(support, oppose, stopSupporting, stopOpposing));
   }
 
   submitStopSupportingClick () {
-    const { supportersCount } = this.state;
+    const { supportersCount, voterSupports } = this.state;
+    // WV-2664: No-op if voter wasn't supporting to begin with — nothing to roll back.
+    if (!voterSupports) return;
     const oppose = false;
     const support = false;
     const stopOpposing = false;
     const stopSupporting = true;
     // console.log('submitStopSupportingClick');
     this.setState({
-      supportersCount: supportersCount - 1,
-      // supportersCountNextGoal: supportersCountNextGoalWithFloor,
+      supportersCount: Math.max(0, supportersCount - 1),
       voterOpposes: false,
       voterSupports: false,
     }, () => this.submitActionClick(support, oppose, stopSupporting, stopOpposing));
   }
 
   submitSupportClick () {
-    const { voterFirstName, voterIsSignedIn, voterLastName } = this.state;
+    const { voterFirstName, voterIsSignedIn, voterLastName, voterSupports } = this.state;
+    // WV-2664: No-op if voter is already supporting — prevents accidental double-increment.
+    if (voterSupports) return;
     if (!voterIsSignedIn || !voterFirstName || !voterLastName) {
       this.submitActionClick(true, false, false, false);
       return;
@@ -342,7 +374,6 @@ class HeartFavoriteToggleLive extends React.Component {
     this.setState({
       opposersCount,
       supportersCount: supportersCount + 1,
-      // supportersCountNextGoal: supportersCountNextGoalWithFloor,
       voterOpposes: false,
       voterSupports: true,
     }, () => this.submitActionClick(true, false, false, false));
@@ -364,23 +395,35 @@ class HeartFavoriteToggleLive extends React.Component {
         () => {
           let { supportersCount, opposersCount, voterSupports, voterOpposes } = this.state;
 
+          // WV-2664: Skip only the count mutation if the voter is already in the target state — this
+          // prevents a double-increment when the callback fires for a state we already hold. We must
+          // NOT early-return: the setState callback below both fires the backend save and closes the
+          // Complete-Your-Profile modal, so bailing here would leave the modal stuck open.
+          const alreadyInTargetState =
+            (support && voterSupports) ||
+            (oppose && voterOpposes) ||
+            (stopSupporting && !voterSupports) ||
+            (stopOpposing && !voterOpposes);
+
           // modify count of supporters here
-          if (support) {
-            if (voterOpposes) opposersCount -= 1;
-            supportersCount += 1;
-            voterSupports = true;
-            voterOpposes = false;
-          } else if (oppose) {
-            if (voterSupports) supportersCount -= 1;
-            opposersCount += 1;
-            voterSupports = false;
-            voterOpposes = true;
-          } else if (stopSupporting) {
-            if (voterSupports) supportersCount -= 1;
-            voterSupports = false;
-          } else if (stopOpposing) {
-            if (voterOpposes) opposersCount -= 1;
-            voterOpposes = false;
+          if (!alreadyInTargetState) {
+            if (support) {
+              if (voterOpposes) opposersCount -= 1;
+              supportersCount += 1;
+              voterSupports = true;
+              voterOpposes = false;
+            } else if (oppose) {
+              if (voterSupports) supportersCount -= 1;
+              opposersCount += 1;
+              voterSupports = false;
+              voterOpposes = true;
+            } else if (stopSupporting) {
+              supportersCount = Math.max(0, supportersCount - 1);
+              voterSupports = false;
+            } else if (stopOpposing) {
+              opposersCount = Math.max(0, opposersCount - 1);
+              voterOpposes = false;
+            }
           }
           // set new support and oppose count states here
           this.setState({

--- a/src/js/common/stores/CampaignStore.js
+++ b/src/js/common/stores/CampaignStore.js
@@ -560,10 +560,11 @@ class CampaignStore extends ReduceStore {
           const campaignXWeVoteId = action.payload.campaignXWeVoteId || '';
           if (campaignXWeVoteId in allCachedCampaignXDicts) {
             campaignX = this.getCampaignXByWeVoteId(campaignXWeVoteId);
-            if (action.payload.opposers_count) {
+            // WV-2664: check for undefined, not truthiness, so an explicit 0 isn't dropped.
+            if (action.payload.opposers_count !== undefined) {
               campaignX.opposers_count = action.payload.opposers_count;
             }
-            if (action.payload.supporters_count) {
+            if (action.payload.supporters_count !== undefined) {
               campaignX.supporters_count = action.payload.supporters_count;
             }
             allCachedCampaignXDicts[campaignXWeVoteId] = campaignX;

--- a/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
+++ b/src/js/components/Widgets/ItemActionBar/ItemActionBar.jsx
@@ -13,9 +13,11 @@ import TagManager from 'react-gtm-module';
 import styled from 'styled-components';
 import SupportActions from '../../../actions/SupportActions';
 import VoterActions from '../../../actions/VoterActions';
+import CampaignActions from '../../../common/actions/CampaignActions';
 import DesignTokenColors from '../../../common/components/Style/DesignTokenColors';
 import { openSnackbar } from '../../../common/components/Widgets/SnackNotifier';
 import AppObservableStore, { messageService } from '../../../common/stores/AppObservableStore';
+import CampaignStore from '../../../common/stores/CampaignStore';
 import PoliticianStore from '../../../common/stores/PoliticianStore';
 import convertToInteger from '../../../common/utils/convertToInteger';
 import isMobileScreenSize from '../../../common/utils/isMobileScreenSize';
@@ -26,6 +28,7 @@ import stringContains from '../../../common/utils/stringContains';
 import webAppConfig from '../../../config';
 import VoterConstants from '../../../constants/VoterConstants';
 import CandidateStore from '../../../stores/CandidateStore';
+import OrganizationStore from '../../../stores/OrganizationStore';
 import SupportStore from '../../../stores/SupportStore';
 import VoterStore from '../../../stores/VoterStore';
 import { possibleAppReview } from '../../../utils/appReviewFunctions';
@@ -673,6 +676,46 @@ class ItemActionBar extends PureComponent {
     return this.isOpposeCalculated() || this.isSupportCalculated() || this.state.voterTextStatement || this.state.voterTextStatementOpened;
   }
 
+  voterHeartIsCleanSlate () {
+    // WV-2664: true when the voter has no heart yet for this politician (neither following nor
+    // disliking) — the first-action case that will set the heart. Read before the save dispatches,
+    // which optimistically writes the follow/dislike list.
+    const { politicianWeVoteId } = this.props;
+    if (!politicianWeVoteId) return false;
+    // WV-2664: Until the follow/dislike lists have hydrated, isVoter*ThisPolitician returns false for
+    // everyone, which would misclassify an already-hearted voter as a clean slate and inflate the
+    // tally. Only assert clean-slate once the authoritative list is known; otherwise skip the
+    // optimistic bump and let the server response set the count.
+    if (!OrganizationStore.voterOrganizationsFollowedRetrievedOnce()) return false;
+    return !OrganizationStore.isVoterFollowingThisPolitician(politicianWeVoteId) &&
+      !OrganizationStore.isVoterDislikingThisPolitician(politicianWeVoteId);
+  }
+
+  optimisticallyUpdateCounts (action, wasCleanSlateHeart = false) {
+    // WV-2664: The tally tracks the heart (follow/dislike), not the Choose/Oppose position, and the
+    // server only moves the heart on the voter's first action. So bump only on a clean-slate
+    // Choose/Oppose; bumping otherwise double-counts a voter who is already hearted.
+    if (!VoterStore.getVoterIsSignedIn()) return; // signed-out actions do not persist
+    if ((action !== 'support' && action !== 'oppose') || !wasCleanSlateHeart) return;
+    // Prefer the prop (CardForListBody passes it where CandidateStore isn't populated).
+    const { ballotItemWeVoteId } = this.state;
+    let { campaignXWeVoteId } = this.props;
+    if (!campaignXWeVoteId && ballotItemWeVoteId) {
+      const candidate = CandidateStore.getCandidateByWeVoteId(ballotItemWeVoteId);
+      campaignXWeVoteId = candidate && candidate.linked_campaignx_we_vote_id;
+    }
+    if (!campaignXWeVoteId) return;
+    const campaign = CampaignStore.getCampaignXByWeVoteId(campaignXWeVoteId);
+    let supportersCount = (campaign && campaign.supporters_count) || 0;
+    let opposersCount = (campaign && campaign.opposers_count) || 0;
+    if (action === 'support') {
+      supportersCount += 1;
+    } else if (action === 'oppose') {
+      opposersCount += 1;
+    }
+    CampaignActions.campaignLocalAttributesUpdate(campaignXWeVoteId, supportersCount, opposersCount);
+  }
+
   supportItem (buttonId) {
     const { politicianWeVoteId } = this.props;
     const { ballotItemType, ballotItemWeVoteId, transitioning } = this.state;
@@ -684,6 +727,7 @@ class ItemActionBar extends PureComponent {
       this.stopSupportingItem(buttonId);
       return;
     }
+    const wasCleanSlateHeart = this.voterHeartIsCleanSlate(); // capture before the save dispatches
     // console.log('supportItem setState');
     this.setState({
       isOpposeLocalState: false,
@@ -710,6 +754,7 @@ class ItemActionBar extends PureComponent {
     TagManager.dataLayer({ dataLayer: dataLayerObject });
 
     SupportActions.voterSupportingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
+    this.optimisticallyUpdateCounts('support', wasCleanSlateHeart);
     this.setState({ transitioning: true });
     openSnackbar({ message: 'Support added!' });
   }
@@ -721,6 +766,7 @@ class ItemActionBar extends PureComponent {
     this.sendGTMDataLayer({ buttonId });
     possibleAppReview('ITEM');
     SupportActions.voterStopSupportingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
+    this.optimisticallyUpdateCounts('stopSupporting');
     this.setState({ transitioning: true });
     openSnackbar({ message: 'Support removed!' });
   }
@@ -737,12 +783,14 @@ class ItemActionBar extends PureComponent {
       this.stopOpposingItem(buttonId);
       return;
     }
+    const wasCleanSlateHeart = this.voterHeartIsCleanSlate(); // capture before the save dispatches
     this.setState({ isOpposeLocalState: true, isSupportLocalState: false });
     this.showChooseOrOpposeIntroModalDecision();
     this.sendGTMDataLayer({ buttonId });
 
     possibleAppReview('ITEM');
     SupportActions.voterOpposingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
+    this.optimisticallyUpdateCounts('oppose', wasCleanSlateHeart);
     this.setState({ transitioning: true });
     openSnackbar({ message: 'Opposition added!', severity: 'error' });
   }
@@ -754,6 +802,7 @@ class ItemActionBar extends PureComponent {
     this.sendGTMDataLayer({ buttonId });
     possibleAppReview('ITEM');
     SupportActions.voterStopOpposingSave(ballotItemWeVoteId, ballotItemType, politicianWeVoteId);
+    this.optimisticallyUpdateCounts('stopOpposing');
     this.setState({ transitioning: true });
     openSnackbar({ message: 'Opposition removed!', severity: 'error' });
   }
@@ -1199,6 +1248,7 @@ ItemActionBar.propTypes = {
   ballotItemDisplayName: PropTypes.string,
   ballotItemWeVoteId: PropTypes.string,
   buttonsOnly: PropTypes.bool,
+  campaignXWeVoteId: PropTypes.string,
   classes: PropTypes.object,
   commentButtonHide: PropTypes.bool,
   commentButtonHideInMobile: PropTypes.bool,

--- a/src/js/stores/OrganizationStore.js
+++ b/src/js/stores/OrganizationStore.js
@@ -46,6 +46,7 @@ class OrganizationStore extends ReduceStore {
         featuresProvidedBitmap: 0,
       },
       positionListForOpinionMakerHasBeenRetrievedOnce: {}, // Dictionary with googleCivicElectionId as key and organizationWeVoteId as key and true/false as value
+      voterOrganizationsFollowedRetrievedOnce: false, // WV-2664: true once the authoritative followed/disliked lists have hydrated
     };
   }
 
@@ -304,6 +305,13 @@ class OrganizationStore extends ReduceStore {
     }
   }
 
+  voterOrganizationsFollowedRetrievedOnce () {
+    // WV-2664: Whether organizationsFollowedRetrieve has hydrated the authoritative follow/dislike
+    // lists at least once. Before that, an empty follow list is indistinguishable from "voter has
+    // no hearts", so callers must not treat an un-hydrated store as a reliable clean-slate signal.
+    return this.getState().voterOrganizationsFollowedRetrievedOnce || false;
+  }
+
 
   isVoterIgnoringThisOrganization (organizationWeVoteId) {
     const { organizationWeVoteIdsVoterIsIgnoring } = this.getState();
@@ -421,6 +429,8 @@ class OrganizationStore extends ReduceStore {
     let {
       organizationDislikeCount, organizationFollowersCount,
       organizationWeVoteIdsVoterIsDisliking, organizationWeVoteIdsVoterIsFollowing, organizationWeVoteIdsVoterIsIgnoring,
+    } = state;
+    const {
       politicianWeVoteIdsVoterIsDisliking, politicianWeVoteIdsVoterIsFollowing,
     } = state;
     const allCachedPositionsForOneOrganization = [];
@@ -778,6 +788,9 @@ class OrganizationStore extends ReduceStore {
         // If not auto_followed_from_twitter_suggestion, continue with organizations voter is Following.
         organizationList = action.res.organization_list;
         organizationWeVoteIdsVoterIsFollowing = [...explanationOrganizationsVoterIsFollowing]; // Refresh this variable
+        // WV-2664: Rebuild the politician following list from server truth so any stale optimistic
+        // entry (pushed during the pre-hydration clean-slate guess) is dropped, not just appended to.
+        politicianWeVoteIdsVoterIsFollowing.length = 0;
         organizationList.forEach((oneOrganization) => {
           organizationWeVoteId = oneOrganization.organization_we_vote_id;
           politicianWeVoteId = oneOrganization.politician_we_vote_id;
@@ -801,6 +814,8 @@ class OrganizationStore extends ReduceStore {
         // Now bring in the disliked organizations
         organizationDislikedList = action.res.organization_disliked_list;
         organizationWeVoteIdsVoterIsDisliking = []; // Refresh this variable
+        // WV-2664: Rebuild the politician disliking list from server truth (see following list above).
+        politicianWeVoteIdsVoterIsDisliking.length = 0;
         organizationDislikedList.forEach((oneOrganization) => {
           organizationWeVoteId = oneOrganization.organization_we_vote_id;
           politicianWeVoteId = oneOrganization.politician_we_vote_id;
@@ -829,6 +844,7 @@ class OrganizationStore extends ReduceStore {
           organizationWeVoteIdsVoterIsFollowing,
           politicianWeVoteIdsVoterIsDisliking,
           politicianWeVoteIdsVoterIsFollowing,
+          voterOrganizationsFollowedRetrievedOnce: true,
         };
 
       case 'organizationStopDisliking':
@@ -1307,6 +1323,9 @@ class OrganizationStore extends ReduceStore {
           },
           politicianWeVoteIdsVoterIsDisliking: [],
           politicianWeVoteIdsVoterIsFollowing: [],
+          // WV-2664: Re-gate until the fresh organizationsFollowedRetrieve (dispatched above) hydrates,
+          // so a just-signed-in voter's empty lists aren't mistaken for a clean slate.
+          voterOrganizationsFollowedRetrievedOnce: false,
           voterOrganizationFeaturesProvided: {
             chosenFaviconAllowed: false,
             chosenFeaturePackage: 'FREE',
@@ -1392,22 +1411,33 @@ class OrganizationStore extends ReduceStore {
           }
         }
         if (politicianWeVoteId) {
-          // console.log('OrganizationStore politicianWeVoteId:', politicianWeVoteId, ', action.type: ', action.type);
+          // WV-2664: Optimistically mirror the server's "first-action-wins" coupling so the heart
+          // reacts immediately. The WeVoteServer (WV-2664HeartFollowDecouple) is the source of
+          // truth — it sets the matching heart only on a clean slate and keeps heart/position
+          // decoupled afterwards — and organizationsFollowedRetrieve confirms/corrects this state.
+          // Clean slate here = signed-in voter not yet in either follow/dislike list for this
+          // politician; after that, Choose/Oppose changes do NOT move the heart. Direct heart
+          // clicks (organizationFollow / organizationDislike / stop*) always win via their own cases.
+          const voterHasHeartChoice =
+            arrayContains(politicianWeVoteId, politicianWeVoteIdsVoterIsFollowing) ||
+            arrayContains(politicianWeVoteId, politicianWeVoteIdsVoterIsDisliking);
+          const cleanSlate = VoterStore.getVoterIsSignedIn() && !voterHasHeartChoice;
           if (action.type === 'voterOpposingSave') {
-            if (!arrayContains(politicianWeVoteId, politicianWeVoteIdsVoterIsDisliking)) {
+            if (cleanSlate) {
               politicianWeVoteIdsVoterIsDisliking.push(politicianWeVoteId);
             }
-            politicianWeVoteIdsVoterIsFollowing = politicianWeVoteIdsVoterIsFollowing.filter((id) => id !== politicianWeVoteId);
           } else if (action.type === 'voterSupportingSave') {
-            if (!arrayContains(politicianWeVoteId, politicianWeVoteIdsVoterIsFollowing)) {
+            if (cleanSlate) {
               politicianWeVoteIdsVoterIsFollowing.push(politicianWeVoteId);
             }
-            politicianWeVoteIdsVoterIsDisliking = politicianWeVoteIdsVoterIsDisliking.filter((id) => id !== politicianWeVoteId);
           } else if (action.type === 'voterStopOpposingSave') {
             // We don't want to roll back the Organization Dislike when the voter stops opposing
           } else if (action.type === 'voterStopSupportingSave') {
             // We don't want to roll back the Organization Follow when the voter stops supporting
           // } else if (action.type === 'voterPositionCommentSave') {
+            // Intentionally not touched. The CampaignSupportThermometer progress bar reads
+            // SupportStore (current stance) so Edit-opinion → Save still updates the bar correctly
+            // without forcing the sticky heart to flip.
           // } else if (action.type === 'voterPositionVisibilitySave') {
           }
           revisedState = { ...revisedState, politicianWeVoteIdsVoterIsDisliking };


### PR DESCRIPTION
TL;DR: The heart (like/dislike) and the Choose/Oppose position are now independent soclicking one no longer secretly flips the other. Support counts stay accurate and update live, and a batch of loading-race glitches are gone: phantom +1 counts, a heart stuck in the wrong state, and a frozen "complete your profile" popup.

- OrganizationStore optimistically mirrors the server's first-action-wins coupling, and organizationsFollowedRetrieve now rebuilds the politician follow/dislike lists from server truth so stale optimistic entries get reconciled (not just appended).
- ItemActionBar optimistically bumps the campaign tally only on a genuine clean-slate first action, gated on the follow lists being hydrated to avoid over-counting an already-hearted voter.
- HeartFavoriteToggleLive syncs counts live, floors them at 0, no-ops redundant actions, and no longer leaves the complete-your-profile modal stuck open.
- CampaignSupportThermometer reads the voter's current stance from SupportStore; CampaignStore preserves an explicit 0 supporters/opposers count.