### PR TITLE
When using wdio-BVT npm script, we don't need to copy the browserstack config template since wdio.config.BVT.js doesn't reference it.

### DIFF
--- a/codebuild/buildspec-quality-test.yaml
+++ b/codebuild/buildspec-quality-test.yaml
@@ -12,5 +12,4 @@ phases:
       - echo "Installing dependencies"
       - npm install
       - echo "Running Browserstack tests"
-      - cp -f tests/browserstack_automation/config/browserstack.config.template.js tests/browserstack_automation/config/browserstack.config.js
       - npm run wdio-BVT


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

### Changes included this pull request?
