### PR TITLE
[WV-4828]Update the OpenReplay tracker to version 18.0.17 in WebApp [TEAM_REVIEW]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@mui/styled-engine-sc": "^5.10.1",
         "@mui/styles": "^5.18.0",
         "@noble/hashes": "^2.0.1",
-        "@openreplay/tracker": "^8.1.1",
+        "@openreplay/tracker": "^18.0.7",
         "@stripe/react-stripe-js": "^1.3.0",
         "@stripe/stripe-js": "^1.13.0",
         "@vis.gl/react-google-maps": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "@mui/styled-engine-sc": "^5.10.1",
     "@mui/styles": "^5.18.0",
     "@noble/hashes": "^2.0.1",
-    "@openreplay/tracker": "^8.1.1",
+    "@openreplay/tracker": "^18.0.7",
     "@stripe/react-stripe-js": "^1.3.0",
     "@stripe/stripe-js": "^1.13.0",
     "@vis.gl/react-google-maps": "^1.7.1",


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-4828]Update the OpenReplay tracker to version 18.0.17 in WebApp
### Changes included this pull request?
Updated OpenReplay tracker to version 18.0.17 in WebApp and verified session in openreplay no issues found.

[WV-4828]: https://wevoteusa.atlassian.net/browse/WV-4828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ