### PR TITLE
Show photo upload progress for slow animated profile saves and clarify 20 MB limit copy

### DIFF
--- a/src/js/common/components/Settings/PhotoUploadProgressIndicator.jsx
+++ b/src/js/common/components/Settings/PhotoUploadProgressIndicator.jsx
@@ -1,0 +1,69 @@
+import { CircularProgress } from '@mui/material';
+import PropTypes from 'prop-types';
+import React, { useEffect, useState } from 'react';
+import styled from 'styled-components';
+
+export const PHOTO_UPLOAD_EARLY_MESSAGE = 'Uploading photo…';
+export const PHOTO_UPLOAD_LONG_WAIT_MESSAGE = 'Still working. Large animations can take longer…';
+export const PHOTO_UPLOAD_TOO_BIG_MESSAGE = 'This photo is too large. Please choose a file under 20 MB.';
+export const PHOTO_UPLOAD_FAILED_MESSAGE = 'Couldn\'t upload photo. Please try again.';
+
+const SHOW_DELAY_MS = 400;
+const LONG_WAIT_MS = 10000;
+
+/**
+ * Time-based photo upload progress UI.
+ * Shows after a short delay so fast uploads don't flash; escalates copy after ~10s.
+ */
+export default function PhotoUploadProgressIndicator ({ inProgress }) {
+  const [visible, setVisible] = useState(false);
+  const [longWait, setLongWait] = useState(false);
+
+  useEffect(() => {
+    if (!inProgress) {
+      setVisible(false);
+      setLongWait(false);
+      return undefined;
+    }
+    const showTimer = setTimeout(() => setVisible(true), SHOW_DELAY_MS);
+    const longWaitTimer = setTimeout(() => setLongWait(true), LONG_WAIT_MS);
+    return () => {
+      clearTimeout(showTimer);
+      clearTimeout(longWaitTimer);
+    };
+  }, [inProgress]);
+
+  if (!inProgress || !visible) {
+    return null;
+  }
+
+  return (
+    <ProgressWrapper>
+      <CircularProgress color="primary" size={32} />
+      <ProgressText>
+        {longWait ? PHOTO_UPLOAD_LONG_WAIT_MESSAGE : PHOTO_UPLOAD_EARLY_MESSAGE}
+      </ProgressText>
+    </ProgressWrapper>
+  );
+}
+PhotoUploadProgressIndicator.propTypes = {
+  inProgress: PropTypes.bool,
+};
+
+const ProgressWrapper = styled('div')`
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 12px 0 4px 0;
+  width: 100%;
+`;
+
+const ProgressText = styled('div')`
+  color: #818181;
+  font-family: 'Poppins', 'Helvetica Neue Light', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  font-size: 16px;
+  font-weight: 300;
+  margin-top: 12px;
+  text-align: center;
+`;

--- a/src/js/common/components/Settings/VoterPhotoUpload.jsx
+++ b/src/js/common/components/Settings/VoterPhotoUpload.jsx
@@ -331,6 +331,12 @@ class VoterPhotoUpload extends Component {
                       }}
                       dropzoneText={dropzoneText}
                       filesLimit={1}
+                      getDropRejectMessage={(rejectedFile) => {
+                        if (rejectedFile && rejectedFile.size > 20000000) {
+                          return 'File is too large. Please choose a file under 20 MB.';
+                        }
+                        return 'File type not supported. Please choose an image file.';
+                      }}
                       Icon={AccountCircle}
                       initialFiles={initialFiles}
                       maxFileSize={20000000}

--- a/src/js/components/PoliticianSelfEdit/SettingsPoliticianPicture.jsx
+++ b/src/js/components/PoliticianSelfEdit/SettingsPoliticianPicture.jsx
@@ -10,6 +10,10 @@ import {
   Separator,
 } from '../Style/ProfilePictureStyles';
 import PoliticianActions from '../../common/actions/PoliticianActions';
+import PhotoUploadProgressIndicator, {
+  PHOTO_UPLOAD_FAILED_MESSAGE,
+  PHOTO_UPLOAD_TOO_BIG_MESSAGE,
+} from '../../common/components/Settings/PhotoUploadProgressIndicator';
 import VoterPhotoUpload from '../../common/components/Settings/VoterPhotoUpload';
 import PoliticianStore from '../../common/stores/PoliticianStore';
 import VoterStore from '../../stores/VoterStore';
@@ -19,6 +23,8 @@ class SettingsPoliticianPicture extends Component {
   constructor (props) {
     super(props);
     this.state = {
+      photoUploadErrorMessage: '',
+      photoUploadInProgress: false,
       politicianBallotpediaImageUrlLarge: '',
       politicianFacebookImageUrlLarge: '',
       politicianLinkedInImageUrlLarge: '',
@@ -42,11 +48,31 @@ class SettingsPoliticianPicture extends Component {
   componentWillUnmount () {
     // console.log('SettingsPoliticianPicture componentWillUnmount');
     this.politicianStoreListener.remove();
+    this.clearPhotoUploadSafetyTimeout();
+  }
+
+  clearPhotoUploadSafetyTimeout () {
+    if (this.photoUploadSafetyTimeout) {
+      clearTimeout(this.photoUploadSafetyTimeout);
+      this.photoUploadSafetyTimeout = null;
+    }
+  }
+
+  startPhotoUploadSafetyTimeout () {
+    this.clearPhotoUploadSafetyTimeout();
+    this.photoUploadSafetyTimeout = setTimeout(() => {
+      if (this.state.photoUploadInProgress) {
+        this.setState({
+          photoUploadErrorMessage: PHOTO_UPLOAD_FAILED_MESSAGE,
+          photoUploadInProgress: false,
+        });
+      }
+    }, 120000);
   }
 
   onPoliticianStoreChange = () => {
     const { politicianWeVoteId } = this.props;
-    const { uploadedFileStaged } = this.state;
+    const { photoUploadInProgress, uploadedFileStaged } = this.state;
     const politician = PoliticianStore.getPoliticianByWeVoteId(politicianWeVoteId);
     let profileImageTypeCurrentlyActive = 'UPLOADED';
     if (politician.profile_image_type_currently_active && !uploadedFileStaged) {
@@ -54,7 +80,7 @@ class SettingsPoliticianPicture extends Component {
         profileImageTypeCurrentlyActive = politician.profile_image_type_currently_active;
       }
     }
-    this.setState({
+    const nextState = {
       profileImageTypeCurrentlyActive,
       politicianBallotpediaImageUrlLarge: politician.we_vote_hosted_profile_ballotpedia_image_url_large,
       politicianFacebookImageUrlLarge: politician.we_vote_hosted_profile_facebook_image_url_large,
@@ -62,7 +88,14 @@ class SettingsPoliticianPicture extends Component {
       politicianTwitterImageUrlLarge: politician.we_vote_hosted_profile_twitter_image_url_large,
       politicianVoteUSAImageUrlLarge: politician.we_vote_hosted_profile_vote_usa_image_url_large,
       politicianWikipediaImageUrlLarge: politician.we_vote_hosted_profile_wikipedia_image_url_large,
-    });
+    };
+    if (photoUploadInProgress) {
+      // politicianSave returned — clear the in-flight loader
+      this.clearPhotoUploadSafetyTimeout();
+      nextState.photoUploadInProgress = false;
+      nextState.photoUploadErrorMessage = PoliticianStore.getPoliticianPhotoTooBig() ? PHOTO_UPLOAD_TOO_BIG_MESSAGE : '';
+    }
+    this.setState(nextState);
   };
 
   // setProfileImageTypeCurrentlyActive (type) {
@@ -79,6 +112,7 @@ class SettingsPoliticianPicture extends Component {
   onUploadLocal = (file) => {
     console.log('SettingsPoliticianPicture onUploadLocal (not used):', file);
     this.setState({
+      photoUploadErrorMessage: '',
       profileImageTypeCurrentlyActive: 'UPLOADED',
       profileImageTypeCurrentlyActiveSet: true,
       // uploadedFile: file,
@@ -88,10 +122,16 @@ class SettingsPoliticianPicture extends Component {
 
   submitPoliticianPhotoSave = (buttonId) => {
     const { politicianWeVoteId } = this.props;
-    const { profileImageTypeCurrentlyActive } = this.state;
+    const { photoUploadInProgress, profileImageTypeCurrentlyActive } = this.state;
+    if (photoUploadInProgress) {
+      return;
+    }
     const politicianPhotoQueuedToSave = PoliticianStore.getPoliticianPhotoQueuedToSave();
     const politicianPhotoQueuedToSaveSet = PoliticianStore.getPoliticianPhotoQueuedToSaveSet();
+    const uploadingPhoto = !!politicianPhotoQueuedToSaveSet;
     if (politicianPhotoQueuedToSaveSet || profileImageTypeCurrentlyActive) {
+      // Fire async save before clearing the queue so the sync queue-clear store update
+      // does not clear photoUploadInProgress early.
       PoliticianActions.politicianPhotoSave(politicianWeVoteId, politicianPhotoQueuedToSave, politicianPhotoQueuedToSaveSet, profileImageTypeCurrentlyActive);
       PoliticianActions.politicianPhotoQueuedToSave(undefined);
 
@@ -111,7 +151,12 @@ class SettingsPoliticianPicture extends Component {
       TagManager.dataLayer({ dataLayer: dataLayerObject });
     }
 
+    if (uploadingPhoto) {
+      this.startPhotoUploadSafetyTimeout();
+    }
     this.setState({
+      photoUploadErrorMessage: '',
+      photoUploadInProgress: uploadingPhoto,
       politicianPhotoQueuedToSaveSet: false,
       profileImageTypeCurrentlyActiveSet: false,
       uploadedFileStaged: false,
@@ -128,12 +173,19 @@ class SettingsPoliticianPicture extends Component {
 
   render () {
     const {
+      photoUploadErrorMessage, photoUploadInProgress,
       politicianBallotpediaImageUrlLarge, profileImageTypeCurrentlyActive, profileImageTypeCurrentlyActiveSet,
       politicianFacebookImageUrlLarge, politicianLinkedInImageUrlLarge, politicianPhotoQueuedToSaveSet, politicianTwitterImageUrlLarge,
       politicianVoteUSAImageUrlLarge, politicianWikipediaImageUrlLarge,
     } = this.state;
     const { classes, politicianWeVoteId } = this.props;
     const onlyOneOption = !(politicianFacebookImageUrlLarge || politicianTwitterImageUrlLarge);
+    let saveButtonLabel = 'Save photo';
+    if (photoUploadInProgress) {
+      saveButtonLabel = 'Uploading…';
+    } else if (!politicianPhotoQueuedToSaveSet && !profileImageTypeCurrentlyActiveSet) {
+      saveButtonLabel = 'Photo saved';
+    }
 
     return (
       <Wrapper>
@@ -253,17 +305,21 @@ class SettingsPoliticianPicture extends Component {
             )}
           </ColumnWrapper>
         </RadioWrapper>
+        <PhotoUploadProgressIndicator inProgress={photoUploadInProgress} />
+        {!!photoUploadErrorMessage && (
+          <PhotoUploadErrorMessage>{photoUploadErrorMessage}</PhotoUploadErrorMessage>
+        )}
         <SaveOuterWrapper>
           <SaveInnerWrapper>
             <Button
               classes={{ root: classes.buttonSave }}
               color="primary"
-              disabled={!politicianPhotoQueuedToSaveSet && !profileImageTypeCurrentlyActiveSet}
+              disabled={photoUploadInProgress || (!politicianPhotoQueuedToSaveSet && !profileImageTypeCurrentlyActiveSet)}
               id="saveEditYourPhotoBottom"
               onClick={() => this.submitPoliticianPhotoSave('saveEditYourPhotoBottom')}
               variant="contained"
             >
-              {(!politicianPhotoQueuedToSaveSet && !profileImageTypeCurrentlyActiveSet) ? 'Photo saved' : 'Save photo'}
+              {saveButtonLabel}
             </Button>
           </SaveInnerWrapper>
         </SaveOuterWrapper>
@@ -291,6 +347,15 @@ const styles = () => ({
     // width: 150,
   },
 });
+
+const PhotoUploadErrorMessage = styled('div')`
+  color: #d32f2f;
+  font-family: 'Poppins', 'Helvetica Neue Light', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  font-size: 14px;
+  margin: 8px 0;
+  text-align: center;
+  width: 100%;
+`;
 
 const Wrapper = styled('div')`
 `;

--- a/src/js/components/SetUpAccount/SetUpAccountAddPhoto.jsx
+++ b/src/js/components/SetUpAccount/SetUpAccountAddPhoto.jsx
@@ -3,6 +3,10 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import React, { Suspense } from 'react';
 import VoterActions from '../../actions/VoterActions';
+import PhotoUploadProgressIndicator, {
+  PHOTO_UPLOAD_FAILED_MESSAGE,
+  PHOTO_UPLOAD_TOO_BIG_MESSAGE,
+} from '../../common/components/Settings/PhotoUploadProgressIndicator';
 import { renderLog } from '../../common/utils/logging';
 import VoterStore from '../../stores/VoterStore';
 import {
@@ -20,6 +24,8 @@ class SetUpAccountAddPhoto extends React.Component {
   constructor (props) {
     super(props);
     this.state = {
+      photoUploadErrorMessage: '',
+      photoUploadInProgress: false,
       voterFirstName: '',
       voterLastName: '',
       voterPhotoMissing: false,
@@ -41,6 +47,7 @@ class SetUpAccountAddPhoto extends React.Component {
 
   componentWillUnmount () {
     this.voterStoreListener.remove();
+    this.clearPhotoUploadSafetyTimeout();
     if (this.functionToUseWhenProfileCompleteTimer) {
       clearTimeout(this.functionToUseWhenProfileCompleteTimer);
     }
@@ -49,15 +56,48 @@ class SetUpAccountAddPhoto extends React.Component {
     }
   }
 
+  clearPhotoUploadSafetyTimeout () {
+    if (this.photoUploadSafetyTimeout) {
+      clearTimeout(this.photoUploadSafetyTimeout);
+      this.photoUploadSafetyTimeout = null;
+    }
+  }
+
+  startPhotoUploadSafetyTimeout () {
+    this.clearPhotoUploadSafetyTimeout();
+    this.photoUploadSafetyTimeout = setTimeout(() => {
+      if (this.state.photoUploadInProgress) {
+        this.setState({
+          photoUploadErrorMessage: PHOTO_UPLOAD_FAILED_MESSAGE,
+          photoUploadInProgress: false,
+        }, () => this.functionToUseWhenProfileNotCompleteLocal());
+      }
+    }, 120000);
+  }
+
   onVoterStoreChange () {
+    const { photoUploadInProgress } = this.state;
     const voterFirstName = VoterStore.getFirstName();
     const voterLastName = VoterStore.getLastName();
     const voterProfileUploadedImageUrlLarge = VoterStore.getVoterProfileUploadedImageUrlLarge();
-    this.setState({
+    const nextState = {
       voterFirstName,
       voterLastName,
       voterProfileUploadedImageUrlLarge,
-    });
+    };
+    if (photoUploadInProgress) {
+      this.clearPhotoUploadSafetyTimeout();
+      nextState.photoUploadInProgress = false;
+      if (VoterStore.getVoterPhotoTooBig()) {
+        nextState.photoUploadErrorMessage = PHOTO_UPLOAD_TOO_BIG_MESSAGE;
+        this.setState(nextState, () => this.functionToUseWhenProfileNotCompleteLocal());
+        return;
+      }
+      nextState.photoUploadErrorMessage = '';
+      this.setState(nextState, () => this.finishAfterPhotoUpload());
+      return;
+    }
+    this.setState(nextState);
   }
 
   functionToUseWhenProfileCompleteLocal = () => {
@@ -78,38 +118,59 @@ class SetUpAccountAddPhoto extends React.Component {
     }
   };
 
+  finishAfterPhotoUpload = () => {
+    this.functionToUseWhenProfileCompleteTimer = setTimeout(() => {
+      this.functionToUseWhenProfileCompleteLocal();
+    }, 500);
+    this.goToNextStepTimer = setTimeout(() => {
+      this.goToNextStepLocal();
+    }, 500);
+  };
+
   submitSavePhoto = () => {
     // console.log('SetUpAccountAddPhoto submitSavePhoto');
+    const { photoUploadInProgress } = this.state;
+    if (photoUploadInProgress) {
+      return;
+    }
     let voterPhotoMissing = false;
     const voterPhotoQueuedToSave = VoterStore.getVoterPhotoQueuedToSave();
     const voterPhotoQueuedToSaveSet = VoterStore.getVoterPhotoQueuedToSaveSet();
+    const uploadingNewPhoto = !!voterPhotoQueuedToSaveSet;
+    VoterActions.profilePhotoTooBigReset();
     VoterActions.voterCompleteYourProfileSave(null, false, null, false, voterPhotoQueuedToSave, voterPhotoQueuedToSaveSet);
     VoterActions.voterFirstNameQueuedToSave(undefined);
     VoterActions.voterLastNameQueuedToSave(undefined);
     VoterActions.voterPhotoQueuedToSave(undefined);
-    VoterActions.profilePhotoTooBigReset();
 
     if (!voterPhotoQueuedToSave && !VoterStore.getVoterProfileUploadedImageUrlLarge()) {
       voterPhotoMissing = true;
     }
     if (voterPhotoMissing) {
       this.setState({
+        photoUploadErrorMessage: '',
+        photoUploadInProgress: false,
         voterPhotoMissing,
       }, () => this.functionToUseWhenProfileNotCompleteLocal());
+    } else if (uploadingNewPhoto) {
+      // Stay on this step with a loading indicator until voterUpdate returns.
+      // Set inProgress after sync queue-clear store updates so they don't clear the loader early.
+      this.startPhotoUploadSafetyTimeout();
+      this.setState({
+        photoUploadErrorMessage: '',
+        photoUploadInProgress: true,
+        voterPhotoMissing: false,
+      });
     } else {
       VoterActions.voterRetrieve();
-      this.functionToUseWhenProfileCompleteTimer = setTimeout(() => {
-        this.functionToUseWhenProfileCompleteLocal();
-      }, 500);
-      this.goToNextStepTimer = setTimeout(() => {
-        this.goToNextStepLocal();
-      }, 500);
+      this.finishAfterPhotoUpload();
     }
   };
 
   render () {
     renderLog('SetUpAccountAddPhoto');  // Set LOG_RENDER_EVENTS to log all renders
     const {
+      photoUploadErrorMessage, photoUploadInProgress,
       voterFirstName, voterLastName, voterPhotoMissing, voterProfileUploadedImageUrlLarge,
     } = this.state;
 
@@ -131,11 +192,15 @@ class SetUpAccountAddPhoto extends React.Component {
               Please upload a photo, or click `Skip for now`.
             </VoterPhotoMissing>
           )}
+          {!!photoUploadErrorMessage && (
+            <PhotoUploadErrorMessage>{photoUploadErrorMessage}</PhotoUploadErrorMessage>
+          )}
           <VoterPhotoOuterWrapper>
             <Suspense fallback={<></>}>
               <VoterPhotoUpload showLabel />
             </Suspense>
           </VoterPhotoOuterWrapper>
+          <PhotoUploadProgressIndicator inProgress={photoUploadInProgress} />
         </InputFieldsWrapper>
         <VoterNameWrapper>
           {voterFirstName}
@@ -155,6 +220,13 @@ SetUpAccountAddPhoto.propTypes = {
 
 const styles = () => ({
 });
+
+const PhotoUploadErrorMessage = styled('div')`
+  color: #d32f2f;
+  font-size: 16px;
+  margin-bottom: 8px;
+  text-align: center;
+`;
 
 const VoterPhotoMissing = styled('div')`
   font-size: 18px;

--- a/src/js/components/Settings/SettingsProfilePicture.jsx
+++ b/src/js/components/Settings/SettingsProfilePicture.jsx
@@ -10,6 +10,10 @@ import {
   Separator,
 } from '../Style/ProfilePictureStyles';
 import VoterActions from '../../actions/VoterActions';
+import PhotoUploadProgressIndicator, {
+  PHOTO_UPLOAD_FAILED_MESSAGE,
+  PHOTO_UPLOAD_TOO_BIG_MESSAGE,
+} from '../../common/components/Settings/PhotoUploadProgressIndicator';
 import VoterPhotoUpload from '../../common/components/Settings/VoterPhotoUpload';
 import VoterStore from '../../stores/VoterStore';
 import { getPageDetails } from '../../utils/lookupPageNameAndPageTypeDict';
@@ -18,6 +22,8 @@ class SettingsProfilePicture extends Component {
   constructor (props) {
     super(props);
     this.state = {
+      photoUploadErrorMessage: '',
+      photoUploadInProgress: false,
       profileImageTypeCurrentlyActive: 'UPLOADED',
       profileImageTypeCurrentlyActiveSet: false,
       uploadedFile: '',
@@ -36,20 +42,43 @@ class SettingsProfilePicture extends Component {
 
   componentWillUnmount () {
     this.voterStoreListener.remove();
+    this.clearPhotoUploadSafetyTimeout();
+  }
+
+  clearPhotoUploadSafetyTimeout () {
+    if (this.photoUploadSafetyTimeout) {
+      clearTimeout(this.photoUploadSafetyTimeout);
+      this.photoUploadSafetyTimeout = null;
+    }
+  }
+
+  startPhotoUploadSafetyTimeout () {
+    this.clearPhotoUploadSafetyTimeout();
+    this.photoUploadSafetyTimeout = setTimeout(() => {
+      if (this.state.photoUploadInProgress) {
+        this.setState({
+          photoUploadErrorMessage: PHOTO_UPLOAD_FAILED_MESSAGE,
+          photoUploadInProgress: false,
+        });
+      }
+    }, 120000);
   }
 
   onVoterStoreChange () {
-    // const { uploadedFileStaged } = this.state;
     const voter = VoterStore.getVoter();
-    // let profileImageTypeCurrentlyActive = 'UPLOADED';
-    // if (voter.profile_image_type_currently_active !== 'UNKNOWN' && !uploadedFileStaged) {
-    //   profileImageTypeCurrentlyActive = voter.profile_image_type_currently_active;
-    // }
-    this.setState({
+    const { photoUploadInProgress } = this.state;
+    const nextState = {
       profileImageTypeCurrentlyActive: voter.profile_image_type_currently_active,
       voterFacebookImageUrlLarge: voter.we_vote_hosted_profile_facebook_image_url_large,
       voterTwitterImageUrlLarge: voter.we_vote_hosted_profile_twitter_image_url_large,
-    });
+    };
+    if (photoUploadInProgress) {
+      // voterUpdate (or related) returned — clear the in-flight loader
+      this.clearPhotoUploadSafetyTimeout();
+      nextState.photoUploadInProgress = false;
+      nextState.photoUploadErrorMessage = VoterStore.getVoterPhotoTooBig() ? PHOTO_UPLOAD_TOO_BIG_MESSAGE : '';
+    }
+    this.setState(nextState);
   }
 
   setProfileImageTypeCurrentlyActive () {
@@ -61,14 +90,19 @@ class SettingsProfilePicture extends Component {
 
   save = (buttonId) => {
     const {
+      photoUploadInProgress,
       profileImageTypeCurrentlyActive,
       profileImageTypeCurrentlyActiveSet,
       uploadedFile,
       uploadedFileStaged,
     } = this.state;
+    if (photoUploadInProgress) {
+      return;
+    }
     // const voterPhotoQueuedToSave = VoterStore.getVoterPhotoQueuedToSave();
     // const voterPhotoQueuedToSaveSet = VoterStore.getVoterPhotoQueuedToSaveSet();
     if (profileImageTypeCurrentlyActiveSet && uploadedFileStaged) {
+      VoterActions.profilePhotoTooBigReset();
       VoterActions.voterPhotoSave(uploadedFile, uploadedFileStaged, profileImageTypeCurrentlyActive);
       // VoterActions.voterPhotoQueuedToSave(undefined);
 
@@ -83,9 +117,20 @@ class SettingsProfilePicture extends Component {
         pageDetails: getPageDetails(),
       };
       TagManager.dataLayer({ dataLayer: dataLayerObject });
+
+      this.startPhotoUploadSafetyTimeout();
+      this.setState({
+        photoUploadErrorMessage: '',
+        photoUploadInProgress: true,
+        profileImageTypeCurrentlyActiveSet: false,
+        uploadedFile: '',
+        uploadedFileStaged: false,
+      });
+      return;
     }
 
     this.setState({
+      photoUploadErrorMessage: '',
       profileImageTypeCurrentlyActiveSet: false,
       uploadedFile: '',
       uploadedFileStaged: false,
@@ -94,6 +139,7 @@ class SettingsProfilePicture extends Component {
 
   onUploadLocal = (file) => {
     this.setState({
+      photoUploadErrorMessage: '',
       profileImageTypeCurrentlyActive: 'UPLOADED',
       profileImageTypeCurrentlyActiveSet: true,
       uploadedFile: file,
@@ -119,10 +165,17 @@ class SettingsProfilePicture extends Component {
 
   render () {
     const {
+      photoUploadErrorMessage, photoUploadInProgress,
       profileImageTypeCurrentlyActive, profileImageTypeCurrentlyActiveSet, uploadedFileStaged, voterFacebookImageUrlLarge, voterTwitterImageUrlLarge,
     } = this.state;
     const { classes } = this.props;
     const onlyOneOption = !(voterFacebookImageUrlLarge || voterTwitterImageUrlLarge);
+    let saveButtonLabel = 'Save photo';
+    if (photoUploadInProgress) {
+      saveButtonLabel = 'Uploading…';
+    } else if (!profileImageTypeCurrentlyActiveSet && !uploadedFileStaged) {
+      saveButtonLabel = 'Photo saved';
+    }
 
     return (
       <Wrapper>
@@ -173,17 +226,21 @@ class SettingsProfilePicture extends Component {
             )}
           </ColumnWrapper>
         </RadioWrapper>
+        <PhotoUploadProgressIndicator inProgress={photoUploadInProgress} />
+        {!!photoUploadErrorMessage && (
+          <PhotoUploadErrorMessage>{photoUploadErrorMessage}</PhotoUploadErrorMessage>
+        )}
         <SaveOuterWrapper>
           <SaveInnerWrapper>
             <Button
               classes={{ root: classes.buttonSave }}
               color="primary"
-              disabled={!profileImageTypeCurrentlyActiveSet && !uploadedFileStaged}
+              disabled={photoUploadInProgress || (!profileImageTypeCurrentlyActiveSet && !uploadedFileStaged)}
               id="saveEditYourPhotoBottom"
               onClick={() => this.save('saveEditYourPhotoBottom')}
               variant="contained"
             >
-              {(!profileImageTypeCurrentlyActiveSet && !uploadedFileStaged) ? 'Photo saved' : 'Save photo'}
+              {saveButtonLabel}
             </Button>
           </SaveInnerWrapper>
         </SaveOuterWrapper>
@@ -210,6 +267,15 @@ const styles = () => ({
     // width: 150,
   },
 });
+
+const PhotoUploadErrorMessage = styled('div')`
+  color: #d32f2f;
+  font-family: 'Poppins', 'Helvetica Neue Light', 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
+  font-size: 14px;
+  margin: 8px 0;
+  text-align: center;
+  width: 100%;
+`;
 
 const Wrapper = styled('div')`
 `;


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
## Summary
- Show an in-progress loading state while profile photo uploads are in flight (important for animated GIF/WebP, which can take several seconds to tens of seconds after server-side crop).
- Escalate copy after ~10s: **“Still working. Large animations can take longer…”**; keep the spinner until success or error.
- Cover settings profile photo, politician photo settings, and account-setup add photo; disable Save / hold the setup step until the API returns.
- Keep the `20000000`-byte cap; override dropzone reject copy to **“File is too large. Please choose a file under 20 MB.”** so users don’t see the misleading ~19 MB conversion.