### PR TITLE
[WV-2132]Ballot:Search Result found in Explanation shows "Twitter" instead of "X" [TEAM_REVIEW]

### DIFF
--- a/src/js/utils/ballotSearchPriority.jsx
+++ b/src/js/utils/ballotSearchPriority.jsx
@@ -69,12 +69,12 @@ export default function ballotSearchPriority (originalString, item, ignoreDescri
         if (!ignoreDescriptionFields && countMatches(searchNeedleString, candidate.twitter_description)) {
           oneWordScore += countMatches(searchNeedleString, candidate.twitter_description);
           foundInThisCandidate = true;
-          if (!candidateDetailsArray.includes('Twitter description')) candidateDetailsArray.push('Twitter description');
+          if (!candidateDetailsArray.includes('Twitter description')) candidateDetailsArray.push('X description');
         }
         if (countMatches(searchNeedleString, candidate.twitter_handle)) {
           oneWordScore += countMatches(searchNeedleString, candidate.twitter_handle) * 2;
           foundInThisCandidate = true;
-          if (!candidateDetailsArray.includes('Twitter handle')) candidateDetailsArray.push('Twitter handle');
+          if (!candidateDetailsArray.includes('Twitter handle')) candidateDetailsArray.push('X handle');
         }
         if (countMatches(searchNeedleString, candidate.party)) {
           oneWordScore += countMatches(searchNeedleString, candidate.party) * 2;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-2132]Ballot:Search Result found in Explanation shows "Twitter" instead of "X"
### Changes included this pull request?
_src/js/utils/ballotSearchPriority.jsx_
Replaced the Twitter representation in candidateDetailsArray with X, so the search result explanation is now displayed as X.


[WV-2132]: https://wevoteusa.atlassian.net/browse/WV-2132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ