### PR TITLE
Change npm script name to wdio-BVT to properly use quality site and credentials from environment variables.

### DIFF
--- a/codebuild/buildspec-quality-test.yaml
+++ b/codebuild/buildspec-quality-test.yaml
@@ -13,4 +13,4 @@ phases:
       - npm install
       - echo "Running Browserstack tests"
       - cp -f tests/browserstack_automation/config/browserstack.config.template.js tests/browserstack_automation/config/browserstack.config.js
-      - npm run wdio
+      - npm run wdio-BVT


### PR DESCRIPTION

### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
