### PR TITLE
Fix web photo upload crash when Cordova dropzone element is missing

### DIFF
--- a/src/js/common/components/Settings/VoterPhotoUpload.jsx
+++ b/src/js/common/components/Settings/VoterPhotoUpload.jsx
@@ -216,7 +216,8 @@ class VoterPhotoUpload extends Component {
       thumbnail.style.display = 'inline';
       thumbnail.src = dataUrl;
       // console.log('preparePhotoForUpload cordovaDropZone display none', dataUrl);
-      cordovaDropZone.style.display = 'none';
+      // cordovaDropZone.style.display = 'none';
+      if (cordovaDropZone) cordovaDropZone.style.display = 'none';
     }
     const { politicianWeVoteId, onUpload } = this.props;
     if (politicianWeVoteId) {


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix? [WV-4728](https://wevoteusa.atlassian.net/browse/WV-4728)

### Changes included this pull request?
- Fix a web-only crash when uploading a profile photo: `preparePhotoForUpload` tried to hide `#cordovaDropZoneReplica`, which only exists in the Cordova UI.
- Guard that DOM update so web uploads continue normally; Cordova behavior is unchanged.

[WV-4728]: https://wevoteusa.atlassian.net/browse/WV-4728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ