### PR TITLE
Add buildspec files for post-deployment and quality-test phases.

### DIFF
--- a/codebuild/buildspec-post-deployment.yaml
+++ b/codebuild/buildspec-post-deployment.yaml
@@ -1,0 +1,10 @@
+version: 0.2
+
+env:
+  shell: bash
+phases:
+  build:
+    on-failure: ABORT
+    commands:
+      - echo "Purging Fastly Cache"
+      - curl -X POST -H "Fastly-Key: $FASTLY_API_KEY" -H "Accept: application/json" https://api.fastly.com/service/$FASTLY_SERVICE_ID/purge_all

--- a/codebuild/buildspec-quality-test.yaml
+++ b/codebuild/buildspec-quality-test.yaml
@@ -1,0 +1,16 @@
+version: 0.2
+
+env:
+  shell: bash
+phases:
+  install:
+    runtime-versions:
+      nodejs: 25
+  build:
+    on-failure: ABORT
+    commands:
+      - echo "Installing dependencies"
+      - npm install
+      - echo "Running Browserstack tests"
+      - cp -f tests/browserstack_automation/config/browserstack.config.template.js tests/browserstack_automation/config/browserstack.config.js
+      - npm run wdio


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
WV-4929 - purge fastly cache after deployment
WV-1882 - run browserstack tests after quality site deployment

### Changes included this pull request?
Add new buildspec files that will be referenced by CDK AWS infra code.