### PR TITLE
Show politician name and state from the URL in the loading card skeleton before the API responds

### DIFF
--- a/src/js/common/components/CardForListBody.jsx
+++ b/src/js/common/components/CardForListBody.jsx
@@ -85,14 +85,14 @@ function CardForListBody (props) {
         >
           <OneCampaignTextColumn hideCardMargins={hideCardMargins}>
             <TitleAndTextWrapper hideCardMargins={hideCardMargins}>
-              {stateName && (
+              {(stateName || stateFromUrl) && (
                 <StateName id={`stateName-${stateCode}-${candidateWeVoteId}`}>
                   {stateName || stateFromUrl}
                 </StateName>
               )}
               {hideCardMargins && isWebApp() ? (
                 <OneCampaignTitle>
-                  {highlightSearchText(ballotItemDisplayName, searchText)}
+                  {highlightSearchText(ballotItemDisplayName || nameFromUrl, searchText)}
                   {showPoliticianOpenInNewWindow && (
                     <LaunchIconWrapper>
                       <Suspense fallback={<Skeleton variant="rounded" width={16} height={14} sx={{ display: 'inline-block', borderRadius: 0.5 }} />}>

--- a/src/js/common/components/CardForListBodySkeleton.jsx
+++ b/src/js/common/components/CardForListBodySkeleton.jsx
@@ -2,8 +2,10 @@ import { Box } from '@mui/material';
 import Skeleton from '@mui/material/Skeleton';
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import isMobileScreenSize from '../utils/isMobileScreenSize';
+import extractPoliticianDetailsFromUrl from '../utils/extractPoliticianDetailsFromUrl';
 import {
   CampaignActionButtonsWrapper,
   CandidateCardForListWrapper,
@@ -14,6 +16,8 @@ import {
   OneCampaignPhotoDesktopColumn,
   OneCampaignPhotoWrapperMobile,
   OneCampaignTextColumn,
+  OneCampaignTitle,
+  StateName,
   TitleAndTextWrapper,
 } from './Style/CampaignCardStyles';
 import { renderLog } from '../utils/logging';
@@ -43,6 +47,8 @@ function CardForListBodySkeleton (props) {
   renderLog('CardForListBodySkeleton');
   const { hideCardMargins, hideItemActionBar, limitCardWidth, showPoliticianOpenInNewWindow, useVerticalCard } = props;
   const useVerticalLayout = limitCardWidth || useVerticalCard || isMobileScreenSize();
+  const location = useLocation();
+  const { state: stateFromUrl, name: nameFromUrl } = extractPoliticianDetailsFromUrl(location.pathname);
 
   return (
     <CandidateCardForListWrapper limitCardWidth={limitCardWidth}>
@@ -53,11 +59,23 @@ function CardForListBodySkeleton (props) {
         >
           <OneCampaignTextColumn hideCardMargins={hideCardMargins}>
             <TitleAndTextWrapper hideCardMargins={hideCardMargins}>
-              {/* State */}
-              <Skeleton variant="text" width={80} height={12} sx={{ mb: 0.5 }} />
+              {/* State: prefer URL-derived text while API is still loading */}
+              {stateFromUrl ? (
+                <StateName>
+                  {stateFromUrl}
+                </StateName>
+              ) : (
+                <Skeleton variant="text" width={80} height={12} sx={{ mb: 0.5 }} />
+              )}
               {/* Name + optional Launch icon */}
               <Box display="flex" alignItems="center" gap={0.5} sx={{ mb: 0.5 }}>
-                <Skeleton variant="text" width={200} height={24} />
+                {nameFromUrl ? (
+                  <OneCampaignTitle>
+                    {nameFromUrl}
+                  </OneCampaignTitle>
+                ) : (
+                  <Skeleton variant="text" width={200} height={24} />
+                )}
                 {showPoliticianOpenInNewWindow && (
                   <Skeleton variant="rounded" width={14} height={14} sx={{ borderRadius: 0.5 }} />
                 )}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
#### [WV-4778](https://wevoteusa.atlassian.net/browse/WV-4778)

### Changes included this pull request?
- Restore URL-derived politician name and state in `CardForListBodySkeleton` so the loading card is not empty while `politicianRetrieve` is still in flight
- Fall back to URL-parsed name/state in `CardForListBody` when API values are not available yet
- Helps keep politician SEO pages usable for voters (and more identifiable for crawlers) during slow API responses

[WV-4778]: https://wevoteusa.atlassian.net/browse/WV-4778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ