### PR TITLE
[WV-2488]SnackNotifier was not initialized before first use in the parent class [TEAM_REVIEW]

### DIFF
--- a/src/js/components/Drawers/Drawers.jsx
+++ b/src/js/components/Drawers/Drawers.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import SnackNotifier from '../../common/components/Widgets/SnackNotifier';
 import { renderLog } from '../../common/utils/logging';
 import HeaderProfileDrawer from './HeaderProfileDrawer';
 import PoliticianSelfEditDrawer from './PoliticianSelfEditDrawer';
@@ -11,6 +12,7 @@ function Drawers () {
     <>
       <HeaderProfileDrawer />
       <PoliticianSelfEditDrawer />
+      <SnackNotifier />
     </>
   );
 }


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-2488]SnackNotifier was not initialized before first use in the parent class
### Changes included this pull request?
_src/js/components/Drawers/Drawers.jsx_
Made SnackNotifier globally available by mounting <SnackNotifier /> inside Drawers.jsx.

[WV-2488]: https://wevoteusa.atlassian.net/browse/WV-2488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ