### PR TITLE
[WV-4859]"View Your Full Ballot" sticky button overlaps social media icons and footer content on the Candidate page [TEAM_VIEW]

### DIFF
--- a/src/js/components/Style/pageLayoutStyles.js
+++ b/src/js/components/Style/pageLayoutStyles.js
@@ -94,7 +94,7 @@ export const PageContentContainer = styled('div')(({ theme }) => (`
   padding-top: ${getPaddingTop()};
   padding-bottom: ${getPaddingBottom()};
   position: relative;
-  z-index: 0;
+  z-index: 1;
   ${theme.breakpoints.down('sm')} {
     min-height: ${isWebApp() ? '10px' : `${window.innerHeight}px`};
     margin: ${getOuterContainerMargins()};


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?
[WV-4859]"View Your Full Ballot" sticky button overlaps social media icons and footer content on the Candidate page
### Changes included this pull request?
_src/js/components/Style/pageLayoutStyles.js_
Changed the z-index value of PageContainer from 0 to 1 to ensure it stays on the top layer relative to the footer and prevents the footer from overlapping it.

[WV-4859]: https://wevoteusa.atlassian.net/browse/WV-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ