### PR TITLE
WV-4763: Create "Add ballot item" modal

### DIFF
--- a/src/js/common/stores/AppObservableStore.js
+++ b/src/js/common/stores/AppObservableStore.js
@@ -62,6 +62,7 @@ const nonFluxState = {
   whatAndHowMuchToShare: '',
   sharedItemCode: '',
   showActivityTidbitDrawer: false,
+  showAddBallotItemModal: false,
   showAdviserIntroModal: false,
   showAskFriendsModal: false,
   showBallotChoicesAndSettingsModal: false,
@@ -687,6 +688,11 @@ export default {
     messageService.sendMessage('state updated showActivityTidbitDrawer');
   },
 
+  setShowAddBallotItemModal (show) {
+    nonFluxState.showAddBallotItemModal = show;
+    messageService.sendMessage('state updated showAddBallotItemModal');
+  },
+
   setShowAdviserIntroModal (show) {
     nonFluxState.showAdviserIntroModal = show;
     messageService.sendMessage('state updated showAdviserIntroModal');
@@ -912,6 +918,10 @@ export default {
 
   showActivityTidbitDrawer () {
     return nonFluxState.showActivityTidbitDrawer;
+  },
+
+  showAddBallotItemModal () {
+    return nonFluxState.showAddBallotItemModal;
   },
 
   showAdviserIntroModal () {

--- a/src/js/components/Ballot/DisplayWhileRetrievingBallot.jsx
+++ b/src/js/components/Ballot/DisplayWhileRetrievingBallot.jsx
@@ -201,10 +201,8 @@ export default function DisplayWhileRetrievingBallot ({ ballotWithAllItems }) {
   );
 
   renderLog('DisplayWhileRetrievingBallot functional component');
-  // if (!ballotWithAllItems || ballotWithAllItems.length === 0) {
-  //   return showNoBallotItems ? noBallotItemsJsx : loadingJsx;
-  if (true) { // TEMP - for testing add ballot item modal
-    return noBallotItemsJsx; // TEMP - for testing add ballot item modal
+  if (!ballotWithAllItems || ballotWithAllItems.length === 0) {
+    return showNoBallotItems ? noBallotItemsJsx : loadingJsx;
   } else {
     return null;
   }

--- a/src/js/components/Ballot/DisplayWhileRetrievingBallot.jsx
+++ b/src/js/components/Ballot/DisplayWhileRetrievingBallot.jsx
@@ -52,6 +52,11 @@ export default function DisplayWhileRetrievingBallot ({ ballotWithAllItems }) {
     };
   }, []);
 
+  const showAddBallotItemModal = () => {
+    console.log('DisplayWhileRetrievingBallot showAddBallotItemModal');
+    AppObservableStore.setShowAddBallotItemModal(true);
+  }
+  
   const showSelectBallotModalChooseElection = () => {
     const showEditAddress = false;
     const showSelectBallotModal = true;
@@ -144,6 +149,7 @@ export default function DisplayWhileRetrievingBallot ({ ballotWithAllItems }) {
                 <Button
                   color="primary"
                   id="noDataAddBallotItem"
+                  onClick={showAddBallotItemModal}
                   variant="contained"
                 >
                   Add ballot item
@@ -195,8 +201,10 @@ export default function DisplayWhileRetrievingBallot ({ ballotWithAllItems }) {
   );
 
   renderLog('DisplayWhileRetrievingBallot functional component');
-  if (!ballotWithAllItems || ballotWithAllItems.length === 0) {
-    return showNoBallotItems ? noBallotItemsJsx : loadingJsx;
+  // if (!ballotWithAllItems || ballotWithAllItems.length === 0) {
+  //   return showNoBallotItems ? noBallotItemsJsx : loadingJsx;
+  if (true) { // TEMP - for testing add ballot item modal
+    return noBallotItemsJsx; // TEMP - for testing add ballot item modal
   } else {
     return null;
   }

--- a/src/js/components/BallotItem/AddBallotItemModal.jsx
+++ b/src/js/components/BallotItem/AddBallotItemModal.jsx
@@ -1,81 +1,79 @@
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
+
 import { 
-    FormControl, FormControlLabel, FormGroup, FormLabel, 
-    Radio, RadioGroup,TextField, ToggleButton, ToggleButtonGroup,  
-    Button,
-    Box, 
+    Box, Button, FormControl, FormControlLabel, FormGroup, FormLabel, 
+    Radio, RadioGroup, TextField, ToggleButton, ToggleButtonGroup
 } from '@mui/material';
-import { Check, DoNotDisturb } from '@mui/icons-material';
-import styled from 'styled-components';
+import CheckIcon from '@mui/icons-material/Check';
+import BlockIcon from '@mui/icons-material/Block';
+
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
+
+import styled, { createGlobalStyle } from 'styled-components';
 import PropTypes from 'prop-types';
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import ModalDisplayTemplateA, { templateAStyles, TextFieldWrapper } from '../Widgets/ModalDisplayTemplateA';
+
 import { renderLog } from '../../common/utils/logging';
 
 
-class AddBallotItemModal extends Component {
-    constructor (props) {
-        super(props);
-        this.state = {
-            itemName: '',
-            itemRadioSelection: null,
-            candidateOfficeName: '',
-            candidatePartySelection: '',
-            otherPartyText: '',
-            chooseOpposeSelection: null,
-            opinionText: '',
-        };
-    }
 
-    handleItemRadioSelection = (event) => {
-        this.setState({ itemRadioSelection: event.target.value });
+function AddBallotItemModal ({ show, toggleFunction }) {
+    renderLog('AddBallotItemModal');  // Set LOG_RENDER_EVENTS to log all renders
+
+    const [itemName, setItemName] = useState('');
+    const [itemRadioSelection, setItemRadioSelection] = useState(null);
+    const [candidateOfficeName, setCandidateOfficeName] = useState('');
+    const [candidatePartySelection, setCandidatePartySelection] = useState('');
+    const [otherPartyText, setOtherPartyText] = useState('');
+    const [stanceSelection, setStanceSelection] = useState(null);
+    const [opinionText, setOpinionText] = useState('');
+
+    const handleItemRadioSelection = (event) => {
+        setItemRadioSelection(event.target.value);
     };
 
-    handleCandidatePartySelection = (event) => {
-        this.setState({ candidatePartySelection: event.target.value });
+    const handleCandidatePartySelection = (event) => {
+        setCandidatePartySelection(event.target.value);
     };
 
-    handleOtherTextChange = (event) => {
-        this.setState({ otherPartyText: event.target.value });
+    const handleOtherTextChange = (event) => {
+        setOtherPartyText(event.target.value);
     };
 
-    handlechooseOpposeSelection = (event, newSelection) => {
-        this.setState({ chooseOpposeSelection: newSelection });
-    };
-
-    handleSubmit = () => {
+    const handleSubmit = () => {
         let submissionData = {
-            itemName: this.state.itemName,
-            itemRadioSelection: this.state.itemRadioSelection,
-            chooseOpposeSelection: this.state.chooseOpposeSelection,
-            opinionText: this.state.opinionText,
-        }
+            itemName,
+            itemRadioSelection,
+            stanceSelection,
+            opinionText,
+            // only include these fields in submission data if user made relevant selections
+            ...(itemRadioSelection === 'candidate' && {
+                candidateOfficeName,
+                candidatePartySelection,
+                ...(candidatePartySelection === 'other' && { otherPartyText })
+            })
+            
+            // ...(itemRadioSelection === 'candidate' && candidateOfficeName && { candidateOfficeName }),
+            // ...(itemRadioSelection === 'candidate' && candidatePartySelection && { candidatePartySelection}),
+            // ...(candidatePartySelection === 'other' && otherPartyText && { otherPartyText })
 
-        if (this.state.itemRadioSelection === 'candidate') {
-            submissionData.candidateOfficeName ??= this.state.candidateOfficeName;
-            submissionData.candidatePartySelection ??= this.state.candidatePartySelection;
-            if (this.state.candidatePartySelection === 'other') {
-                submissionData.otherPartyText = this.state.otherPartyText;
-            }
-        }
+        };
 
+        // TODO: replace with real submission call & desired data structure, 
+        // then close modal once submission succeeds
         console.log('AddBallotItemModal handleSubmit called with values:', submissionData);
+    };
+
+    if (!show) {
+        return null;
     }
 
-
-    render () {
-        renderLog('AddBallotItemModal');  // Set LOG_RENDER_EVENTS to log all renders
-        
-        const { itemName, itemRadioSelection, candidateOfficeName, candidatePartySelection, otherPartyText, opinionText } = this.state;
-        const { show } = this.props;
-       
-        if (!show) {
-            return null;
-        }
-
-        const dialogTitleText = 'Add an item to your ballot';
-        const textFieldJSX = (
+    const dialogTitleText = 'Add an item to your ballot';
+    const textFieldJSX = (
+        <>
+            <ModalFont />
             <TextFieldWrapper>
                 <div>
                     <UnorderedList>
@@ -87,18 +85,18 @@ class AddBallotItemModal extends Component {
                             Once your friends like this item and add their opinions, 
                             it will become visible to everyone else. 
                         </li>
-                    {/* </ul> */}
                     </UnorderedList>
+
                     <TextField
                         id="addBallotItemInput"
                         label="Item name"
                         required
                         value={itemName}
-                        onChange={(e) => this.setState({ itemName: e.target.value })}
+                        onChange={(e) => setItemName(e.target.value)}
                         placeholder="Name of candidate, proposition, measure, or referendum"
                         variant="outlined"
                         fullWidth
-                        InputLabelProps={{ shrink: true }}
+                        // InputLabelProps={{ shrink: true }}
                         sx={{
                             '& .MuiOutlinedInput-root': {
                                 '& fieldset': {
@@ -115,99 +113,143 @@ class AddBallotItemModal extends Component {
                     <FormGroup>
                         <FormControl>
                             <FormLabel id="item-type-label">Item type (optional)</FormLabel>
+
                             <RadioGroup
                                 aria-labelledby="item-type-label"
                                 name="item-type-radio-group"
                                 value={itemRadioSelection}
-                                onChange={this.handleItemRadioSelection}
+                                onChange={handleItemRadioSelection}
                             >
-                                <FormControlLabel value="candidate" control={<Radio />} label="Candidate" />
+                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                                    <FormControlLabel 
+                                        value="candidate" 
+                                        control={<Radio />} 
+                                        label="Candidate"
+                                        sx={{ flexShrink: 0, alignSelf: 'flex-start' }}
+                                    />
 
-                                {itemRadioSelection === 'candidate' &&
-                                    <Box>
-                                        <TextField
-                                            id="outlined-candidateDetailsInput"
-                                            label="Office name"
-                                            value={candidateOfficeName}
-                                            onChange={(e) => this.setState({ candidateOfficeName: e.target.value })}
-                                            variant="outlined"
-                                            disabled={itemRadioSelection !== 'candidate'}
+                                    {itemRadioSelection === 'candidate' &&
+                                        <Box
                                             sx={{
-                                                '& .MuiOutlinedInput-root': {
-                                                    '& fieldset': {
-                                                        borderRadius: '10px',
-                                                    },
-                                                },
+                                                flex: 1,
+                                                display: 'flex',
+                                                flexDirection: 'column',
+                                                minWidth: 0
                                             }}
-                                        />
-                                        <RadioGroup
-                                            aria-labelledby="candidate-party-label"
-                                            name="candidate-party-radio-group"
-                                            value={candidatePartySelection}
-                                            onChange={this.handleCandidatePartySelection}
                                         >
-                                            <FormControlLabel value="democrat" control={<Radio />} label="Democrat" />
-                                            <FormControlLabel value="republican" control={<Radio />} label="Republican" />
-                                            <FormControlLabel value="independent" control={<Radio />} label="Independent" />
-                                            <FormControlLabel
-                                                value="other"
-                                                control={<Radio />}
-                                                label={
+                                            <TextField
+                                                id="outlined-candidateDetailsInput"
+                                                label="Office name"
+                                                value={candidateOfficeName}
+                                                onChange={(e) => setCandidateOfficeName(e.target.value)}
+                                                variant="outlined"
+                                                fullWidth
+                                                disabled={itemRadioSelection !== 'candidate'}
+                                                sx={{
+                                                    '& .MuiOutlinedInput-root': {
+                                                        '& fieldset': {
+                                                            borderRadius: '10px',
+                                                        },
+                                                    },
+                                                }}
+                                            />
+                                            <RadioGroup
+                                                aria-labelledby="candidate-party-label"
+                                                name="candidate-party-radio-group"
+                                                value={candidatePartySelection}
+                                                onChange={handleCandidatePartySelection}
+                                                sx={{ gap: 1, minWidth: 0 }}
+                                            >
+                                                <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', minWidth: 0 }}>
+                                                {/* <Box sx={{ display: 'flex', flexDirection: 'row', minWidth: 0 }}> */}
+                                                    <FormControlLabel value="democrat" control={<Radio />} label="Democrat" />
+                                                    <FormControlLabel value="republican" control={<Radio />} label="Republican" />
+                                                    <FormControlLabel value="independent" control={<Radio />} label="Independent" />
+                                                </Box>
+                                            
+                                                <Box sx= {{ display: 'flex', alignItems: 'center', ml: '-11px' }}>
+                                                    <Radio
+                                                        checked={candidatePartySelection === 'other'}
+                                                        onChange={(e) => {
+                                                            e.stopPropagation();
+                                                            setCandidatePartySelection('other');
+                                                        }}
+                                                        value="other"
+                                                        name="candidate-party-radio-group"
+                                                        disabled={itemRadioSelection !== 'candidate'}
+                                                    />
                                                     <TextField
                                                         variant="outlined"
+                                                        fullWidth
                                                         placeholder="Other (please specify)"
                                                         value={otherPartyText}
-                                                        onChange={this.handleOtherTextChange}
-                                                        // Prevents the radio button from losing focus or toggling unexpectedly
-                                                        onClick={() => this.setState({ candidatePartySelection: 'other' })}
-                                                        disabled={itemRadioSelection !== 'candidate' || (candidatePartySelection !== 'other' && otherPartyText === '')}
+                                                        onChange={handleOtherTextChange}
+                                                        onFocus={() => setCandidatePartySelection('other')}                                                     
+                                                        disabled={itemRadioSelection !== 'candidate'}
                                                         sx={{ 
                                                             minWidth: 200,
-
                                                             '& .MuiOutlinedInput-root': {
                                                                 '& fieldset': {
                                                                     borderRadius: '10px',
                                                                 },
                                                             },
-
                                                         }}
                                                     />
-                                                }
-                                            />
-                                        </RadioGroup>
-                                    </Box>
-                                }
-                                <FormControlLabel value="proposition" control={<Radio />} label="Proposition / Measure / Referendum" />
+                                                </Box>
+                                            </RadioGroup>
+                                        </Box>
+                                    }
+                                </Box>
+
+                                <FormControlLabel 
+                                    value="proposition" 
+                                    control={<Radio />} 
+                                    label="Proposition / Measure / Referendum"
+                                />
                             </RadioGroup>
                         </FormControl>
                     </FormGroup>
                 </div>
-                
+
                 <HorizontalRule />
 
-                <div style={{ marginTop: '20px' }}>
-                    <ToggleButtonGroup
-                        value={this.state.chooseOpposeSelection}
-                        onChange={this.handlechooseOpposeSelection}
-                        color={this.state.chooseOpposeSelection === 'choose' ? 'success' : this.state.chooseOpposeSelection === 'oppose' ? 'error' : 'primary'}
-                        size="large"
-                        exclusive
-                        aria-label="choose-oppose-toggle"
-                    >
-                        <ToggleButton value="choose" aria-label="choose">
-                            <Check fontSize="small" sx={{ mr: 1 }} />
+                <div style={{ marginTop: '20px' }}>  
+                    <StanceToggleRow>
+
+                        <StanceToggleButton
+                            type="button"
+                            selected={stanceSelection === 'support'}
+                            stanceType="support"
+                            onClick={() => setStanceSelection("support")}
+                        >
+                            <CheckIcon style={{ fontSize: 18, marginRight: 4 }} />
                             Choose
-                        </ToggleButton>
-                        <ToggleButton value="oppose" aria-label="oppose">
-                            <DoNotDisturb fontSize="small" sx={{ mr: 1 }} />
+                        </StanceToggleButton>
+
+                        <StanceToggleButton
+                            type="button"
+                            selected={stanceSelection === 'oppose'}
+                            stanceType="oppose"
+                            onClick={() => setStanceSelection('oppose')}
+                            >
+                            <BlockIcon style={{ fontSize: 18, marginRight: 4 }} />
                             Oppose
-                        </ToggleButton>
-                    </ToggleButtonGroup>
+                        </StanceToggleButton>
+
+                        <StanceToggleButton
+                            type="button"
+                            selected={stanceSelection === 'undecided'}
+                            stanceType="undecided"
+                            onClick={() => setStanceSelection('undecided')}
+                        >
+                            Undecided
+                        </StanceToggleButton>
+                    </StanceToggleRow>
 
                     <TextField
                         label="What's your opinion on this ballot item?"
                         value={opinionText}
-                        onChange={(e) => this.setState({ opinionText: e.target.value })}
+                        onChange={(e) => setOpinionText(e.target.value)}
                         multiline
                         minRows={3}
                         fullWidth
@@ -227,7 +269,7 @@ class AddBallotItemModal extends Component {
                         variant="outlined"
                         color="secondary"
                         sx={{ mt: 2, mr: 2 }}
-                        onClick={this.props.toggleFunction}
+                        onClick={toggleFunction}
                     >
                         Cancel
                     </CancelButton>
@@ -235,31 +277,41 @@ class AddBallotItemModal extends Component {
                         variant="contained"
                         color="primary"
                         sx={{ mt: 2 }}
-                        onClick={() => {this.handleSubmit();}}
+                        onClick={() => { handleSubmit(); }}
                     >
                         Add Ballot Item
                     </SubmitButton>
                 </SubmitActionsWrapper>
+
             </TextFieldWrapper>
-        );
-        
-        return (
-            <ModalDisplayTemplateA
-                show={show}
-                dialogTitleJSX={<>{dialogTitleText}</>}
-                toggleModal={this.props.toggleFunction}
-                textFieldJSX={textFieldJSX}
-                tallMode
-            />
-        );
-    }
+        </>
+    );
+
+    return (
+        <ModalDisplayTemplateA 
+            show={show}
+            toggleModal={toggleFunction}
+            dialogTitleJSX={<>{dialogTitleText}</>}
+            toggleModal={toggleFunction}
+            textFieldJSX={textFieldJSX}
+            tallMode
+        />
+    );
 }
 
 AddBallotItemModal.propTypes = {
-  show: PropTypes.bool,
+  show: PropTypes.bool.isRequired,
   toggleFunction: PropTypes.func.isRequired,
 };
 
+// override existing font-family rules which uniquely impact MUI Typography elements 
+// so that font is consistent throughout modal
+const ModalFont = createGlobalStyle`
+  .MuiDialog-paper:has(#addBallotItemInput) .MuiTypography-root,
+  .MuiDialog-paper:has(#addBallotItemInput) .MuiFormLabel-root {
+    font-family: "Poppins", "Helvetica Neue Light", "Helvetica Neue", "Helvetica", "Arial", sans-serif !important;
+  }
+`;
 
 const UnorderedList = styled('ul')`
     margin: 20px 0px; 
@@ -276,6 +328,41 @@ const UnorderedList = styled('ul')`
 const HorizontalRule = styled('hr')`
     width: 90%;
 `;
+
+
+const StanceToggleRow = styled('div')`
+    display: flex;
+    margin-bottom: 6px;
+`;
+
+// map both button background color when selected & text/icon color when hovered
+// to match currently active stanceType
+const stanceColor = (stanceType) => {
+    if (stanceType === 'support') return DesignTokenColors.confirmation800;
+    if (stanceType === 'oppose') return DesignTokenColors.alert800;
+    return DesignTokenColors.info800; // undecided
+}
+
+const StanceToggleButton = styled('button')`
+    align-items: center;
+    background-color: ${(props) => (props.selected ? stanceColor(props.stanceType) : DesignTokenColors.whiteUI)};
+    border: 2px solid ${(props) => (props.selected ? DesignTokenColors.info800 : DesignTokenColors.neutralUI300)};
+    border-radius: 20px;
+    color: ${(props) => (props.selected ? DesignTokenColors.whiteUI : DesignTokenColors.neutral900)};
+    cursor: pointer;
+    display: flex;
+    font-size: 14px;
+    font-weight: ${(props) => (props.selected ? '600' : '400')};
+    margin-right: 8px;
+    padding: 4px 16px;
+
+    &:hover,
+    &:focus-visible {
+        border-color: ${DesignTokenColors.info800};
+        color: ${(props) => (props.selected ? DesignTokenColors.whiteUI : stanceColor(props.stanceType))};
+    }
+`;
+
 
 const SubmitActionsWrapper = styled('div')`
     display: flex;
@@ -305,4 +392,3 @@ const SubmitButton = styled(Button)`
 
 
 export default withTheme(withStyles(templateAStyles)(AddBallotItemModal));
-// export default AddBallotItemModal;

--- a/src/js/components/BallotItem/AddBallotItemModal.jsx
+++ b/src/js/components/BallotItem/AddBallotItemModal.jsx
@@ -5,6 +5,7 @@ import {
     Box, Button, FormControl, FormControlLabel, FormGroup, FormLabel, 
     Radio, RadioGroup, TextField, ToggleButton, ToggleButtonGroup
 } from '@mui/material';
+
 import CheckIcon from '@mui/icons-material/Check';
 import BlockIcon from '@mui/icons-material/Block';
 
@@ -16,7 +17,6 @@ import React, { useState } from 'react';
 import ModalDisplayTemplateA, { templateAStyles, TextFieldWrapper } from '../Widgets/ModalDisplayTemplateA';
 
 import { renderLog } from '../../common/utils/logging';
-
 
 
 function AddBallotItemModal ({ show, toggleFunction }) {
@@ -54,15 +54,10 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                 candidatePartySelection,
                 ...(candidatePartySelection === 'other' && { otherPartyText })
             })
-            
-            // ...(itemRadioSelection === 'candidate' && candidateOfficeName && { candidateOfficeName }),
-            // ...(itemRadioSelection === 'candidate' && candidatePartySelection && { candidatePartySelection}),
-            // ...(candidatePartySelection === 'other' && otherPartyText && { otherPartyText })
-
         };
 
-        // TODO: replace with real submission call & desired data structure, 
-        // then close modal once submission succeeds
+        // // TODO: replace with real submission call & desired data structure, 
+        // // then close modal with toggleFunction once submission succeeds
         console.log('AddBallotItemModal handleSubmit called with values:', submissionData);
     };
 
@@ -74,6 +69,10 @@ function AddBallotItemModal ({ show, toggleFunction }) {
     const textFieldJSX = (
         <>
             <ModalFont />
+            <ModalScrollFix />
+            <ModalFooterSticky />
+            <ModalTitleBackground />
+
             <TextFieldWrapper>
                 <div>
                     <UnorderedList>
@@ -96,7 +95,6 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                         placeholder="Name of candidate, proposition, measure, or referendum"
                         variant="outlined"
                         fullWidth
-                        // InputLabelProps={{ shrink: true }}
                         sx={{
                             '& .MuiOutlinedInput-root': {
                                 '& fieldset': {
@@ -107,12 +105,10 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                     />
                 </div>
 
-                <HorizontalRule />
-
-                <div style={{ marginBottom: '20px' }}>
+                <div style={{ marginTop: '25px', marginLeft: '5px' }}>
                     <FormGroup>
                         <FormControl>
-                            <FormLabel id="item-type-label">Item type (optional)</FormLabel>
+                            <FormLabel id="item-type-label" sx={{ marginBottom: '10px'}}>Item type (optional)</FormLabel>
 
                             <RadioGroup
                                 aria-labelledby="item-type-label"
@@ -140,6 +136,7 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                                             <TextField
                                                 id="outlined-candidateDetailsInput"
                                                 label="Office name"
+                                                size="small"
                                                 value={candidateOfficeName}
                                                 onChange={(e) => setCandidateOfficeName(e.target.value)}
                                                 variant="outlined"
@@ -161,7 +158,6 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                                                 sx={{ gap: 1, minWidth: 0 }}
                                             >
                                                 <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', minWidth: 0 }}>
-                                                {/* <Box sx={{ display: 'flex', flexDirection: 'row', minWidth: 0 }}> */}
                                                     <FormControlLabel value="democrat" control={<Radio />} label="Democrat" />
                                                     <FormControlLabel value="republican" control={<Radio />} label="Republican" />
                                                     <FormControlLabel value="independent" control={<Radio />} label="Independent" />
@@ -181,7 +177,8 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                                                     <TextField
                                                         variant="outlined"
                                                         fullWidth
-                                                        placeholder="Other (please specify)"
+                                                        size="small"
+                                                        label="Other (please specify)"
                                                         value={otherPartyText}
                                                         onChange={handleOtherTextChange}
                                                         onFocus={() => setCandidatePartySelection('other')}                                                     
@@ -205,6 +202,7 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                                     value="proposition" 
                                     control={<Radio />} 
                                     label="Proposition / Measure / Referendum"
+                                    sx={{ mt: itemRadioSelection === 'candidate' ? 3 : 1 }}
                                 />
                             </RadioGroup>
                         </FormControl>
@@ -213,7 +211,7 @@ function AddBallotItemModal ({ show, toggleFunction }) {
 
                 <HorizontalRule />
 
-                <div style={{ marginTop: '20px' }}>  
+                <div style={{ marginBottom: '10px' }}>   
                     <StanceToggleRow>
 
                         <StanceToggleButton
@@ -222,7 +220,7 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                             stanceType="support"
                             onClick={() => setStanceSelection("support")}
                         >
-                            <CheckIcon style={{ fontSize: 18, marginRight: 4 }} />
+                            <CheckIcon style={{ fontSize: 22, marginRight: 4 }} />
                             Choose
                         </StanceToggleButton>
 
@@ -232,7 +230,7 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                             stanceType="oppose"
                             onClick={() => setStanceSelection('oppose')}
                             >
-                            <BlockIcon style={{ fontSize: 18, marginRight: 4 }} />
+                            <BlockIcon style={{ fontSize: 22, marginRight: 4 }} />
                             Oppose
                         </StanceToggleButton>
 
@@ -282,7 +280,6 @@ function AddBallotItemModal ({ show, toggleFunction }) {
                         Add Ballot Item
                     </SubmitButton>
                 </SubmitActionsWrapper>
-
             </TextFieldWrapper>
         </>
     );
@@ -304,6 +301,7 @@ AddBallotItemModal.propTypes = {
   toggleFunction: PropTypes.func.isRequired,
 };
 
+
 // override existing font-family rules which uniquely impact MUI Typography elements 
 // so that font is consistent throughout modal
 const ModalFont = createGlobalStyle`
@@ -313,10 +311,51 @@ const ModalFont = createGlobalStyle`
   }
 `;
 
+const ModalFooterSticky = createGlobalStyle`
+  /* Mobile --> < sm breakpoint (576px) */
+  @media (max-width: 575.95px) {
+    .MuiDialog-paper:has(#addBallotItemInput) {
+      max-height: 95vh !important;
+      margin: 16px !important;
+    }
+
+    .MuiDialogContent-root:has(#addBallotItemInput) {
+      padding-bottom: 0px !important;
+      overflow-y: auto !important;
+      flex: 1 1 auto !important;
+    }
+  }
+
+  /* Desktop/tablet --> >= sm breakpoint (576px) */
+  @media (min-width: 576px) {
+    .MuiDialog-paper:has(#addBallotItemInput) {
+      max-height: min(750px, calc(100vh - 96px)) !important;
+    }
+
+    .MuiDialogContent-root:has(#addBallotItemInput) {
+      overflow-y: auto !important;
+      flex: 1 1 auto !important;
+    }
+  }
+`;
+
+const ModalScrollFix = createGlobalStyle`
+  .MuiDialog-container:has(#addBallotItemInput) {
+    align-items: flex-start !important;
+  }
+`;
+
+const ModalTitleBackground = createGlobalStyle`
+  .MuiDialog-paper:has(#addBallotItemInput) .MuiDialogTitle-root {
+    background-color: ${DesignTokenColors.neutralUI50} !important;
+  }
+`;
+
+
 const UnorderedList = styled('ul')`
-    margin: 20px 0px; 
-    padding-top: 20px;
-    padding-bottom: 20px;
+    margin: 20px 0px;
+    padding-top: 18px;
+    padding-bottom: 18px;
     display: flex;
     flex-direction: column;
     gap: 12px;
@@ -326,13 +365,18 @@ const UnorderedList = styled('ul')`
 `;
 
 const HorizontalRule = styled('hr')`
-    width: 90%;
+    width: 100%;
+    margin-top: 30px;
+    margin-bottom: 30px;
 `;
 
 
 const StanceToggleRow = styled('div')`
     display: flex;
-    margin-bottom: 6px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 30px;
+    gap: 8px;
 `;
 
 // map both button background color when selected & text/icon color when hovered
@@ -347,14 +391,13 @@ const StanceToggleButton = styled('button')`
     align-items: center;
     background-color: ${(props) => (props.selected ? stanceColor(props.stanceType) : DesignTokenColors.whiteUI)};
     border: 2px solid ${(props) => (props.selected ? DesignTokenColors.info800 : DesignTokenColors.neutralUI300)};
-    border-radius: 20px;
+    border-radius: 24px;
     color: ${(props) => (props.selected ? DesignTokenColors.whiteUI : DesignTokenColors.neutral900)};
     cursor: pointer;
     display: flex;
-    font-size: 14px;
+    font-size: 16px;
     font-weight: ${(props) => (props.selected ? '600' : '400')};
-    margin-right: 8px;
-    padding: 4px 16px;
+    padding: 10px 24px;
 
     &:hover,
     &:focus-visible {
@@ -366,15 +409,25 @@ const StanceToggleButton = styled('button')`
 
 const SubmitActionsWrapper = styled('div')`
     display: flex;
-    justify-content: space-between;
-    margin-top: 20px;
+    justify-content: center;
+    gap: 10px;
+    padding: 10px 0 20px;
+    position: sticky;
+    bottom: 0;
+    z-index: 2;
+    background: rgb(230, 243, 255);
+    background-color: ${DesignTokenColors.whiteUI};
+    border-top: 1px solid #eee
 `;
 
 const CancelButton = styled(Button)`
     border-radius: 50px;
     background-color: #f5f5f5;
     color: #555;
+    border: 1px solid #ccc;
     flex: 1;
+    padding: 10px 24px;
+
     &:hover {
         background-color: #e0e0e0;
     }
@@ -385,6 +438,8 @@ const SubmitButton = styled(Button)`
     background-color: #1976d2;
     color: white;
     flex: 2;
+    padding: 10px 24px;
+
     &:hover {
         background-color: #115293;
     }

--- a/src/js/components/BallotItem/AddBallotItemModal.jsx
+++ b/src/js/components/BallotItem/AddBallotItemModal.jsx
@@ -1,299 +1,298 @@
 import withStyles from '@mui/styles/withStyles';
 import withTheme from '@mui/styles/withTheme';
 
-import { 
-    Box, Button, FormControl, FormControlLabel, FormGroup, FormLabel, 
-    Radio, RadioGroup, TextField, ToggleButton, ToggleButtonGroup
+import {
+  Box, Button, FormControl, FormControlLabel, FormGroup, FormLabel,
+  Radio, RadioGroup, TextField,
 } from '@mui/material';
 
 import CheckIcon from '@mui/icons-material/Check';
 import BlockIcon from '@mui/icons-material/Block';
 
-import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 
 import styled, { createGlobalStyle } from 'styled-components';
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
+import DesignTokenColors from '../../common/components/Style/DesignTokenColors';
 import ModalDisplayTemplateA, { templateAStyles, TextFieldWrapper } from '../Widgets/ModalDisplayTemplateA';
 
 import { renderLog } from '../../common/utils/logging';
 
 
 function AddBallotItemModal ({ show, toggleFunction }) {
-    renderLog('AddBallotItemModal');  // Set LOG_RENDER_EVENTS to log all renders
+  renderLog('AddBallotItemModal');  // Set LOG_RENDER_EVENTS to log all renders
 
-    const [itemName, setItemName] = useState('');
-    const [itemRadioSelection, setItemRadioSelection] = useState(null);
-    const [candidateOfficeName, setCandidateOfficeName] = useState('');
-    const [candidatePartySelection, setCandidatePartySelection] = useState('');
-    const [otherPartyText, setOtherPartyText] = useState('');
-    const [stanceSelection, setStanceSelection] = useState(null);
-    const [opinionText, setOpinionText] = useState('');
+  const [itemName, setItemName] = useState('');
+  const [itemRadioSelection, setItemRadioSelection] = useState(null);
+  const [candidateOfficeName, setCandidateOfficeName] = useState('');
+  const [candidatePartySelection, setCandidatePartySelection] = useState('');
+  const [otherPartyText, setOtherPartyText] = useState('');
+  const [stanceSelection, setStanceSelection] = useState(null);
+  const [opinionText, setOpinionText] = useState('');
 
-    const handleItemRadioSelection = (event) => {
-        setItemRadioSelection(event.target.value);
+  const handleItemRadioSelection = (event) => {
+    setItemRadioSelection(event.target.value);
+  };
+
+  const handleCandidatePartySelection = (event) => {
+    setCandidatePartySelection(event.target.value);
+  };
+
+  const handleOtherTextChange = (event) => {
+    setOtherPartyText(event.target.value);
+  };
+
+  const handleSubmit = () => {
+    const submissionData = {
+      itemName,
+      itemRadioSelection,
+      stanceSelection,
+      opinionText,
+      // only include these fields in submission data if user made relevant selections
+      ...(itemRadioSelection === 'candidate' && {
+        candidateOfficeName,
+        candidatePartySelection,
+        ...(candidatePartySelection === 'other' && { otherPartyText }),
+      }),
     };
 
-    const handleCandidatePartySelection = (event) => {
-        setCandidatePartySelection(event.target.value);
-    };
+    // // TODO: replace with real submission call & desired data structure,
+    // // then close modal with toggleFunction once submission succeeds
+    console.log('AddBallotItemModal handleSubmit called with values:', submissionData);
+  };
 
-    const handleOtherTextChange = (event) => {
-        setOtherPartyText(event.target.value);
-    };
+  if (!show) {
+    return null;
+  }
 
-    const handleSubmit = () => {
-        let submissionData = {
-            itemName,
-            itemRadioSelection,
-            stanceSelection,
-            opinionText,
-            // only include these fields in submission data if user made relevant selections
-            ...(itemRadioSelection === 'candidate' && {
-                candidateOfficeName,
-                candidatePartySelection,
-                ...(candidatePartySelection === 'other' && { otherPartyText })
-            })
-        };
+  const dialogTitleText = 'Add an item to your ballot';
+  const textFieldJSX = (
+    <>
+      <ModalFont />
+      <ModalScrollFix />
+      <ModalFooterSticky />
+      <ModalTitleBackground />
 
-        // // TODO: replace with real submission call & desired data structure, 
-        // // then close modal with toggleFunction once submission succeeds
-        console.log('AddBallotItemModal handleSubmit called with values:', submissionData);
-    };
+      <TextFieldWrapper>
+        <div>
+          <UnorderedList>
+            <li>
+              Initially, this added item will only be visible to your
+              friends in ballot locations within 25 miles of you.
+            </li>
+            <li>
+              Once your friends like this item and add their opinions,
+              it will become visible to everyone else.
+            </li>
+          </UnorderedList>
 
-    if (!show) {
-        return null;
-    }
+          <TextField
+            id="addBallotItemInput"
+            label="Item name"
+            required
+            value={itemName}
+            onChange={(e) => setItemName(e.target.value)}
+            placeholder="Name of candidate, proposition, measure, or referendum"
+            variant="outlined"
+            fullWidth
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderRadius: '10px',
+                },
+              },
+            }}
+          />
+        </div>
 
-    const dialogTitleText = 'Add an item to your ballot';
-    const textFieldJSX = (
-        <>
-            <ModalFont />
-            <ModalScrollFix />
-            <ModalFooterSticky />
-            <ModalTitleBackground />
+        <div style={{ marginTop: '25px', marginLeft: '5px' }}>
+          <FormGroup>
+            <FormControl>
+              <FormLabel id="item-type-label" sx={{ marginBottom: '10px' }}>Item type (optional)</FormLabel>
 
-            <TextFieldWrapper>
-                <div>
-                    <UnorderedList>
-                        <li>
-                            Initially, this added item will only be visible to your 
-                            friends in ballot locations within 25 miles of you.
-                        </li>
-                        <li>
-                            Once your friends like this item and add their opinions, 
-                            it will become visible to everyone else. 
-                        </li>
-                    </UnorderedList>
+              <RadioGroup
+                aria-labelledby="item-type-label"
+                name="item-type-radio-group"
+                value={itemRadioSelection}
+                onChange={handleItemRadioSelection}
+              >
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
+                  <FormControlLabel
+                    value="candidate"
+                    control={<Radio />}
+                    label="Candidate"
+                    sx={{ flexShrink: 0, alignSelf: 'flex-start' }}
+                  />
 
-                    <TextField
-                        id="addBallotItemInput"
-                        label="Item name"
-                        required
-                        value={itemName}
-                        onChange={(e) => setItemName(e.target.value)}
-                        placeholder="Name of candidate, proposition, measure, or referendum"
+                  {itemRadioSelection === 'candidate' && (
+                    <Box
+                      sx={{
+                        flex: 1,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        minWidth: 0,
+                      }}
+                    >
+                      <TextField
+                        id="outlined-candidateDetailsInput"
+                        label="Office name"
+                        size="small"
+                        value={candidateOfficeName}
+                        onChange={(e) => setCandidateOfficeName(e.target.value)}
                         variant="outlined"
                         fullWidth
+                        disabled={itemRadioSelection !== 'candidate'}
                         sx={{
-                            '& .MuiOutlinedInput-root': {
-                                '& fieldset': {
-                                    borderRadius: '10px',
-                                },
+                          '& .MuiOutlinedInput-root': {
+                            '& fieldset': {
+                              borderRadius: '10px',
                             },
+                          },
                         }}
-                    />
-                </div>
+                      />
+                      <RadioGroup
+                        aria-labelledby="candidate-party-label"
+                        name="candidate-party-radio-group"
+                        value={candidatePartySelection}
+                        onChange={handleCandidatePartySelection}
+                        sx={{ gap: 1, minWidth: 0 }}
+                      >
+                        <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', minWidth: 0 }}>
+                          <FormControlLabel value="democrat" control={<Radio />} label="Democrat" />
+                          <FormControlLabel value="republican" control={<Radio />} label="Republican" />
+                          <FormControlLabel value="independent" control={<Radio />} label="Independent" />
+                        </Box>
 
-                <div style={{ marginTop: '25px', marginLeft: '5px' }}>
-                    <FormGroup>
-                        <FormControl>
-                            <FormLabel id="item-type-label" sx={{ marginBottom: '10px'}}>Item type (optional)</FormLabel>
-
-                            <RadioGroup
-                                aria-labelledby="item-type-label"
-                                name="item-type-radio-group"
-                                value={itemRadioSelection}
-                                onChange={handleItemRadioSelection}
-                            >
-                                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 1 }}>
-                                    <FormControlLabel 
-                                        value="candidate" 
-                                        control={<Radio />} 
-                                        label="Candidate"
-                                        sx={{ flexShrink: 0, alignSelf: 'flex-start' }}
-                                    />
-
-                                    {itemRadioSelection === 'candidate' &&
-                                        <Box
-                                            sx={{
-                                                flex: 1,
-                                                display: 'flex',
-                                                flexDirection: 'column',
-                                                minWidth: 0
-                                            }}
-                                        >
-                                            <TextField
-                                                id="outlined-candidateDetailsInput"
-                                                label="Office name"
-                                                size="small"
-                                                value={candidateOfficeName}
-                                                onChange={(e) => setCandidateOfficeName(e.target.value)}
-                                                variant="outlined"
-                                                fullWidth
-                                                disabled={itemRadioSelection !== 'candidate'}
-                                                sx={{
-                                                    '& .MuiOutlinedInput-root': {
-                                                        '& fieldset': {
-                                                            borderRadius: '10px',
-                                                        },
-                                                    },
-                                                }}
-                                            />
-                                            <RadioGroup
-                                                aria-labelledby="candidate-party-label"
-                                                name="candidate-party-radio-group"
-                                                value={candidatePartySelection}
-                                                onChange={handleCandidatePartySelection}
-                                                sx={{ gap: 1, minWidth: 0 }}
-                                            >
-                                                <Box sx={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', minWidth: 0 }}>
-                                                    <FormControlLabel value="democrat" control={<Radio />} label="Democrat" />
-                                                    <FormControlLabel value="republican" control={<Radio />} label="Republican" />
-                                                    <FormControlLabel value="independent" control={<Radio />} label="Independent" />
-                                                </Box>
-                                            
-                                                <Box sx= {{ display: 'flex', alignItems: 'center', ml: '-11px' }}>
-                                                    <Radio
-                                                        checked={candidatePartySelection === 'other'}
-                                                        onChange={(e) => {
-                                                            e.stopPropagation();
-                                                            setCandidatePartySelection('other');
-                                                        }}
-                                                        value="other"
-                                                        name="candidate-party-radio-group"
-                                                        disabled={itemRadioSelection !== 'candidate'}
-                                                    />
-                                                    <TextField
-                                                        variant="outlined"
-                                                        fullWidth
-                                                        size="small"
-                                                        label="Other (please specify)"
-                                                        value={otherPartyText}
-                                                        onChange={handleOtherTextChange}
-                                                        onFocus={() => setCandidatePartySelection('other')}                                                     
-                                                        disabled={itemRadioSelection !== 'candidate'}
-                                                        sx={{ 
-                                                            minWidth: 200,
-                                                            '& .MuiOutlinedInput-root': {
-                                                                '& fieldset': {
-                                                                    borderRadius: '10px',
-                                                                },
-                                                            },
-                                                        }}
-                                                    />
-                                                </Box>
-                                            </RadioGroup>
-                                        </Box>
-                                    }
-                                </Box>
-
-                                <FormControlLabel 
-                                    value="proposition" 
-                                    control={<Radio />} 
-                                    label="Proposition / Measure / Referendum"
-                                    sx={{ mt: itemRadioSelection === 'candidate' ? 3 : 1 }}
-                                />
-                            </RadioGroup>
-                        </FormControl>
-                    </FormGroup>
-                </div>
-
-                <HorizontalRule />
-
-                <div style={{ marginBottom: '10px' }}>   
-                    <StanceToggleRow>
-
-                        <StanceToggleButton
-                            type="button"
-                            selected={stanceSelection === 'support'}
-                            stanceType="support"
-                            onClick={() => setStanceSelection("support")}
-                        >
-                            <CheckIcon style={{ fontSize: 22, marginRight: 4 }} />
-                            Choose
-                        </StanceToggleButton>
-
-                        <StanceToggleButton
-                            type="button"
-                            selected={stanceSelection === 'oppose'}
-                            stanceType="oppose"
-                            onClick={() => setStanceSelection('oppose')}
-                            >
-                            <BlockIcon style={{ fontSize: 22, marginRight: 4 }} />
-                            Oppose
-                        </StanceToggleButton>
-
-                        <StanceToggleButton
-                            type="button"
-                            selected={stanceSelection === 'undecided'}
-                            stanceType="undecided"
-                            onClick={() => setStanceSelection('undecided')}
-                        >
-                            Undecided
-                        </StanceToggleButton>
-                    </StanceToggleRow>
-
-                    <TextField
-                        label="What's your opinion on this ballot item?"
-                        value={opinionText}
-                        onChange={(e) => setOpinionText(e.target.value)}
-                        multiline
-                        minRows={3}
-                        fullWidth
-                        variant="outlined"
-                        sx={{
-                            '& .MuiOutlinedInput-root': {
-                                '& fieldset': {
+                        <Box sx={{ display: 'flex', alignItems: 'center', ml: '-11px' }}>
+                          <Radio
+                              checked={candidatePartySelection === 'other'}
+                              onChange={(e) => {
+                                e.stopPropagation();
+                                setCandidatePartySelection('other');
+                              }}
+                              value="other"
+                              name="candidate-party-radio-group"
+                              disabled={itemRadioSelection !== 'candidate'}
+                          />
+                          <TextField
+                              variant="outlined"
+                              fullWidth
+                              size="small"
+                              label="Other (please specify)"
+                              value={otherPartyText}
+                              onChange={handleOtherTextChange}
+                              onFocus={() => setCandidatePartySelection('other')}
+                              disabled={itemRadioSelection !== 'candidate'}
+                              sx={{
+                                minWidth: 200,
+                                '& .MuiOutlinedInput-root': {
+                                  '& fieldset': {
                                     borderRadius: '10px',
+                                  },
                                 },
-                            },
-                        }}
-                    />
-                </div>
+                              }}
+                          />
+                        </Box>
+                      </RadioGroup>
+                    </Box>
+                  )}
+                </Box>
 
-                <SubmitActionsWrapper>
-                    <CancelButton
-                        variant="outlined"
-                        color="secondary"
-                        sx={{ mt: 2, mr: 2 }}
-                        onClick={toggleFunction}
-                    >
-                        Cancel
-                    </CancelButton>
-                    <SubmitButton
-                        variant="contained"
-                        color="primary"
-                        sx={{ mt: 2 }}
-                        onClick={() => { handleSubmit(); }}
-                    >
-                        Add Ballot Item
-                    </SubmitButton>
-                </SubmitActionsWrapper>
-            </TextFieldWrapper>
-        </>
-    );
+                <FormControlLabel
+                  value="proposition"
+                  control={<Radio />}
+                  label="Proposition / Measure / Referendum"
+                  sx={{ mt: itemRadioSelection === 'candidate' ? 3 : 1 }}
+                />
+              </RadioGroup>
+            </FormControl>
+          </FormGroup>
+        </div>
 
-    return (
-        <ModalDisplayTemplateA 
-            show={show}
-            toggleModal={toggleFunction}
-            dialogTitleJSX={<>{dialogTitleText}</>}
-            toggleModal={toggleFunction}
-            textFieldJSX={textFieldJSX}
-            tallMode
-        />
-    );
+        <HorizontalRule />
+
+        <div style={{ marginBottom: '10px' }}>
+          <StanceToggleRow>
+
+            <StanceToggleButton
+              type="button"
+              selected={stanceSelection === 'support'}
+              stanceType="support"
+              onClick={() => setStanceSelection('support')}
+            >
+              <CheckIcon style={{ fontSize: 22, marginRight: 4 }} />
+              Choose
+            </StanceToggleButton>
+
+            <StanceToggleButton
+              type="button"
+              selected={stanceSelection === 'oppose'}
+              stanceType="oppose"
+              onClick={() => setStanceSelection('oppose')}
+            >
+              <BlockIcon style={{ fontSize: 22, marginRight: 4 }} />
+              Oppose
+            </StanceToggleButton>
+
+            <StanceToggleButton
+              type="button"
+              selected={stanceSelection === 'undecided'}
+              stanceType="undecided"
+              onClick={() => setStanceSelection('undecided')}
+            >
+              Undecided
+            </StanceToggleButton>
+          </StanceToggleRow>
+
+          <TextField
+            label="What's your opinion on this ballot item?"
+            value={opinionText}
+            onChange={(e) => setOpinionText(e.target.value)}
+            multiline
+            minRows={3}
+            fullWidth
+            variant="outlined"
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                '& fieldset': {
+                  borderRadius: '10px',
+                },
+              },
+            }}
+          />
+        </div>
+
+        <SubmitActionsWrapper>
+          <CancelButton
+            variant="outlined"
+            color="secondary"
+            sx={{ mt: 2, mr: 2 }}
+            onClick={toggleFunction}
+          >
+            Cancel
+          </CancelButton>
+          <SubmitButton
+            variant="contained"
+            color="primary"
+            sx={{ mt: 2 }}
+            onClick={() => { handleSubmit(); }}
+          >
+            Add Ballot Item
+          </SubmitButton>
+        </SubmitActionsWrapper>
+      </TextFieldWrapper>
+    </>
+  );
+
+  return (
+    <ModalDisplayTemplateA
+      show={show}
+      toggleModal={toggleFunction}
+      dialogTitleJSX={<>{dialogTitleText}</>}
+      textFieldJSX={textFieldJSX}
+      tallMode
+    />
+  );
 }
 
 AddBallotItemModal.propTypes = {
@@ -302,7 +301,7 @@ AddBallotItemModal.propTypes = {
 };
 
 
-// override existing font-family rules which uniquely impact MUI Typography elements 
+// override existing font-family rules which uniquely impact MUI Typography elements
 // so that font is consistent throughout modal
 const ModalFont = createGlobalStyle`
   .MuiDialog-paper:has(#addBallotItemInput) .MuiTypography-root,
@@ -382,10 +381,10 @@ const StanceToggleRow = styled('div')`
 // map both button background color when selected & text/icon color when hovered
 // to match currently active stanceType
 const stanceColor = (stanceType) => {
-    if (stanceType === 'support') return DesignTokenColors.confirmation800;
-    if (stanceType === 'oppose') return DesignTokenColors.alert800;
-    return DesignTokenColors.info800; // undecided
-}
+  if (stanceType === 'support') return DesignTokenColors.confirmation800;
+  if (stanceType === 'oppose') return DesignTokenColors.alert800;
+  return DesignTokenColors.info800; // undecided
+};
 
 const StanceToggleButton = styled('button')`
     align-items: center;

--- a/src/js/components/BallotItem/AddBallotItemModal.jsx
+++ b/src/js/components/BallotItem/AddBallotItemModal.jsx
@@ -1,0 +1,308 @@
+import withStyles from '@mui/styles/withStyles';
+import withTheme from '@mui/styles/withTheme';
+import { 
+    FormControl, FormControlLabel, FormGroup, FormLabel, 
+    Radio, RadioGroup,TextField, ToggleButton, ToggleButtonGroup,  
+    Button,
+    Box, 
+} from '@mui/material';
+import { Check, DoNotDisturb } from '@mui/icons-material';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+import ModalDisplayTemplateA, { templateAStyles, TextFieldWrapper } from '../Widgets/ModalDisplayTemplateA';
+import { renderLog } from '../../common/utils/logging';
+
+
+class AddBallotItemModal extends Component {
+    constructor (props) {
+        super(props);
+        this.state = {
+            itemName: '',
+            itemRadioSelection: null,
+            candidateOfficeName: '',
+            candidatePartySelection: '',
+            otherPartyText: '',
+            chooseOpposeSelection: null,
+            opinionText: '',
+        };
+    }
+
+    handleItemRadioSelection = (event) => {
+        this.setState({ itemRadioSelection: event.target.value });
+    };
+
+    handleCandidatePartySelection = (event) => {
+        this.setState({ candidatePartySelection: event.target.value });
+    };
+
+    handleOtherTextChange = (event) => {
+        this.setState({ otherPartyText: event.target.value });
+    };
+
+    handlechooseOpposeSelection = (event, newSelection) => {
+        this.setState({ chooseOpposeSelection: newSelection });
+    };
+
+    handleSubmit = () => {
+        let submissionData = {
+            itemName: this.state.itemName,
+            itemRadioSelection: this.state.itemRadioSelection,
+            chooseOpposeSelection: this.state.chooseOpposeSelection,
+            opinionText: this.state.opinionText,
+        }
+
+        if (this.state.itemRadioSelection === 'candidate') {
+            submissionData.candidateOfficeName ??= this.state.candidateOfficeName;
+            submissionData.candidatePartySelection ??= this.state.candidatePartySelection;
+            if (this.state.candidatePartySelection === 'other') {
+                submissionData.otherPartyText = this.state.otherPartyText;
+            }
+        }
+
+        console.log('AddBallotItemModal handleSubmit called with values:', submissionData);
+    }
+
+
+    render () {
+        renderLog('AddBallotItemModal');  // Set LOG_RENDER_EVENTS to log all renders
+        
+        const { itemName, itemRadioSelection, candidateOfficeName, candidatePartySelection, otherPartyText, opinionText } = this.state;
+        const { show } = this.props;
+       
+        if (!show) {
+            return null;
+        }
+
+        const dialogTitleText = 'Add an item to your ballot';
+        const textFieldJSX = (
+            <TextFieldWrapper>
+                <div>
+                    <UnorderedList>
+                        <li>
+                            Initially, this added item will only be visible to your 
+                            friends in ballot locations within 25 miles of you.
+                        </li>
+                        <li>
+                            Once your friends like this item and add their opinions, 
+                            it will become visible to everyone else. 
+                        </li>
+                    {/* </ul> */}
+                    </UnorderedList>
+                    <TextField
+                        id="addBallotItemInput"
+                        label="Item name"
+                        required
+                        value={itemName}
+                        onChange={(e) => this.setState({ itemName: e.target.value })}
+                        placeholder="Name of candidate, proposition, measure, or referendum"
+                        variant="outlined"
+                        fullWidth
+                        InputLabelProps={{ shrink: true }}
+                        sx={{
+                            '& .MuiOutlinedInput-root': {
+                                '& fieldset': {
+                                    borderRadius: '10px',
+                                },
+                            },
+                        }}
+                    />
+                </div>
+
+                <HorizontalRule />
+
+                <div style={{ marginBottom: '20px' }}>
+                    <FormGroup>
+                        <FormControl>
+                            <FormLabel id="item-type-label">Item type (optional)</FormLabel>
+                            <RadioGroup
+                                aria-labelledby="item-type-label"
+                                name="item-type-radio-group"
+                                value={itemRadioSelection}
+                                onChange={this.handleItemRadioSelection}
+                            >
+                                <FormControlLabel value="candidate" control={<Radio />} label="Candidate" />
+
+                                {itemRadioSelection === 'candidate' &&
+                                    <Box>
+                                        <TextField
+                                            id="outlined-candidateDetailsInput"
+                                            label="Office name"
+                                            value={candidateOfficeName}
+                                            onChange={(e) => this.setState({ candidateOfficeName: e.target.value })}
+                                            variant="outlined"
+                                            disabled={itemRadioSelection !== 'candidate'}
+                                            sx={{
+                                                '& .MuiOutlinedInput-root': {
+                                                    '& fieldset': {
+                                                        borderRadius: '10px',
+                                                    },
+                                                },
+                                            }}
+                                        />
+                                        <RadioGroup
+                                            aria-labelledby="candidate-party-label"
+                                            name="candidate-party-radio-group"
+                                            value={candidatePartySelection}
+                                            onChange={this.handleCandidatePartySelection}
+                                        >
+                                            <FormControlLabel value="democrat" control={<Radio />} label="Democrat" />
+                                            <FormControlLabel value="republican" control={<Radio />} label="Republican" />
+                                            <FormControlLabel value="independent" control={<Radio />} label="Independent" />
+                                            <FormControlLabel
+                                                value="other"
+                                                control={<Radio />}
+                                                label={
+                                                    <TextField
+                                                        variant="outlined"
+                                                        placeholder="Other (please specify)"
+                                                        value={otherPartyText}
+                                                        onChange={this.handleOtherTextChange}
+                                                        // Prevents the radio button from losing focus or toggling unexpectedly
+                                                        onClick={() => this.setState({ candidatePartySelection: 'other' })}
+                                                        disabled={itemRadioSelection !== 'candidate' || (candidatePartySelection !== 'other' && otherPartyText === '')}
+                                                        sx={{ 
+                                                            minWidth: 200,
+
+                                                            '& .MuiOutlinedInput-root': {
+                                                                '& fieldset': {
+                                                                    borderRadius: '10px',
+                                                                },
+                                                            },
+
+                                                        }}
+                                                    />
+                                                }
+                                            />
+                                        </RadioGroup>
+                                    </Box>
+                                }
+                                <FormControlLabel value="proposition" control={<Radio />} label="Proposition / Measure / Referendum" />
+                            </RadioGroup>
+                        </FormControl>
+                    </FormGroup>
+                </div>
+                
+                <HorizontalRule />
+
+                <div style={{ marginTop: '20px' }}>
+                    <ToggleButtonGroup
+                        value={this.state.chooseOpposeSelection}
+                        onChange={this.handlechooseOpposeSelection}
+                        color={this.state.chooseOpposeSelection === 'choose' ? 'success' : this.state.chooseOpposeSelection === 'oppose' ? 'error' : 'primary'}
+                        size="large"
+                        exclusive
+                        aria-label="choose-oppose-toggle"
+                    >
+                        <ToggleButton value="choose" aria-label="choose">
+                            <Check fontSize="small" sx={{ mr: 1 }} />
+                            Choose
+                        </ToggleButton>
+                        <ToggleButton value="oppose" aria-label="oppose">
+                            <DoNotDisturb fontSize="small" sx={{ mr: 1 }} />
+                            Oppose
+                        </ToggleButton>
+                    </ToggleButtonGroup>
+
+                    <TextField
+                        label="What's your opinion on this ballot item?"
+                        value={opinionText}
+                        onChange={(e) => this.setState({ opinionText: e.target.value })}
+                        multiline
+                        minRows={3}
+                        fullWidth
+                        variant="outlined"
+                        sx={{
+                            '& .MuiOutlinedInput-root': {
+                                '& fieldset': {
+                                    borderRadius: '10px',
+                                },
+                            },
+                        }}
+                    />
+                </div>
+
+                <SubmitActionsWrapper>
+                    <CancelButton
+                        variant="outlined"
+                        color="secondary"
+                        sx={{ mt: 2, mr: 2 }}
+                        onClick={this.props.toggleFunction}
+                    >
+                        Cancel
+                    </CancelButton>
+                    <SubmitButton
+                        variant="contained"
+                        color="primary"
+                        sx={{ mt: 2 }}
+                        onClick={() => {this.handleSubmit();}}
+                    >
+                        Add Ballot Item
+                    </SubmitButton>
+                </SubmitActionsWrapper>
+            </TextFieldWrapper>
+        );
+        
+        return (
+            <ModalDisplayTemplateA
+                show={show}
+                dialogTitleJSX={<>{dialogTitleText}</>}
+                toggleModal={this.props.toggleFunction}
+                textFieldJSX={textFieldJSX}
+                tallMode
+            />
+        );
+    }
+}
+
+AddBallotItemModal.propTypes = {
+  show: PropTypes.bool,
+  toggleFunction: PropTypes.func.isRequired,
+};
+
+
+const UnorderedList = styled('ul')`
+    margin: 20px 0px; 
+    padding-top: 20px;
+    padding-bottom: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    background: rgb(230, 243, 255);
+    border: 1px solid rgb(174, 178, 190);
+    border-radius: 10px;
+`;
+
+const HorizontalRule = styled('hr')`
+    width: 90%;
+`;
+
+const SubmitActionsWrapper = styled('div')`
+    display: flex;
+    justify-content: space-between;
+    margin-top: 20px;
+`;
+
+const CancelButton = styled(Button)`
+    border-radius: 50px;
+    background-color: #f5f5f5;
+    color: #555;
+    flex: 1;
+    &:hover {
+        background-color: #e0e0e0;
+    }
+`;
+
+const SubmitButton = styled(Button)`
+    border-radius: 50px;
+    background-color: #1976d2;
+    color: white;
+    flex: 2;
+    &:hover {
+        background-color: #115293;
+    }
+`;
+
+
+export default withTheme(withStyles(templateAStyles)(AddBallotItemModal));
+// export default AddBallotItemModal;

--- a/src/js/components/Navigation/HeaderBarModals.jsx
+++ b/src/js/components/Navigation/HeaderBarModals.jsx
@@ -14,6 +14,7 @@ import AppObservableStore, { messageService } from '../../common/stores/AppObser
 import PoliticianStore from '../../common/stores/PoliticianStore';
 import SignInJoinText from '../SignIn/SignInJoinText';
 
+const AddBallotItemModal = React.lazy(() => import(/* webpackChunkName: 'AddBallotItemModal' */ '../BallotItem/AddBallotItemModal'));
 const AdviserIntroModal = React.lazy(() => import(/* webpackChunkName: 'AdviserIntroModal' */ '../CompleteYourProfile/AdviserIntroModal'));
 const AskFriendsModal = React.lazy(() => import(/* webpackChunkName: 'AskFriendsModal' */ '../Friends/AskFriendsModal'));
 const BallotChoicesAndSettingsModal = React.lazy(() => import(/* webpackChunkName: 'BallotChoicesAndSettingsModal' */ '../CompleteYourProfile/BallotChoicesAndSettingsModal'));
@@ -38,6 +39,7 @@ class HeaderBarModals extends Component {
   constructor (props) {
     super(props);
     this.state = {
+      showAddBallotItemModal: false,
       showAdviserIntroModal: false,
       showChooseOrOpposeIntroModal: false,
       showChooseOrOpposeSignInModal: false,
@@ -84,6 +86,7 @@ class HeaderBarModals extends Component {
     // console.log('HeaderBar onAppObservableStoreChange showPaidAccountUpgradeModal:', showPaidAccountUpgradeModal);
     this.setState({
       // paidAccountUpgradeMode,
+      showAddBallotItemModal: AppObservableStore.showAddBallotItemModal(),
       showAdviserIntroModal: AppObservableStore.showAdviserIntroModal(),
       showAskFriendsModal: AppObservableStore.showAskFriendsModal(),
       showBallotChoicesAndSettingsModal: AppObservableStore.showBallotChoicesAndSettingsModal(),
@@ -104,6 +107,10 @@ class HeaderBarModals extends Component {
       showImageUploadModal: AppObservableStore.showImageUploadModal(),
     });
   }
+
+  closeAddBallotItemModal = () => {
+    AppObservableStore.setShowAddBallotItemModal(false);
+  };
 
   closeAdviserIntroModal = () => {
     AppObservableStore.setShowAdviserIntroModal(false);
@@ -208,7 +215,7 @@ class HeaderBarModals extends Component {
 
     const { classes } = this.props;
     const {
-      showAdviserIntroModal, showAskFriendsModal, showBallotChoicesAndSettingsModal, showChooseOrOpposeIntroModal, showChooseOrOpposeSignInModal,
+      showAddBallotItemModal, showAdviserIntroModal, showAskFriendsModal, showBallotChoicesAndSettingsModal, showChooseOrOpposeIntroModal, showChooseOrOpposeSignInModal,
       showClaimProfileWithEmailModal, showClaimProfileWithOtherWaysModal, showEditPositionModal, showFirstPositionIntroModal,
       showMakePublicGateModal, showPaidAccountUpgradeModal, showPersonalizedScoreIntroModal,
       showSelectBallotModal, showSelectBallotModalEditAddress,
@@ -219,6 +226,17 @@ class HeaderBarModals extends Component {
 
     // renderLog(`HeaderBarModals`);
     // console.log('HeaderBarModals showSignInModal:', showSignInModal);
+    let addBallotItemModal = <></>;
+    if (showAddBallotItemModal) {
+      addBallotItemModal = (
+        <Suspense fallback={<></>}>
+          <AddBallotItemModal
+            show={showAddBallotItemModal}
+            toggleFunction={this.closeAddBallotItemModal}
+          />
+        </Suspense>
+      );
+    }
     let advisorIntroModalHtml = <></>;
     if (showAdviserIntroModal) {
       advisorIntroModalHtml = (
@@ -437,6 +455,7 @@ class HeaderBarModals extends Component {
     );
     return (
       <>
+        {addBallotItemModal}
         {advisorIntroModalHtml}
         {askFriendsModal}
         {ballotChoicesAndSettingsModal}


### PR DESCRIPTION
### What github.com/wevote/WebApp/issues does this fix?

this is a new modal component, **AddBallotItemModal** based on the specifications in ticket [WV-4763](https://wevoteusa.atlassian.net/browse/WV-4763)

### _new modal appearance & functionality_
<img width="1006" height="1252" alt="Screenshot 2026-08-28 at 1 23 58 AM" src="https://github.com/user-attachments/assets/71539389-5684-4e41-a305-6c2b7fe4b1d6" />


https://github.com/user-attachments/assets/3a703ce4-47fe-417b-bf19-8abb44e3df67




### Changes included this pull request?

- new **AddBallotItemModal** component
    _beyond specs from ticket, implemented:_
                   - **sticky footer** for the cancel/submit buttons (similar to that in ImportConfirmModal)
                   - **choose/oppose/undecided buttons** (very similar to buttons in VoterPositionEntryAndDisplay, but needing fewer props due to different usage & having additional styling not present in original buttons)

- changes to _AppObservableStore_, _DisplayWhileRetrievingBallot_, and _HeaderBarModals_ to set up modal appearance & basic functionality

[WV-4763]: https://wevoteusa.atlassian.net/browse/WV-4763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ